### PR TITLE
Add secure logging foundation with credential redaction

### DIFF
--- a/.claude/skills/add-logs/SKILL.md
+++ b/.claude/skills/add-logs/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: add-logs
+description: Add secure, compliant slog logging to Go code following the project's secure logging rules
+user_invocable: true
+---
+
+# Add Logs
+
+Add structured `log/slog` logging to Go code that follows the project's secure logging rules. Invoked with `/add-logs`.
+
+## When to use
+
+- After implementing a new feature or function that needs logging
+- When migrating `log.Printf` calls to `slog`
+- When adding logging to an existing file that lacks it
+
+## Usage
+
+- `/add-logs <file_path>` — add logging to a specific file
+- `/add-logs <file_path> <function_name>` — add logging to a specific function
+
+If invoked without arguments, ask the user which file or function to target.
+
+## Steps
+
+### Step 1: Read the rules
+
+Read the secure logging rules at `docs/secure-logging-rules.md` in the project root. These rules are non-negotiable — every log line you write must comply.
+
+### Step 2: Read the target code
+
+Read the file or function the user specified. Understand what it does, what events are significant, and what data flows through it.
+
+### Step 3: Identify loggable events
+
+For each function, identify events that belong in the Always-Log list from the rules:
+
+- Server startup/shutdown
+- Tool invocations (tool name, broker alias, status, duration_ms)
+- Tool errors (tool name, broker alias, error_type, http_status)
+- Broker connections created (broker alias, URL)
+- Config loaded (broker_count, port)
+- Any error or failure path
+
+### Step 4: Write the log calls
+
+For each event, write a `slog` call following these constraints:
+
+**Always:**
+- Use `slog.Info()`, `slog.Warn()`, or `slog.Error()` — not `log.Printf`
+- Use structured fields: `slog.String("key", value)`, `slog.Int("key", value)`, `slog.Duration("key", value)`
+- Keep the message string static and descriptive (no variable data in the message)
+- Include all required fields from the Always-Log table
+
+**Never:**
+- Never log anything on the Never-Log list (passwords, usernames, tokens, auth headers, raw config maps, URLs with embedded credentials)
+- Never use `fmt.Sprintf` in the message string with external data
+- Never log raw structs with `slog.Any("key", someStruct)` — log explicit fields
+- Never log raw `err.Error()` from external systems (SEMP, HTTP) without reviewing what it could contain
+- Never log to stdout — always stderr
+
+### Step 5: Check for imports
+
+Ensure the file imports `log/slog`. If it still imports `log`, check if any `log.Printf` calls remain. If not, remove the `log` import.
+
+### Step 6: Present the changes
+
+Show the user the changes with clear explanation of what each log line captures and why.
+
+## Examples
+
+### Good log calls
+
+```go
+// Tool invocation — all required fields present
+slog.Info("tool invoked",
+    slog.String("tool", toolName),
+    slog.String("broker", brokerAlias),
+    slog.String("status", "success"),
+    slog.Duration("duration", elapsed))
+
+// Error with structured context — no raw err.Error() from external source
+slog.Error("SEMP call failed",
+    slog.String("tool", toolName),
+    slog.String("broker", brokerAlias),
+    slog.String("operation", opID),
+    slog.Int("http_status", statusCode))
+
+// Startup — alias list, not config map
+slog.Info("server starting",
+    slog.String("port", cfg.Port),
+    slog.Int("broker_count", len(cfg.Brokers)),
+    slog.Any("broker_aliases", pool.Aliases()))
+```
+
+### Bad log calls (never write these)
+
+```go
+// BAD: raw struct may contain credentials
+slog.Info("config loaded", slog.Any("config", cfg))
+
+// BAD: fmt.Sprintf with external data in message
+slog.Info(fmt.Sprintf("tool %s called", userInput))
+
+// BAD: logging password
+slog.Info("broker connected", slog.String("password", config.Auth.Password))
+
+// BAD: raw error from SEMP may contain credentials
+slog.Error("failed", slog.String("error", err.Error()))
+```
+
+## Rules
+
+- Every log line must pass the Never-Log list check from `docs/secure-logging-rules.md`
+- Every significant event must include the fields from the Always-Log table
+- If unsure whether something is safe to log, don't log it — flag it for the user
+- When migrating from `log.Printf`, don't just swap the call — redesign it with structured fields

