### PR TITLE
SOL-148433: Implement Remaining Monitoring Tools (DMR, Message Rates, RDP)

### DIFF
--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -266,7 +266,6 @@ tools:
           dmrClusterName: "{{.Params.dmrClusterName}}"
       - id: links
         operation: monitor/getDmrClusterLinks
-        parallel: true
         args:
           dmrClusterName: "{{.Params.dmrClusterName}}"
     result:

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -226,3 +226,75 @@ tools:
           count: "100"
     result:
       strategy: collect
+
+  - name: get-message-rates
+    description: >
+      Get current and average message and byte throughput rates for a Message
+      VPN. Use this to assess traffic volume and identify high-traffic VPNs.
+    annotations:
+      readOnly: true
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The name of the Message VPN"
+    steps:
+      - id: rates
+        operation: monitor/getMsgVpn
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+    result:
+      strategy: collect
+
+  - name: get-dmr-status
+    description: >
+      Get the status of a DMR cluster including its enabled state, uptime, and
+      all link statuses. Returns the cluster object and a links array. To find
+      upLinkCount and downLinkCount, count links where up is true or false
+      respectively. Use this to diagnose mesh connectivity issues.
+    annotations:
+      readOnly: true
+    parameters:
+      - name: dmrClusterName
+        type: string
+        required: true
+        description: "The name of the DMR cluster"
+    steps:
+      - id: cluster
+        operation: monitor/getDmrCluster
+        args:
+          dmrClusterName: "{{.Params.dmrClusterName}}"
+      - id: links
+        operation: monitor/getDmrClusterLinks
+        parallel: true
+        args:
+          dmrClusterName: "{{.Params.dmrClusterName}}"
+    result:
+      strategy: collect
+
+  - name: list-rdps
+    description: >
+      List all REST Delivery Points in a Message VPN with their enabled state,
+      up/down status, and last failure reason. Use this to discover which RDPs
+      exist and identify any that are down. For detailed RDP status including
+      consumers and queue bindings, use get-rdp-status.
+    annotations:
+      readOnly: true
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to list REST Delivery Points for"
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of RDPs to return (default 100, max 500)"
+    steps:
+      - id: rdps
+        operation: monitor/getMsgVpnRestDeliveryPoints
+        followPages: true
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          count: "100"
+    result:
+      strategy: collect

--- a/internal/composite/executor_test.go
+++ b/internal/composite/executor_test.go
@@ -107,6 +107,21 @@ func testOperations() map[string]*sempv2.Operation {
 			Method: "GET",
 			Path:   "/SEMP/v2/__private_monitor__/msgVpns/{msgVpnName}/clients",
 		},
+		"monitor/getDmrCluster": {
+			ID:     "getDmrCluster",
+			Method: "GET",
+			Path:   "/SEMP/v2/__private_monitor__/dmrClusters/{dmrClusterName}",
+		},
+		"monitor/getDmrClusterLinks": {
+			ID:     "getDmrClusterLinks",
+			Method: "GET",
+			Path:   "/SEMP/v2/__private_monitor__/dmrClusters/{dmrClusterName}/links",
+		},
+		"monitor/getMsgVpnRestDeliveryPoints": {
+			ID:     "getMsgVpnRestDeliveryPoints",
+			Method: "GET",
+			Path:   "/SEMP/v2/__private_monitor__/msgVpns/{msgVpnName}/restDeliveryPoints",
+		},
 	}
 }
 
@@ -958,6 +973,15 @@ func makeClientItems(n int) []any {
 	return items
 }
 
