### PR TITLE
SOL-148422 - Configuration Management 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,18 @@ Create a `broker-config.yaml` file in the repo root (this file is gitignored):
 brokers:
   my-broker:
     url: "http://my-broker.example.com:8080"
-    env_prefix: "MY_BROKER"
     auth:
       method: basic
+      username: ${MY_BROKER_USERNAME}
+      password: ${MY_BROKER_PASSWORD}
 ```
 
 Each broker needs:
-- `url` — the SEMP management API base URL
-- `env_prefix` — prefix for credential environment variables (uppercase letters, numbers, underscores only)
+- `url` — the SEMP management API base URL (hardcode or use `${VAR_NAME}` for env var)
 - `auth.method` — `basic` (only supported method currently)
+- `auth.username` / `auth.password` — credentials (use `${VAR_NAME}` to keep secrets out of YAML)
+
+Any field can use `${VAR_NAME}` syntax to reference environment variables. The server replaces these with actual values before parsing. Fields without `${...}` are used as-is.
 
 You can configure multiple brokers:
 
@@ -42,14 +45,16 @@ You can configure multiple brokers:
 brokers:
   dev:
     url: "http://dev-broker.example.com:8080"
-    env_prefix: "DEV"
     auth:
       method: basic
+      username: ${DEV_USERNAME}
+      password: ${DEV_PASSWORD}
   staging:
-    url: "http://staging-broker.example.com:8080"
-    env_prefix: "STAGING"
+    url: ${STAGING_URL}
     auth:
       method: basic
+      username: ${STAGING_USERNAME}
+      password: ${STAGING_PASSWORD}
 ```
 
 ### 3. Set up credentials
@@ -61,9 +66,7 @@ MY_BROKER_USERNAME=admin
 MY_BROKER_PASSWORD=admin
 ```
 
-The naming convention is `{ENV_PREFIX}_USERNAME` and `{ENV_PREFIX}_PASSWORD`. For multiple brokers, add credentials for each using their `env_prefix`.
-
-The server automatically loads the `.env` file on startup. You can also set environment variables directly (e.g., in CI/CD) — they take precedence over `.env` values.
+The `.env` file is loaded automatically on startup. You can also set environment variables directly (e.g., in CI/CD) — they take precedence over `.env` values. Any `${VAR_NAME}` in the YAML config will be replaced with the corresponding environment variable.
 
 ### 4. Run the server
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,11 +27,16 @@ import (
 // in depth — credential-carrying types also implement slog.LogValuer to exclude
 // secrets, but ReplaceAttr catches anything that slips through.
 // See docs/secure-logging-rules.md Rule 3.
-func newSlogHandler() slog.Handler {
+//
+// The level parameter controls the minimum level emitted. main() calls this
+// twice: once at INFO to bootstrap logging before LoadConfig runs (so config
+// loading itself can emit logs), then again with the user-configured level
+// from cfg.LogLevel after validation.
+func newSlogHandler(level slog.Level) slog.Handler {
 	redactedKeys := []string{"password", "token", "secret", "authorization", "credential", "api_key", "private_key"}
 
 	return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: level,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			key := strings.ToLower(a.Key)
 			for _, redacted := range redactedKeys {
@@ -71,8 +76,12 @@ func buildMux(server *mcp.Server) *http.ServeMux {
 }
 
 func main() {
-	// 0. Set up structured logging with credential redaction safety net
-	slog.SetDefault(slog.New(newSlogHandler()))
+	// 0. Bootstrap slog at INFO so LoadConfig can emit logs. The handler is
+	//    swapped with the user-configured level (cfg.LogLevel) after LoadConfig
+	//    validates it. UnmarshalText is infallible here because validate() in
+	//    the config package already proved cfg.LogLevel is one of the valid
+	//    level names.
+	slog.SetDefault(slog.New(newSlogHandler(slog.LevelInfo)))
 
 	// 1. Load config
 	configPath := os.Getenv("CONFIG_FILE")
@@ -85,9 +94,17 @@ func main() {
 		slog.Error("failed to load config", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
+
+	// Reconfigure slog with the user-configured level. cfg.LogLevel is
+	// validated and normalized to one of debug/info/warn/error.
+	var level slog.Level
+	_ = level.UnmarshalText([]byte(cfg.LogLevel))
+	slog.SetDefault(slog.New(newSlogHandler(level)))
+
 	slog.Info("config loaded",
 		slog.Int("broker_count", len(cfg.Brokers)),
-		slog.Int("port", cfg.Port))
+		slog.Int("port", cfg.Port),
+		slog.String("log_level", cfg.LogLevel))
 
 	// 2. Parse embedded OpenAPI specs
 	operations, err := sempv2.ParseSpecs(specs.FS)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -83,13 +83,10 @@ func main() {
 	//    level names.
 	slog.SetDefault(slog.New(newSlogHandler(slog.LevelInfo)))
 
-	// 1. Load config
-	configPath := os.Getenv("CONFIG_FILE")
-	if configPath == "" {
-		configPath = defaults.DefaultConfigPath
-	}
-
-	cfg, err := config.LoadConfig(configPath)
+	// 1. Load config. config.Load handles path resolution internally
+	//    (CONFIG_FILE env var, then /etc/mcp-server/config.yaml, then
+	//    ./broker-config.yaml). See config.Load docs for exact semantics.
+	cfg, err := config.Load()
 	if err != nil {
 		slog.Error("failed to load config", slog.String("error", err.Error()))
 		os.Exit(1)

--- a/docs/secure-logging-rules.md
+++ b/docs/secure-logging-rules.md
@@ -12,7 +12,7 @@ These must never appear in log output, in any environment:
 |---|---|
 | SEMP passwords | `AuthConfig.Password`, `HTTPClient.password` |
 | SEMP usernames | `AuthConfig.Username`, `HTTPClient.username` |
-| SEMP bearer tokens | `AuthConfig.Token` |
+| SEMP bearer tokens | `AuthConfig.Token`, `HTTPClient.token` |
 | Raw `Authorization` header values | Built in `HTTPClient.Execute()` |
 | TLS private keys | If we ever load them |
 | URLs with embedded credentials | `http://user:pass@host` patterns |
@@ -45,8 +45,8 @@ Never `fmt.Sprintf` into the message string with external data. Always `slog.Str
 
 ### Rule 2: Credential-carrying types must implement `slog.LogValuer`
 
-- `AuthConfig` — expose only `Method`
-- `BrokerConfig` — expose `URL`, `TLSSkipVerify`, `EnvPrefix`, `Auth.Method`
+- `AuthConfig` — expose only `Mode`
+- `BrokerConfig` — expose `URL`, `TLSSkipVerify`, `Auth.Mode`
 - `HTTPClient` — lower risk (unexported fields) but should still get `LogValuer` for defense in depth
 - When Story 1B adds OAuth config, that struct gets `LogValuer` too
 

--- a/docs/secure-logging-rules.md
+++ b/docs/secure-logging-rules.md
@@ -18,7 +18,7 @@ These must never appear in log output, in any environment:
 | URLs with embedded credentials | `http://user:pass@host` patterns |
 | Full broker config maps | `map[string]*BrokerConfig` contains credentials via `AuthConfig` |
 
-**What to log instead:** auth method (`basic`/`bearer`), env_prefix source, broker alias, broker URL (without credentials).
+**What to log instead:** auth method (`basic`/`bearer`), broker alias, broker URL (without credentials).
 
 ---
 