--- a/.claude/skills/check-logs/SKILL.md
+++ b/.claude/skills/check-logs/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: check-logs
+description: Scan Go code for logging violations — credential leaks, missing LogValuer, raw structs, stdout usage, unsafe patterns
+user_invocable: true
+---
+
+# Check Logs
+
+Scan Go code for logging security violations and compliance issues. Invoked with `/check-logs`.
+
+## When to use
+
+- Before committing code
+- After adding logging to a file
+- As a periodic audit of the codebase
+- When reviewing someone else's changes
+
+## Usage
+
+- `/check-logs` — scan the entire codebase
+- `/check-logs <file_path>` — scan a specific file
+- `/check-logs staged` — scan only git-staged files
+
+## Steps
+
+### Step 1: Read the rules
+
+Read the secure logging rules at `docs/secure-logging-rules.md` in the project root. These are the rules you're checking against.
+
+### Step 2: Identify files to scan
+
+Based on the invocation:
+- No args: scan all `.go` files under `cmd/` and `internal/`
+- File path: scan that file
+- `staged`: run `git diff --cached --name-only -- '*.go'` and scan those files
+
+### Step 3: Run violation checks
+
+For each file, check for the following violations in order of severity:
+
+#### CRITICAL — Credential exposure
+
+- [ ] **C-01: Credentials in log calls** — Any log call that includes `Password`, `Username`, `Token`, `Secret`, or `Authorization` field values
+- [ ] **C-02: Raw struct logging** — `slog.Any("key", someStruct)` or `log.Printf("%+v", someStruct)` where the struct is or contains a credential-carrying type (`BrokerConfig`, `AuthConfig`, `ServerConfig`, `HTTPClient`)
+- [ ] **C-03: Config map logging** — Logging `map[string]*BrokerConfig` or the full `ServerConfig.Brokers` map
+- [ ] **C-04: Raw Authorization header** — Logging the value of an `Authorization` HTTP header
+- [ ] **C-05: URL with credentials** — Logging a URL that matches `://.*:.*@` pattern
+
+#### HIGH — Missing protections
+
+- [ ] **H-01: Missing LogValuer** — Credential-carrying types (`AuthConfig`, `BrokerConfig`, and any struct with password/token/secret fields) that don't implement `slog.LogValuer`
+- [ ] **H-02: Missing ReplaceAttr** — slog handler created without `ReplaceAttr` safety net
+- [ ] **H-03: Stdout logging** — Any log output directed to `os.Stdout` instead of `os.Stderr`
+- [ ] **H-04: Old log package** — Usage of `log.Printf`, `log.Println`, `log.Fatalf`, `log.Fatal` instead of `slog`
+
+#### MEDIUM — Unsafe patterns
+
+- [ ] **M-01: fmt.Sprintf in message** — `slog.Info(fmt.Sprintf(...))` or similar — variable data should be in structured fields, not the message
+- [ ] **M-02: Raw external errors** — `slog.String("error", err.Error())` where the error comes from SEMP, HTTP, or external systems that might include credentials in error messages
+- [ ] **M-03: String concatenation in message** — `slog.Info("action: " + userInput)` — use structured fields instead
+
+#### LOW — Best practice
+
+- [ ] **L-01: Missing required fields** — Tool invocation logs without all required fields (tool, broker, status, duration_ms)
+- [ ] **L-02: Unstructured fmt.Print** — Any `fmt.Printf`, `fmt.Println` used for logging purposes
+
+### Step 4: Report findings
+
+Present findings grouped by severity with file path, line number, the offending code, and a fix suggestion.
+
+### Output format
+
+```
+Log Security Check Results
+==========================
+
+Files scanned: 14
+Violations found: 3
+
+CRITICAL:
+- internal/config/config.go:94 — H-04: Uses log.Printf (old log package)
+  Code: log.Printf("WARNING: env_prefix naming convention...")
+  Fix: Replace with slog.Warn("env_prefix naming convention is provisional")
+
+HIGH:
+- internal/config/config.go — H-01: AuthConfig does not implement slog.LogValuer
+  Fix: Add LogValue() method that exposes only Method field
+
+MEDIUM:
+- (none)
+
+LOW:
+- cmd/server/main.go:35 — L-01: Startup log missing auth_mode field
+  Code: log.Printf("Loaded config with %d broker(s)", len(cfg.Brokers))
+  Fix: slog.Info("config loaded", slog.Int("broker_count", len(cfg.Brokers)), slog.String("auth_mode", "basic"))
+
+Clean:
+- internal/composite/ — no violations
+- internal/registry/ — no violations
+- internal/semp/sempv2/ — no violations
+```
+
+### Step 5: Summary
+
+End with a one-line summary:
+- All clear: "No violations found. Logging is compliant."
+- Issues found: "Found N violations (X critical, Y high, Z medium). Fix critical and high before committing."
+
+## Rules
+
+- CRITICAL violations must be fixed before any commit — no exceptions
+- HIGH violations should be fixed before commit
+- MEDIUM and LOW are recommendations — flag them but don't block
+- If you're unsure whether something is a violation, flag it as MEDIUM with a note explaining the uncertainty
+- Never modify code during a check — only report. Use `/add-logs` to fix.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,9 @@ linters:
     - noctx         # http.NewRequest must use context variant (http.NewRequestWithContext)
 
   settings:
