### PR TITLE
SOL-148234: [Prod] Add golangci-lint config and CI job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,22 @@ on:
   push:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.11.4
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +41,10 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test -v ./...
+        # -race enables the Go race detector to catch data races on shared state (e.g. BrokerPool).
+        # This adds ~2-3x overhead to test execution. Acceptable now given the small test suite,
+        # but worth revisiting if test times become a problem as the suite grows.
+        run: go test -race -v ./...
 
       - name: Check for test files
         run: |
@@ -38,12 +57,7 @@ jobs:
 
 # --- FUTURE ENHANCEMENTS ---
 #
-# 1. Add golangci-lint for linting
-#    Use the official golangci/golangci-lint-action@v9 GitHub Action.
-#    This should be added as a separate job in this workflow.
-#    Reference: https://github.com/golangci/golangci-lint-action
-#
-# 2. Make test warning a hard failure
+# 1. Make test warning a hard failure
 #    Once the team has tests in place, change the "Check for test files" step
 #    to fail the build if no *_test.go files are found, ensuring no PR can
 #    merge without tests.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,10 +17,10 @@ linters:
         - name: exported
           disabled: true  # don't require doc comments on all exported symbols yet
 
-issues:
-  exclude-rules:
-    # Test files: relax errcheck and gosec
-    - path: _test\.go
-      linters:
-        - errcheck
-        - gosec
+  exclusions:
+    rules:
+      # Test files: relax errcheck and gosec
+      - path: ".*_test\\.go"
+        linters:
+          - errcheck
+          - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+linters:
+  enable:
+    - errcheck      # unchecked error return values
+    - staticcheck   # dead code, nil deref, misuse patterns
+    - gosec         # security issues (TLS, credentials, etc.)
+    - govet         # vet checks including copylocks
+    - revive        # style and correctness
+    - bodyclose     # HTTP response bodies must be closed — critical for broker API calls
+    - ineffassign   # ineffective assignments (e.g. assigning a value that is never used)
+    - noctx         # http.NewRequest must use context variant (http.NewRequestWithContext)
+
+linters-settings:
+  revive:
+    rules:
+      - name: exported
+        disabled: true  # don't require doc comments on all exported symbols yet
+
+issues:
+  exclude-rules:
+    # Test files: relax errcheck and gosec
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 linters:
   enable:
     - errcheck      # unchecked error return values
@@ -9,11 +11,11 @@ linters:
     - ineffassign   # ineffective assignments (e.g. assigning a value that is never used)
     - noctx         # http.NewRequest must use context variant (http.NewRequestWithContext)
 
-linters-settings:
-  revive:
-    rules:
-      - name: exported
-        disabled: true  # don't require doc comments on all exported symbols yet
+  settings:
+    revive:
+      rules:
+        - name: exported
+          disabled: true  # don't require doc comments on all exported symbols yet
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,9 @@ linters:
           disabled: true  # don't require doc comments on all exported symbols yet
 
   exclusions:
+    presets:
+      - common-false-positives   # gosec taint-analysis FPs (G304, G402, G706)
+      - std-error-handling       # unchecked Close(), Setenv(), etc.
     rules:
       # Test files: relax errcheck and gosec
       - path: ".*_test\\.go"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -62,13 +62,15 @@ func main() {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status": "ok"}`))
+		if _, err := w.Write([]byte(`{"status": "ok"}`)); err != nil {
+			http.Error(w, "failed to write response", http.StatusInternalServerError)
+		}
 	})
 
 	// 7. Start server
 	addr := fmt.Sprintf(":%s", cfg.Port)
