### PR TITLE
SOL-149663: Fix stale documentation (architecture, release guide, contributing, e2e)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -123,7 +123,7 @@ go run ./cmd/server
 
 ## Coding Standards
 
-This project follows the principles documented in `docs/good-code.md`. Key guidelines:
+This project follows standard Go coding principles. Key guidelines:
 
 ### Go Style
 

--- a/.github/RELEASE_GUIDE.md
+++ b/.github/RELEASE_GUIDE.md
@@ -96,12 +96,12 @@ gh run list --workflow=release.yml --limit 1
 gh run view --log
 ```
 
-**Expected output**: Binaries created in ~2-3 minutes
-- `solace-broker-mcp-linux-amd64`
-- `solace-broker-mcp-darwin-amd64`
-- `solace-broker-mcp-darwin-arm64`
-- `solace-broker-mcp-windows-amd64.exe`
-- `checksums.txt`
+**Expected output**: Archives created in ~2-3 minutes
+- `solace-broker-mcp-{version}-linux-amd64.tar.gz`
+- `solace-broker-mcp-{version}-linux-arm64.tar.gz`
+- `solace-broker-mcp-{version}-darwin-amd64.tar.gz`
+- `solace-broker-mcp-{version}-darwin-arm64.tar.gz`
+- `checksums-sha256.txt`
 
 ### 5. Verify GitHub Release
 
@@ -118,8 +118,8 @@ https://github.com/SolaceDev/solace-broker-mcp/releases/tag/v0.1.0
 **Verify:**
 - [ ] Release title is correct ("v0.1.0")
 - [ ] Release notes are auto-generated from merged PRs
-- [ ] All 5 binaries are attached
-- [ ] Checksums file is attached
+- [ ] All 4 archives are attached
+- [ ] `checksums-sha256.txt` is attached
 - [ ] "Latest" badge is applied
 
 ### 6. Test the Release Binaries
@@ -127,17 +127,17 @@ https://github.com/SolaceDev/solace-broker-mcp/releases/tag/v0.1.0
 **Download and test a binary:**
 ```bash
 # macOS arm64 example
-curl -LO https://github.com/SolaceDev/solace-broker-mcp/releases/download/v0.1.0/solace-broker-mcp-darwin-arm64
-chmod +x solace-broker-mcp-darwin-arm64
-./solace-broker-mcp-darwin-arm64 -version
+curl -LO https://github.com/SolaceDev/solace-broker-mcp/releases/download/v0.1.0/solace-broker-mcp-v0.1.0-darwin-arm64.tar.gz
+tar xzf solace-broker-mcp-v0.1.0-darwin-arm64.tar.gz
+./solace-broker-mcp -version
 # Should output: v0.1.0
 ```
 
 **Verify checksum:**
 ```bash
-curl -LO https://github.com/SolaceDev/solace-broker-mcp/releases/download/v0.1.0/checksums.txt
-shasum -a 256 -c checksums.txt --ignore-missing
-# Should output: solace-broker-mcp-darwin-arm64: OK
+curl -LO https://github.com/SolaceDev/solace-broker-mcp/releases/download/v0.1.0/checksums-sha256.txt
+shasum -a 256 -c checksums-sha256.txt --ignore-missing
+# Should output: solace-broker-mcp-v0.1.0-darwin-arm64.tar.gz: OK
 ```
 
 ### 7. Update README (Optional Enhancement)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,15 +28,21 @@ solace-broker-mcp/
 │   │           ├── embed.go       # //go:embed for spec files
 │   │           └── *.json         # Swagger 2.0 specs (monitor, config, action)
 │   │
-│   ├── composite/                 # (Task 4 — not yet implemented)
+│   ├── composite/                 # YAML-driven composite tool engine
 │   │   ├── definition.go          # Tool/step/parameter structs
 │   │   ├── loader.go              # YAML loading + validation
 │   │   ├── executor.go            # Step orchestration, templates, result strategies
 │   │   └── definitions/
-│   │       └── tools.yaml         # Tool definitions (queue-replay-recovery)
+│   │       └── tools.yaml         # Tool definitions (11 composite tools)
 │   │
-│   └── registry/                  # (Task 5 — not yet implemented)
-│       └── registry.go            # MCP tool registration, broker resolution
+│   └── tools/                     # MCP tool registration, routing, native handlers
+│       ├── manager.go             # ToolManager — registers and routes tool calls
+│       ├── register.go            # Wires composite + native tools into MCP server
+│       ├── composite_handler.go   # Bridges composite executor to MCP SDK
+│       ├── validation.go          # Parameter validation helpers
+│       └── sempv1/                # Native SEMPv1 tool handlers
+│           ├── brokerhealth/      # get-broker-health
+│           └── redundancy/        # get-redundancy-status
 │
 ├── docs/                          # This directory
 └── specs/                         # Design specs, task breakdowns, test plans
@@ -71,13 +77,13 @@ graph TB
         end
     end
 
-    subgraph "internal/composite (Task 4)"
+    subgraph "internal/composite"
         EXECUTOR["executor.go<br/>Step orchestration<br/>Template resolution"]
         LOADER["loader.go<br/>YAML tool definitions"]
     end
 
-    subgraph "internal/registry (Task 5)"
-        REGISTRY["registry.go<br/>MCP tool registration<br/>Broker resolution per call"]
+    subgraph "internal/tools"
+        REGISTRY["tools/<br/>ToolManager, register.go<br/>MCP tool registration<br/>Broker resolution per call"]
     end
 
     subgraph "External"
@@ -103,12 +109,8 @@ graph TB
     CLIENT --> BROKER_X
     CLIENT --> BROKER_Y
 
-    style EXECUTOR stroke-dasharray: 5 5
-    style LOADER stroke-dasharray: 5 5
-    style REGISTRY stroke-dasharray: 5 5
 ```
 