--- a/docs/secure-logging-rules.md
+++ b/docs/secure-logging-rules.md
@@ -46,7 +46,7 @@ Never `fmt.Sprintf` into the message string with external data. Always `slog.Str
 ### Rule 2: Credential-carrying types must implement `slog.LogValuer`
 
 - `AuthConfig` — expose only `Mode`
-- `BrokerConfig` — expose `URL`, `TLSSkipVerify`, `Auth.Mode`
+- `BrokerConfig` — expose `URL`, `InsecureSkipVerify`, `Auth.Mode`
 - `HTTPClient` — lower risk (unexported fields) but should still get `LogValuer` for defense in depth
 - When Story 1B adds OAuth config, that struct gets `LogValuer` too
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // Package config loads and validates the Solace Broker MCP Server configuration
-// from a YAML file. It supports multiple brokers with independent credentials
-// loaded from environment variables using per-broker env_prefix, and applies
-// defaults from the defaults package for optional fields.
+// from a YAML file. It supports ${VAR_NAME} env var substitution in any YAML
+// field, multiple brokers with independent credentials, and applies defaults
+// from the defaults package for optional fields.
 package config
 
 import (
@@ -16,10 +16,6 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"gopkg.in/yaml.v3"
 )
-
-// envPrefixPattern validates that env_prefix values contain only uppercase
-// letters, numbers, and underscores.
-var envPrefixPattern = regexp.MustCompile(`^[A-Z0-9_]+$`)
 
 // ServerConfig holds the complete MCP server configuration, including all
 // configured brokers and SEMP client settings.
@@ -36,15 +32,14 @@ type ServerConfig struct {
 type BrokerConfig struct {
 	URL           string     `yaml:"url"`             // SEMP API base URL (e.g., "https://broker:1943")
 	TLSSkipVerify bool       `yaml:"tls_skip_verify"` // skip TLS cert verification (dev only)
-	EnvPrefix     string     `yaml:"env_prefix"`      // prefix for credential env vars ({EnvPrefix}_USERNAME, {EnvPrefix}_PASSWORD)
 	Auth          AuthConfig `yaml:"auth"`             // authentication config
 }
 
 // AuthConfig holds the authentication credentials for a broker connection.
 type AuthConfig struct {
-	Method   string `yaml:"method"` // "basic" for this release
-	Username string // populated from {EnvPrefix}_USERNAME env var
-	Password string // populated from {EnvPrefix}_PASSWORD env var
+	Method   string `yaml:"method"`   // "basic" for this release
+	Username string `yaml:"username"` // basic auth username (use ${VAR_NAME} for env var)
+	Password string `yaml:"password"` // basic auth password (use ${VAR_NAME} for env var)
 }
 
 // LogValue implements slog.LogValuer for AuthConfig. It exposes only the auth
@@ -57,13 +52,12 @@ func (a AuthConfig) LogValue() slog.Value {
 }
 
 // LogValue implements slog.LogValuer for BrokerConfig. It exposes connection
-// metadata (URL, TLS settings, env prefix, auth method) but excludes credentials.
+// metadata (URL, TLS settings, auth method) but excludes credentials.
 // See docs/secure-logging-rules.md Rule 2.
 func (b BrokerConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("url", b.URL),
 		slog.Bool("tls_skip_verify", b.TLSSkipVerify),
-		slog.String("env_prefix", b.EnvPrefix),
 		slog.String("auth_method", b.Auth.Method),
 	)
 }
@@ -85,22 +79,29 @@ type yamlConfig struct {
 	TLSKeyFile  string                   `yaml:"tls_key_file"`
 }
 
-// LoadConfig reads a YAML configuration file from path, applies defaults for
-// missing optional fields, validates the structure, resolves credentials from
-// environment variables, applies env var overrides, and returns a ServerConfig
-// ready for use.
+// LoadConfig reads a YAML configuration file from path, substitutes ${VAR_NAME}
+// env var references, parses YAML, applies defaults, validates, and returns a
+// ServerConfig ready for use.
 //
 // Processing order:
-//  1. Parse YAML
-//  2. Apply defaults (fill missing optional fields)
-//  3. Validate (required fields, value ranges, TLS pairing)
-//  4. Load .env file
-//  5. Resolve credentials from environment variables
-//  6. Apply env var overrides (MCP_SERVER_PORT — env var wins over YAML/default)
+//  1. Read YAML file (raw bytes)
+//  2. Load .env file (so env vars are available for substitution)
+//  3. Substitute ${VAR_NAME} in raw bytes
+//  4. Parse YAML
+//  5. Apply defaults (fill missing optional fields)
+//  6. Apply env var overrides (MCP_SERVER_PORT — runtime override)
+//  7. Validate (required fields, value ranges, TLS pairing)
 func LoadConfig(path string) (*ServerConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	loadEnvFile(path)
+
+	data, err = substituteEnvVars(data)
+	if err != nil {
+		return nil, fmt.Errorf("substituting env vars: %w", err)
 	}
 
 	var raw yamlConfig
@@ -118,56 +119,17 @@ func LoadConfig(path string) (*ServerConfig, error) {
 
 	applyDefaults(cfg)
 
-	if err := validate(cfg); err != nil {
-		return nil, fmt.Errorf("validating config: %w", err)
-	}
-
-	loadEnvFile(path)
-
-	if err := resolveCredentials(cfg); err != nil {
-		return nil, fmt.Errorf("resolving credentials: %w", err)
-	}
-
 	if err := applyEnvOverrides(cfg); err != nil {
 		return nil, fmt.Errorf("applying env overrides: %w", err)
 	}
 
-	slog.Warn("env_prefix naming convention is provisional",
-		slog.String("convention", "uppercase letters, numbers, and underscores only"))
+	if err := validate(cfg); err != nil {
+		return nil, fmt.Errorf("validating config: %w", err)
+	}
 
 	return cfg, nil
 }
 
-// resolveCredentials reads credentials from environment variables for each
-// broker using the broker's env_prefix. For a broker with env_prefix "PROD_US",
-// it reads PROD_US_USERNAME and PROD_US_PASSWORD.
-func resolveCredentials(cfg *ServerConfig) error {
-	for alias, broker := range cfg.Brokers {
-		if broker.EnvPrefix == "" {
-			return fmt.Errorf("broker %q: env_prefix is required", alias)
-		}
-
-		if !envPrefixPattern.MatchString(broker.EnvPrefix) {
-			return fmt.Errorf("broker %q: env_prefix must contain only uppercase letters, numbers, and underscores, got %q", alias, broker.EnvPrefix)
-		}
-
-		usernameVar := broker.EnvPrefix + "_USERNAME"
-		username, exists := os.LookupEnv(usernameVar)
-		if !exists {
-			return fmt.Errorf("broker %q: environment variable %s is not set (required by env_prefix %q). Set it in your environment or in a .env file next to the config file", alias, usernameVar, broker.EnvPrefix)
-		}
-
-		passwordVar := broker.EnvPrefix + "_PASSWORD"
-		password, exists := os.LookupEnv(passwordVar)
-		if !exists {
-			return fmt.Errorf("broker %q: environment variable %s is not set (required by env_prefix %q). Set it in your environment or in a .env file next to the config file", alias, passwordVar, broker.EnvPrefix)
-		}
-
-		broker.Auth.Username = username
-		broker.Auth.Password = password
-	}
-	return nil
-}
 
 // applyDefaults fills in missing optional fields from the defaults package.
 func applyDefaults(cfg *ServerConfig) {
@@ -220,9 +182,37 @@ func loadEnvFile(configPath string) {
 		slog.String("path", envPath))
 }
 
+// envVarPattern matches ${VAR_NAME} in raw YAML bytes. VAR_NAME must be
+// uppercase letters, numbers, and underscores.
+var envVarPattern = regexp.MustCompile(`\$\{([A-Z0-9_]+)\}`)
+
+// substituteEnvVars replaces all ${VAR_NAME} occurrences in raw YAML bytes with
+// the corresponding environment variable values. Returns an error if any
+// referenced env var is not set. This runs before YAML parsing so any field
+// can reference env vars.
+func substituteEnvVars(data []byte) ([]byte, error) {
+	var missing []string
+
+	result := envVarPattern.ReplaceAllFunc(data, func(match []byte) []byte {
+		// Extract var name from ${VAR_NAME}
+		varName := string(envVarPattern.FindSubmatch(match)[1])
+		value, exists := os.LookupEnv(varName)
+		if !exists {
+			missing = append(missing, varName)
+			return match // leave as-is, error reported after
+		}
+		return []byte(value)
+	})
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("environment variables not set: %s", strings.Join(missing, ", "))
+	}
+
+	return result, nil
+}
+
 // validate checks that the config has all required fields and that values are
-// within acceptable ranges. Credential validation happens in resolveCredentials,
-// not here — this function validates structure only.
+// within acceptable ranges.
 func validate(cfg *ServerConfig) error {
 	if len(cfg.Brokers) == 0 {
 		return fmt.Errorf("at least one broker must be configured")
@@ -233,23 +223,23 @@ func validate(cfg *ServerConfig) error {
 			return fmt.Errorf("broker %q: url is required", alias)
 		}
 
-		if broker.EnvPrefix == "" {
-			return fmt.Errorf("broker %q: env_prefix is required", alias)
-		}
-
-		if !envPrefixPattern.MatchString(broker.EnvPrefix) {
-			return fmt.Errorf("broker %q: env_prefix must contain only uppercase letters, numbers, and underscores, got %q", alias, broker.EnvPrefix)
-		}
-
-		// ASSUMPTION: defaulting to basic auth when method is not specified.
-		// Only basic auth is supported in this PR. When OAuth is added, this
-		// default may need to change or become an error.
+		// Default to basic auth when method is not specified.
 		if broker.Auth.Method == "" {
 			broker.Auth.Method = "basic"
 		}
 
 		if broker.Auth.Method != "basic" {
 			return fmt.Errorf("broker %q: unsupported auth method %q (only \"basic\" is supported)", alias, broker.Auth.Method)
+		}
+
+		// Validate credentials are present based on auth method.
+		if broker.Auth.Method == "basic" {
+			if broker.Auth.Username == "" {
+				return fmt.Errorf("broker %q: username is required for basic auth", alias)
+			}
+			if broker.Auth.Password == "" {
+				return fmt.Errorf("broker %q: password is required for basic auth", alias)
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,10 +84,29 @@ func (b BrokerConfig) LogValue() slog.Value {
 }
 
 // SEMPConfig holds settings that control how the MCP server communicates with
-// brokers over the SEMP API.
+// brokers over the SEMP API. The rate-limit and retry fields below are
+// defined here but not yet consumed -- they will be wired up in Story 5 when
+// the rate limiter and retry policy are implemented.
+//
+// Field names match the Solace Terraform provider's naming convention so
+// operators familiar with terraform-provider-solacebroker get a consistent
+// experience across tools.
+//
+// RequestMinInterval and Retries use pointer types so we can distinguish
+// "field omitted in YAML" (nil) from "field set to 0" (non-nil pointer to
+// zero). Zero is a legitimate operator choice for both -- the Terraform
+// provider documents "set request_min_interval to 0 for no rate limit", and
+// retries=0 means no retries by analogy. Plain int/time.Duration cannot tell
+// those two cases apart, because both produce the zero value. After
+// applyDefaults runs, these fields are guaranteed non-nil so downstream code
+// can dereference safely.
 type SEMPConfig struct {
-	MaxConcurrentPerBroker int           `yaml:"max_concurrent_per_broker"` // semaphore size per broker
-	RequestTimeout         time.Duration `yaml:"request_timeout"`           // HTTP request timeout for SEMP calls (e.g., "30s")
+	MaxConcurrentPerBroker int            `yaml:"max_concurrent_per_broker"` // semaphore size per broker
+	RequestTimeoutDuration time.Duration  `yaml:"request_timeout_duration"`  // HTTP request timeout for SEMP calls (e.g., "30s")
+	RequestMinInterval     *time.Duration `yaml:"request_min_interval"`      // minimum spacing between SEMP requests; 0 = no throttle
+	Retries                *int           `yaml:"retries"`                   // max retry attempts for a failed SEMP call; 0 = no retries
+	RetryMinInterval       time.Duration  `yaml:"retry_min_interval"`        // starting backoff before the first retry (must be > 0)
+	RetryMaxInterval       time.Duration  `yaml:"retry_max_interval"`        // cap on retry backoff, must be >= RetryMinInterval
 }
 
 // yamlConfig is the intermediate representation used for YAML unmarshalling.
@@ -164,8 +183,26 @@ func applyDefaults(cfg *ServerConfig) {
 	if cfg.SEMP.MaxConcurrentPerBroker == 0 {
 		cfg.SEMP.MaxConcurrentPerBroker = defaults.DefaultMaxConcurrentPerBroker
 	}
-	if cfg.SEMP.RequestTimeout == 0 {
-		cfg.SEMP.RequestTimeout = defaults.DefaultSEMPRequestTimeout
+	if cfg.SEMP.RequestTimeoutDuration == 0 {
+		cfg.SEMP.RequestTimeoutDuration = defaults.DefaultSEMPRequestTimeoutDuration
+	}
+	// RequestMinInterval and Retries are pointers so we can distinguish
+	// "operator omitted the field" (nil) from "operator set it to 0" (non-nil
+	// pointer to zero). Apply the default only when nil. See the SEMPConfig
+	// struct doc for the full rationale.
+	if cfg.SEMP.RequestMinInterval == nil {
+		def := defaults.DefaultRequestMinInterval
+		cfg.SEMP.RequestMinInterval = &def
+	}
+	if cfg.SEMP.Retries == nil {
+		def := defaults.DefaultRetries
+		cfg.SEMP.Retries = &def
+	}
+	if cfg.SEMP.RetryMinInterval == 0 {
+		cfg.SEMP.RetryMinInterval = defaults.DefaultRetryMinInterval
+	}
+	if cfg.SEMP.RetryMaxInterval == 0 {
+		cfg.SEMP.RetryMaxInterval = defaults.DefaultRetryMaxInterval
 	}
 	// TLSSkipVerify is not defaulted here — Go's zero value for bool (false)
 	// already matches the intended default (verify TLS certificates).
@@ -265,8 +302,29 @@ func validate(cfg *ServerConfig) error {
 		errs = append(errs, fmt.Errorf("semp.max_concurrent_per_broker must be > 0, got %d", cfg.SEMP.MaxConcurrentPerBroker))
 	}
 
-	if cfg.SEMP.RequestTimeout < 0 {
-		errs = append(errs, fmt.Errorf("semp.request_timeout must be > 0, got %s", cfg.SEMP.RequestTimeout))
+	if cfg.SEMP.RequestTimeoutDuration <= 0 {
+		errs = append(errs, fmt.Errorf("semp.request_timeout_duration must be > 0, got %s", cfg.SEMP.RequestTimeoutDuration))
+	}
+
+	// RequestMinInterval and Retries are guaranteed non-nil by applyDefaults,
+	// so dereferencing is safe here. Story rule: non-negative for both; zero is
+	// explicitly allowed (0 = no rate limit / no retries).
+	if *cfg.SEMP.RequestMinInterval < 0 {
+		errs = append(errs, fmt.Errorf("semp.request_min_interval must be >= 0, got %s", *cfg.SEMP.RequestMinInterval))
+	}
+
+	if *cfg.SEMP.Retries < 0 {
+		errs = append(errs, fmt.Errorf("semp.retries must be >= 0, got %d", *cfg.SEMP.Retries))
+	}
+
+	if cfg.SEMP.RetryMinInterval <= 0 {
+		errs = append(errs, fmt.Errorf("semp.retry_min_interval must be > 0, got %s", cfg.SEMP.RetryMinInterval))
+	}
+
+	if cfg.SEMP.RetryMaxInterval <= 0 {
+		errs = append(errs, fmt.Errorf("semp.retry_max_interval must be > 0, got %s", cfg.SEMP.RetryMaxInterval))
+	} else if cfg.SEMP.RetryMinInterval > 0 && cfg.SEMP.RetryMaxInterval < cfg.SEMP.RetryMinInterval {
+		errs = append(errs, fmt.Errorf("semp.retry_max_interval (%s) must be >= semp.retry_min_interval (%s)", cfg.SEMP.RetryMaxInterval, cfg.SEMP.RetryMinInterval))
 	}
 
 	// TLS: both cert and key must be provided together, or neither.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -223,61 +224,79 @@ func substituteEnvVars(data []byte) ([]byte, error) {
 }
 
 // validate checks that the config has all required fields and that values are
-// within acceptable ranges.
+// within acceptable ranges. All validation errors are collected and returned as
+// a single joined error so operators see every issue in one run instead of
+// fixing them one-by-one across multiple reloads.
 func validate(cfg *ServerConfig) error {
+	var errs []error
+
 	if len(cfg.Brokers) == 0 {
-		return fmt.Errorf("at least one broker must be configured")
+		errs = append(errs, fmt.Errorf("at least one broker must be configured"))
 	}
 
 	for alias, broker := range cfg.Brokers {
-		if broker.URL == "" {
-			return fmt.Errorf("broker %q: url is required", alias)
-		}
-
-		// Normalize auth mode and require it to be set (per story spec: auth_mode is required).
-		broker.Auth.Mode = strings.ToLower(broker.Auth.Mode)
-		if broker.Auth.Mode == "" {
-			return fmt.Errorf("broker %q: auth.mode is required (must be one of %v)", alias, validAuthModes)
-		}
-
-		if !slices.Contains(validAuthModes, broker.Auth.Mode) {
-			return fmt.Errorf("broker %q: unsupported auth mode %q (must be one of %v)", alias, broker.Auth.Mode, validAuthModes)
-		}
-
-		// Validate credentials are present based on auth mode.
-		switch broker.Auth.Mode {
-		case AuthModeBasic:
-			if broker.Auth.Username == "" {
-				return fmt.Errorf("broker %q: username is required for basic auth", alias)
-			}
-			if broker.Auth.Password == "" {
-				return fmt.Errorf("broker %q: password is required for basic auth", alias)
-			}
-		case AuthModeBearer:
-			if broker.Auth.Token == "" {
-				return fmt.Errorf("broker %q: token is required for bearer auth", alias)
-			}
-		}
+		errs = append(errs, validateBroker(alias, broker)...)
 	}
 
 	if err := ValidatePort(cfg.Port); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 
 	if cfg.SEMP.MaxConcurrentPerBroker < 0 {
-		return fmt.Errorf("semp.max_concurrent_per_broker must be > 0, got %d", cfg.SEMP.MaxConcurrentPerBroker)
+		errs = append(errs, fmt.Errorf("semp.max_concurrent_per_broker must be > 0, got %d", cfg.SEMP.MaxConcurrentPerBroker))
 	}
 
 	if cfg.SEMP.RequestTimeoutSeconds < 0 {
-		return fmt.Errorf("semp.request_timeout_seconds must be > 0, got %d", cfg.SEMP.RequestTimeoutSeconds)
+		errs = append(errs, fmt.Errorf("semp.request_timeout_seconds must be > 0, got %d", cfg.SEMP.RequestTimeoutSeconds))
 	}
 
 	// TLS: both cert and key must be provided together, or neither.
 	if (cfg.TLSCertFile == "") != (cfg.TLSKeyFile == "") {
-		return fmt.Errorf("both tls_cert_file and tls_key_file must be provided together; got cert=%q, key=%q", cfg.TLSCertFile, cfg.TLSKeyFile)
+		errs = append(errs, fmt.Errorf("both tls_cert_file and tls_key_file must be provided together; got cert=%q, key=%q", cfg.TLSCertFile, cfg.TLSKeyFile))
 	}
 
-	return nil
+	return errors.Join(errs...)
+}
+
+// validateBroker returns all validation errors for a single broker. Credential
+// checks are skipped when auth.mode is missing or invalid because there are no
+// meaningful credential rules to apply without a known mode.
+func validateBroker(alias string, broker *BrokerConfig) []error {
+	var errs []error
+
+	if broker.URL == "" {
+		errs = append(errs, fmt.Errorf("broker %q: url is required", alias))
+	}
+
+	// Normalize auth mode (case-insensitive per story spec).
+	broker.Auth.Mode = strings.ToLower(broker.Auth.Mode)
+
+	if broker.Auth.Mode == "" {
+		errs = append(errs, fmt.Errorf("broker %q: auth.mode is required (must be one of %v)", alias, validAuthModes))
+		return errs
+	}
+
+	if !slices.Contains(validAuthModes, broker.Auth.Mode) {
+		errs = append(errs, fmt.Errorf("broker %q: unsupported auth mode %q (must be one of %v)", alias, broker.Auth.Mode, validAuthModes))
+		return errs
+	}
+
+	// Validate credentials are present based on auth mode.
+	switch broker.Auth.Mode {
+	case AuthModeBasic:
+		if broker.Auth.Username == "" {
+			errs = append(errs, fmt.Errorf("broker %q: username is required for basic auth", alias))
+		}
+		if broker.Auth.Password == "" {
+			errs = append(errs, fmt.Errorf("broker %q: password is required for basic auth", alias))
+		}
+	case AuthModeBearer:
+		if broker.Auth.Token == "" {
+			errs = append(errs, fmt.Errorf("broker %q: token is required for bearer auth", alias))
+		}
+	}
+
+	return errs
 }
 
 // ValidatePort checks that a port number is within the valid TCP range (1-65535).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"gopkg.in/yaml.v3"
@@ -85,8 +86,8 @@ func (b BrokerConfig) LogValue() slog.Value {
 // SEMPConfig holds settings that control how the MCP server communicates with
 // brokers over the SEMP API.
 type SEMPConfig struct {
-	MaxConcurrentPerBroker int `yaml:"max_concurrent_per_broker"` // semaphore size per broker
-	RequestTimeoutSeconds  int `yaml:"request_timeout_seconds"`   // HTTP request timeout for SEMP calls
+	MaxConcurrentPerBroker int           `yaml:"max_concurrent_per_broker"` // semaphore size per broker
+	RequestTimeout         time.Duration `yaml:"request_timeout"`           // HTTP request timeout for SEMP calls (e.g., "30s")
 }
 
 // yamlConfig is the intermediate representation used for YAML unmarshalling.
@@ -163,8 +164,8 @@ func applyDefaults(cfg *ServerConfig) {
 	if cfg.SEMP.MaxConcurrentPerBroker == 0 {
 		cfg.SEMP.MaxConcurrentPerBroker = defaults.DefaultMaxConcurrentPerBroker
 	}
-	if cfg.SEMP.RequestTimeoutSeconds == 0 {
-		cfg.SEMP.RequestTimeoutSeconds = defaults.DefaultSEMPRequestTimeoutSeconds
+	if cfg.SEMP.RequestTimeout == 0 {
+		cfg.SEMP.RequestTimeout = defaults.DefaultSEMPRequestTimeout
 	}
 	// TLSSkipVerify is not defaulted here — Go's zero value for bool (false)
 	// already matches the intended default (verify TLS certificates).
@@ -264,8 +265,8 @@ func validate(cfg *ServerConfig) error {
 		errs = append(errs, fmt.Errorf("semp.max_concurrent_per_broker must be > 0, got %d", cfg.SEMP.MaxConcurrentPerBroker))
 	}
 
-	if cfg.SEMP.RequestTimeoutSeconds < 0 {
-		errs = append(errs, fmt.Errorf("semp.request_timeout_seconds must be > 0, got %d", cfg.SEMP.RequestTimeoutSeconds))
+	if cfg.SEMP.RequestTimeout < 0 {
+		errs = append(errs, fmt.Errorf("semp.request_timeout must be > 0, got %s", cfg.SEMP.RequestTimeout))
 	}
 
 	// TLS: both cert and key must be provided together, or neither.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -32,22 +33,33 @@ type ServerConfig struct {
 type BrokerConfig struct {
 	URL           string     `yaml:"url"`             // SEMP API base URL (e.g., "https://broker:1943")
 	TLSSkipVerify bool       `yaml:"tls_skip_verify"` // skip TLS cert verification (dev only)
-	Auth          AuthConfig `yaml:"auth"`             // authentication config
+	Auth          AuthConfig `yaml:"auth"`            // authentication config
 }
+
+// Auth mode constants for broker authentication (Hop 2: MCP Server → Broker).
+const (
+	AuthModeBasic  = "basic"
+	AuthModeBearer = "bearer"
+)
+
+// validAuthModes is the allowlist of supported auth modes for broker connections.
+// Add new modes (e.g., "oauth") here — validate() and error messages derive from this slice.
+var validAuthModes = []string{AuthModeBasic, AuthModeBearer}
 
 // AuthConfig holds the authentication credentials for a broker connection.
 type AuthConfig struct {
-	Method   string `yaml:"method"`   // "basic" for this release
+	Mode     string `yaml:"mode"`     // "basic" or "bearer"
 	Username string `yaml:"username"` // basic auth username (use ${VAR_NAME} for env var)
 	Password string `yaml:"password"` // basic auth password (use ${VAR_NAME} for env var)
+	Token    string `yaml:"token"`    // bearer token (use ${VAR_NAME} for env var)
 }
 
 // LogValue implements slog.LogValuer for AuthConfig. It exposes only the auth
-// method — username and password are deliberately excluded to prevent credential
-// leaks in log output. See docs/secure-logging-rules.md Rule 2.
+// mode — username, password, and token are deliberately excluded to prevent
+// credential leaks in log output. See docs/secure-logging-rules.md Rule 2.
 func (a AuthConfig) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("method", a.Method),
+		slog.String("mode", a.Mode),
 	)
 }
 
@@ -58,7 +70,7 @@ func (b BrokerConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("url", b.URL),
 		slog.Bool("tls_skip_verify", b.TLSSkipVerify),
-		slog.String("auth_method", b.Auth.Method),
+		slog.String("auth_mode", b.Auth.Mode),
 	)
 }
 
@@ -129,7 +141,6 @@ func LoadConfig(path string) (*ServerConfig, error) {
 
 	return cfg, nil
 }
-
 
 // applyDefaults fills in missing optional fields from the defaults package.
 func applyDefaults(cfg *ServerConfig) {
@@ -223,22 +234,28 @@ func validate(cfg *ServerConfig) error {
 			return fmt.Errorf("broker %q: url is required", alias)
 		}
 
-		// Default to basic auth when method is not specified.
-		if broker.Auth.Method == "" {
-			broker.Auth.Method = "basic"
+		// Normalize auth mode and require it to be set (per story spec: auth_mode is required).
+		broker.Auth.Mode = strings.ToLower(broker.Auth.Mode)
+		if broker.Auth.Mode == "" {
+			return fmt.Errorf("broker %q: auth.mode is required (must be one of %v)", alias, validAuthModes)
 		}
 
-		if broker.Auth.Method != "basic" {
-			return fmt.Errorf("broker %q: unsupported auth method %q (only \"basic\" is supported)", alias, broker.Auth.Method)
+		if !slices.Contains(validAuthModes, broker.Auth.Mode) {
+			return fmt.Errorf("broker %q: unsupported auth mode %q (must be one of %v)", alias, broker.Auth.Mode, validAuthModes)
 		}
 
-		// Validate credentials are present based on auth method.
-		if broker.Auth.Method == "basic" {
+		// Validate credentials are present based on auth mode.
+		switch broker.Auth.Mode {
+		case AuthModeBasic:
 			if broker.Auth.Username == "" {
 				return fmt.Errorf("broker %q: username is required for basic auth", alias)
 			}
 			if broker.Auth.Password == "" {
 				return fmt.Errorf("broker %q: password is required for basic auth", alias)
+			}
+		case AuthModeBearer:
+			if broker.Auth.Token == "" {
+				return fmt.Errorf("broker %q: token is required for bearer auth", alias)
 			}
 		}
 	}
@@ -288,4 +305,3 @@ func applyEnvOverrides(cfg *ServerConfig) error {
 	}
 	return nil
 }
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -266,6 +267,8 @@ func validateBroker(alias string, broker *BrokerConfig) []error {
 
 	if broker.URL == "" {
 		errs = append(errs, fmt.Errorf("broker %q: url is required", alias))
+	} else if err := validateBrokerURL(broker.URL); err != nil {
+		errs = append(errs, fmt.Errorf("broker %q: %w", alias, err))
 	}
 
 	// Normalize auth mode (case-insensitive per story spec).
@@ -304,6 +307,26 @@ func validateBroker(alias string, broker *BrokerConfig) []error {
 func ValidatePort(port int) error {
 	if port < 1 || port > 65535 {
 		return fmt.Errorf("port must be between 1 and 65535, got %d", port)
+	}
+	return nil
+}
+
+// validateBrokerURL checks that s is a well-formed http or https URL with a
+// host component. This is structural validation only — it does NOT verify
+// that the host resolves, is reachable, or actually runs a SEMP endpoint.
+// Those are deliberately runtime concerns surfaced on the first tool call.
+// Both http and https are permitted; production-mode https-only enforcement
+// will be added with the dev/prod flag from Story 1B.
+func validateBrokerURL(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("url is not a valid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("url scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("url must include a host, got %q", s)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,9 +40,9 @@ var validLogLevels = []string{"debug", "info", "warn", "error"}
 // BrokerConfig holds the connection and authentication configuration for a
 // single Solace broker.
 type BrokerConfig struct {
-	URL           string     `yaml:"url"`             // SEMP API base URL (e.g., "https://broker:1943")
-	TLSSkipVerify bool       `yaml:"tls_skip_verify"` // skip TLS cert verification (dev only)
-	Auth          AuthConfig `yaml:"auth"`            // authentication config
+	URL                string     `yaml:"url"`                  // SEMP API base URL (e.g., "https://broker:1943")
+	InsecureSkipVerify bool       `yaml:"insecure_skip_verify"` // skip TLS cert verification (dev only, self-signed certs)
+	Auth               AuthConfig `yaml:"auth"`                 // authentication config
 }
 
 // Auth mode constants for broker authentication (Hop 2: MCP Server → Broker).
@@ -78,7 +78,7 @@ func (a AuthConfig) LogValue() slog.Value {
 func (b BrokerConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("url", b.URL),
-		slog.Bool("tls_skip_verify", b.TLSSkipVerify),
+		slog.Bool("insecure_skip_verify", b.InsecureSkipVerify),
 		slog.String("auth_mode", b.Auth.Mode),
 	)
 }
@@ -249,8 +249,8 @@ func applyDefaults(cfg *ServerConfig) {
 	if cfg.SEMP.RetryMaxInterval == 0 {
 		cfg.SEMP.RetryMaxInterval = defaults.DefaultRetryMaxInterval
 	}
-	// TLSSkipVerify is not defaulted here — Go's zero value for bool (false)
-	// already matches the intended default (verify TLS certificates).
+	// InsecureSkipVerify is not defaulted here — Go's zero value for bool
+	// (false) already matches the intended default (verify TLS certificates).
 }
 
 // loadEnvFile loads a .env file into the process environment. It checks two

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,9 +26,15 @@ type ServerConfig struct {
 	Brokers     map[string]*BrokerConfig // broker alias → config
 	SEMP        SEMPConfig               // SEMP client settings
 	Port        int                      // HTTP port the MCP server listens on (1-65535)
+	LogLevel    string                   // slog level name: "debug", "info", "warn", "error"
 	TLSCertFile string                   // path to TLS certificate file (optional, enables HTTPS)
 	TLSKeyFile  string                   // path to TLS private key file (optional, requires TLSCertFile)
 }
+
+// validLogLevels is the allowlist of slog levels operators may configure.
+// Matches the story spec: strict exactly these four values. Excludes slog's
+// offset syntax (e.g., "INFO+3") which UnmarshalText would otherwise accept.
+var validLogLevels = []string{"debug", "info", "warn", "error"}
 
 // BrokerConfig holds the connection and authentication configuration for a
 // single Solace broker.
@@ -89,6 +95,7 @@ type yamlConfig struct {
 	Brokers     map[string]*BrokerConfig `yaml:"brokers"`
 	SEMP        SEMPConfig               `yaml:"semp"`
 	Port        int                      `yaml:"port"`
+	LogLevel    string                   `yaml:"log_level"`
 	TLSCertFile string                   `yaml:"tls_cert_file"`
 	TLSKeyFile  string                   `yaml:"tls_key_file"`
 }
@@ -127,6 +134,7 @@ func LoadConfig(path string) (*ServerConfig, error) {
 		Brokers:     raw.Brokers,
 		SEMP:        raw.SEMP,
 		Port:        raw.Port,
+		LogLevel:    raw.LogLevel,
 		TLSCertFile: raw.TLSCertFile,
 		TLSKeyFile:  raw.TLSKeyFile,
 	}
@@ -148,6 +156,9 @@ func LoadConfig(path string) (*ServerConfig, error) {
 func applyDefaults(cfg *ServerConfig) {
 	if cfg.Port == 0 {
 		cfg.Port = defaults.DefaultPort
+	}
+	if cfg.LogLevel == "" {
+		cfg.LogLevel = defaults.DefaultLogLevel
 	}
 	if cfg.SEMP.MaxConcurrentPerBroker == 0 {
 		cfg.SEMP.MaxConcurrentPerBroker = defaults.DefaultMaxConcurrentPerBroker
@@ -241,6 +252,12 @@ func validate(cfg *ServerConfig) error {
 
 	if err := ValidatePort(cfg.Port); err != nil {
 		errs = append(errs, err)
+	}
+
+	// Normalize log_level and check against the allowlist.
+	cfg.LogLevel = strings.ToLower(cfg.LogLevel)
+	if !slices.Contains(validLogLevels, cfg.LogLevel) {
+		errs = append(errs, fmt.Errorf("log_level %q is invalid (must be one of %v)", cfg.LogLevel, validLogLevels))
 	}
 
 	if cfg.SEMP.MaxConcurrentPerBroker < 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,7 +178,7 @@ func Load() (*ServerConfig, error) {
 //  6. Apply env var overrides (MCP_SERVER_PORT — runtime override)
 //  7. Validate (required fields, value ranges, TLS pairing)
 func LoadConfig(path string) (*ServerConfig, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // G304/G703 — path is the operator-provided config file location (CONFIG_FILE env var, /etc/mcp-server/config.yaml, or ./broker-config.yaml), not untrusted external input
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,51 @@ type yamlConfig struct {
 	TLSKeyFile  string                   `yaml:"tls_key_file"`
 }
 
+// Load locates the server configuration file, loads it, and returns a ready
+// ServerConfig. It checks the following in order:
+//
+//  1. CONFIG_FILE env var — explicit operator override. Strict: any error
+//     loading this file is fatal. We do NOT silently fall through to the
+//     other paths, because if the operator explicitly pointed at a file,
+//     they meant THAT file.
+//  2. defaults.DefaultConfigPathSystem (/etc/mcp-server/config.yaml) —
+//     production-install location.
+//  3. defaults.DefaultConfigPathLocal (broker-config.yaml in CWD) —
+//     developer-convenience fallback for running out of the repo.
+//
+// Only "file does not exist" errors from step 2 or 3 trigger fallback to the
+// next path. Parse errors, permission errors, validation errors, or any other
+// failure from an existing file are always fatal — never silently masked by
+// trying another path. If nothing is found, returns an error listing all
+// paths tried.
+func Load() (*ServerConfig, error) {
+	// Step 1: CONFIG_FILE env var (explicit, strict)
+	if envPath := os.Getenv("CONFIG_FILE"); envPath != "" {
+		return LoadConfig(envPath)
+	}
+
+	// Step 2: system path
+	if _, err := os.Stat(defaults.DefaultConfigPathSystem); err == nil {
+		return LoadConfig(defaults.DefaultConfigPathSystem)
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat %s: %w", defaults.DefaultConfigPathSystem, err)
+	}
+
+	// Step 3: local path
+	if _, err := os.Stat(defaults.DefaultConfigPathLocal); err == nil {
+		return LoadConfig(defaults.DefaultConfigPathLocal)
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat %s: %w", defaults.DefaultConfigPathLocal, err)
+	}
+
+	// Nothing found
+	return nil, fmt.Errorf(
+		"no config file found; set CONFIG_FILE env var or place config at one of: %s, %s",
+		defaults.DefaultConfigPathSystem,
+		defaults.DefaultConfigPathLocal,
+	)
+}
+
 // LoadConfig reads a YAML configuration file from path, substitutes ${VAR_NAME}
 // env var references, parses YAML, applies defaults, validates, and returns a
 // ServerConfig ready for use.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,16 +21,17 @@ func writeTemp(t *testing.T, content string) string {
 }
 
 func TestLoadConfig_SingleBroker(t *testing.T) {
-	t.Setenv("TEST_SINGLE_USERNAME", "admin")
-	t.Setenv("TEST_SINGLE_PASSWORD", "secret")
+	t.Setenv("TEST_USERNAME", "admin")
+	t.Setenv("TEST_PASSWORD", "secret")
 
 	yaml := `
 brokers:
   prod-us:
     url: "https://broker-us.example.com:1943"
