### PR TITLE
SOL-148429: Implement VPN-Level Monitoring Tools (Health, List, Queues, Clients)

### DIFF
--- a/internal/composite/definition.go
+++ b/internal/composite/definition.go
@@ -54,8 +54,8 @@ type Step struct {
 	ID        string            `yaml:"id"`
 	Operation string            `yaml:"operation"` // prefixed operationId (e.g., "monitor/getMsgVpnQueue")
 	Args      map[string]string `yaml:"args"`      // values are Go text/template expressions
-	Parallel  bool              `yaml:"parallel"`  // group with adjacent parallel:true steps
-	Paginate  bool              `yaml:"paginate"`  // follow SEMP nextPageUri links and aggregate all pages
+	Parallel    bool              `yaml:"parallel"`    // group with adjacent parallel:true steps
+	FollowPages bool              `yaml:"followPages"` // follow SEMP nextPageUri links and aggregate all pages
 }
 
 // ResultStrategy defines how step results are combined into the tool's final

--- a/internal/composite/definition.go
+++ b/internal/composite/definition.go
@@ -55,6 +55,7 @@ type Step struct {
 	Operation string            `yaml:"operation"` // prefixed operationId (e.g., "monitor/getMsgVpnQueue")
 	Args      map[string]string `yaml:"args"`      // values are Go text/template expressions
 	Parallel  bool              `yaml:"parallel"`  // group with adjacent parallel:true steps
+	Paginate  bool              `yaml:"paginate"`  // follow SEMP nextPageUri links and aggregate all pages
 }
 
 // ResultStrategy defines how step results are combined into the tool's final

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -139,6 +139,8 @@ tools:
       state, active connection count, total subscription count, and service
       states for SMF, REST, and MQTT protocols. Use this to assess whether a
       VPN is operational and identify service-level problems.
+    annotations:
+      readOnly: true
     parameters:
       - name: msgVpnName
         type: string
@@ -157,6 +159,8 @@ tools:
       List all Message VPNs on the broker with their enabled state, connection
       count, and basic health status. Use this to discover which VPNs exist and
       identify any that are down or have no active connections.
+    annotations:
+      readOnly: true
     parameters:
       - name: maxResults
         type: integer
@@ -165,17 +169,19 @@ tools:
     steps:
       - id: vpns
         operation: monitor/getMsgVpns
-        paginate: true
+        followPages: true
         args:
           count: "100"
     result:
-      strategy: paginate
+      strategy: collect
 
   - name: list-queues
     description: >
       List all queues in a Message VPN with depth, bind count, and throughput
       rates. Use this to get an overview of queue health across a VPN and
       identify queues with backlogs or no consumers.
+    annotations:
+      readOnly: true
     parameters:
       - name: msgVpnName
         type: string
@@ -188,18 +194,20 @@ tools:
     steps:
       - id: queues
         operation: monitor/getMsgVpnQueues
-        paginate: true
+        followPages: true
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
     result:
-      strategy: paginate
+      strategy: collect
 
   - name: list-clients
     description: >
       List all active client connections in a Message VPN with connection
       details, uptime, and slow subscriber status. Use this to discover which
       clients are connected and identify slow or stalled consumers.
+    annotations:
+      readOnly: true
     parameters:
       - name: msgVpnName
         type: string
@@ -212,9 +220,9 @@ tools:
     steps:
       - id: clients
         operation: monitor/getMsgVpnClients
-        paginate: true
+        followPages: true
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
     result:
-      strategy: paginate
+      strategy: collect

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -132,3 +132,89 @@ tools:
           count: '{{with index .Params "maxResults"}}{{.}}{{else}}100{{end}}'
     result:
       strategy: collect
+
+  - name: get-vpn-health
+    description: >
+      Get health and connection statistics for a Message VPN. Returns enabled
+      state, active connection count, total subscription count, and service
+      states for SMF, REST, and MQTT protocols. Use this to assess whether a
+      VPN is operational and identify service-level problems.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The name of the Message VPN"
+    steps:
+      - id: vpnHealth
+        operation: monitor/getMsgVpn
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+    result:
+      strategy: collect
+
+  - name: list-vpns
+    description: >
+      List all Message VPNs on the broker with their enabled state, connection
+      count, and basic health status. Use this to discover which VPNs exist and
+      identify any that are down or have no active connections.
+    parameters:
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of VPNs to return (default 100, max 500)"
+    steps:
+      - id: vpns
+        operation: monitor/getMsgVpns
+        paginate: true
+        args:
+          count: "100"
+    result:
+      strategy: paginate
+
+  - name: list-queues
+    description: >
+      List all queues in a Message VPN with depth, bind count, and throughput
+      rates. Use this to get an overview of queue health across a VPN and
+      identify queues with backlogs or no consumers.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to list queues for"
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of queues to return (default 100, max 500)"
+    steps:
+      - id: queues
+        operation: monitor/getMsgVpnQueues
+        paginate: true
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          count: "100"
+    result:
+      strategy: paginate
+
+  - name: list-clients
+    description: >
+      List all active client connections in a Message VPN with connection
+      details, uptime, and slow subscriber status. Use this to discover which
+      clients are connected and identify slow or stalled consumers.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to list clients for"
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of clients to return (default 100, max 500)"
+    steps:
+      - id: clients
+        operation: monitor/getMsgVpnClients
+        paginate: true
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          count: "100"
+    result:
+      strategy: paginate

--- a/internal/composite/executor.go
+++ b/internal/composite/executor.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 	"text/template"
 
 	"golang.org/x/sync/errgroup"
