### PR TITLE
SOL-148423: Fix SEMP client foundation implementation gaps

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -78,7 +78,7 @@ func buildMux(server *mcp.Server) *http.ServeMux {
 
 func main() {
 	if len(os.Args) == 2 && (os.Args[1] == "-version" || os.Args[1] == "--version") {
-		fmt.Println(version.Version)
+		fmt.Println(version.Version())
 		os.Exit(0)
 	}
 
@@ -105,7 +105,7 @@ func main() {
 	slog.SetDefault(slog.New(newSlogHandler(level)))
 
 	slog.Info("config loaded",
-		slog.String("version", version.Version),
+		slog.String("version", version.Version()),
 		slog.Int("broker_count", len(cfg.Brokers)),
 		slog.Int("port", cfg.Port),
 		slog.String("log_level", cfg.LogLevel))
@@ -139,7 +139,7 @@ func main() {
 	// 6. Create MCP server
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "solace-broker-mcp",
-		Version: version.Version,
+		Version: version.Version(),
 	}, nil)
 
 	// 7. Register composite tools

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,6 +77,11 @@ func buildMux(server *mcp.Server) *http.ServeMux {
 }
 
 func main() {
+	if len(os.Args) == 2 && (os.Args[1] == "-version" || os.Args[1] == "--version") {
+		fmt.Println(version.Version)
+		os.Exit(0)
+	}
+
 	// 0. Bootstrap slog at INFO so LoadConfig can emit logs. The handler is
 	//    swapped with the user-configured level (cfg.LogLevel) after LoadConfig
 	//    validates it. UnmarshalText is infallible here because validate() in
@@ -100,6 +105,7 @@ func main() {
 	slog.SetDefault(slog.New(newSlogHandler(level)))
 
 	slog.Info("config loaded",
+		slog.String("version", version.Version),
 		slog.Int("broker_count", len(cfg.Brokers)),
 		slog.Int("port", cfg.Port),
 		slog.String("log_level", cfg.LogLevel))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2/specs"
+	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -132,7 +133,7 @@ func main() {
 	// 6. Create MCP server
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "solace-broker-mcp",
-		Version: "0.1.0",
+		Version: version.Version,
 	}, nil)
 
 	// 7. Register composite tools

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -14,7 +15,7 @@ import (
 func testMux() *http.ServeMux {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "solace-broker-mcp",
-		Version: "0.1.0",
+		Version: version.Version,
 	}, nil)
 	return buildMux(server)
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -15,7 +15,7 @@ import (
 func testMux() *http.ServeMux {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "solace-broker-mcp",
-		Version: version.Version,
+		Version: version.Version(),
 	}, nil)
 	return buildMux(server)
 }

--- a/docs/packaging-release.md
+++ b/docs/packaging-release.md
@@ -1,0 +1,72 @@
+# Packaging & Release
+
+## Versioning
+
+The MCP server version is managed via Go **ldflags build-time injection**. The
+source code contains a fallback default; the real version is injected during the
+build.
+
+### Source
+
+```go
+// internal/version/version.go
+package version
+
+var Version = "dev"
+```
+
+`Version` is a package-level variable imported wherever the version string is
+needed (MCP server metadata, User-Agent header, health endpoints, etc.).
+
+### Local development
+
+Local builds use the fallback value. No action required:
+
+```bash
+go build ./cmd/server
+# Version = "dev"
+```
+
+### How ldflags works
+
+ldflags is a **compile-time string substitution** mechanism. It does not fetch
+anything from a remote repository. The long module path
+(`github.com/SolaceDev/solace-broker-mcp/internal/version.Version`) is the
+same path used in Go `import` statements — the compiler resolves it against
+whatever source is on disk and replaces the variable's initial value in the
+compiled binary.
+
+The version value itself comes from whatever string you pass. Common sources:
+
+| Source | Command | Example output |
+|---|---|---|
+| Git tag | `git describe --tags --always` | `v0.1.0` or `v0.1.0-3-gabcdef` |
+| CI variable | `$CI_TAG` or `$GITHUB_REF_NAME` | `v0.2.0` |
+| Manual | Hardcoded in build script | `0.1.0` |
+
+### Injecting a version at build time
+
+Pass the fully-qualified variable path via `-ldflags -X`:
+
+```bash
+go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.Version=0.1.0" ./cmd/server
+```
+
+### CI / release builds
+
+Use a git tag as the version source so the binary version always matches the
+repository tag:
+
+```bash
+VERSION=$(git describe --tags --always)
+go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.Version=${VERSION}" ./cmd/server
+```
+
+### Cutting a new release
+
+1. Merge all changes to the release branch.
+2. Create an annotated tag: `git tag -a v0.2.0 -m "Release v0.2.0"`
+3. Push the tag: `git push origin v0.2.0`
+4. CI picks up the tag and injects it via ldflags into the build.
+
+No source files need to be edited to bump the version.

--- a/docs/packaging-release.md
+++ b/docs/packaging-release.md
@@ -31,7 +31,7 @@ go build ./cmd/server
 
 ldflags is a **compile-time string substitution** mechanism. It does not fetch
 anything from a remote repository. The long module path
-(`github.com/SolaceDev/solace-broker-mcp/internal/version.Version`) is the
+(`github.com/SolaceDev/solace-broker-mcp/internal/version.version`) is the
 same path used in Go `import` statements — the compiler resolves it against
 whatever source is on disk and replaces the variable's initial value in the
 compiled binary.
@@ -49,7 +49,7 @@ The version value itself comes from whatever string you pass. Common sources:
 Pass the fully-qualified variable path via `-ldflags -X`:
 
 ```bash
-go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.Version=0.1.0" ./cmd/server
+go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.version=0.1.0" ./cmd/server
 ```
 
 ### CI / release builds
@@ -59,7 +59,7 @@ repository tag:
 
 ```bash
 VERSION=$(git describe --tags --always)
-go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.Version=${VERSION}" ./cmd/server
+go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.version=${VERSION}" ./cmd/server
 ```
 
 ### Cutting a new release

--- a/docs/todo-gaps.md
+++ b/docs/todo-gaps.md
@@ -1,0 +1,22 @@
+# Outstanding Implementation Gaps
+
+Tracked gaps from Jira stories that are deferred or pending further discussion.
+
+## SOL-148423 — Implement SEMP Client Foundation with Connection Pool
+
+### Integration tests against live broker
+
+**Status:** Deferred
+
+**Story requirement:** Under "Testing Approach" and "Definition of Done":
+- Integration test: Authenticate to test broker with basic auth, GET
+  /SEMP/v2/monitor/broker, verify 200 response
+- Integration test: Authenticate to test broker with bearer token, verify 200
+  response
+- Integration test: Test with invalid credentials, verify 401 error returned
+- Integration test succeeds against live broker (both auth modes)
+- Session cookies handled automatically (verified via integration test)
+
+**Reason deferred:** Requires a test broker environment and decision on test
+gating strategy (env-var skip vs. build tags). To be implemented when CI broker
+infrastructure is ready.

--- a/internal/semp/broker.go
+++ b/internal/semp/broker.go
@@ -5,6 +5,8 @@
 package semp
 
 import (
+	"fmt"
+
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 )
@@ -19,11 +21,15 @@ type BrokerClient struct {
 
 // NewBrokerClient creates a BrokerClient for the given broker configuration.
 // It initializes the SEMPv2 HTTP client with the broker's connection settings.
-func NewBrokerClient(alias string, brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *BrokerClient {
-	return &BrokerClient{
-		sempV2: sempv2.NewHTTPClient(brokerCfg, sempCfg),
-		alias:  alias,
+func NewBrokerClient(alias string, brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (*BrokerClient, error) {
+	httpClient, err := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating SEMP client for broker %q: %w", alias, err)
 	}
+	return &BrokerClient{
+		sempV2: httpClient,
+		alias:  alias,
+	}, nil
 }
 
 // SempV2 returns the SEMPv2 client for this broker. This is the client that

--- a/internal/semp/broker_test.go
+++ b/internal/semp/broker_test.go
@@ -30,7 +30,10 @@ func TestBrokerClient_V2_ReturnsClient(t *testing.T) {
 	}
 	sempCfg := &config.SEMPConfig{RequestTimeoutDuration: 5 * time.Second}
 
-	bc := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
+	bc, err := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
+	if err != nil {
+		t.Fatalf("NewBrokerClient() error: %v", err)
+	}
 	client := bc.SempV2()
 
 	if client == nil {
@@ -57,7 +60,10 @@ func TestBrokerClient_V2_ExecutePassesThrough(t *testing.T) {
 	}
 	sempCfg := &config.SEMPConfig{RequestTimeoutDuration: 5 * time.Second}
 
-	bc := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
+	bc, err := semp.NewBrokerClient("test-broker", brokerCfg, sempCfg)
+	if err != nil {
+		t.Fatalf("NewBrokerClient() error: %v", err)
+	}
 	client := bc.SempV2()
 
 	op := &sempv2.Operation{
@@ -66,9 +72,9 @@ func TestBrokerClient_V2_ExecutePassesThrough(t *testing.T) {
 		Path:   "/SEMP/v2/monitor/test",
 	}
 
-	_, err := client.Execute(context.Background(), op, map[string]any{})
-	if err != nil {
-		t.Fatalf("Execute() error: %v", err)
+	_, execErr := client.Execute(context.Background(), op, map[string]any{})
+	if execErr != nil {
+		t.Fatalf("Execute() error: %v", execErr)
 	}
 
 	if !called {

--- a/internal/semp/pool.go
+++ b/internal/semp/pool.go
@@ -58,7 +58,10 @@ func (p *BrokerPool) GetSempV2(alias string) (sempv2.Client, error) {
 		return nil, fmt.Errorf("unknown broker: %q", alias)
 	}
 
-	client := NewBrokerClient(alias, cfg, p.sempCfg)
+	client, err := NewBrokerClient(alias, cfg, p.sempCfg)
+	if err != nil {
+		return nil, err
+	}
 	p.clients[alias] = client
 	slog.Info("broker connection created",
 		slog.String("broker", alias),

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -77,12 +77,15 @@ func (c *HTTPClient) LogValue() slog.Value {
 // NewHTTPClient creates an HTTPClient configured for a specific broker.
 // It sets up a per-broker HTTP transport with TLS settings and connection pool
 // tuning appropriate for concurrent SEMP calls.
-func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *HTTPClient {
+func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (*HTTPClient, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: brokerCfg.InsecureSkipVerify}, //nolint:gosec // G402 — user-configurable TLS skip for dev environments; defaults to false
 	}
 
-	jar, _ := cookiejar.New(nil) // nil options uses the default public suffix list
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating cookie jar: %w", err)
+	}
 
 	if brokerCfg.InsecureSkipVerify {
 		slog.Warn("INSECURE: TLS verification disabled for broker",
@@ -100,7 +103,7 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *
 		username: brokerCfg.Auth.Username,
 		password: brokerCfg.Auth.Password,
 		token:    brokerCfg.Auth.Token,
-	}
+	}, nil
 }
 
 // Execute makes an authenticated HTTP request to the broker's SEMPv2 API for

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -9,10 +9,12 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 )
 
 // Client executes operations against a Solace broker's SEMPv2 API.
@@ -80,8 +82,16 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: brokerCfg.InsecureSkipVerify}, //nolint:gosec // G402 — user-configurable TLS skip for dev environments; defaults to false
 	}
 
+	jar, _ := cookiejar.New(nil) // nil options uses the default public suffix list
+
+	if brokerCfg.InsecureSkipVerify {
+		slog.Warn("INSECURE: TLS verification disabled for broker",
+			slog.String("url", brokerCfg.URL))
+	}
+
 	return &HTTPClient{
 		httpClient: &http.Client{
+			Jar:       jar,
 			Timeout:   sempCfg.RequestTimeoutDuration,
 			Transport: transport,
 		},
@@ -196,6 +206,7 @@ func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL str
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "solace/broker-mcp-server/"+version.Version)
 
 	return req, nil
 }

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -209,7 +209,7 @@ func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL str
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "solace/broker-mcp-server/"+version.Version)
+	req.Header.Set("User-Agent", "solace/broker-mcp-server/"+version.Version())
 
 	return req, nil
 }

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -295,6 +295,65 @@ func TestClient_Execute_BearerAuth(t *testing.T) {
 	}
 }
 
+func TestClient_Execute_CookieJar(t *testing.T) {
+	callCount := 0
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if callCount == 0 {
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "abc123"})
+		} else {
+			cookie, err := r.Cookie("session")
+			if err != nil {
+				t.Error("cookie not sent back on second request")
+			} else if cookie.Value != "abc123" {
+				t.Errorf("cookie value = %q, want abc123", cookie.Value)
+			}
+		}
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+	}
+
+	if _, err := client.Execute(context.Background(), op, map[string]any{}); err != nil {
+		t.Fatalf("first Execute() error: %v", err)
+	}
+	if _, err := client.Execute(context.Background(), op, map[string]any{}); err != nil {
+		t.Fatalf("second Execute() error: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("handler called %d times, want 2", callCount)
+	}
+}
+
+func TestClient_Execute_UserAgent(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		ua := r.Header.Get("User-Agent")
+		if !strings.HasPrefix(ua, "solace/broker-mcp-server/") {
+			t.Errorf("User-Agent = %q, want prefix solace/broker-mcp-server/", ua)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+	}
+
+	if _, err := client.Execute(context.Background(), op, map[string]any{}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
 func TestClient_Execute_Timeout(t *testing.T) {
 	_, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Second)

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -27,7 +27,10 @@ func newTestClient(t *testing.T, handler http.HandlerFunc) (*sempv2.HTTPClient, 
 	sempCfg := &config.SEMPConfig{
 		RequestTimeoutDuration: 5 * time.Second,
 	}
-	client := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error: %v", err)
+	}
 	return client, server
 }
 
@@ -278,7 +281,10 @@ func TestClient_Execute_BearerAuth(t *testing.T) {
 		},
 	}
 	sempCfg := &config.SEMPConfig{RequestTimeoutDuration: 5 * time.Second}
-	bearerClient := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	bearerClient, err := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error: %v", err)
+	}
 
 	op := &sempv2.Operation{
 		ID:     "testOp",
@@ -372,7 +378,10 @@ func TestClient_Execute_Timeout(t *testing.T) {
 	sempCfg := &config.SEMPConfig{
 		RequestTimeoutDuration: time.Second,
 	}
-	client := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg)
+	if err != nil {
+		t.Fatalf("NewHTTPClient() error: %v", err)
+	}
 
 	op := &sempv2.Operation{
 		ID:     "testOp",
@@ -380,8 +389,8 @@ func TestClient_Execute_Timeout(t *testing.T) {
 		Path:   "/SEMP/v2/monitor/test",
 	}
 
-	_, err := client.Execute(context.Background(), op, map[string]any{})
-	if err == nil {
+	_, execErr := client.Execute(context.Background(), op, map[string]any{})
+	if execErr == nil {
 		t.Fatal("expected timeout error")
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,10 @@
 // ldflags. See docs/packaging-release.md for details.
 package version
 
-// Version is set at build time via:
+// version is set at build time via:
 //
-//	go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.Version=X.Y.Z" ./cmd/server
-var Version = "dev"
+//	go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.version=X.Y.Z" ./cmd/server
+var version = "dev"
+
+// Version returns the server version string.
+func Version() string { return version }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+// Package version holds the server version string, set at build time via
+// ldflags. See docs/packaging-release.md for details.
+package version
+
+// Version is set at build time via:
+//
+//	go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.Version=X.Y.Z" ./cmd/server
+var Version = "dev"


### PR DESCRIPTION
## Summary

Closes implementation gaps identified in [SOL-148423](https://sol-jira.atlassian.net/browse/SOL-148423) (Implement SEMP Client Foundation with Connection Pool) by reviewing the story acceptance criteria against the current codebase.

## Identified Gaps and Resolution

| # | Gap | Resolution |
|---|---|---|
| 1 | No cookie jar on `http.Client` — broker session cookies not handled | Added `cookiejar.New()` to `NewHTTPClient()` |
| 2 | No `User-Agent` header on SEMP requests — required for broker audit logs | Added `User-Agent: solace/broker-mcp-server/{version}` in `buildRequest()` |
| 3 | No WARNING log when `insecure_skip_verify` is enabled | Added `slog.Warn("INSECURE: TLS verification disabled for broker")` in `NewHTTPClient()` |
| 4 | No unit test verifying cookie jar works | Added roundtrip httptest verifying cookies echo back on second request |
| 5 | No integration tests against live broker | **Deferred** — tracked in `docs/todo-gaps.md`, pending CI broker infrastructure |

Additionally, the project had no version management strategy. Introduced:
- `internal/version` package with ldflags-injectable `Version` variable (default: `"dev"`)
- Replaced hardcoded `"0.1.0"` in MCP server metadata with `version.Version`
- `docs/packaging-release.md` documenting the versioning and release strategy

## Test plan

- [x] All 103 unit tests pass (`go test ./...`)
- [x] New `TestClient_Execute_CookieJar` verifies cookies are sent back automatically
- [x] New `TestClient_Execute_UserAgent` verifies header prefix `solace/broker-mcp-server/`
- [ ] Integration tests against live broker (deferred — see `docs/todo-gaps.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-148423]: https://sol-jira.atlassian.net/browse/SOL-148423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