### PR TITLE
SOL-149404: Apply select= field filtering to all monitoring tools to reduce response size returned to the LLM

### DIFF
--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -48,12 +48,14 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           restDeliveryPointName: "{{.Params.restDeliveryPointName}}"
+          select: "lastFailureReason, lastFailureTime, postRequestTarget, queueBindingName, restDeliveryPointName, up, uptime"
       - id: restConsumers
         operation: monitor/getMsgVpnRestDeliveryPointRestConsumers
         parallel: true
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           restDeliveryPointName: "{{.Params.restDeliveryPointName}}"
+          select: "authenticationScheme, enabled, httpRequestOutstandingTxMsgCount, httpRequestTimedOutTxMsgCount, httpRequestTxMsgCount, httpResponseErrorRxMsgCount, httpResponseSuccessRxMsgCount, lastConnectionFailureReason, lastConnectionFailureTime, lastFailureReason, lastFailureTime, outgoingConnectionCount, remoteHost, remotePort, restConsumerName, restDeliveryPointName, up"
     result:
       strategy: collect
 
@@ -79,6 +81,7 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           queueName: "{{.Params.queueName}}"
+          select: "accessType, averageRxMsgRate, averageTxMsgRate, bindCount, durable, egressEnabled, ingressEnabled, lowPriorityMsgCongestionState, maxBindCount, maxMsgSize, maxMsgSpoolUsage, maxMsgSpoolUsageExceededDiscardedMsgCount, maxRedeliveryCount, maxRedeliveryExceededDiscardedMsgCount, maxTtl, maxTtlExceededDiscardedMsgCount, msgSpoolUsage, msgVpnName, noLocalDeliveryDiscardedMsgCount, owner, queueName, redeliveredMsgCount, rxByteRate, rxMsgRate, spooledMsgCount, txByteRate, txMsgRate, txUnackedMsgCount"
     result:
       strategy: collect
 
@@ -104,6 +107,7 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           clientName: "{{.Params.clientName}}"
+          select: "averageRxMsgRate, averageTxMsgRate, clientAddress, clientName, clientUsername, elidingTopicCount, keepalive, msgVpnName, platform, rxByteRate, rxDiscardedMsgCount, rxFlowCount, rxMsgCount, rxMsgRate, slowSubscriber, softwareVersion, subscriptionCount, txByteRate, txDiscardedMsgCount, txFlowCount, txMsgCount, txMsgRate, uptime"
     result:
       strategy: collect
 
@@ -155,6 +159,7 @@ tools:
         operation: monitor/getMsgVpn
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
+          select: "discardedRxMsgCount, discardedTxMsgCount, enabled, maxConnectionCount, msgSpoolMsgCount, msgSpoolUsage, msgVpnConnections, msgVpnConnectionsServiceMqtt, msgVpnConnectionsServiceRestIncoming, msgVpnConnectionsServiceRestOutgoing, msgVpnConnectionsServiceSmf, msgVpnConnectionsServiceWeb, msgVpnName, msgVpnTotalUniqueSubscriptions, serviceAmqpPlainTextFailureReason, serviceAmqpPlainTextUp, serviceMqttPlainTextFailureReason, serviceMqttPlainTextUp, serviceMqttTlsFailureReason, serviceMqttTlsUp, serviceRestIncomingPlainTextFailureReason, serviceRestIncomingPlainTextUp, serviceRestIncomingTlsFailureReason, serviceRestIncomingTlsUp, serviceSmfPlainTextFailureReason, serviceSmfPlainTextUp, serviceSmfTlsFailureReason, serviceSmfTlsUp, state"
     result:
       strategy: collect
 
@@ -177,6 +182,7 @@ tools:
         followPages: true
         args:
           count: "100"
+          select: "discardedRxMsgCount, discardedTxMsgCount, dmrEnabled, enabled, msgSpoolMsgCount, msgSpoolUsage, msgVpnConnections, msgVpnConnectionsServiceMqtt, msgVpnConnectionsServiceRestIncoming, msgVpnConnectionsServiceSmf, msgVpnConnectionsServiceWeb, msgVpnName, msgVpnTotalUniqueSubscriptions, replicationEnabled, serviceMqttPlainTextFailureReason, serviceMqttPlainTextUp, serviceRestIncomingPlainTextFailureReason, serviceRestIncomingPlainTextUp, serviceSmfPlainTextFailureReason, serviceSmfPlainTextUp, state"
     result:
       strategy: collect
 