-*Dashed borders = not yet implemented.*
 
 ---
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -218,7 +218,7 @@ Fixtures are cleaned up before creation (to handle leftover state) and after tes
 |---|---|
 | `test_health_endpoint` | `GET /health` returns `{"status": "ok"}` |
 | `test_initialize` | MCP handshake completes, server returns `Mcp-Session-Id` |
-| `test_list_tools` | `tools/list` returns all 5 tools (`get-rdp-status`, `list-brokers`, `get-queue-metrics`, `get-client-details`, `list-client-subscriptions`) |
+| `test_list_tools` | `tools/list` returns all 14 tools (composite: `get-rdp-status`, `get-queue-metrics`, `get-client-details`, `list-client-subscriptions`, `get-vpn-health`, `list-vpns`, `list-queues`, `list-clients`, `get-message-rates`, `get-dmr-status`, `list-rdps`; native: `list-brokers`, `get-broker-health`, `get-redundancy-status`) |
 | `test_list_brokers` | `list-brokers` response includes both `broker-a` and `broker-b` |
 | `test_get_rdp_status_broker_a` | `get-rdp-status` on broker-a returns 3-step response |
 | `test_get_rdp_status_not_found` | Nonexistent RDP name returns a JSON-RPC error |
@@ -250,7 +250,7 @@ Usage: `./bin/agent <server-url>`
 
 It performs:
 1. Connect to the MCP server via `StreamableClientTransport`
-2. Call `session.ListTools()` — verify all 5 tools are present
+2. Call `session.ListTools()` — verify all 14 tools are present
 3. Call `list-brokers` tool — verify both `broker-a` and `broker-b` aliases appear
 4. For each broker (`broker-a`, `broker-b`):
    - Call `get-rdp-status` with the test fixtures — verify 3-step structured response


### PR DESCRIPTION
## Summary

- **docs/architecture.md** — Removed stale "Task 4/5 — not yet implemented" labels; replaced `internal/registry` with `internal/tools` (the actual package); dropped dashed-border diagram styles and the caption claiming components are unimplemented
- **docs/e2e-testing.md** — Updated tool count from 5 → 14, with the full tool list enumerated in the test table and agent verification step
- **.github/RELEASE_GUIDE.md** — Removed the nonexistent Windows binary; corrected artifact format to `.tar.gz`; fixed checksums filename from `checksums.txt` → `checksums-sha256.txt` in three places (expected output, verify checklist, and download example)
- **.github/CONTRIBUTING.md** — Removed broken link to nonexistent `docs/good-code.md`

## Test plan

- [ ] Review `docs/architecture.md` folder tree and mermaid diagram — verify they match the actual repo structure
- [ ] Run `grep -r 'not yet implemented' docs/ .github/` — should return no matches
- [ ] Run `grep -r 'checksums\.txt' .github/RELEASE_GUIDE.md` — should return no matches (only `checksums-sha256.txt`)
- [ ] Run `grep -r 'good-code\.md' .github/CONTRIBUTING.md` — should return no matches
- [ ] Run `grep -r 'windows' .github/RELEASE_GUIDE.md` — should return no matches in the artifact list
- [ ] Confirm tool count: `grep -c '^  - name:' internal/composite/definitions/tools.yaml` = 11, plus 3 native = 14 total

Closes SOL-149663

🤖 Generated with [Claude Code](https://claude.com/claude-code)