+    gosec:
+      excludes:
+        - G706  # log injection via taint analysis — false positive with log/slog typed attrs (auto-escaped). Fix merged in gosec PR #1623, pending next release after v2.25.0. Re-enable when golangci-lint bundles the fix.
     revive:
       rules:
         - name: exported
@@ -19,7 +22,7 @@ linters:
 
   exclusions:
     presets:
-      - common-false-positives   # gosec taint-analysis FPs (G304, G402, G706)
+      - common-false-positives   # gosec taint-analysis FPs (G103, G204, G304)
       - std-error-handling       # unchecked Close(), Setenv(), etc.
     rules:
       # Test files: relax errcheck and gosec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Solace Broker MCP Server
+
+## Before committing
+
+Run `/check-logs` to scan for logging security violations. Fix all CRITICAL and HIGH issues before committing.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
@@ -15,7 +15,33 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// newSlogHandler creates a slog handler with the ReplaceAttr safety net that
+// redacts values for keys matching common credential patterns. This is defense
+// in depth — credential-carrying types also implement slog.LogValuer to exclude
+// secrets, but ReplaceAttr catches anything that slips through.
+// See docs/secure-logging-rules.md Rule 3.
+func newSlogHandler() slog.Handler {
+	redactedKeys := []string{"password", "token", "secret", "authorization", "credential", "api_key", "private_key"}
+
+	return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			key := strings.ToLower(a.Key)
+			for _, redacted := range redactedKeys {
+				if strings.Contains(key, redacted) {
+					a.Value = slog.StringValue("[REDACTED]")
+					return a
+				}
+			}
+			return a
+		},
+	})
+}
+
 func main() {
+	// 0. Set up structured logging with credential redaction safety net
+	slog.SetDefault(slog.New(newSlogHandler()))
+
 	// 1. Load config
 	configPath := os.Getenv("CONFIG_PATH")
 	if configPath == "" {
@@ -24,20 +50,26 @@ func main() {
 
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
-		log.Fatalf("Failed to load config: %v", err)
+		slog.Error("failed to load config", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
-	slog.Info("Loaded config", "broker_count", len(cfg.Brokers)) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
+	slog.Info("config loaded",
+		slog.Int("broker_count", len(cfg.Brokers)),
+		slog.String("port", cfg.Port))
 
 	// 2. Parse embedded OpenAPI specs
 	operations, err := sempv2.ParseSpecs(specs.FS)
 	if err != nil {
-		log.Fatalf("Failed to parse OpenAPI specs: %v", err)
+		slog.Error("failed to parse OpenAPI specs", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
-	slog.Info("Parsed operations from embedded specs", "count", len(operations))
+	slog.Info("parsed OpenAPI specs",
+		slog.Int("operation_count", len(operations)))
 
 	// 3. Create broker pool
 	pool := semp.NewBrokerPool(cfg)
-	slog.Info("Created broker pool", "aliases", pool.Aliases()) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
+	slog.Info("created broker pool",
+		slog.Any("broker_aliases", pool.Aliases()))
 
 	// 4. Create MCP server
 	server := mcp.NewServer(&mcp.Implementation{
@@ -70,8 +102,10 @@ func main() {
 
 	// 7. Start server
 	addr := fmt.Sprintf(":%s", cfg.Port)
-	slog.Info("MCP server listening", "addr", addr) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
+	slog.Info("server starting",
+		slog.String("addr", addr))
 	if err := http.ListenAndServe(addr, mux); err != nil { //nolint:gosec // G114: no timeout by design — MCP uses long-lived streaming HTTP connections
-		log.Fatalf("Server failed: %v", err)
+		slog.Error("server failed", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 }

--- a/docs/secure-logging-rules.md
+++ b/docs/secure-logging-rules.md
@@ -1,0 +1,87 @@
+# Secure Logging Rules
+
+Rules for writing safe, secure, and compliant log output in the Solace Broker MCP Server. These rules apply identically in dev and prod — the only differences between environments are level, format, and source info.
+
+---
+
+## Never-Log List
+
+These must never appear in log output, in any environment:
+
+| Item | Where it lives in our code |
+|---|---|
+| SEMP passwords | `AuthConfig.Password`, `HTTPClient.password` |
+| SEMP usernames | `AuthConfig.Username`, `HTTPClient.username` |
+| Raw `Authorization` header values | Built in `HTTPClient.Execute()` |
+| TLS private keys | If we ever load them |
+| URLs with embedded credentials | `http://user:pass@host` patterns |
+| Full broker config maps | `map[string]*BrokerConfig` contains credentials via `AuthConfig` |
+
+**What to log instead:** auth method (`basic`/`bearer`), env_prefix source, broker alias, broker URL (without credentials).
+
+---
+
+## Always-Log List (INFO level)
+
+| Event | Required fields |
+|---|---|
+| Server startup | port, broker_count, broker alias list (`[]string`), auth_mode, log_level |
+| Server shutdown | reason (signal, error) |
+| Tool invocation | tool name, broker alias, status, duration_ms |
+| Tool error | tool name, broker alias, error_type, http_status |
+| Broker connection created | broker alias, URL |
+| Config loaded | broker_count, port |
+
+**Important:** At startup, log the broker alias list (`[]string`) — never the broker config map. The config map contains `AuthConfig` which holds credentials.
+
+---
+
+## Implementation Rules
+
+### Rule 1: Always use structured fields
+
+Never `fmt.Sprintf` into the message string with external data. Always `slog.String("key", value)` for variable data. This prevents log injection attacks.
+
+### Rule 2: Credential-carrying types must implement `slog.LogValuer`
+
+- `AuthConfig` — expose only `Method`
+- `BrokerConfig` — expose `URL`, `TLSSkipVerify`, `EnvPrefix`, `Auth.Method`
+- `HTTPClient` — lower risk (unexported fields) but should still get `LogValuer` for defense in depth
+- When Story 1B adds OAuth config, that struct gets `LogValuer` too
+
+### Rule 3: `ReplaceAttr` safety net on the handler
+
+Keys matching `password`, `token`, `secret`, `authorization`, `credential`, `api_key`, `private_key` get replaced with `[REDACTED]`. This is defense in depth — catches anything that slips past Rule 2.
+
+### Rule 4: Never log raw structs
+
+Always log explicit fields, even if `LogValuer` is implemented.
+
+- Avoid: `slog.Any("config", brokerConfig)`
+- Prefer: `slog.String("url", config.URL)`
+
+### Rule 5: Review errors from external systems before logging
+
+SEMP errors and HTTP responses may contain credential context. Log structured error context (operation, broker, http_status) instead of raw `err.Error()` when the error source is external.
+
+### Rule 6: Log to stderr, never stdout
+
+MCP protocol reserves stdout for JSON-RPC messages. Go's `log/slog` defaults to stderr — keep it that way.
+
+### Rule 7: Same security rules in dev and prod
+
+Credential redaction is identical in both modes. `LogValuer` and `ReplaceAttr` are active in both modes. Only differences are level, format, and source info (see table below).
+
+---
+
+## Dev vs Prod Configuration
+
+| Setting | Dev | Prod |
+|---|---|---|
+| Level | DEBUG (when added later) | INFO |
+| Format | `slog.TextHandler` (human-readable) | `slog.JSONHandler` (machine-parseable) |
+| Output | stderr | stderr |
+| AddSource | true (includes file:line for debugging) | false (skip for performance) |
+| Credential redaction | Yes | Yes |
+| `ReplaceAttr` safety net | Yes | Yes |
+| `LogValuer` on credential types | Yes | Yes |

--- a/docs/secure-logging-rules.md
+++ b/docs/secure-logging-rules.md
@@ -12,6 +12,7 @@ These must never appear in log output, in any environment:
 |---|---|
 | SEMP passwords | `AuthConfig.Password`, `HTTPClient.password` |
 | SEMP usernames | `AuthConfig.Username`, `HTTPClient.username` |
+| SEMP bearer tokens | `AuthConfig.Token` |
 | Raw `Authorization` header values | Built in `HTTPClient.Execute()` |
 | TLS private keys | If we ever load them |
 | URLs with embedded credentials | `http://user:pass@host` patterns |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,27 @@ type AuthConfig struct {
 	Password string // populated from {EnvPrefix}_PASSWORD env var
 }
 
+// LogValue implements slog.LogValuer for AuthConfig. It exposes only the auth
+// method — username and password are deliberately excluded to prevent credential
+// leaks in log output. See docs/secure-logging-rules.md Rule 2.
+func (a AuthConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("method", a.Method),
+	)
+}
+
+// LogValue implements slog.LogValuer for BrokerConfig. It exposes connection
+// metadata (URL, TLS settings, env prefix, auth method) but excludes credentials.
+// See docs/secure-logging-rules.md Rule 2.
+func (b BrokerConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("url", b.URL),
+		slog.Bool("tls_skip_verify", b.TLSSkipVerify),
+		slog.String("env_prefix", b.EnvPrefix),
+		slog.String("auth_method", b.Auth.Method),
+	)
+}
+
 // SEMPConfig holds settings that control how the MCP server communicates with
 // brokers over the SEMP API.
 type SEMPConfig struct {
@@ -91,7 +112,8 @@ func LoadConfig(path string) (*ServerConfig, error) {
 		return nil, fmt.Errorf("resolving credentials: %w", err)
 	}
 
-	slog.Warn("env_prefix naming convention is provisional — only uppercase letters, numbers, and underscores allowed; this may change")
+	slog.Warn("env_prefix naming convention is provisional",
+		slog.String("convention", "uppercase letters, numbers, and underscores only"))
 
 	return cfg, nil
 }
@@ -174,7 +196,8 @@ func loadEnvFile(configPath string) {
 		}
 	}
 
-	slog.Info("Loaded .env file", "path", envPath) //nolint:gosec // G706 — slog attrs are auto-escaped; fix in gosec v2.26.0
+	slog.Info("loaded .env file",
+		slog.String("path", envPath))
 }
 
 // validate checks that the config has all required fields and that values are

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -36,6 +37,16 @@ type HTTPClient struct {
 	baseURL    string
 	username   string
 	password   string
+}
+
+// LogValue implements slog.LogValuer for HTTPClient. It exposes only the base
+// URL — username and password are deliberately excluded. Although these fields
+// are unexported, this provides defense in depth against reflection-based logging.
+// See docs/secure-logging-rules.md Rule 2.
+func (c *HTTPClient) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("base_url", c.baseURL),
+	)
 }
 
 // NewHTTPClient creates an HTTPClient configured for a specific broker.


### PR DESCRIPTION
## Purpose
Establish secure logging foundations so that credentials, tokens, and sensitive data can never leak into log output — in dev or prod. This gives the team a standard to follow (rules doc), tools to enforce it (skills), and the base implementation (slog migration with redaction).

## Summary
- Add secure logging rules doc (`docs/secure-logging-rules.md`) defining never-log list, always-log list, and 7 implementation rules for credential protection
- Add `/check-logs` and `/add-logs` Claude Code skills at the project level so the whole team can scan for violations and add compliant logs
- Add `CLAUDE.md` with pre-commit instruction to run `/check-logs`
- Migrate all `log.Printf`/`log.Fatalf` to `log/slog` with typed structured fields per Q-005 and Story 1
- Add `LogValuer` on `AuthConfig`, `BrokerConfig`, `HTTPClient` — credential-carrying types control their own safe log representation
- Add `ReplaceAttr` safety net on the slog handler — redacts keys matching password, token, secret, etc.
- Fatal startup errors use `slog.Error` + `os.Exit(1)` — fully structured, fail-fast preserved

## Test plan
- [x] All existing tests pass (config, semp, sempv2 — verified)
- [x] Server starts and produces structured JSON logs to stderr — no credentials in output (manually verified)
- [x] MCP initialize request succeeds with server running
- [x] Run `/check-logs` on the codebase — only known issue is temporary `smoketest.go` (being deleted)