@@ -204,6 +210,7 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
+          select: "accessType, bindCount, egressEnabled, ingressEnabled, lowPriorityMsgCongestionState, maxMsgSpoolUsage, msgSpoolUsage, msgVpnName, queueName, rxMsgRate, spooledMsgCount, txMsgRate, txUnackedMsgCount"
     result:
       strategy: collect
 
@@ -231,6 +238,7 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
+          select: "clientAddress, clientName, clientUsername, msgVpnName, platform, rxMsgRate, slowSubscriber, txMsgRate, uptime"
     result:
       strategy: collect
 
@@ -250,6 +258,7 @@ tools:
         operation: monitor/getMsgVpn
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
+          select: "averageRxByteRate, averageRxMsgRate, averageTxByteRate, averageTxMsgRate, msgVpnName, rxByteRate, rxMsgRate, txByteRate, txMsgRate"
     result:
       strategy: collect
 
@@ -271,10 +280,12 @@ tools:
         operation: monitor/getDmrCluster
         args:
           dmrClusterName: "{{.Params.dmrClusterName}}"
+          select: "dmrClusterName, enabled, failureReason, nodeName, subscriptionDbBuildPercentage, syncComplete, topologyIssueCount, up, uptime"
       - id: links
         operation: monitor/getDmrClusterLinks
         args:
           dmrClusterName: "{{.Params.dmrClusterName}}"
+          select: "connectionRetryCount, dmrClusterName, enabled, failureReason, remoteNodeName, span, transportTlsEnabled, up, uptime"
     result:
       strategy: collect
 
@@ -302,5 +313,6 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
+          select: "clientName, enabled, lastFailureReason, lastFailureTime, msgVpnName, restDeliveryPointName, up"
     result:
       strategy: collect

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -42,6 +42,7 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           restDeliveryPointName: "{{.Params.restDeliveryPointName}}"
+          select: "clientName, clientProfileName, enabled, lastFailureReason, lastFailureTime, msgVpnName, restDeliveryPointName, timeConnectionsBlocked, up"
       - id: queueBindings
         operation: monitor/getMsgVpnRestDeliveryPointQueueBindings
         parallel: true

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -181,6 +181,7 @@ func (c *HTTPClient) buildURL(op *Operation, args map[string]any) string {
 // based on the operation's parameter definitions.
 func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL string, args map[string]any) (*http.Request, error) {
 	queryParams := url.Values{}
+	var arrayQueryParts []string // pre-encoded "name=v1,v2,v3" segments for array-typed params
 	var bodyData []byte
 
 	for _, param := range op.Parameters {
@@ -188,9 +189,19 @@ func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL str
 		case "path":
 			continue
 		case "query":
-			if val, ok := args[param.Name]; ok {
-				queryParams.Set(param.Name, fmt.Sprintf("%v", val))
+			val, ok := args[param.Name]
+			if !ok {
+				continue
 			}
+			if param.Type == "array" {
+				// SEMP v2 declares select/where as type=array, collectionFormat=csv: a single
+				// query param whose value is a comma-joined list. url.Values.Encode percent-
+				// encodes the commas to %2C, which the broker rejects ("'a,b,c' not a valid
+				// attribute"). Encode each element individually and join with raw commas.
+				arrayQueryParts = append(arrayQueryParts, encodeCSVQueryParam(param.Name, val))
+				continue
+			}
+			queryParams.Set(param.Name, fmt.Sprintf("%v", val))
 		case "body":
 			if body, ok := args["body"]; ok {
 				var err error
@@ -207,8 +218,17 @@ func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL str
 		}
 	}
 
-	if len(queryParams) > 0 {
-		reqURL = reqURL + "?" + queryParams.Encode()
+	queryString := queryParams.Encode()
+	if len(arrayQueryParts) > 0 {
+		joined := strings.Join(arrayQueryParts, "&")
+		if queryString != "" {
+			queryString += "&" + joined
+		} else {
+			queryString = joined
+		}
+	}
+	if queryString != "" {
+		reqURL = reqURL + "?" + queryString
 	}
 
 	var bodyReader io.Reader
@@ -225,6 +245,36 @@ func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL str
 	req.Header.Set("User-Agent", "solace/broker-mcp-server/"+version.Version())
 
 	return req, nil
+}
+
+// encodeCSVQueryParam serializes an array-typed query parameter in SEMP v2's
+// collectionFormat=csv shape: each element is percent-encoded individually,
+// then joined with literal commas (e.g. "select=a,b,c"). The input value is
+// either a comma-joined string (the typical YAML path) or a slice; both are
+// flattened to a single comma-separated query param value.
+func encodeCSVQueryParam(name string, val any) string {
+	var parts []string
+	switch v := val.(type) {
+	case []string:
+		parts = v
+	case []any:
+		parts = make([]string, len(v))
+		for i, e := range v {
+			parts[i] = fmt.Sprintf("%v", e)
+		}
+	default:
+		parts = strings.Split(fmt.Sprintf("%v", v), ",")
+	}
+
+	encoded := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		encoded = append(encoded, url.QueryEscape(p))
+	}
+	return url.QueryEscape(name) + "=" + strings.Join(encoded, ",")
 }
 
 // parseSEMPError creates a SEMPError with best-effort extraction of the

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -169,6 +169,141 @@ func TestClient_Execute_QueryParams_ArrayCSVRawCommas(t *testing.T) {
 	}
 }
 