@@ -127,7 +128,13 @@ func GroupStepsIntoBatches(steps []Step) []ExecutionBatch {
 
 // executeStep executes a single step: resolves template args, looks up the
 // operation, calls the client, and stores the result in the execution context.
+// If the step has Paginate set, it delegates to executePaginatedStep to follow
+// SEMP nextPageUri links and aggregate results across pages.
 func (ce *CompositeExecutor) executeStep(ctx context.Context, step Step, client sempv2.Client, execCtx *ExecuteContext) error {
+	if step.Paginate {
+		return ce.executePaginatedStep(ctx, step, client, execCtx)
+	}
+
 	args, err := ResolveArgs(step.Args, execCtx)
 	if err != nil {
 		return fmt.Errorf("tool step %s: failed to resolve args: %w", step.ID, err)
@@ -145,6 +152,145 @@ func (ce *CompositeExecutor) executeStep(ctx context.Context, step Step, client 
 
 	execCtx.StepResults[step.ID] = result.Data
 	return nil
+}
+
+// executePaginatedStep executes a step that returns paginated results. It follows
+// SEMP's nextPageUri links until all pages are collected or maxResults is reached.
+// The merged data array is stored in execCtx.StepResults keyed by step ID, alongside
+// a truncated flag indicating whether more results exist beyond maxResults.
+func (ce *CompositeExecutor) executePaginatedStep(ctx context.Context, step Step, client sempv2.Client, execCtx *ExecuteContext) error {
+	baseArgs, err := ResolveArgs(step.Args, execCtx)
+	if err != nil {
+		return fmt.Errorf("tool step %s: failed to resolve args: %w", step.ID, err)
+	}
+
+	op, ok := ce.operations[step.Operation]
+	if !ok {
+		return fmt.Errorf("tool step %s: operation %q not found in operation catalog", step.ID, step.Operation)
+	}
+
+	maxResults := resolveMaxResults(execCtx.Params)
+	var allItems []any
+	truncated := false
+	args := baseArgs
+
+	for {
+		result, err := client.Execute(ctx, op, args)
+		if err != nil {
+			return fmt.Errorf("tool step %s: %w", step.ID, err)
+		}
+
+		items := extractDataItems(result.Data)
+		if len(items) == 0 {
+			break
+		}
+
+		remaining := maxResults - len(allItems)
+		if len(items) >= remaining {
+			allItems = append(allItems, items[:remaining]...)
+			// Truncated if the page had more items than we needed, or if more pages exist.
+			truncated = len(items) > remaining || extractNextPageURI(result.Data) != ""
+			break
+		}
+
+		allItems = append(allItems, items...)
+
+		nextURI := extractNextPageURI(result.Data)
+		if nextURI == "" {
+			break
+		}
+
+		cursor, parseErr := parseCursorFromURI(nextURI)
+		if parseErr != nil || cursor == "" {
+			break
+		}
+
+		args = appendCursor(baseArgs, cursor)
+	}
+
+	execCtx.StepResults[step.ID] = map[string]any{
+		"data":      allItems,
+		"truncated": truncated,
+	}
+	return nil
+}
+
+// resolveMaxResults reads maxResults from the execution params, applying a
+// default of 100 and a cap of 500 as specified in SOL-148429 acceptance criteria.
+func resolveMaxResults(params map[string]any) int {
+	const defaultMax = 100
+	const capMax = 500
+
+	raw, ok := params["maxResults"]
+	if !ok {
+		return defaultMax
+	}
+
+	var n int
+	switch v := raw.(type) {
+	case float64:
+		n = int(v)
+	case int:
+		n = v
+	case int64:
+		n = int(v)
+	default:
+		return defaultMax
+	}
+
+	if n <= 0 {
+		return defaultMax
+	}
+	if n > capMax {
+		return capMax
+	}
+	return n
+}
+
+// extractDataItems returns the data array from a SEMP list response, or nil
+// if the response contains no data field or it is not a slice.
+func extractDataItems(data map[string]any) []any {
+	raw, ok := data["data"]
+	if !ok {
+		return nil
+	}
+	items, _ := raw.([]any)
+	return items
+}
+
+// extractNextPageURI returns the nextPageUri from SEMP pagination metadata,
+// or an empty string if the response has no further pages.
+func extractNextPageURI(data map[string]any) string {
+	meta, ok := data["meta"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	paging, ok := meta["paging"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	uri, _ := paging["nextPageUri"].(string)
+	return uri
+}
+
+// parseCursorFromURI extracts the cursor query parameter from a SEMP nextPageUri.
+func parseCursorFromURI(rawURI string) (string, error) {
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return "", err
+	}
+	return u.Query().Get("cursor"), nil
+}
+
+// appendCursor returns a copy of baseArgs with the cursor key added for the
+// next paginated SEMP request.
+func appendCursor(baseArgs map[string]any, cursor string) map[string]any {
+	next := make(map[string]any, len(baseArgs)+1)
+	for k, v := range baseArgs {
+		next[k] = v
+	}
+	next["cursor"] = cursor
+	return next
 }
 
 // executeBatch runs multiple parallel steps concurrently using errgroup. If any
@@ -239,15 +385,15 @@ func safeTemplateExecute(tmpl *template.Template, data any) (result string, err 
 }
 
 // ApplyResultStrategy combines step results according to the tool's result
-// strategy configuration. Currently only "collect" is supported. Additional
-// strategies (merge, unwrap) are deferred pending design discussion around
-// SEMP response envelope overlap and per-step data transformation needs.
+// strategy configuration. "collect" returns all step results keyed by step ID.
+// "paginate" uses the same envelope — the paginated data array and truncated flag
+// are already assembled by executePaginatedStep before this is called.
 func ApplyResultStrategy(strategy ResultStrategy, stepResults map[string]map[string]any) (map[string]any, error) {
 	switch strategy.Strategy {
-	case "collect":
+	case "collect", "paginate":
 		return collectStrategy(stepResults)
 	default:
-		return nil, fmt.Errorf("result strategy %q is not supported; only collect is currently supported", strategy.Strategy)
+		return nil, fmt.Errorf("result strategy %q is not supported; supported values: collect, paginate", strategy.Strategy)
 	}
 }
 

--- a/internal/composite/executor.go
+++ b/internal/composite/executor.go
@@ -128,10 +128,8 @@ func GroupStepsIntoBatches(steps []Step) []ExecutionBatch {
 
 // executeStep executes a single step: resolves template args, looks up the
 // operation, calls the client, and stores the result in the execution context.
-// If the step has Paginate set, it delegates to executePaginatedStep to follow
-// SEMP nextPageUri links and aggregate results across pages.
 func (ce *CompositeExecutor) executeStep(ctx context.Context, step Step, client sempv2.Client, execCtx *ExecuteContext) error {
-	if step.Paginate {
+	if step.FollowPages {
 		return ce.executePaginatedStep(ctx, step, client, execCtx)
 	}
 
@@ -170,7 +168,7 @@ func (ce *CompositeExecutor) executePaginatedStep(ctx context.Context, step Step
 	}
 
 	maxResults := resolveMaxResults(execCtx.Params)
-	var allItems []any
+	allItems := make([]any, 0)
 	truncated := false
 	args := baseArgs
 
@@ -201,8 +199,11 @@ func (ce *CompositeExecutor) executePaginatedStep(ctx context.Context, step Step
 		}
 
 		cursor, parseErr := parseCursorFromURI(nextURI)
-		if parseErr != nil || cursor == "" {
-			break
+		if parseErr != nil {
+			return fmt.Errorf("tool step %s: failed to parse pagination cursor from nextPageUri %q: %w", step.ID, nextURI, parseErr)
+		}
+		if cursor == "" {
+			return fmt.Errorf("tool step %s: empty pagination cursor extracted from nextPageUri %q", step.ID, nextURI)
 		}
 
 		args = appendCursor(baseArgs, cursor)
@@ -216,7 +217,7 @@ func (ce *CompositeExecutor) executePaginatedStep(ctx context.Context, step Step
 }
 
 // resolveMaxResults reads maxResults from the execution params, applying a
-// default of 100 and a cap of 500 as specified in SOL-148429 acceptance criteria.
+// default of 100 and a cap of 500.
 func resolveMaxResults(params map[string]any) int {
 	const defaultMax = 100
 	const capMax = 500
@@ -386,14 +387,12 @@ func safeTemplateExecute(tmpl *template.Template, data any) (result string, err 
 
 // ApplyResultStrategy combines step results according to the tool's result
 // strategy configuration. "collect" returns all step results keyed by step ID.
-// "paginate" uses the same envelope — the paginated data array and truncated flag
-// are already assembled by executePaginatedStep before this is called.
 func ApplyResultStrategy(strategy ResultStrategy, stepResults map[string]map[string]any) (map[string]any, error) {
 	switch strategy.Strategy {
-	case "collect", "paginate":
+	case "collect":
 		return collectStrategy(stepResults)
 	default:
-		return nil, fmt.Errorf("result strategy %q is not supported; supported values: collect, paginate", strategy.Strategy)
+		return nil, fmt.Errorf("result strategy %q is not supported; supported values: collect", strategy.Strategy)
 	}
 }
 

--- a/internal/composite/executor_test.go
+++ b/internal/composite/executor_test.go
@@ -873,13 +873,13 @@ func listVPNsTool() CompositeTool {
 			{
 				ID:        "vpns",
 				Operation: "monitor/getMsgVpns",
-				Paginate:  true,
+				FollowPages: true,
 				Args: map[string]string{
 					"count": "100",
 				},
 			},
 		},
-		Result: ResultStrategy{Strategy: "paginate"},
+		Result: ResultStrategy{Strategy: "collect"},
 	}
 }
 
@@ -896,14 +896,14 @@ func listQueuesTool() CompositeTool {
 			{
 				ID:        "queues",
 				Operation: "monitor/getMsgVpnQueues",
-				Paginate:  true,
+				FollowPages: true,
 				Args: map[string]string{
 					"msgVpnName": "{{.Params.msgVpnName}}",
 					"count":      "100",
 				},
 			},
 		},
-		Result: ResultStrategy{Strategy: "paginate"},
+		Result: ResultStrategy{Strategy: "collect"},
 	}
 }
 
@@ -920,14 +920,14 @@ func listClientsTool() CompositeTool {
 			{
 				ID:        "clients",
 				Operation: "monitor/getMsgVpnClients",
-				Paginate:  true,
+				FollowPages: true,
 				Args: map[string]string{
 					"msgVpnName": "{{.Params.msgVpnName}}",
 					"count":      "100",
 				},
 			},
 		},
-		Result: ResultStrategy{Strategy: "paginate"},
+		Result: ResultStrategy{Strategy: "collect"},
 	}
 }
 
@@ -1219,6 +1219,10 @@ func TestExecute_ListQueues_MaxResultsCappedAt500(t *testing.T) {
 	}
 	if queues["truncated"] != true {
 		t.Errorf("truncated = %v, want true", queues["truncated"])
+	}
+	// Cap stops after 5 pages (500 items), page6 must not be fetched.
+	if len(client.calls) != 5 {
+		t.Errorf("expected 5 SEMP calls, got %d", len(client.calls))
 	}
 }
 

--- a/internal/composite/executor_test.go
+++ b/internal/composite/executor_test.go
@@ -87,7 +87,73 @@ func testOperations() map[string]*sempv2.Operation {
 			Method: "PUT",
 			Path:   "/SEMP/v2/action/msgVpns/{msgVpnName}/queues/{queueName}/startReplay",
 		},
+		"monitor/getMsgVpn": {
+			ID:     "getMsgVpn",
+			Method: "GET",
+			Path:   "/SEMP/v2/__private_monitor__/msgVpns/{msgVpnName}",
+		},
+		"monitor/getMsgVpns": {
+			ID:     "getMsgVpns",
+			Method: "GET",
+			Path:   "/SEMP/v2/__private_monitor__/msgVpns",
+		},
+		"monitor/getMsgVpnQueues": {
+			ID:     "getMsgVpnQueues",
+			Method: "GET",
+			Path:   "/SEMP/v2/__private_monitor__/msgVpns/{msgVpnName}/queues",
+		},
+		"monitor/getMsgVpnClients": {
+			ID:     "getMsgVpnClients",
+			Method: "GET",
+			Path:   "/SEMP/v2/__private_monitor__/msgVpns/{msgVpnName}/clients",
+		},
 	}
+}
+
+// seqMockClient returns pre-configured responses for operations in sequence.
+// Each Execute call for an operation advances to the next response in its sequence.
+// When the sequence is exhausted the last response is repeated.
+type seqMockClient struct {
+	mu     sync.Mutex
+	calls  []callRecord
+	seqs   map[string][]*sempv2.Result
+	errors map[string]error
+	idx    map[string]int
+}
+
+func newSeqMockClient() *seqMockClient {
+	return &seqMockClient{
+		seqs:   make(map[string][]*sempv2.Result),
+		errors: make(map[string]error),
+		idx:    make(map[string]int),
+	}
+}
+
+func (m *seqMockClient) addResponses(opID string, results ...*sempv2.Result) {
+	m.seqs[opID] = append(m.seqs[opID], results...)
+}
+
+func (m *seqMockClient) Execute(_ context.Context, op *sempv2.Operation, args map[string]any) (*sempv2.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = append(m.calls, callRecord{opID: op.ID, args: args})
+
+	if err, ok := m.errors[op.ID]; ok {
+		return nil, err
+	}
+
+	seq, ok := m.seqs[op.ID]
+	if !ok || len(seq) == 0 {
+		return &sempv2.Result{Data: map[string]any{}, StatusCode: 200}, nil
+	}
+
+	idx := m.idx[op.ID]
+	if idx >= len(seq) {
+		idx = len(seq) - 1
+	}
+	m.idx[op.ID] = idx + 1
+	return seq[idx], nil
 }
 
 // getQueueMetricsTool returns the get-queue-metrics tool definition for tests.
@@ -771,6 +837,424 @@ func TestExecute_ListClientSubscriptions_DefaultsCountQuery(t *testing.T) {
 
 	if recorded[0].args["count"] != "100" {
 		t.Errorf("expected count to default to %q, got %v", "100", recorded[0].args["count"])
+	}
+}
+
+// getVPNHealthTool returns the get-vpn-health tool definition for tests.
+func getVPNHealthTool() CompositeTool {
+	return CompositeTool{
+		Name:        "get-vpn-health",
+		Description: "Get health and connection statistics for a Message VPN",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+		},
+		Steps: []Step{
+			{
+				ID:        "vpnHealth",
+				Operation: "monitor/getMsgVpn",
+				Args: map[string]string{
+					"msgVpnName": "{{.Params.msgVpnName}}",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+}
+
+// listVPNsTool returns the list-vpns tool definition for tests.
+func listVPNsTool() CompositeTool {
+	return CompositeTool{
+		Name:        "list-vpns",
+		Description: "List all Message VPNs on the broker",
+		Parameters: []ParameterDef{
+			{Name: "maxResults", Type: "integer", Required: false},
+		},
+		Steps: []Step{
+			{
+				ID:        "vpns",
+				Operation: "monitor/getMsgVpns",
+				Paginate:  true,
+				Args: map[string]string{
+					"count": "100",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "paginate"},
+	}
+}
+
+// listQueuesTool returns the list-queues tool definition for tests.
+func listQueuesTool() CompositeTool {
+	return CompositeTool{
+		Name:        "list-queues",
+		Description: "List all queues in a Message VPN",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+			{Name: "maxResults", Type: "integer", Required: false},
+		},
+		Steps: []Step{
+			{
+				ID:        "queues",
+				Operation: "monitor/getMsgVpnQueues",
+				Paginate:  true,
+				Args: map[string]string{
+					"msgVpnName": "{{.Params.msgVpnName}}",
+					"count":      "100",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "paginate"},
+	}
+}
+
+// listClientsTool returns the list-clients tool definition for tests.
+func listClientsTool() CompositeTool {
+	return CompositeTool{
+		Name:        "list-clients",
+		Description: "List all active client connections in a Message VPN",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+			{Name: "maxResults", Type: "integer", Required: false},
+		},
+		Steps: []Step{
+			{
+				ID:        "clients",
+				Operation: "monitor/getMsgVpnClients",
+				Paginate:  true,
+				Args: map[string]string{
+					"msgVpnName": "{{.Params.msgVpnName}}",
+					"count":      "100",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "paginate"},
+	}
+}
+
+// makeVPNItems builds a slice of n mock VPN objects for use in paginated responses.
+func makeVPNItems(n int) []any {
+	items := make([]any, n)
+	for i := range items {
+		items[i] = map[string]any{"msgVpnName": fmt.Sprintf("vpn-%d", i), "enabled": true}
+	}
+	return items
+}
+
+// makeQueueItems builds a slice of n mock queue objects for use in paginated responses.
+func makeQueueItems(n int) []any {
+	items := make([]any, n)
+	for i := range items {
+		items[i] = map[string]any{"queueName": fmt.Sprintf("queue-%d", i), "bindCount": float64(0)}
+	}
+	return items
+}
+
+// makeClientItems builds a slice of n mock client objects for use in paginated responses.
+func makeClientItems(n int) []any {
+	items := make([]any, n)
+	for i := range items {
+		items[i] = map[string]any{"clientName": fmt.Sprintf("client-%d", i), "slowSubscriber": false}
+	}
+	return items
+}
+
+// pageResult builds a SEMP list response with optional pagination cursor.
+func pageResult(items []any, nextCursor string) *sempv2.Result {
+	data := map[string]any{"data": items}
+	if nextCursor != "" {
+		data["meta"] = map[string]any{
+			"paging": map[string]any{
+				"nextPageUri": "/SEMP/v2/__private_monitor__/resource?cursor=" + nextCursor + "&count=100",
+			},
+		}
+	}
+	return &sempv2.Result{Data: data, StatusCode: 200}
+}
+
+func TestExecute_GetVPNHealth_ReturnsData(t *testing.T) {
+	client := newMockClient()
+	client.responses["getMsgVpn"] = &sempv2.Result{
+		Data: map[string]any{
+			"msgVpnName":                      "default",
+			"enabled":                         true,
+			"msgVpnConnections":               float64(5),
+			"msgVpnTotalUniqueSubscriptions":  float64(42),
+			"state":                           "up",
+		},
+		StatusCode: 200,
+	}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), getVPNHealthTool(), client, map[string]any{
+		"msgVpnName": "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	vpnData, ok := result["vpnHealth"].(map[string]any)
+	if !ok {
+		t.Fatal("expected vpnHealth key containing a map")
+	}
+	if vpnData["msgVpnName"] != "default" {
+		t.Errorf("msgVpnName = %v, want default", vpnData["msgVpnName"])
+	}
+	if vpnData["enabled"] != true {
+		t.Errorf("enabled = %v, want true", vpnData["enabled"])
+	}
+}
+
+func TestExecute_ListVPNs_SinglePage(t *testing.T) {
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpns", pageResult(makeVPNItems(3), ""))
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listVPNsTool(), client, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	vpns, ok := result["vpns"].(map[string]any)
+	if !ok {
+		t.Fatal("expected vpns key containing a map")
+	}
+
+	items, ok := vpns["data"].([]any)
+	if !ok {
+		t.Fatal("expected vpns.data to be a slice")
+	}
+	if len(items) != 3 {
+		t.Errorf("len(items) = %d, want 3", len(items))
+	}
+	if vpns["truncated"] != false {
+		t.Errorf("truncated = %v, want false", vpns["truncated"])
+	}
+	if len(client.calls) != 1 {
+		t.Errorf("expected 1 SEMP call, got %d", len(client.calls))
+	}
+}
+
+func TestExecute_ListVPNs_MultiPage(t *testing.T) {
+	// Page 1: 10 VPNs with nextPageUri; page 2: 5 VPNs, no nextPageUri. Total: 15.
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpns",
+		pageResult(makeVPNItems(10), "cursor-page2"),
+		pageResult(makeVPNItems(5), ""),
+	)
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listVPNsTool(), client, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	vpns := result["vpns"].(map[string]any)
+	items := vpns["data"].([]any)
+
+	if len(items) != 15 {
+		t.Errorf("len(items) = %d, want 15", len(items))
+	}
+	if vpns["truncated"] != false {
+		t.Errorf("truncated = %v, want false", vpns["truncated"])
+	}
+	if len(client.calls) != 2 {
+		t.Errorf("expected 2 SEMP calls, got %d", len(client.calls))
+	}
+	// Second call must include the cursor from the first page's nextPageUri.
+	if client.calls[1].args["cursor"] != "cursor-page2" {
+		t.Errorf("second call cursor = %v, want cursor-page2", client.calls[1].args["cursor"])
+	}
+}
+
+func TestExecute_ListQueues_MultiPage(t *testing.T) {
+	// Page 1: 100 queues + cursor; page 2: 50 queues, no cursor. Total: 150.
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnQueues",
+		pageResult(makeQueueItems(100), "cursor-q2"),
+		pageResult(makeQueueItems(50), ""),
+	)
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listQueuesTool(), client, map[string]any{
+		"msgVpnName": "default",
+		"maxResults": float64(200), // larger than 150 total so paginator follows all pages
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	queues := result["queues"].(map[string]any)
+	items := queues["data"].([]any)
+
+	if len(items) != 150 {
+		t.Errorf("len(items) = %d, want 150", len(items))
+	}
+	if queues["truncated"] != false {
+		t.Errorf("truncated = %v, want false", queues["truncated"])
+	}
+	if len(client.calls) != 2 {
+		t.Errorf("expected 2 SEMP calls, got %d", len(client.calls))
+	}
+}
+
+func TestExecute_ListQueues_TruncatesAtMaxResults(t *testing.T) {
+	// Page has 100 items but maxResults=50, paginator should stop and set truncated.
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnQueues", pageResult(makeQueueItems(100), "cursor-next"))
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listQueuesTool(), client, map[string]any{
+		"msgVpnName": "default",
+		"maxResults": float64(50),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	queues := result["queues"].(map[string]any)
+	items := queues["data"].([]any)
+
+	if len(items) != 50 {
+		t.Errorf("len(items) = %d, want 50", len(items))
+	}
+	if queues["truncated"] != true {
+		t.Errorf("truncated = %v, want true", queues["truncated"])
+	}
+	// Paginator stopped after the first page, no second call.
+	if len(client.calls) != 1 {
+		t.Errorf("expected 1 SEMP call, got %d", len(client.calls))
+	}
+}
+
+func TestExecute_ListClients_DefaultMaxResults(t *testing.T) {
+	// 80 clients on a single page, fits within the default 100 limit.
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnClients", pageResult(makeClientItems(80), ""))
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listClientsTool(), client, map[string]any{
+		"msgVpnName": "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clients := result["clients"].(map[string]any)
+	items := clients["data"].([]any)
+
+	if len(items) != 80 {
+		t.Errorf("len(items) = %d, want 80", len(items))
+	}
+	if clients["truncated"] != false {
+		t.Errorf("truncated = %v, want false", clients["truncated"])
+	}
+}
+
+func TestExecute_ListClients_MultiPage(t *testing.T) {
+	// Page 1: 100 clients + cursor; page 2: 20 clients, no cursor. Total: 120.
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnClients",
+		pageResult(makeClientItems(100), "cursor-c2"),
+		pageResult(makeClientItems(20), ""),
+	)
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listClientsTool(), client, map[string]any{
+		"msgVpnName": "default",
+		"maxResults": float64(200), // larger than 120 total so paginator follows all pages
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clients := result["clients"].(map[string]any)
+	items := clients["data"].([]any)
+
+	if len(items) != 120 {
+		t.Errorf("len(items) = %d, want 120", len(items))
+	}
+	if clients["truncated"] != false {
+		t.Errorf("truncated = %v, want false", clients["truncated"])
+	}
+	if len(client.calls) != 2 {
+		t.Errorf("expected 2 SEMP calls, got %d", len(client.calls))
+	}
+}
+
+func TestExecute_ListQueues_MaxResultsCappedAt500(t *testing.T) {
+	// maxResults=1000 exceeds the 500 cap, paginator should stop at 500.
+	page1 := pageResult(makeQueueItems(100), "c2")
+	page2 := pageResult(makeQueueItems(100), "c3")
+	page3 := pageResult(makeQueueItems(100), "c4")
+	page4 := pageResult(makeQueueItems(100), "c5")
+	page5 := pageResult(makeQueueItems(100), "c6")
+	// page6 would push beyond cap, should not be fetched.
+	page6 := pageResult(makeQueueItems(100), "")
+
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnQueues", page1, page2, page3, page4, page5, page6)
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listQueuesTool(), client, map[string]any{
+		"msgVpnName": "default",
+		"maxResults": float64(1000),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	queues := result["queues"].(map[string]any)
+	items := queues["data"].([]any)
+
+	if len(items) != 500 {
+		t.Errorf("len(items) = %d, want 500 (cap)", len(items))
+	}
+	if queues["truncated"] != true {
+		t.Errorf("truncated = %v, want true", queues["truncated"])
+	}
+}
+
+func TestExecute_ListQueues_MissingVPNName(t *testing.T) {
+	client := newSeqMockClient()
+	executor := NewCompositeExecutor(testOperations())
+
+	// msgVpnName is required by the template, omitting it should return an error.
+	_, err := executor.Execute(context.Background(), listQueuesTool(), client, map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing msgVpnName, got nil")
+	}
+}
+
+func TestExecute_GetVPNHealth_SEMPError(t *testing.T) {
+	client := newMockClient()
+	client.errors["getMsgVpn"] = &sempv2.SEMPError{
+		Operation:  "getMsgVpn",
+		StatusCode: 400,
+		Body:       `{"meta":{"error":{"code":400,"description":"VPN not found","status":"NOT_FOUND"}}}`,
+	}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	_, err := executor.Execute(context.Background(), getVPNHealthTool(), client, map[string]any{
+		"msgVpnName": "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var sempErr *sempv2.SEMPError
+	if !errors.As(err, &sempErr) {
+		t.Errorf("expected SEMPError in error chain, got: %v", err)
+	} else if sempErr.StatusCode != 400 {
+		t.Errorf("StatusCode = %d, want 400", sempErr.StatusCode)
 	}
 }
 

--- a/internal/composite/executor_test.go
+++ b/internal/composite/executor_test.go
@@ -1262,6 +1262,94 @@ func TestExecute_GetVPNHealth_SEMPError(t *testing.T) {
 	}
 }
 
+func TestExecute_ListQueues_EmptyFirstPage(t *testing.T) {
+	// First page returns an empty data array — result should be [] not null, truncated=false.
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnQueues", pageResult([]any{}, ""))
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listQueuesTool(), client, map[string]any{
+		"msgVpnName": "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	queues := result["queues"].(map[string]any)
+	items, ok := queues["data"].([]any)
+	if !ok {
+		t.Fatal("expected queues.data to be a slice, got nil")
+	}
+	if len(items) != 0 {
+		t.Errorf("len(items) = %d, want 0", len(items))
+	}
+	if queues["truncated"] != false {
+		t.Errorf("truncated = %v, want false", queues["truncated"])
+	}
+}
+
+
+func TestExecute_ListQueues_EmptyCursorInNextPageURI(t *testing.T) {
+	// nextPageUri is present but has no cursor query param, executor must return an error.
+	response := &sempv2.Result{
+		Data: map[string]any{
+			"data": makeQueueItems(10),
+			"meta": map[string]any{
+				"paging": map[string]any{
+					"nextPageUri": "/SEMP/v2/monitor/msgVpns/default/queues?count=100",
+				},
+			},
+		},
+		StatusCode: 200,
+	}
+
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnQueues", response)
+
+	executor := NewCompositeExecutor(testOperations())
+
+	_, err := executor.Execute(context.Background(), listQueuesTool(), client, map[string]any{
+		"msgVpnName": "default",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty cursor in nextPageUri, got nil")
+	}
+	if !contains(err.Error(), "empty pagination cursor") {
+		t.Errorf("expected error mentioning 'empty pagination cursor', got: %v", err)
+	}
+}
+
+func TestExecute_ListQueues_UnparsableNextPageURI(t *testing.T) {
+	// nextPageUri cannot be parsed by url.Parse — executor must return an error.
+	response := &sempv2.Result{
+		Data: map[string]any{
+			"data": makeQueueItems(10),
+			"meta": map[string]any{
+				"paging": map[string]any{
+					"nextPageUri": ":not-a-valid-uri",
+				},
+			},
+		},
+		StatusCode: 200,
+	}
+
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnQueues", response)
+
+	executor := NewCompositeExecutor(testOperations())
+
+	_, err := executor.Execute(context.Background(), listQueuesTool(), client, map[string]any{
+		"msgVpnName": "default",
+	})
+	if err == nil {
+		t.Fatal("expected error for unparsable nextPageUri, got nil")
+	}
+	if !contains(err.Error(), "failed to parse pagination cursor") {
+		t.Errorf("expected error mentioning 'failed to parse pagination cursor', got: %v", err)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/composite/loader.go
+++ b/internal/composite/loader.go
@@ -79,11 +79,11 @@ func validateTool(tool *CompositeTool) error {
 	}
 
 	if tool.Result.Strategy == "" {
-		return fmt.Errorf("result strategy is required; supported values: collect, paginate")
+		return fmt.Errorf("result strategy is required; supported values: collect")
 	}
 
-	if tool.Result.Strategy != "collect" && tool.Result.Strategy != "paginate" {
-		return fmt.Errorf("result strategy %q is not supported; supported values: collect, paginate", tool.Result.Strategy)
+	if tool.Result.Strategy != "collect" {
+		return fmt.Errorf("result strategy %q is not supported; supported values: collect", tool.Result.Strategy)
 	}
 
 	return nil

--- a/internal/composite/loader.go
+++ b/internal/composite/loader.go
@@ -79,11 +79,11 @@ func validateTool(tool *CompositeTool) error {
 	}
 
 	if tool.Result.Strategy == "" {
-		return fmt.Errorf("result strategy is required; only \"collect\" is currently supported")
+		return fmt.Errorf("result strategy is required; supported values: collect, paginate")
 	}
 
-	if tool.Result.Strategy != "collect" {
-		return fmt.Errorf("result strategy %q is not supported; only collect is currently supported", tool.Result.Strategy)
+	if tool.Result.Strategy != "collect" && tool.Result.Strategy != "paginate" {
+		return fmt.Errorf("result strategy %q is not supported; supported values: collect, paginate", tool.Result.Strategy)
 	}
 
 	return nil

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -482,3 +482,262 @@ tools:
 		t.Error("expected count arg in step, not found")
 	}
 }
+
+func TestLoadTools_GetVPNHealth(t *testing.T) {
+	yaml := `
+tools:
+  - name: get-vpn-health
+    description: >
+      Get health and connection statistics for a Message VPN.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The name of the Message VPN"
+    steps:
+      - id: vpnHealth
+        operation: monitor/getMsgVpn
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+    result:
+      strategy: collect
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "get-vpn-health" {
+		t.Errorf("expected name %q, got %q", "get-vpn-health", tool.Name)
+	}
+	if len(tool.Parameters) != 1 {
+		t.Fatalf("expected 1 parameter, got %d", len(tool.Parameters))
+	}
+	if tool.Parameters[0].Name != "msgVpnName" || !tool.Parameters[0].Required {
+		t.Errorf("expected msgVpnName required parameter, got %+v", tool.Parameters[0])
+	}
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if tool.Steps[0].ID != "vpnHealth" {
+		t.Errorf("expected step ID %q, got %q", "vpnHealth", tool.Steps[0].ID)
+	}
+	if tool.Steps[0].Operation != "monitor/getMsgVpn" {
+		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpn", tool.Steps[0].Operation)
+	}
+	if tool.Steps[0].Paginate {
+		t.Error("expected Paginate=false for get-vpn-health step")
+	}
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
+	}
+}
+
+func TestLoadTools_ListVPNs(t *testing.T) {
+	yaml := `
+tools:
+  - name: list-vpns
+    description: >
+      List all Message VPNs on the broker.
+    parameters:
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of VPNs to return (default 100, max 500)"
+    steps:
+      - id: vpns
+        operation: monitor/getMsgVpns
+        paginate: true
+        args:
+          count: "100"
+    result:
+      strategy: paginate
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "list-vpns" {
+		t.Errorf("expected name %q, got %q", "list-vpns", tool.Name)
+	}
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tools))
+	}
+	if !tool.Steps[0].Paginate {
+		t.Error("expected Paginate=true for list-vpns step")
+	}
+	if tool.Steps[0].Operation != "monitor/getMsgVpns" {
+		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpns", tool.Steps[0].Operation)
+	}
+	if tool.Result.Strategy != "paginate" {
+		t.Errorf("expected strategy %q, got %q", "paginate", tool.Result.Strategy)
+	}
+}
+
+func TestLoadTools_ListQueues(t *testing.T) {
+	yaml := `
+tools:
+  - name: list-queues
+    description: >
+      List all queues in a Message VPN.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to list queues for"
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of queues to return (default 100, max 500)"
+    steps:
+      - id: queues
+        operation: monitor/getMsgVpnQueues
+        paginate: true
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          count: "100"
+    result:
+      strategy: paginate
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "list-queues" {
+		t.Errorf("expected name %q, got %q", "list-queues", tool.Name)
+	}
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if !tool.Steps[0].Paginate {
+		t.Error("expected Paginate=true for list-queues step")
+	}
+	if tool.Steps[0].Operation != "monitor/getMsgVpnQueues" {
+		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpnQueues", tool.Steps[0].Operation)
+	}
+	if tool.Result.Strategy != "paginate" {
+		t.Errorf("expected strategy %q, got %q", "paginate", tool.Result.Strategy)
+	}
+
+	// Verify optional maxResults parameter.
+	maxResults := tool.Parameters[1]
+	if maxResults.Name != "maxResults" {
+		t.Errorf("expected parameter name %q, got %q", "maxResults", maxResults.Name)
+	}
+	if maxResults.Required {
+		t.Error("expected maxResults to be optional (required=false)")
+	}
+}
+
+func TestLoadTools_ListClients(t *testing.T) {
+	yaml := `
+tools:
+  - name: list-clients
+    description: >
+      List all active client connections in a Message VPN.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to list clients for"
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of clients to return (default 100, max 500)"
+    steps:
+      - id: clients
+        operation: monitor/getMsgVpnClients
+        paginate: true
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          count: "100"
+    result:
+      strategy: paginate
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "list-clients" {
+		t.Errorf("expected name %q, got %q", "list-clients", tool.Name)
+	}
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if !tool.Steps[0].Paginate {
+		t.Error("expected Paginate=true for list-clients step")
+	}
+	if tool.Steps[0].Operation != "monitor/getMsgVpnClients" {
+		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpnClients", tool.Steps[0].Operation)
+	}
+	if tool.Result.Strategy != "paginate" {
+		t.Errorf("expected strategy %q, got %q", "paginate", tool.Result.Strategy)
+	}
+}
+
+func TestLoadTools_PaginateStrategyValid(t *testing.T) {
+	yaml := `
+tools:
+  - name: paginate-tool
+    description: A tool using paginate strategy
+    steps:
+      - id: items
+        operation: monitor/getMsgVpns
+        paginate: true
+        args:
+          count: "100"
+    result:
+      strategy: paginate
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error for paginate strategy: %v", err)
+	}
+
+	if tools[0].Result.Strategy != "paginate" {
+		t.Errorf("expected strategy %q, got %q", "paginate", tools[0].Result.Strategy)
+	}
+}

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -534,8 +534,8 @@ tools:
 	if tool.Steps[0].Operation != "monitor/getMsgVpn" {
 		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpn", tool.Steps[0].Operation)
 	}
-	if tool.Steps[0].Paginate {
-		t.Error("expected Paginate=false for get-vpn-health step")
+	if tool.Steps[0].FollowPages {
+		t.Error("expected FollowPages=false for get-vpn-health step")
 	}
 	if tool.Result.Strategy != "collect" {
 		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
@@ -556,11 +556,11 @@ tools:
     steps:
       - id: vpns
         operation: monitor/getMsgVpns
-        paginate: true
+        followPages: true
         args:
           count: "100"
     result:
-      strategy: paginate
+      strategy: collect
 `
 	fsys := fstest.MapFS{
 		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
@@ -580,16 +580,16 @@ tools:
 		t.Errorf("expected name %q, got %q", "list-vpns", tool.Name)
 	}
 	if len(tool.Steps) != 1 {
-		t.Fatalf("expected 1 step, got %d", len(tools))
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
 	}
-	if !tool.Steps[0].Paginate {
-		t.Error("expected Paginate=true for list-vpns step")
+	if !tool.Steps[0].FollowPages {
+		t.Error("expected FollowPages=true for list-vpns step")
 	}
 	if tool.Steps[0].Operation != "monitor/getMsgVpns" {
 		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpns", tool.Steps[0].Operation)
 	}
-	if tool.Result.Strategy != "paginate" {
-		t.Errorf("expected strategy %q, got %q", "paginate", tool.Result.Strategy)
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
 	}
 }
 
@@ -611,12 +611,12 @@ tools:
     steps:
       - id: queues
         operation: monitor/getMsgVpnQueues
-        paginate: true
+        followPages: true
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
     result:
-      strategy: paginate
+      strategy: collect
 `
 	fsys := fstest.MapFS{
 		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
@@ -638,14 +638,14 @@ tools:
 	if len(tool.Steps) != 1 {
 		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
 	}
-	if !tool.Steps[0].Paginate {
-		t.Error("expected Paginate=true for list-queues step")
+	if !tool.Steps[0].FollowPages {
+		t.Error("expected FollowPages=true for list-queues step")
 	}
 	if tool.Steps[0].Operation != "monitor/getMsgVpnQueues" {
 		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpnQueues", tool.Steps[0].Operation)
 	}
-	if tool.Result.Strategy != "paginate" {
-		t.Errorf("expected strategy %q, got %q", "paginate", tool.Result.Strategy)
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
 	}
 
 	// Verify optional maxResults parameter.
@@ -676,12 +676,12 @@ tools:
     steps:
       - id: clients
         operation: monitor/getMsgVpnClients
-        paginate: true
+        followPages: true
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
     result:
-      strategy: paginate
+      strategy: collect
 `
 	fsys := fstest.MapFS{
 		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
@@ -703,41 +703,13 @@ tools:
 	if len(tool.Steps) != 1 {
 		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
 	}
-	if !tool.Steps[0].Paginate {
-		t.Error("expected Paginate=true for list-clients step")
+	if !tool.Steps[0].FollowPages {
+		t.Error("expected FollowPages=true for list-clients step")
 	}
 	if tool.Steps[0].Operation != "monitor/getMsgVpnClients" {
 		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpnClients", tool.Steps[0].Operation)
 	}
-	if tool.Result.Strategy != "paginate" {
-		t.Errorf("expected strategy %q, got %q", "paginate", tool.Result.Strategy)
-	}
-}
-
-func TestLoadTools_PaginateStrategyValid(t *testing.T) {
-	yaml := `
-tools:
-  - name: paginate-tool
-    description: A tool using paginate strategy
-    steps:
-      - id: items
-        operation: monitor/getMsgVpns
-        paginate: true
-        args:
-          count: "100"
-    result:
-      strategy: paginate
-`
-	fsys := fstest.MapFS{
-		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
-	}
-
-	tools, err := LoadTools(fsys, "tools.yaml")
-	if err != nil {
-		t.Fatalf("unexpected error for paginate strategy: %v", err)
-	}
-
-	if tools[0].Result.Strategy != "paginate" {
-		t.Errorf("expected strategy %q, got %q", "paginate", tools[0].Result.Strategy)
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
 	}
 }


### PR DESCRIPTION
## Summary

- Implements 4 new composite monitoring tools: `get-vpn-health`, `list-vpns`, `list-queues`, `list-clients`
- All tools use the private SEMP monitor API (`__private_monitor__`) — consistent with the existing tools in this repo
- Extends the composite engine with automatic SEMP pagination support (`paginate: true` step field, `executePaginatedStep`), `maxResults` defaults to 100 and is capped at 500, `truncated` flag returned when results are capped

## Test plan

- [x] Unit tests added to `executor_test.go` — single-page, multi-page, truncation at `maxResults`, cap at 500, error cases
- [x] Unit tests added to `loader_test.go` — all 4 new tools load and validate correctly, `paginate` strategy accepted
- [x] All existing tests pass (`go test ./...`)
- [x] Live tested against VMR at 192.168.134.40 — all 4 tools return correct data
- [x] Pagination verified live: `list-queues` with `count=1` follows `nextPageUri` across pages and merges results correctly