-    env_prefix: "TEST_SINGLE"
     auth:
       method: basic
+      username: ${TEST_USERNAME}
+      password: ${TEST_PASSWORD}
 `
 	cfg, err := LoadConfig(writeTemp(t, yaml))
 	if err != nil {
@@ -60,23 +61,25 @@ brokers:
 }
 
 func TestLoadConfig_MultiBroker(t *testing.T) {
-	t.Setenv("TEST_US_USERNAME", "admin-us")
-	t.Setenv("TEST_US_PASSWORD", "secret-us")
-	t.Setenv("TEST_EU_USERNAME", "admin-eu")
-	t.Setenv("TEST_EU_PASSWORD", "secret-eu")
+	t.Setenv("US_USER", "admin-us")
+	t.Setenv("US_PASS", "secret-us")
+	t.Setenv("EU_USER", "admin-eu")
+	t.Setenv("EU_PASS", "secret-eu")
 
 	yaml := `
 brokers:
   prod-us:
     url: "https://broker-us.example.com:1943"
-    env_prefix: "TEST_US"
     auth:
       method: basic
+      username: ${US_USER}
+      password: ${US_PASS}
   prod-eu:
     url: "https://broker-eu.example.com:1943"
-    env_prefix: "TEST_EU"
     auth:
       method: basic