+// TestClient_Execute_QueryParams_ArrayCSV_StringSlice pins the []string input
+// path: array params constructed in Go code (not via YAML) must still produce
+// raw-comma CSV.
+func TestClient_Execute_QueryParams_ArrayCSV_StringSlice(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw := r.URL.RawQuery
+		if !strings.Contains(raw, "select=a,b,c") {
+			t.Errorf("RawQuery = %q, expected select=a,b,c", raw)
+		}
+		if strings.Contains(raw, "%2C") || strings.Contains(raw, "%2c") {
+			t.Errorf("RawQuery = %q, expected raw commas in array params, not %%2C", raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+		Parameters: []sempv2.Parameter{
+			{Name: "select", In: "query", Type: "array"},
+		},
+	}
+
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"select": []string{"a", "b", "c"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+// TestClient_Execute_QueryParams_ArrayCSV_AnySlice pins the []any input path:
+// YAML unmarshalling produces []any for a list, and that shape must serialize
+// the same as []string.
+func TestClient_Execute_QueryParams_ArrayCSV_AnySlice(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw := r.URL.RawQuery
+		if !strings.Contains(raw, "select=a,b,c") {
+			t.Errorf("RawQuery = %q, expected select=a,b,c", raw)
+		}
+		if strings.Contains(raw, "%2C") || strings.Contains(raw, "%2c") {
+			t.Errorf("RawQuery = %q, expected raw commas in array params, not %%2C", raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+		Parameters: []sempv2.Parameter{
+			{Name: "select", In: "query", Type: "array"},
+		},
+	}
+
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"select": []any{"a", "b", "c"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+// TestClient_Execute_QueryParams_ArrayCSV_TrimsAndDropsEmpty pins the
+// whitespace-trim and empty-element-drop behavior so a sloppy input like
+// "a, b , ,c" still produces a clean "a,b,c" on the wire.
+func TestClient_Execute_QueryParams_ArrayCSV_TrimsAndDropsEmpty(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw := r.URL.RawQuery
+		if !strings.Contains(raw, "select=a,b,c") {
+			t.Errorf("RawQuery = %q, expected trimmed select=a,b,c", raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+		Parameters: []sempv2.Parameter{
+			{Name: "select", In: "query", Type: "array"},
+		},
+	}
+
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"select": "a, b , ,c",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+// TestClient_Execute_QueryParams_ArrayCSV_CoexistsWithRegularParam ensures the
+// raw-comma array param and a standard-encoded query param both reach the
+// broker in the same request.
+func TestClient_Execute_QueryParams_ArrayCSV_CoexistsWithRegularParam(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw := r.URL.RawQuery
+		if !strings.Contains(raw, "select=a,b") {
+			t.Errorf("RawQuery = %q, missing raw-comma select=a,b", raw)
+		}
+		if r.URL.Query().Get("count") != "100" {
+			t.Errorf("count = %q, want 100", r.URL.Query().Get("count"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+		Parameters: []sempv2.Parameter{
+			{Name: "select", In: "query", Type: "array"},
+			{Name: "count", In: "query"},
+		},
+	}
+
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"select": "a,b",
+		"count":  "100",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
 func TestClient_Execute_RequestBody(t *testing.T) {
 	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PUT" {

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -134,6 +134,41 @@ func TestClient_Execute_QueryParams(t *testing.T) {
 	}
 }
 
+// TestClient_Execute_QueryParams_ArrayCSVRawCommas pins the wire format for
+// SEMP v2 array query params (select, where): a single param whose value uses
+// raw commas, not %2C. The broker treats %2C-encoded commas as part of the
+// attribute name and rejects the request with "not a valid attribute".
+func TestClient_Execute_QueryParams_ArrayCSVRawCommas(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw := r.URL.RawQuery
+		if !strings.Contains(raw, "select=clientName,msgVpnName,uptime") {
+			t.Errorf("RawQuery = %q, expected raw-comma-joined select=clientName,msgVpnName,uptime", raw)
+		}
+		if strings.Contains(raw, "%2C") || strings.Contains(raw, "%2c") {
+			t.Errorf("RawQuery = %q, expected raw commas in array params, not %%2C", raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+		Parameters: []sempv2.Parameter{
+			{Name: "select", In: "query", Type: "array"},
+		},
+	}
+
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"select": "clientName,msgVpnName,uptime",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
 func TestClient_Execute_RequestBody(t *testing.T) {
 	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PUT" {


### PR DESCRIPTION
## Summary

Reduces the size of SEMP monitoring responses sent to the LLM by requesting
only the fields each tool actually uses, via the SEMP v2 `select=` query
parameter. Also fixes the HTTP client so array-typed query parameters
(`select`, `where`) are encoded in SEMP's `collectionFormat=csv` shape
instead of being rejected by the broker.

Fixes [SOL-149404](https://sol-jira.atlassian.net/browse/SOL-149404)

## Type of Change

- [x] Performance improvement
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Monitoring tools were returning full objects from the broker, which pushed
large, mostly-unused payloads into the LLM context and inflated token
usage. SEMP v2 supports `select=` for field filtering, but our HTTP client
was url-encoding the commas in array-typed query params (`%2C`), and the
broker rejects those with `'a,b,c' not a valid attribute`. So enabling
`select=` required fixing the encoding path first.

## Changes Made

- `internal/semp/sempv2/client.go`: split query-param construction so
  array-typed params (e.g. `select`, `where`) are pre-encoded as
  `name=v1,v2,v3` with literal commas and appended alongside the
  standard-encoded params.
- `internal/semp/sempv2/client.go`: new `encodeCSVQueryParam` helper that
  accepts `[]string`, `[]any`, or a comma-joined string, trims empties,
  and percent-encodes each element individually.
- `internal/semp/sempv2/client_test.go`: tests covering the CSV encoding
  (string / slice inputs, empty-element trimming, coexistence with
  non-array query params).
- `internal/composite/definitions/tools.yaml`: added curated `select=`
  lists to 10 monitoring tool operations (VPN, queues, clients, RDP,
  DMR cluster + links, rates, etc.), keeping only fields the tool
  actually surfaces.

## Testing

**Test Environment:**
- Go version: 1.25.0 linux/amd64
- OS: Linux (Fedora) 40
- Broker version: Solace PubSub+ Software (VMR), SEMP 100.0main.0.7549 (internal lab build)

**Tests Performed:**
- [x] Unit tests added/updated (`client_test.go`)
- [x] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker 

**Test Coverage:**
- CSV-encoded `select` values reach the broker with raw commas
- Array param coexists with non-array params in the same request
- Empty / whitespace entries in the select list are dropped
- Existing (non-array) query-param behavior is unchanged

## Breaking Changes

None. Tools return a strict subset of the fields they returned before; no
public Go API changed.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Comment on `buildRequest` explains *why* CSV is encoded manually
- [x] No commented-out code or debug statements

### Security
- [x] No credentials in code
- [x] No new credential-carrying types
- [x] `/check-logs` run — no new logging violations

### Testing
- [x] `go test -race ./...` passes locally
- [x] Edge cases covered (empty entries, slice vs string input)

### Documentation
- [x] README.md — N/A (no user-facing surface change)
- [x] docs/ — N/A
- [x] godoc on `encodeCSVQueryParam` explains the SEMP CSV contract

### Git & CI
- [x] Commits signed off (DCO)  <!-- verify with `git log --show-signature` -->
- [x] Clear commit message (`SOL-149404: ...`)
- [x] Branch up to date with main
- [x] No merge conflicts

## Additional Notes

The `select=` lists are hand-curated per tool. If a tool is extended to
show more fields in the future, the corresponding `select=` list in
`tools.yaml` must be expanded too, or the new field will silently be
absent from the response.

## Related Issues/PRs

- SOL-149343 (prior PR correcting list tool descriptions — same series)

---

**For Reviewers:**

**Focus Areas:**
- `encodeCSVQueryParam` — correctness of the manual encoding (matches
  what SEMP expects, handles all input shapes we produce from YAML).
- The `select=` field lists in `tools.yaml` — are any important fields
  missing for the use cases each tool supports?



[SOL-149404]: https://sol-jira.atlassian.net/browse/SOL-149404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