### PR TITLE
DATAGO-133545: Add FOSSA scan to build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,24 @@ on:
       - 'v*'
   workflow_call:
 
+permissions:
+  contents: read
+  packages: read
+  pull-requests: write
+  id-token: write
+  actions: read
+  checks: write
+  statuses: write
+
 jobs:
+  fossa_scan:
+    if: github.event_name == 'push'
+    name: FOSSA Scan
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    with:
+      use_vault: true
+      config_file: '.github/workflow-config.json'
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds a `fossa_scan` job to the `build-and-test.yml` workflow so FOSSA runs on every branch push, establishing baseline scans on `main`
- Guarded with `if: github.event_name == 'push'` to avoid duplicate scans when called via `workflow_call` from the release workflow
- Adds required permissions (`id-token: write`, `pull-requests: write`, etc.) for Vault-based FOSSA authentication

## Test plan
- [ ] Verify FOSSA scan runs on push to a feature branch
- [ ] Verify FOSSA scan runs on push to `main`
- [ ] Verify FOSSA scan is skipped when `build-and-test` is called via `workflow_call` from `release.yml`
- [ ] Confirm existing lint, build, and e2e jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)