+      username: ${EU_USER}
+      password: ${EU_PASS}
 `
 	cfg, err := LoadConfig(writeTemp(t, yaml))
 	if err != nil {
@@ -99,9 +102,10 @@ func TestLoadConfig_MissingBrokerURL(t *testing.T) {
 	yaml := `
 brokers:
   dev:
-    env_prefix: "TEST_DEV"
     auth:
       method: basic
+      username: admin
+      password: secret
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
@@ -113,21 +117,19 @@ brokers:
 }
 
 func TestLoadConfig_MissingBasicAuthCreds(t *testing.T) {
-	// env_prefix set but env vars not set — should error about missing env var
 	yaml := `
 brokers:
   dev:
     url: "https://broker.example.com:1943"
-    env_prefix: "TEST_NOCREDS"
     auth:
       method: basic
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
-		t.Fatal("expected error for missing credentials env vars")
+		t.Fatal("expected error for missing credentials")
 	}
-	if !strings.Contains(err.Error(), "TEST_NOCREDS_USERNAME") {
-		t.Errorf("error should mention the missing env var: %v", err)
+	if !strings.Contains(err.Error(), "username is required for basic auth") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 
@@ -139,16 +141,14 @@ func TestLoadConfig_MalformedYAML(t *testing.T) {
 }
 
 func TestLoadConfig_DefaultsApplied(t *testing.T) {
-	t.Setenv("TEST_DEF_USERNAME", "admin")
-	t.Setenv("TEST_DEF_PASSWORD", "secret")
-
 	yaml := `
 brokers:
   dev:
     url: "https://broker.example.com:1943"
-    env_prefix: "TEST_DEF"
     auth:
       method: basic
+      username: admin
+      password: secret
 `
 	cfg, err := LoadConfig(writeTemp(t, yaml))
 	if err != nil {
@@ -167,16 +167,14 @@ brokers:
 }
 
 func TestLoadConfig_InvalidAuthMethod(t *testing.T) {
-	t.Setenv("TEST_OAUTH_USERNAME", "admin")
-	t.Setenv("TEST_OAUTH_PASSWORD", "secret")
-
 	yaml := `
 brokers:
   dev:
     url: "https://broker.example.com:1943"
-    env_prefix: "TEST_OAUTH"
     auth:
       method: oauth
+      username: admin
+      password: secret
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
@@ -187,119 +185,67 @@ brokers:
 	}
 }
 