-	log.Printf("MCP server listening on %s", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	log.Printf("MCP server listening on %s", addr) //nolint:gosec // addr is derived from config, not external user input
+	if err := http.ListenAndServe(addr, mux); err != nil { //nolint:gosec // G114: no timeout by design — MCP uses long-lived streaming HTTP connections
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 
@@ -25,18 +26,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to load config: %v", err)
 	}
-	log.Printf("Loaded config with %d broker(s)", len(cfg.Brokers))
+	slog.Info("Loaded config", "broker_count", len(cfg.Brokers)) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
 
 	// 2. Parse embedded OpenAPI specs
 	operations, err := sempv2.ParseSpecs(specs.FS)
 	if err != nil {
 		log.Fatalf("Failed to parse OpenAPI specs: %v", err)
 	}
-	log.Printf("Parsed %d operations from embedded specs", len(operations))
+	slog.Info("Parsed operations from embedded specs", "count", len(operations))
 
 	// 3. Create broker pool
 	pool := semp.NewBrokerPool(cfg)
-	log.Printf("Created broker pool with aliases: %v", pool.Aliases())
+	slog.Info("Created broker pool", "aliases", pool.Aliases()) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
 
 	// 4. Create MCP server
 	server := mcp.NewServer(&mcp.Implementation{
@@ -69,7 +70,7 @@ func main() {
 
 	// 7. Start server
 	addr := fmt.Sprintf(":%s", cfg.Port)
-	log.Printf("MCP server listening on %s", addr) //nolint:gosec // addr is derived from config, not external user input
+	slog.Info("MCP server listening", "addr", addr) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
 	if err := http.ListenAndServe(addr, mux); err != nil { //nolint:gosec // G114: no timeout by design — MCP uses long-lived streaming HTTP connections
 		log.Fatalf("Server failed: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,7 +174,7 @@ func loadEnvFile(configPath string) {
 		}
 	}
 
-	log.Printf("Loaded .env file from %s", envPath)
+	log.Printf("Loaded .env file from %q", envPath)
 }
 
 // validate checks that the config has all required fields and that values are

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,7 @@ package config
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -91,7 +91,7 @@ func LoadConfig(path string) (*ServerConfig, error) {
 		return nil, fmt.Errorf("resolving credentials: %w", err)
 	}
 
-	log.Printf("WARNING: env_prefix naming convention is provisional — only uppercase letters, numbers, and underscores allowed. This convention may change.")
+	slog.Warn("env_prefix naming convention is provisional — only uppercase letters, numbers, and underscores allowed; this may change")
 
 	return cfg, nil
 }
@@ -153,7 +153,7 @@ func loadEnvFile(configPath string) {
 	if envPath == "" {
 		envPath = filepath.Join(filepath.Dir(configPath), ".env")
 	}
-	data, err := os.ReadFile(envPath)
+	data, err := os.ReadFile(envPath) //nolint:gosec // G703 — path from trusted config/env, not external user input
 	if err != nil {
 		return // .env file is optional — if it doesn't exist, silently skip
 	}
@@ -170,11 +170,11 @@ func loadEnvFile(configPath string) {
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
 		if _, exists := os.LookupEnv(key); !exists {
-			os.Setenv(key, value)
+			os.Setenv(key, value) //nolint:gosec // G104 — os.Setenv only fails on Plan 9; safe to ignore
 		}
 	}
 
-	log.Printf("Loaded .env file from %q", envPath)
+	slog.Info("Loaded .env file", "path", envPath) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
 }
 
 // validate checks that the config has all required fields and that values are

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -43,7 +43,7 @@ type HTTPClient struct {
 // tuning appropriate for concurrent SEMP calls.
 func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *HTTPClient {
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: brokerCfg.TLSSkipVerify},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: brokerCfg.TLSSkipVerify}, //nolint:gosec // G402 — user-configurable TLS skip for dev environments; defaults to false
 	}
 
 	return &HTTPClient{

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -254,12 +254,12 @@ func TestClient_Execute_InvalidJSON(t *testing.T) {
 }
 
 func TestClient_Execute_Timeout(t *testing.T) {
-	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	_, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Second)
 	})
 	defer server.Close()
 
-	// Override with a very short timeout client.
+	// Create a client with a very short timeout.
 	brokerCfg := &config.BrokerConfig{
 		URL: server.URL,
 		Auth: config.AuthConfig{
@@ -271,7 +271,7 @@ func TestClient_Execute_Timeout(t *testing.T) {
 	sempCfg := &config.SEMPConfig{
 		RequestTimeoutSeconds: 1,
 	}
-	client = sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	client := sempv2.NewHTTPClient(brokerCfg, sempCfg)
 
 	op := &sempv2.Operation{
 		ID:     "testOp",


### PR DESCRIPTION
Add golangci-lint config and CI lint job to catch issues early before the composite executor and registry work lands.

- .golangci.yml with errcheck, staticcheck, gosec, govet, revive, bodyclose, ineffassign, noctx
- Lint job in CI pinned to golangci-lint v2.11.4
- -race flag added to test step to catch data races on shared state (BrokerPool)