+// makeRDPItems builds a slice of n mock RDP objects for use in paginated responses.
+func makeRDPItems(n int) []any {
+	items := make([]any, n)
+	for i := range items {
+		items[i] = map[string]any{"restDeliveryPointName": fmt.Sprintf("rdp-%d", i), "enabled": true}
+	}
+	return items
+}
+
 // pageResult builds a SEMP list response with optional pagination cursor.
 func pageResult(items []any, nextCursor string) *sempv2.Result {
 	data := map[string]any{"data": items}
@@ -1360,4 +1384,238 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// getMessageRatesTool returns the get-message-rates tool definition for tests.
+func getMessageRatesTool() CompositeTool {
+	return CompositeTool{
+		Name:        "get-message-rates",
+		Description: "Get current and average message and byte rates for a Message VPN",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+		},
+		Steps: []Step{
+			{
+				ID:        "rates",
+				Operation: "monitor/getMsgVpn",
+				Args: map[string]string{
+					"msgVpnName": "{{.Params.msgVpnName}}",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+}
+
+// getDMRStatusTool returns the get-dmr-status tool definition for tests.
+func getDMRStatusTool() CompositeTool {
+	return CompositeTool{
+		Name:        "get-dmr-status",
+		Description: "Get the status of a DMR cluster",
+		Parameters: []ParameterDef{
+			{Name: "dmrClusterName", Type: "string", Required: true},
+		},
+		Steps: []Step{
+			{
+				ID:        "cluster",
+				Operation: "monitor/getDmrCluster",
+				Args: map[string]string{
+					"dmrClusterName": "{{.Params.dmrClusterName}}",
+				},
+			},
+			{
+				ID:        "links",
+				Operation: "monitor/getDmrClusterLinks",
+				Parallel:  true,
+				Args: map[string]string{
+					"dmrClusterName": "{{.Params.dmrClusterName}}",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+}
+
+// listRDPsTool returns the list-rdps tool definition for tests.
+func listRDPsTool() CompositeTool {
+	return CompositeTool{
+		Name:        "list-rdps",
+		Description: "List all REST Delivery Points in a Message VPN",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+			{Name: "maxResults", Type: "integer", Required: false},
+		},
+		Steps: []Step{
+			{
+				ID:          "rdps",
+				Operation:   "monitor/getMsgVpnRestDeliveryPoints",
+				FollowPages: true,
+				Args: map[string]string{
+					"msgVpnName": "{{.Params.msgVpnName}}",
+					"count":      "100",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+}
+
+func TestExecute_GetMessageRates_ReturnsData(t *testing.T) {
+	client := newMockClient()
+	client.responses["getMsgVpn"] = &sempv2.Result{
+		Data: map[string]any{
+			"rxMsgRate":              float64(150),
+			"txMsgRate":              float64(200),
+			"rxByteRate":             float64(15000),
+			"txByteRate":             float64(20000),
+			"averageRxMsgRate":       float64(140),
+			"averageTxMsgRate":       float64(190),
+			"averageRxByteRate":      float64(14000),
+			"averageTxByteRate":      float64(19000),
+		},
+		StatusCode: 200,
+	}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), getMessageRatesTool(), client, map[string]any{
+		"msgVpnName": "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rates, ok := result["rates"].(map[string]any)
+	if !ok {
+		t.Fatal("expected rates key containing a map")
+	}
+	if rates["rxMsgRate"] != float64(150) {
+		t.Errorf("rxMsgRate = %v, want 150", rates["rxMsgRate"])
+	}
+	if rates["txMsgRate"] != float64(200) {
+		t.Errorf("txMsgRate = %v, want 200", rates["txMsgRate"])
+	}
+}
+
+func TestExecute_GetDMRStatus_ReturnsClusterAndLinks(t *testing.T) {
+	client := newMockClient()
+	client.responses["getDmrCluster"] = &sempv2.Result{
+		Data: map[string]any{
+			"dmrClusterName": "cluster-1",
+			"enabled":        true,
+		},
+		StatusCode: 200,
+	}
+	client.responses["getDmrClusterLinks"] = &sempv2.Result{
+		Data: map[string]any{
+			"data": []any{
+				map[string]any{"remoteNodeName": "node-a", "up": true},
+				map[string]any{"remoteNodeName": "node-b", "up": false},
+			},
+		},
+		StatusCode: 200,
+	}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), getDMRStatusTool(), client, map[string]any{
+		"dmrClusterName": "cluster-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterData, ok := result["cluster"].(map[string]any)
+	if !ok {
+		t.Fatal("expected cluster key containing a map")
+	}
+	if clusterData["dmrClusterName"] != "cluster-1" {
+		t.Errorf("dmrClusterName = %v, want cluster-1", clusterData["dmrClusterName"])
+	}
+
+	if _, ok := result["links"]; !ok {
+		t.Fatal("expected links key in result")
+	}
+}
+
+func TestExecute_GetDMRStatus_SEMPError(t *testing.T) {
+	client := newMockClient()
+	client.errors["getDmrCluster"] = &sempv2.SEMPError{
+		Operation:  "getDmrCluster",
+		StatusCode: 404,
+	}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	_, err := executor.Execute(context.Background(), getDMRStatusTool(), client, map[string]any{
+		"dmrClusterName": "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error when cluster step fails, got nil")
+	}
+}
+
+func TestExecute_ListRDPs_SinglePage(t *testing.T) {
+	rdpItems := []any{
+		map[string]any{"restDeliveryPointName": "rdp-1", "enabled": true, "up": true},
+		map[string]any{"restDeliveryPointName": "rdp-2", "enabled": true, "up": false},
+	}
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnRestDeliveryPoints", pageResult(rdpItems, ""))
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listRDPsTool(), client, map[string]any{
+		"msgVpnName": "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rdps, ok := result["rdps"].(map[string]any)
+	if !ok {
+		t.Fatal("expected rdps key containing a map")
+	}
+	items, ok := rdps["data"].([]any)
+	if !ok {
+		t.Fatal("expected rdps.data to be a slice")
+	}
+	if len(items) != 2 {
+		t.Errorf("len(items) = %d, want 2", len(items))
+	}
+	if rdps["truncated"] != false {
+		t.Errorf("truncated = %v, want false", rdps["truncated"])
+	}
+	if len(client.calls) != 1 {
+		t.Errorf("expected 1 SEMP call, got %d", len(client.calls))
+	}
+}
+
+func TestExecute_ListRDPs_TruncatesAtMaxResults(t *testing.T) {
+	// Page has 100 RDPs but maxResults=50, paginator should stop and set truncated.
+	client := newSeqMockClient()
+	client.addResponses("getMsgVpnRestDeliveryPoints", pageResult(makeRDPItems(100), "cursor-next"))
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), listRDPsTool(), client, map[string]any{
+		"msgVpnName": "default",
+		"maxResults": float64(50),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rdps := result["rdps"].(map[string]any)
+	items := rdps["data"].([]any)
+
+	if len(items) != 50 {
+		t.Errorf("len(items) = %d, want 50", len(items))
+	}
+	if rdps["truncated"] != true {
+		t.Errorf("truncated = %v, want true", rdps["truncated"])
+	}
+	if len(client.calls) != 1 {
+		t.Errorf("expected 1 SEMP call, got %d", len(client.calls))
+	}
 }

--- a/internal/composite/executor_test.go
+++ b/internal/composite/executor_test.go
@@ -1426,7 +1426,6 @@ func getDMRStatusTool() CompositeTool {
 			{
 				ID:        "links",
 				Operation: "monitor/getDmrClusterLinks",
-				Parallel:  true,
 				Args: map[string]string{
 					"dmrClusterName": "{{.Params.dmrClusterName}}",
 				},

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -713,3 +713,198 @@ tools:
 		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
 	}
 }
+
+func TestLoadTools_GetMessageRates(t *testing.T) {
+	yaml := `
+tools:
+  - name: get-message-rates
+    description: >
+      Get current and average message and byte rates for a Message VPN.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The name of the Message VPN"
+    steps:
+      - id: rates
+        operation: monitor/getMsgVpn
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+    result:
+      strategy: collect
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "get-message-rates" {
+		t.Errorf("expected name %q, got %q", "get-message-rates", tool.Name)
+	}
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if tool.Steps[0].Operation != "monitor/getMsgVpn" {
+		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpn", tool.Steps[0].Operation)
+	}
+	if tool.Steps[0].FollowPages {
+		t.Error("expected FollowPages=false for get-message-rates step")
+	}
+	if tool.Steps[0].Parallel {
+		t.Error("expected Parallel=false for get-message-rates step")
+	}
+	if len(tool.Parameters) != 1 {
+		t.Fatalf("expected 1 parameter, got %d", len(tool.Parameters))
+	}
+	if tool.Parameters[0].Name != "msgVpnName" || !tool.Parameters[0].Required {
+		t.Error("expected required msgVpnName parameter")
+	}
+}
+
+func TestLoadTools_GetDMRStatus(t *testing.T) {
+	yaml := `
+tools:
+  - name: get-dmr-status
+    description: >
+      Get the status of a DMR cluster.
+    parameters:
+      - name: dmrClusterName
+        type: string
+        required: true
+        description: "The name of the DMR cluster"
+    steps:
+      - id: cluster
+        operation: monitor/getDmrCluster
+        args:
+          dmrClusterName: "{{.Params.dmrClusterName}}"
+      - id: links
+        operation: monitor/getDmrClusterLinks
+        parallel: true
+        args:
+          dmrClusterName: "{{.Params.dmrClusterName}}"
+    result:
+      strategy: collect
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "get-dmr-status" {
+		t.Errorf("expected name %q, got %q", "get-dmr-status", tool.Name)
+	}
+	if len(tool.Steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(tool.Steps))
+	}
+
+	clusterStep := tool.Steps[0]
+	if clusterStep.ID != "cluster" {
+		t.Errorf("expected step ID %q, got %q", "cluster", clusterStep.ID)
+	}
+	if clusterStep.Operation != "monitor/getDmrCluster" {
+		t.Errorf("expected operation %q, got %q", "monitor/getDmrCluster", clusterStep.Operation)
+	}
+	if clusterStep.Parallel {
+		t.Error("expected first step Parallel=false (sequential)")
+	}
+
+	linksStep := tool.Steps[1]
+	if linksStep.ID != "links" {
+		t.Errorf("expected step ID %q, got %q", "links", linksStep.ID)
+	}
+	if linksStep.Operation != "monitor/getDmrClusterLinks" {
+		t.Errorf("expected operation %q, got %q", "monitor/getDmrClusterLinks", linksStep.Operation)
+	}
+	if !linksStep.Parallel {
+		t.Error("expected second step Parallel=true")
+	}
+
+	if len(tool.Parameters) != 1 {
+		t.Fatalf("expected 1 parameter, got %d", len(tool.Parameters))
+	}
+	if tool.Parameters[0].Name != "dmrClusterName" || !tool.Parameters[0].Required {
+		t.Error("expected required dmrClusterName parameter")
+	}
+}
+
+func TestLoadTools_ListRDPs(t *testing.T) {
+	yaml := `
+tools:
+  - name: list-rdps
+    description: >
+      List all REST Delivery Points in a Message VPN.
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to list REST Delivery Points for"
+      - name: maxResults
+        type: integer
+        required: false
+        description: "Maximum number of RDPs to return (default 100, max 500)"
+    steps:
+      - id: rdps
+        operation: monitor/getMsgVpnRestDeliveryPoints
+        followPages: true
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          count: "100"
+    result:
+      strategy: collect
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "list-rdps" {
+		t.Errorf("expected name %q, got %q", "list-rdps", tool.Name)
+	}
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if !tool.Steps[0].FollowPages {
+		t.Error("expected FollowPages=true for list-rdps step")
+	}
+	if tool.Steps[0].Operation != "monitor/getMsgVpnRestDeliveryPoints" {
+		t.Errorf("expected operation %q, got %q", "monitor/getMsgVpnRestDeliveryPoints", tool.Steps[0].Operation)
+	}
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
+	}
+
+	maxResults := tool.Parameters[1]
+	if maxResults.Name != "maxResults" {
+		t.Errorf("expected parameter name %q, got %q", "maxResults", maxResults.Name)
+	}
+	if maxResults.Required {
+		t.Error("expected maxResults to be optional (required=false)")
+	}
+}

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -788,7 +788,6 @@ tools:
           dmrClusterName: "{{.Params.dmrClusterName}}"
       - id: links
         operation: monitor/getDmrClusterLinks
-        parallel: true
         args:
           dmrClusterName: "{{.Params.dmrClusterName}}"
     result:
@@ -833,8 +832,8 @@ tools:
 	if linksStep.Operation != "monitor/getDmrClusterLinks" {
 		t.Errorf("expected operation %q, got %q", "monitor/getDmrClusterLinks", linksStep.Operation)
 	}
-	if !linksStep.Parallel {
-		t.Error("expected second step Parallel=true")
+	if linksStep.Parallel {
+		t.Error("expected second step Parallel=false (no concurrent partner step)")
 	}
 
 	if len(tool.Parameters) != 1 {
@@ -900,6 +899,12 @@ tools:
 		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
 	}
 
+	if len(tool.Parameters) != 2 {
+		t.Fatalf("expected 2 parameters, got %d", len(tool.Parameters))
+	}
+	if tool.Parameters[0].Name != "msgVpnName" {
+		t.Errorf("expected first parameter name %q, got %q", "msgVpnName", tool.Parameters[0].Name)
+	}
 	maxResults := tool.Parameters[1]
 	if maxResults.Name != "maxResults" {
 		t.Errorf("expected parameter name %q, got %q", "maxResults", maxResults.Name)


### PR DESCRIPTION
## Summary

Adds 3 new composite monitoring tools as pure YAML definitions — no new Go files.

- **`get-message-rates`** — Returns the full VPN object including all throughput rate fields (rx/tx message and byte rates, 1-minute averages) via `monitor/getMsgVpn`
- **`get-dmr-status`** — Two-step tool (cluster sequential + links parallel) via `monitor/getDmrCluster` + `monitor/getDmrClusterLinks`. The composite engine has no aggregation capability so `upLinkCount`/`downLinkCount` are not pre-computed — the tool description instructs the AI to derive them by counting links where `up == true/false`
- **`list-rdps`** — Paginated listing of all REST Delivery Points in a VPN via `monitor/getMsgVpnRestDeliveryPoints`, follows pages up to `maxResults` (default 100, max 500), consistent with `list-queues` and `list-clients`

Server now loads `tool_count: 11`.

## Changes

- `internal/composite/definitions/tools.yaml` — 3 new tool definitions
- `internal/composite/loader_test.go` — 3 new loader tests
- `internal/composite/executor_test.go` — 3 new operations in `testOperations()`, tool helpers, and tests covering happy path, SEMP error propagation, single-page results, and `maxResults` truncation

## Testing

- All unit tests pass
- `get-message-rates` and `list-rdps` verified end-to-end via MCP against a live broker
- `get-dmr-status` not testable on dev broker (no DMR clusters configured) — unit tests cover the logic

## Note on `get-dmr-status` computed fields

[The story](https://sol-jira.atlassian.net/browse/SOL-148433) calls for pre-computing `upLinkCount`/`downLinkCount`. The composite engine returns raw SEMP data only — no aggregation. Rather than extending the engine or writing a Go-native tool for a simple count, the tool returns the raw cluster object and links array and the description instructs the AI to derive the counts. Open to feedback if a different approach is preferred.