-func TestLoadConfig_EnvPrefixMissing(t *testing.T) {
-	yaml := `
-brokers:
-  dev:
-    url: "https://broker.example.com:1943"
-    auth:
-      method: basic
-`
-	_, err := LoadConfig(writeTemp(t, yaml))
-	if err == nil {
-		t.Fatal("expected error for missing env_prefix")
-	}
-	if !strings.Contains(err.Error(), "env_prefix is required") {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-func TestLoadConfig_EnvPrefixInvalidChars(t *testing.T) {
-	yaml := `
-brokers:
-  dev:
-    url: "https://broker.example.com:1943"
-    env_prefix: "prod-us"
-    auth:
-      method: basic
-`
-	_, err := LoadConfig(writeTemp(t, yaml))
-	if err == nil {
-		t.Fatal("expected error for invalid env_prefix characters")
-	}
-	if !strings.Contains(err.Error(), "env_prefix must contain only uppercase letters") {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-func TestLoadConfig_EnvPrefixValid(t *testing.T) {
-	t.Setenv("PROD_US_USERNAME", "prod-admin")
-	t.Setenv("PROD_US_PASSWORD", "prod-secret")
+func TestLoadConfig_EnvVarSubstitution(t *testing.T) {
+	t.Setenv("BROKER_URL", "https://broker.example.com:1943")
+	t.Setenv("BROKER_USER", "admin")
+	t.Setenv("BROKER_PASS", "secret")
 
 	yaml := `
 brokers:
-  prod-us:
-    url: "https://broker.example.com:1943"
-    env_prefix: "PROD_US"
+  prod:
+    url: ${BROKER_URL}
     auth:
       method: basic
+      username: ${BROKER_USER}
+      password: ${BROKER_PASS}
 `
 	cfg, err := LoadConfig(writeTemp(t, yaml))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	broker := cfg.Brokers["prod-us"]
-	if broker.Auth.Username != "prod-admin" {
-		t.Errorf("expected username 'prod-admin', got %q", broker.Auth.Username)
+	broker := cfg.Brokers["prod"]
+	if broker.URL != "https://broker.example.com:1943" {
+		t.Errorf("expected URL from env var, got %q", broker.URL)
 	}
-	if broker.Auth.Password != "prod-secret" {
-		t.Errorf("expected password 'prod-secret', got %q", broker.Auth.Password)
+	if broker.Auth.Username != "admin" {
+		t.Errorf("expected username from env var, got %q", broker.Auth.Username)
+	}
+	if broker.Auth.Password != "secret" {
+		t.Errorf("expected password from env var, got %q", broker.Auth.Password)
 	}
 }
 
-func TestLoadConfig_EnvPrefixUsernameNotSet(t *testing.T) {
+func TestLoadConfig_EnvVarMissing(t *testing.T) {
 	yaml := `
 brokers:
-  dev:
-    url: "https://broker.example.com:1943"
-    env_prefix: "MISSING"
+  prod:
+    url: ${MISSING_URL}
     auth:
       method: basic
+      username: admin
+      password: secret
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
-		t.Fatal("expected error for missing username env var")
+		t.Fatal("expected error for missing env var")
 	}
-	if !strings.Contains(err.Error(), "MISSING_USERNAME") {
-		t.Errorf("error should mention the env var name: %v", err)
+	if !strings.Contains(err.Error(), "MISSING_URL") {
+		t.Errorf("error should mention the missing var name: %v", err)
 	}
 }
 
-func TestLoadConfig_EnvPrefixPasswordNotSet(t *testing.T) {
-	t.Setenv("PARTIAL_USERNAME", "admin")
+func TestLoadConfig_MixedHardcodedAndEnvVars(t *testing.T) {
+	t.Setenv("MIXED_PASS", "env-secret")
 
 	yaml := `
 brokers:
   dev:
-    url: "https://broker.example.com:1943"
-    env_prefix: "PARTIAL"
+    url: "http://localhost:8080"
     auth:
       method: basic
-`
-	_, err := LoadConfig(writeTemp(t, yaml))
-	if err == nil {
-		t.Fatal("expected error for missing password env var")
-	}
-	if !strings.Contains(err.Error(), "PARTIAL_PASSWORD") {
-		t.Errorf("error should mention the env var name: %v", err)
-	}
-}
-
-func TestLoadConfig_CredentialsNotInYAML(t *testing.T) {
-	t.Setenv("TEST_CRED_USERNAME", "env-user")
-	t.Setenv("TEST_CRED_PASSWORD", "env-pass")
-
-	// YAML includes username/password but they should be ignored — env vars win
-	yaml := `
-brokers:
-  dev:
-    url: "https://broker.example.com:1943"
-    env_prefix: "TEST_CRED"
-    auth:
-      method: basic
-      username: yaml-user
-      password: yaml-pass
+      username: hardcoded-user
+      password: ${MIXED_PASS}
 `
 	cfg, err := LoadConfig(writeTemp(t, yaml))
 	if err != nil {
@@ -307,26 +253,24 @@ brokers:
 	}
 
 	broker := cfg.Brokers["dev"]
-	if broker.Auth.Username != "env-user" {
-		t.Errorf("expected username from env var 'env-user', got %q", broker.Auth.Username)
+	if broker.Auth.Username != "hardcoded-user" {
+		t.Errorf("expected hardcoded username, got %q", broker.Auth.Username)
 	}
-	if broker.Auth.Password != "env-pass" {
-		t.Errorf("expected password from env var 'env-pass', got %q", broker.Auth.Password)
+	if broker.Auth.Password != "env-secret" {
+		t.Errorf("expected password from env var, got %q", broker.Auth.Password)
 	}
 }
 
 func TestLoadConfig_PortOutOfRange(t *testing.T) {
-	t.Setenv("TEST_PORT_USERNAME", "admin")
-	t.Setenv("TEST_PORT_PASSWORD", "secret")
-
 	yaml := `
 port: 99999
 brokers:
   dev:
     url: "http://localhost:8080"
-    env_prefix: "TEST_PORT"
     auth:
       method: basic
+      username: admin
+      password: secret
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
@@ -338,17 +282,15 @@ brokers:
 }
 
 func TestLoadConfig_TLSOnlyCert_ReturnsError(t *testing.T) {
-	t.Setenv("TEST_TLS_USERNAME", "admin")
-	t.Setenv("TEST_TLS_PASSWORD", "secret")
-
 	yaml := `
 tls_cert_file: "/tmp/cert.pem"
 brokers:
   dev:
     url: "http://localhost:8080"
-    env_prefix: "TEST_TLS"
     auth:
       method: basic
+      username: admin
+      password: secret
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
@@ -360,18 +302,16 @@ brokers:
 }
 
 func TestLoadConfig_TLSBothFields_Valid(t *testing.T) {
-	t.Setenv("TEST_TLSOK_USERNAME", "admin")
-	t.Setenv("TEST_TLSOK_PASSWORD", "secret")
-
 	yaml := `
 tls_cert_file: "/tmp/cert.pem"
 tls_key_file: "/tmp/key.pem"
 brokers:
   dev:
     url: "http://localhost:8080"
-    env_prefix: "TEST_TLSOK"
     auth:
       method: basic
+      username: admin
+      password: secret
 `
 	cfg, err := LoadConfig(writeTemp(t, yaml))
 	if err != nil {
@@ -386,8 +326,6 @@ brokers:
 }
 
 func TestLoadConfig_EnvOverridePort(t *testing.T) {
-	t.Setenv("TEST_ENVPORT_USERNAME", "admin")
-	t.Setenv("TEST_ENVPORT_PASSWORD", "secret")
 	t.Setenv("MCP_SERVER_PORT", "9091")
 
 	yaml := `
@@ -395,9 +333,10 @@ port: 8080
 brokers:
   dev:
     url: "http://localhost:8080"
-    env_prefix: "TEST_ENVPORT"
     auth:
       method: basic
+      username: admin
+      password: secret
 `
 	cfg, err := LoadConfig(writeTemp(t, yaml))
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,7 +29,7 @@ brokers:
   prod-us:
     url: "https://broker-us.example.com:1943"
     auth:
-      method: basic
+      mode: basic
       username: ${TEST_USERNAME}
       password: ${TEST_PASSWORD}
 `
@@ -49,8 +49,8 @@ brokers:
 	if broker.URL != "https://broker-us.example.com:1943" {
 		t.Errorf("unexpected URL: %s", broker.URL)
 	}
-	if broker.Auth.Method != "basic" {
-		t.Errorf("unexpected auth method: %s", broker.Auth.Method)
+	if broker.Auth.Mode != "basic" {
+		t.Errorf("unexpected auth method: %s", broker.Auth.Mode)
 	}
 	if broker.Auth.Username != "admin" {
 		t.Errorf("unexpected username: %s", broker.Auth.Username)
@@ -71,13 +71,13 @@ brokers:
   prod-us:
     url: "https://broker-us.example.com:1943"
     auth:
-      method: basic
+      mode: basic
       username: ${US_USER}
       password: ${US_PASS}
   prod-eu:
     url: "https://broker-eu.example.com:1943"
     auth:
-      method: basic
+      mode: basic
       username: ${EU_USER}
       password: ${EU_PASS}
 `
@@ -103,7 +103,7 @@ func TestLoadConfig_MissingBrokerURL(t *testing.T) {
 brokers:
   dev:
     auth:
-      method: basic
+      mode: basic
       username: admin
       password: secret
 `
@@ -122,7 +122,7 @@ brokers:
   dev:
     url: "https://broker.example.com:1943"
     auth:
-      method: basic
+      mode: basic
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
@@ -146,7 +146,7 @@ brokers:
   dev:
     url: "https://broker.example.com:1943"
     auth:
-      method: basic
+      mode: basic
       username: admin
       password: secret
 `
@@ -172,15 +172,15 @@ brokers:
   dev:
     url: "https://broker.example.com:1943"
     auth:
-      method: oauth
+      mode: oauth
       username: admin
       password: secret
 `
 	_, err := LoadConfig(writeTemp(t, yaml))
 	if err == nil {
-		t.Fatal("expected error for unsupported auth method")
+		t.Fatal("expected error for unsupported auth mode")
 	}
-	if !strings.Contains(err.Error(), "unsupported auth method") {
+	if !strings.Contains(err.Error(), "unsupported auth mode") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -195,7 +195,7 @@ brokers:
   prod:
     url: ${BROKER_URL}
     auth:
-      method: basic
+      mode: basic
       username: ${BROKER_USER}
       password: ${BROKER_PASS}
 `
@@ -222,7 +222,7 @@ brokers:
   prod:
     url: ${MISSING_URL}
     auth:
-      method: basic
+      mode: basic
       username: admin
       password: secret
 `
@@ -243,7 +243,7 @@ brokers:
   dev:
     url: "http://localhost:8080"
     auth:
-      method: basic
+      mode: basic
       username: hardcoded-user
       password: ${MIXED_PASS}
 `
@@ -268,7 +268,7 @@ brokers:
   dev:
     url: "http://localhost:8080"
     auth:
-      method: basic
+      mode: basic
       username: admin
       password: secret
 `
@@ -288,7 +288,7 @@ brokers:
   dev:
     url: "http://localhost:8080"
     auth:
-      method: basic
+      mode: basic
       username: admin
       password: secret
 `
@@ -309,7 +309,7 @@ brokers:
   dev:
     url: "http://localhost:8080"
     auth:
-      method: basic
+      mode: basic
       username: admin
       password: secret
 `
@@ -334,7 +334,7 @@ brokers:
   dev:
     url: "http://localhost:8080"
     auth:
-      method: basic
+      mode: basic
       username: admin
       password: secret
 `
@@ -344,5 +344,84 @@ brokers:
 	}
 	if cfg.Port != 9091 {
 		t.Errorf("expected port 9091 (from env var), got %d", cfg.Port)
+	}
+}
+
+func TestLoadConfig_BearerAuth(t *testing.T) {
+	t.Setenv("BEARER_TOKEN", "my-secret-token")
+
+	yaml := `
+brokers:
+  prod:
+    url: "https://broker.example.com:8080"
+    auth:
+      mode: bearer
+      token: ${BEARER_TOKEN}
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	broker := cfg.Brokers["prod"]
+	if broker.Auth.Mode != "bearer" {
+		t.Errorf("expected mode bearer, got %q", broker.Auth.Mode)
+	}
+	if broker.Auth.Token != "my-secret-token" {
+		t.Errorf("expected token from env var, got %q", broker.Auth.Token)
+	}
+}
+
+func TestLoadConfig_BearerAuth_MissingToken(t *testing.T) {
+	yaml := `
+brokers:
+  prod:
+    url: "https://broker.example.com:8080"
+    auth:
+      mode: bearer
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for missing bearer token")
+	}
+	if !strings.Contains(err.Error(), "token is required for bearer auth") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_MissingAuthMode(t *testing.T) {
+	yaml := `
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for missing auth mode")
+	}
+	if !strings.Contains(err.Error(), "auth.mode is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_AuthModeCaseInsensitive(t *testing.T) {
+	yaml := `
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: BASIC
+      username: admin
+      password: secret
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Brokers["dev"].Auth.Mode != "basic" {
+		t.Errorf("expected mode normalized to 'basic', got %q", cfg.Brokers["dev"].Auth.Mode)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -760,3 +760,86 @@ brokers:
 		}
 	}
 }
+
+func TestLoad_UsesConfigFileEnv(t *testing.T) {
+	yaml := `
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	path := writeTemp(t, yaml)
+	t.Setenv("CONFIG_FILE", path)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Brokers["dev"] == nil {
+		t.Error("expected broker 'dev' to be loaded")
+	}
+}
+
+func TestLoad_ConfigFileEnvMissing_ReturnsError(t *testing.T) {
+	// When CONFIG_FILE points at a non-existent file, Load MUST NOT silently
+	// fall back to the system/local paths. The operator explicitly pointed
+	// at THIS file; a silent fallback would mask the mistake.
+	t.Setenv("CONFIG_FILE", "/does/not/exist.yaml")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when CONFIG_FILE points to missing file")
+	}
+	// The error should reference the file we tried -- not a "no config found"
+	// error that implies fallback happened.
+	if !strings.Contains(err.Error(), "reading config file") {
+		t.Errorf("expected 'reading config file' error from strict CONFIG_FILE handling, got: %v", err)
+	}
+}
+
+func TestLoad_ConfigFileEnvCorrupt_ReturnsError(t *testing.T) {
+	// CONFIG_FILE points to a file that exists but has broken YAML. Strict:
+	// error bubbles up, no fallback.
+	path := writeTemp(t, `{{{ not yaml`)
+	t.Setenv("CONFIG_FILE", path)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for malformed YAML in CONFIG_FILE path")
+	}
+	if !strings.Contains(err.Error(), "parsing config YAML") {
+		t.Errorf("expected YAML parse error, got: %v", err)
+	}
+}
+
+func TestLoad_NoConfigFileEnv_NoSystemOrLocal_ReturnsError(t *testing.T) {
+	// No CONFIG_FILE set, no /etc/mcp-server/config.yaml (unlikely on dev),
+	// and we chdir to an empty temp directory so broker-config.yaml doesn't
+	// exist in CWD. Load should error with a message listing what was tried.
+	t.Setenv("CONFIG_FILE", "")
+
+	// Switch CWD to an empty temp dir so the local fallback path has nothing
+	// to find. Restore at the end.
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	emptyDir := t.TempDir()
+	if err := os.Chdir(emptyDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWD)
+	})
+
+	_, err = Load()
+	if err == nil {
+		t.Skip("Load succeeded unexpectedly -- likely /etc/mcp-server/config.yaml exists on this machine; skipping")
+	}
+	if !strings.Contains(err.Error(), "no config file found") {
+		t.Errorf("expected 'no config file found' error, got: %v", err)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -426,6 +426,68 @@ brokers:
 	}
 }
 
+func TestLoadConfig_InvalidURLScheme(t *testing.T) {
+	yaml := `
+brokers:
+  dev:
+    url: "ftp://broker.example.com"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for non-http/https URL scheme")
+	}
+	if !strings.Contains(err.Error(), "url scheme must be http or https") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_URLMissingHost(t *testing.T) {
+	yaml := `
+brokers:
+  dev:
+    url: "http://"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for URL with no host")
+	}
+	if !strings.Contains(err.Error(), "url must include a host") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_URLEmpty_ReportsRequired(t *testing.T) {
+	// Empty URL is handled by the "url is required" branch, NOT the
+	// structure-validation branch — verifying we don't double-report.
+	yaml := `
+brokers:
+  dev:
+    url: ""
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+	if !strings.Contains(err.Error(), "url is required") {
+		t.Errorf("expected 'url is required' error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "url scheme must be") {
+		t.Errorf("empty URL should not produce 'url scheme' error — double-reporting: %v", err)
+	}
+}
+
 func TestLoadConfig_CollectsAllErrors(t *testing.T) {
 	// Multiple issues across server-level and multiple brokers — all should
 	// surface in a single error so operators fix them in one pass.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -161,8 +161,8 @@ brokers:
 	if cfg.SEMP.MaxConcurrentPerBroker != defaults.DefaultMaxConcurrentPerBroker {
 		t.Errorf("expected max_concurrent %d, got %d", defaults.DefaultMaxConcurrentPerBroker, cfg.SEMP.MaxConcurrentPerBroker)
 	}
-	if cfg.SEMP.RequestTimeoutSeconds != defaults.DefaultSEMPRequestTimeoutSeconds {
-		t.Errorf("expected request_timeout %d, got %d", defaults.DefaultSEMPRequestTimeoutSeconds, cfg.SEMP.RequestTimeoutSeconds)
+	if cfg.SEMP.RequestTimeout != defaults.DefaultSEMPRequestTimeout {
+		t.Errorf("expected request_timeout %s, got %s", defaults.DefaultSEMPRequestTimeout, cfg.SEMP.RequestTimeout)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 )
@@ -161,8 +162,8 @@ brokers:
 	if cfg.SEMP.MaxConcurrentPerBroker != defaults.DefaultMaxConcurrentPerBroker {
 		t.Errorf("expected max_concurrent %d, got %d", defaults.DefaultMaxConcurrentPerBroker, cfg.SEMP.MaxConcurrentPerBroker)
 	}
-	if cfg.SEMP.RequestTimeout != defaults.DefaultSEMPRequestTimeout {
-		t.Errorf("expected request_timeout %s, got %s", defaults.DefaultSEMPRequestTimeout, cfg.SEMP.RequestTimeout)
+	if cfg.SEMP.RequestTimeoutDuration != defaults.DefaultSEMPRequestTimeoutDuration {
+		t.Errorf("expected request_timeout_duration %s, got %s", defaults.DefaultSEMPRequestTimeoutDuration, cfg.SEMP.RequestTimeoutDuration)
 	}
 }
 
@@ -567,6 +568,161 @@ brokers:
 		t.Fatal("expected error for invalid log_level")
 	}
 	if !strings.Contains(err.Error(), "log_level") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_RateLimit_Defaults(t *testing.T) {
+	yaml := `
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SEMP.RequestMinInterval == nil || *cfg.SEMP.RequestMinInterval != defaults.DefaultRequestMinInterval {
+		t.Errorf("expected default request_min_interval %s, got %v", defaults.DefaultRequestMinInterval, cfg.SEMP.RequestMinInterval)
+	}
+	if cfg.SEMP.Retries == nil || *cfg.SEMP.Retries != defaults.DefaultRetries {
+		t.Errorf("expected default retries %d, got %v", defaults.DefaultRetries, cfg.SEMP.Retries)
+	}
+	if cfg.SEMP.RetryMinInterval != defaults.DefaultRetryMinInterval {
+		t.Errorf("expected default retry_min_interval %s, got %s", defaults.DefaultRetryMinInterval, cfg.SEMP.RetryMinInterval)
+	}
+	if cfg.SEMP.RetryMaxInterval != defaults.DefaultRetryMaxInterval {
+		t.Errorf("expected default retry_max_interval %s, got %s", defaults.DefaultRetryMaxInterval, cfg.SEMP.RetryMaxInterval)
+	}
+}
+
+func TestLoadConfig_RateLimit_ValidValues(t *testing.T) {
+	yaml := `
+semp:
+  request_min_interval: 50ms
+  retries: 5
+  retry_min_interval: 1s
+  retry_max_interval: 10s
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SEMP.RequestMinInterval == nil || *cfg.SEMP.RequestMinInterval != 50*time.Millisecond {
+		t.Errorf("expected request_min_interval 50ms, got %v", cfg.SEMP.RequestMinInterval)
+	}
+	if cfg.SEMP.Retries == nil || *cfg.SEMP.Retries != 5 {
+		t.Errorf("expected retries 5, got %v", cfg.SEMP.Retries)
+	}
+	if cfg.SEMP.RetryMinInterval != time.Second {
+		t.Errorf("expected retry_min_interval 1s, got %s", cfg.SEMP.RetryMinInterval)
+	}
+	if cfg.SEMP.RetryMaxInterval != 10*time.Second {
+		t.Errorf("expected retry_max_interval 10s, got %s", cfg.SEMP.RetryMaxInterval)
+	}
+}
+
+func TestLoadConfig_RateLimit_ExplicitZeroHonored(t *testing.T) {
+	// Zero is a legitimate operator value for retries (no retries) and
+	// request_min_interval (no rate limit per Solace Terraform provider).
+	// Verify applyDefaults does NOT clobber operator-set zero with the default.
+	// This is the reason both fields are pointer types -- without pointers,
+	// "0 in YAML" is indistinguishable from "omitted from YAML".
+	yaml := `
+semp:
+  request_min_interval: 0s
+  retries: 0
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SEMP.RequestMinInterval == nil || *cfg.SEMP.RequestMinInterval != 0 {
+		t.Errorf("expected operator-set request_min_interval=0 to be honored, got %v", cfg.SEMP.RequestMinInterval)
+	}
+	if cfg.SEMP.Retries == nil || *cfg.SEMP.Retries != 0 {
+		t.Errorf("expected operator-set retries=0 to be honored, got %v", cfg.SEMP.Retries)
+	}
+}
+
+func TestLoadConfig_RateLimit_NegativeRetries(t *testing.T) {
+	yaml := `
+semp:
+  retries: -1
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for negative retries")
+	}
+	if !strings.Contains(err.Error(), "semp.retries must be >= 0") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_RateLimit_NegativeRequestMinInterval(t *testing.T) {
+	yaml := `
+semp:
+  request_min_interval: -10ms
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for negative request_min_interval")
+	}
+	if !strings.Contains(err.Error(), "semp.request_min_interval must be >= 0") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_RateLimit_MaxSmallerThanMin(t *testing.T) {
+	yaml := `
+semp:
+  retry_min_interval: 30s
+  retry_max_interval: 3s
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error when retry_max_interval < retry_min_interval")
+	}
+	if !strings.Contains(err.Error(), "retry_max_interval") || !strings.Contains(err.Error(), "must be >= semp.retry_min_interval") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -425,3 +425,37 @@ brokers:
 		t.Errorf("expected mode normalized to 'basic', got %q", cfg.Brokers["dev"].Auth.Mode)
 	}
 }
+
+func TestLoadConfig_CollectsAllErrors(t *testing.T) {
+	// Multiple issues across server-level and multiple brokers — all should
+	// surface in a single error so operators fix them in one pass.
+	yaml := `
+port: 99999
+brokers:
+  broker1:
+    auth:
+      mode: basic
+  broker2:
+    url: "http://localhost:8080"
+    auth:
+      mode: oauth
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for multiple validation issues")
+	}
+
+	msg := err.Error()
+	wantSubstrings := []string{
+		"port must be between 1 and 65535",
+		`broker "broker1": url is required`,
+		`broker "broker1": username is required`,
+		`broker "broker1": password is required`,
+		`broker "broker2": unsupported auth mode "oauth"`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(msg, want) {
+			t.Errorf("combined error missing expected substring %q\nfull error:\n%s", want, msg)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -488,6 +488,89 @@ brokers:
 	}
 }
 
+func TestLoadConfig_LogLevel_Default(t *testing.T) {
+	yaml := `
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LogLevel != defaults.DefaultLogLevel {
+		t.Errorf("expected default log_level %q, got %q", defaults.DefaultLogLevel, cfg.LogLevel)
+	}
+}
+
+func TestLoadConfig_LogLevel_ValidValues(t *testing.T) {
+	for _, level := range []string{"debug", "info", "warn", "error"} {
+		t.Run(level, func(t *testing.T) {
+			yaml := `
+log_level: ` + level + `
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+			cfg, err := LoadConfig(writeTemp(t, yaml))
+			if err != nil {
+				t.Fatalf("unexpected error for level %q: %v", level, err)
+			}
+			if cfg.LogLevel != level {
+				t.Errorf("expected log_level %q, got %q", level, cfg.LogLevel)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_LogLevel_CaseInsensitive(t *testing.T) {
+	yaml := `
+log_level: DEBUG
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("expected log_level normalized to 'debug', got %q", cfg.LogLevel)
+	}
+}
+
+func TestLoadConfig_LogLevel_Invalid(t *testing.T) {
+	yaml := `
+log_level: verbose
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for invalid log_level")
+	}
+	if !strings.Contains(err.Error(), "log_level") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadConfig_CollectsAllErrors(t *testing.T) {
 	// Multiple issues across server-level and multiple brokers — all should
 	// surface in a single error so operators fix them in one pass.

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -60,3 +60,8 @@ const DefaultReadHeaderTimeoutSeconds = 10
 
 // DefaultConfigPath is the default file path for the broker configuration YAML file.
 const DefaultConfigPath = "broker-config.yaml"
+
+// DefaultLogLevel is the default slog level name used when log_level is not
+// specified in the config file. Matches the current hardcoded behavior of the
+// server (slog.LevelInfo).
+const DefaultLogLevel = "info"

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -6,6 +6,8 @@
 // is needed before production release. Review these before deploying to production.
 package defaults
 
+import "time"
+
 // DefaultPort is the HTTP port the MCP server listens on. Uses 9090 to avoid
 // conflict with the Solace broker's SEMP management port (default 8080).
 const DefaultPort = 9090
@@ -20,15 +22,15 @@ const DefaultPort = 9090
 // or adjust this value.
 const DefaultShutdownTimeoutSeconds = 120
 
-// DefaultSEMPRequestTimeoutSeconds is the per-request timeout in seconds for
-// individual SEMP API calls to a broker.
+// DefaultSEMPRequestTimeout is the per-request timeout for individual SEMP
+// API calls to a broker.
 //
 // Assumption: 30 seconds is sufficient for any single SEMP request.
 // Reasoning: Standard HTTP timeout for management API calls. SEMP operations
 // are typically fast, but large result sets or broker load may slow responses.
 // Validation needed: Measure real broker response times under typical and peak
 // load to confirm or adjust this value.
-const DefaultSEMPRequestTimeoutSeconds = 30
+const DefaultSEMPRequestTimeout = 30 * time.Second
 
 // DefaultMaxConcurrentPerBroker is the maximum number of concurrent SEMP
 // requests allowed per broker, enforced via a per-broker semaphore.

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -55,8 +55,16 @@ const DefaultTLSSkipVerify = false
 // this value is not too aggressive for real-world network conditions.
 const DefaultReadHeaderTimeoutSeconds = 10
 
-// DefaultConfigPath is the default file path for the broker configuration YAML file.
-const DefaultConfigPath = "broker-config.yaml"
+// DefaultConfigPathSystem is the production-install location for the config
+// file. Tried when CONFIG_FILE is not set. Follows the conventional Linux
+// /etc/<app>/config.yaml layout used by Linux services, K8s, and Docker.
+const DefaultConfigPathSystem = "/etc/mcp-server/config.yaml"
+
+// DefaultConfigPathLocal is the developer-convenience fallback checked after
+// the system path. Makes `go run ./cmd/server` work in the repo without any
+// env vars, while keeping production safe: if both paths exist, the system
+// path wins.
+const DefaultConfigPathLocal = "broker-config.yaml"
 
 // DefaultLogLevel is the default slog level name used when log_level is not
 // specified in the config file. Matches the current hardcoded behavior of the

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -22,15 +22,10 @@ const DefaultPort = 9090
 // or adjust this value.
 const DefaultShutdownTimeoutSeconds = 120
 
-// DefaultSEMPRequestTimeout is the per-request timeout for individual SEMP
-// API calls to a broker.
-//
-// Assumption: 30 seconds is sufficient for any single SEMP request.
-// Reasoning: Standard HTTP timeout for management API calls. SEMP operations
-// are typically fast, but large result sets or broker load may slow responses.
-// Validation needed: Measure real broker response times under typical and peak
-// load to confirm or adjust this value.
-const DefaultSEMPRequestTimeout = 30 * time.Second
+// DefaultSEMPRequestTimeoutDuration is the per-request timeout for individual
+// SEMP API calls to a broker. Matches the story spec default and the Solace
+// Terraform provider convention.
+const DefaultSEMPRequestTimeoutDuration = time.Minute
 
 // DefaultMaxConcurrentPerBroker is the maximum number of concurrent SEMP
 // requests allowed per broker, enforced via a per-broker semaphore.
@@ -67,3 +62,24 @@ const DefaultConfigPath = "broker-config.yaml"
 // specified in the config file. Matches the current hardcoded behavior of the
 // server (slog.LevelInfo).
 const DefaultLogLevel = "info"
+
+// DefaultRequestMinInterval is the minimum spacing between successive SEMP
+// requests against the same broker, enforced by a future rate limiter (Story 5).
+// Matches the story spec and the Solace Terraform provider default (100ms).
+const DefaultRequestMinInterval = 100 * time.Millisecond
+
+// DefaultRetries is the maximum number of retry attempts for a failed SEMP
+// request before surfacing the error to the caller. Used by the future retry
+// logic (Story 5). Zero disables retries entirely. Matches the story spec and
+// Terraform provider default.
+const DefaultRetries = 10
+
+// DefaultRetryMinInterval is the starting backoff duration before the first
+// retry attempt. Subsequent retries grow toward DefaultRetryMaxInterval via
+// exponential backoff (Story 5). Matches the story spec and Terraform default.
+const DefaultRetryMinInterval = 3 * time.Second
+
+// DefaultRetryMaxInterval caps the retry backoff duration regardless of how
+// many attempts have been made. Must be >= DefaultRetryMinInterval. Matches
+// the story spec and Terraform default.
+const DefaultRetryMaxInterval = 30 * time.Second

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -37,10 +37,11 @@ const DefaultSEMPRequestTimeoutDuration = time.Minute
 // concurrency limit that balances throughput with broker stability.
 const DefaultMaxConcurrentPerBroker = 10
 
-// DefaultTLSSkipVerify controls whether TLS certificate verification is skipped
-// when connecting to brokers. Must be false in production. Only set to true in
-// development environments with self-signed certificates.
-const DefaultTLSSkipVerify = false
+// DefaultInsecureSkipVerify controls whether TLS certificate verification is
+// skipped when connecting to brokers. Must be false in production. Only set
+// to true in development environments with self-signed certificates. Matches
+// the naming of crypto/tls.Config.InsecureSkipVerify.
+const DefaultInsecureSkipVerify = false
 
 // DefaultReadHeaderTimeoutSeconds is the maximum time in seconds the HTTP
 // server waits for a client to send request headers before closing the

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -16,14 +16,12 @@ func newTestPool() *semp.BrokerPool {
 	cfg := &config.ServerConfig{
 		Brokers: map[string]*config.BrokerConfig{
 			"dev": {
-				URL:       "http://localhost:8081",
-				EnvPrefix: "DEV",
-				Auth:      config.AuthConfig{Method: "basic", Username: "admin", Password: "admin"},
+				URL:  "http://localhost:8081",
+				Auth: config.AuthConfig{Method: "basic", Username: "admin", Password: "admin"},
 			},
 			"prod": {
-				URL:       "http://localhost:8082",
-				EnvPrefix: "PROD",
-				Auth:      config.AuthConfig{Method: "basic", Username: "admin", Password: "admin"},
+				URL:  "http://localhost:8082",
+				Auth: config.AuthConfig{Method: "basic", Username: "admin", Password: "admin"},
 			},
 		},
 		SEMP: config.SEMPConfig{RequestTimeoutSeconds: 5},

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite"
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
@@ -24,7 +25,7 @@ func newTestPool() *semp.BrokerPool {
 				Auth: config.AuthConfig{Mode: "basic", Username: "admin", Password: "admin"},
 			},
 		},
-		SEMP: config.SEMPConfig{RequestTimeoutSeconds: 5},
+		SEMP: config.SEMPConfig{RequestTimeout: 5 * time.Second},
 	}
 	return semp.NewBrokerPool(cfg)
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -17,11 +17,11 @@ func newTestPool() *semp.BrokerPool {
 		Brokers: map[string]*config.BrokerConfig{
 			"dev": {
 				URL:  "http://localhost:8081",
-				Auth: config.AuthConfig{Method: "basic", Username: "admin", Password: "admin"},
+				Auth: config.AuthConfig{Mode: "basic", Username: "admin", Password: "admin"},
 			},
 			"prod": {
 				URL:  "http://localhost:8082",
-				Auth: config.AuthConfig{Method: "basic", Username: "admin", Password: "admin"},
+				Auth: config.AuthConfig{Mode: "basic", Username: "admin", Password: "admin"},
 			},
 		},
 		SEMP: config.SEMPConfig{RequestTimeoutSeconds: 5},

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -25,7 +25,7 @@ func newTestPool() *semp.BrokerPool {
 				Auth: config.AuthConfig{Mode: "basic", Username: "admin", Password: "admin"},
 			},
 		},
-		SEMP: config.SEMPConfig{RequestTimeout: 5 * time.Second},
+		SEMP: config.SEMPConfig{RequestTimeoutDuration: 5 * time.Second},
 	}
 	return semp.NewBrokerPool(cfg)
 }

--- a/internal/semp/broker_test.go
+++ b/internal/semp/broker_test.go
@@ -22,7 +22,7 @@ func TestBrokerClient_V2_ReturnsClient(t *testing.T) {
 	brokerCfg := &config.BrokerConfig{
 		URL: server.URL,
 		Auth: config.AuthConfig{
-			Method:   "basic",
+			Mode:     "basic",
 			Username: "admin",
 			Password: "secret",
 		},
@@ -49,7 +49,7 @@ func TestBrokerClient_V2_ExecutePassesThrough(t *testing.T) {
 	brokerCfg := &config.BrokerConfig{
 		URL: server.URL,
 		Auth: config.AuthConfig{
-			Method:   "basic",
+			Mode:     "basic",
 			Username: "admin",
 			Password: "secret",
 		},

--- a/internal/semp/broker_test.go
+++ b/internal/semp/broker_test.go
@@ -28,7 +28,7 @@ func TestBrokerClient_V2_ReturnsClient(t *testing.T) {
 			Password: "secret",
 		},
 	}
-	sempCfg := &config.SEMPConfig{RequestTimeout: 5 * time.Second}
+	sempCfg := &config.SEMPConfig{RequestTimeoutDuration: 5 * time.Second}
 
 	bc := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
 	client := bc.SempV2()
@@ -55,7 +55,7 @@ func TestBrokerClient_V2_ExecutePassesThrough(t *testing.T) {
 			Password: "secret",
 		},
 	}
-	sempCfg := &config.SEMPConfig{RequestTimeout: 5 * time.Second}
+	sempCfg := &config.SEMPConfig{RequestTimeoutDuration: 5 * time.Second}
 
 	bc := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
 	client := bc.SempV2()

--- a/internal/semp/broker_test.go
+++ b/internal/semp/broker_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
@@ -27,7 +28,7 @@ func TestBrokerClient_V2_ReturnsClient(t *testing.T) {
 			Password: "secret",
 		},
 	}
-	sempCfg := &config.SEMPConfig{RequestTimeoutSeconds: 5}
+	sempCfg := &config.SEMPConfig{RequestTimeout: 5 * time.Second}
 
 	bc := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
 	client := bc.SempV2()
@@ -54,7 +55,7 @@ func TestBrokerClient_V2_ExecutePassesThrough(t *testing.T) {
 			Password: "secret",
 		},
 	}
-	sempCfg := &config.SEMPConfig{RequestTimeoutSeconds: 5}
+	sempCfg := &config.SEMPConfig{RequestTimeout: 5 * time.Second}
 
 	bc := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
 	client := bc.SempV2()

--- a/internal/semp/pool.go
+++ b/internal/semp/pool.go
@@ -17,9 +17,9 @@ import (
 // Thread-safe via sync.RWMutex with a double-check pattern for lazy creation.
 type BrokerPool struct {
 	mu      sync.RWMutex
-	clients map[string]*BrokerClient       // broker alias → client (lazily populated)
+	clients map[string]*BrokerClient        // broker alias → client (lazily populated)
 	configs map[string]*config.BrokerConfig // broker alias → config (all brokers)
-	sempCfg *config.SEMPConfig             // shared SEMP settings
+	sempCfg *config.SEMPConfig              // shared SEMP settings
 }
 
 // NewBrokerPool creates a BrokerPool from the server configuration. No
@@ -62,7 +62,8 @@ func (p *BrokerPool) GetSempV2(alias string) (sempv2.Client, error) {
 	p.clients[alias] = client
 	slog.Info("broker connection created",
 		slog.String("broker", alias),
-		slog.String("url", cfg.URL))
+		slog.String("url", cfg.URL),
+		slog.String("auth_mode", cfg.Auth.Mode))
 	return client.SempV2(), nil
 }
 

--- a/internal/semp/pool_test.go
+++ b/internal/semp/pool_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
@@ -33,7 +34,7 @@ func newTestServerConfig(serverURL string) *config.ServerConfig {
 			},
 		},
 		SEMP: config.SEMPConfig{
-			RequestTimeoutSeconds: 5,
+			RequestTimeout: 5 * time.Second,
 		},
 	}
 }

--- a/internal/semp/pool_test.go
+++ b/internal/semp/pool_test.go
@@ -34,7 +34,7 @@ func newTestServerConfig(serverURL string) *config.ServerConfig {
 			},
 		},
 		SEMP: config.SEMPConfig{
-			RequestTimeout: 5 * time.Second,
+			RequestTimeoutDuration: 5 * time.Second,
 		},
 	}
 }

--- a/internal/semp/pool_test.go
+++ b/internal/semp/pool_test.go
@@ -18,7 +18,7 @@ func newTestServerConfig(serverURL string) *config.ServerConfig {
 			"prod-us": {
 				URL: serverURL,
 				Auth: config.AuthConfig{
-					Method:   "basic",
+					Mode:     "basic",
 					Username: "admin",
 					Password: "secret",
 				},
@@ -26,7 +26,7 @@ func newTestServerConfig(serverURL string) *config.ServerConfig {
 			"prod-eu": {
 				URL: serverURL,
 				Auth: config.AuthConfig{
-					Method:   "basic",
+					Mode:     "basic",
 					Username: "admin",
 					Password: "secret",
 				},

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -82,7 +82,7 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *
 
 	return &HTTPClient{
 		httpClient: &http.Client{
-			Timeout:   sempCfg.RequestTimeout,
+			Timeout:   sempCfg.RequestTimeoutDuration,
 			Transport: transport,
 		},
 		baseURL:  strings.TrimSuffix(brokerCfg.URL, "/"),

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 )
@@ -83,7 +82,7 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *
 
 	return &HTTPClient{
 		httpClient: &http.Client{
-			Timeout:   time.Duration(sempCfg.RequestTimeoutSeconds) * time.Second,
+			Timeout:   sempCfg.RequestTimeout,
 			Transport: transport,
 		},
 		baseURL:  strings.TrimSuffix(brokerCfg.URL, "/"),

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -77,7 +77,7 @@ func (c *HTTPClient) LogValue() slog.Value {
 // tuning appropriate for concurrent SEMP calls.
 func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *HTTPClient {
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: brokerCfg.TLSSkipVerify}, //nolint:gosec // G402 — user-configurable TLS skip for dev environments; defaults to false
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: brokerCfg.InsecureSkipVerify}, //nolint:gosec // G402 — user-configurable TLS skip for dev environments; defaults to false
 	}
 
 	return &HTTPClient{

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -57,8 +57,10 @@ func (e *SEMPError) Error() string {
 type HTTPClient struct {
 	httpClient *http.Client
 	baseURL    string
+	authMode   string
 	username   string
 	password   string
+	token      string
 }
 
 // LogValue implements slog.LogValuer for HTTPClient. It exposes only the base
@@ -85,8 +87,10 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *
 			Transport: transport,
 		},
 		baseURL:  strings.TrimSuffix(brokerCfg.URL, "/"),
+		authMode: brokerCfg.Auth.Mode,
 		username: brokerCfg.Auth.Username,
 		password: brokerCfg.Auth.Password,
+		token:    brokerCfg.Auth.Token,
 	}
 }
 
@@ -197,9 +201,19 @@ func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL str
 	return req, nil
 }
 
-// addAuth sets the Basic Auth header on the request.
+// addAuth sets the authentication header on the request based on the configured
+// auth mode. Basic auth sends Authorization: Basic base64(user:pass). Bearer
+// sends Authorization: Bearer <token>.
+//
+// By the time this runs, config validation has guaranteed that authMode is one
+// of validAuthModes and the corresponding credential fields are non-empty, so
+// no defensive emptiness checks are needed here. If a new auth mode is added,
+// config.validAuthModes must be updated AND a new case must be added below.
 func (c *HTTPClient) addAuth(req *http.Request) {
-	if c.username != "" && c.password != "" {
+	switch c.authMode {
+	case config.AuthModeBasic:
 		req.SetBasicAuth(c.username, c.password)
+	case config.AuthModeBearer:
+		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 }

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -25,7 +25,7 @@ func newTestClient(t *testing.T, handler http.HandlerFunc) (*sempv2.HTTPClient, 
 		},
 	}
 	sempCfg := &config.SEMPConfig{
-		RequestTimeoutSeconds: 5,
+		RequestTimeout: 5 * time.Second,
 	}
 	client := sempv2.NewHTTPClient(brokerCfg, sempCfg)
 	return client, server
@@ -277,7 +277,7 @@ func TestClient_Execute_BearerAuth(t *testing.T) {
 			Token: "my-test-token",
 		},
 	}
-	sempCfg := &config.SEMPConfig{RequestTimeoutSeconds: 5}
+	sempCfg := &config.SEMPConfig{RequestTimeout: 5 * time.Second}
 	bearerClient := sempv2.NewHTTPClient(brokerCfg, sempCfg)
 
 	op := &sempv2.Operation{
@@ -311,7 +311,7 @@ func TestClient_Execute_Timeout(t *testing.T) {
 		},
 	}
 	sempCfg := &config.SEMPConfig{
-		RequestTimeoutSeconds: 1,
+		RequestTimeout: time.Second,
 	}
 	client := sempv2.NewHTTPClient(brokerCfg, sempCfg)
 

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -25,7 +25,7 @@ func newTestClient(t *testing.T, handler http.HandlerFunc) (*sempv2.HTTPClient, 
 		},
 	}
 	sempCfg := &config.SEMPConfig{
-		RequestTimeout: 5 * time.Second,
+		RequestTimeoutDuration: 5 * time.Second,
 	}
 	client := sempv2.NewHTTPClient(brokerCfg, sempCfg)
 	return client, server
@@ -277,7 +277,7 @@ func TestClient_Execute_BearerAuth(t *testing.T) {
 			Token: "my-test-token",
 		},
 	}
-	sempCfg := &config.SEMPConfig{RequestTimeout: 5 * time.Second}
+	sempCfg := &config.SEMPConfig{RequestTimeoutDuration: 5 * time.Second}
 	bearerClient := sempv2.NewHTTPClient(brokerCfg, sempCfg)
 
 	op := &sempv2.Operation{
@@ -311,7 +311,7 @@ func TestClient_Execute_Timeout(t *testing.T) {
 		},
 	}
 	sempCfg := &config.SEMPConfig{
-		RequestTimeout: time.Second,
+		RequestTimeoutDuration: time.Second,
 	}
 	client := sempv2.NewHTTPClient(brokerCfg, sempCfg)
 

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -19,7 +19,7 @@ func newTestClient(t *testing.T, handler http.HandlerFunc) (*sempv2.HTTPClient, 
 	brokerCfg := &config.BrokerConfig{
 		URL: server.URL,
 		Auth: config.AuthConfig{
-			Method:   "basic",
+			Mode:     "basic",
 			Username: "admin",
 			Password: "secret",
 		},
@@ -253,6 +253,48 @@ func TestClient_Execute_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestClient_Execute_BearerAuth(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify bearer token is sent
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer my-test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"meta":{"error":{"status":"UNAUTHORIZED"}}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data": {"status": "ok"}}`))
+	})
+	_ = client // not using the basic auth client from newTestClient
+	defer server.Close()
+
+	// Create a bearer auth client pointing at the same test server.
+	brokerCfg := &config.BrokerConfig{
+		URL: server.URL,
+		Auth: config.AuthConfig{
+			Mode:  "bearer",
+			Token: "my-test-token",
+		},
+	}
+	sempCfg := &config.SEMPConfig{RequestTimeoutSeconds: 5}
+	bearerClient := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+	}
+
+	result, err := bearerClient.Execute(context.Background(), op, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", result.StatusCode)
+	}
+}
+
 func TestClient_Execute_Timeout(t *testing.T) {
 	_, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Second)
@@ -263,7 +305,7 @@ func TestClient_Execute_Timeout(t *testing.T) {
 	brokerCfg := &config.BrokerConfig{
 		URL: server.URL,
 		Auth: config.AuthConfig{
-			Method:   "basic",
+			Mode:     "basic",
 			Username: "admin",
 			Password: "secret",
 		},


### PR DESCRIPTION
Implements SOL-148422 (Configuration Management - Development Mode) minus the DevelopmentMode flag. Brings the config package in line with the story's acceptance criteria.

Adds bearer auth support (Hop 2), ${VAR_NAME} env var substitution, URL validation, log_level config, rate-limit/retry fields with proper zero-vs-unset semantics, multi-path config fallback, and collect-all-errors validation.

**Design decision worth flagging:** nested structs vs story's flat sketch
The story describes ServerConfig with ~9 flat fields (Port, LogLevel, TLS, 5 rate-limit fields, brokers). This PR deliberately keeps a nested shape instead:

```
type ServerConfig struct {
    Port        int
    LogLevel    string
    TLSCertFile string
    TLSKeyFile  string
    SEMP        SEMPConfig               // rate-limit + timeout fields grouped here
    Brokers     map[string]*BrokerConfig
}
```
```

type BrokerConfig struct {
    URL                string
    InsecureSkipVerify bool
    Auth               AuthConfig        // auth fields grouped here
}
```