### PR TITLE
SOL-149084: Fix CI workflow not triggering on branch pushes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,8 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
       - 'v*'
   workflow_call:


### PR DESCRIPTION
## Summary
- Adding `tags-ignore` without an explicit `branches` filter in `d87a359` caused GitHub Actions to scope the `on: push` trigger to tag events only, silently skipping all branch pushes since April 24
- Adds `branches: ['**']` to restore CI for all branch pushes
- Verified fix on the `test` branch — workflow triggered successfully

## Test plan
- [x] Pushed fix to `test` branch, confirmed Build and Test workflow triggered
- [ ] Verify this PR itself triggers the Build and Test workflow after merge