### PR TITLE
SOL-149664: Fix .env parser: strip quoted values and warn on unreadable file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,10 +295,12 @@ func applyDefaults(cfg *ServerConfig) {
 
 // loadEnvFile loads a .env file into the process environment. It checks two
 // locations in order: the ENV_FILE environment variable (explicit path), then
-// a .env file in the same directory as the config file (convention). If neither
-// exists, it silently skips — .env files are optional. Variables already set in
-// the environment are not overwritten, so real env vars (e.g., from CI/CD)
-// take precedence over .env values.
+// a .env file in the same directory as the config file (convention). If the
+// file does not exist it is silently skipped — .env files are optional. Any
+// other read error (e.g. permission denied) is logged at WARN so operators
+// get a pointer to the real cause rather than a downstream "env var not set"
+// error. Variables already set in the environment are not overwritten, so
+// real env vars (e.g., from CI/CD) take precedence over .env values.
 func loadEnvFile(configPath string) {
 	envPath := os.Getenv("ENV_FILE")
 	if envPath == "" {
@@ -306,7 +308,10 @@ func loadEnvFile(configPath string) {
 	}
 	data, err := os.ReadFile(envPath) //nolint:gosec // G703 — path from trusted config/env, not external user input
 	if err != nil {
-		return // .env file is optional — if it doesn't exist, silently skip
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("env file unreadable", slog.String("path", envPath))
+		}
+		return
 	}
 
 	for _, line := range strings.Split(string(data), "\n") {
@@ -319,7 +324,10 @@ func loadEnvFile(configPath string) {
 			continue
 		}
 		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		value = stripMatchedQuotes(strings.TrimSpace(value))
 		if _, exists := os.LookupEnv(key); !exists {
 			os.Setenv(key, value) //nolint:gosec // G104 — os.Setenv only fails on Plan 9; safe to ignore
 		}
@@ -327,6 +335,18 @@ func loadEnvFile(configPath string) {
 
 	slog.Info("loaded .env file",
 		slog.String("path", envPath))
+}
+
+// stripMatchedQuotes removes one matching pair of surrounding double or single
+// quotes from a .env value — e.g. "secret" → secret, 'pw' → pw. Unbalanced
+// or unquoted values are returned unchanged.
+func stripMatchedQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }
 
 // envVarPattern matches ${VAR_NAME} in raw YAML bytes. VAR_NAME must be

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -825,6 +827,87 @@ func TestLoad_ConfigFileEnvCorrupt_ReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parsing config YAML") {
 		t.Errorf("expected YAML parse error, got: %v", err)
+	}
+}
+
+// captureSlog redirects the default slog logger to a buffer for the duration
+// of the test and returns the buffer. The original logger is restored via
+// t.Cleanup.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	return &buf
+}
+
+func TestLoadEnvFile_StripsMatchedQuotes(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	content := `
+DOUBLE_QUOTED="bar"
+SINGLE_QUOTED='qux'
+UNBALANCED="unbalanced'
+UNQUOTED=plain
+`
+	if err := os.WriteFile(envFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing .env: %v", err)
+	}
+	t.Setenv("ENV_FILE", envFile)
+	// Unset keys so loadEnvFile sets them.
+	for _, k := range []string{"DOUBLE_QUOTED", "SINGLE_QUOTED", "UNBALANCED", "UNQUOTED"} {
+		t.Setenv(k, "")
+		os.Unsetenv(k)
+	}
+
+	loadEnvFile(filepath.Join(dir, "config.yaml"))
+
+	cases := []struct{ key, want string }{
+		{"DOUBLE_QUOTED", "bar"},
+		{"SINGLE_QUOTED", "qux"},
+		{"UNBALANCED", "\"unbalanced'"},
+		{"UNQUOTED", "plain"},
+	}
+	for _, c := range cases {
+		if got := os.Getenv(c.key); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.key, got, c.want)
+		}
+	}
+}
+
+func TestLoadEnvFile_LogsWarningOnUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte("FOO=bar\n"), 0o600); err != nil {
+		t.Fatalf("writing .env: %v", err)
+	}
+	if err := os.Chmod(envFile, 0o000); err != nil {
+		t.Fatalf("chmod .env: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(envFile, 0o600) }) //nolint:errcheck
+
+	t.Setenv("ENV_FILE", envFile)
+	buf := captureSlog(t)
+
+	loadEnvFile(filepath.Join(dir, "config.yaml"))
+
+	logged := buf.String()
+	if !strings.Contains(logged, "WARN") || !strings.Contains(logged, "env file unreadable") {
+		t.Errorf("expected WARN 'env file unreadable' in log output, got: %s", logged)
+	}
+}
+
+func TestLoadEnvFile_MissingFileIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ENV_FILE", filepath.Join(dir, "nonexistent.env"))
+	buf := captureSlog(t)
+
+	loadEnvFile(filepath.Join(dir, "config.yaml"))
+
+	if strings.Contains(buf.String(), "WARN") {
+		t.Errorf("expected no WARN for missing .env, got: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Strip matched quotes** — `.env` lines like `PASSWORD="secret"` now load as `secret`, not `"secret"`. Single quotes work the same way. Unbalanced or unquoted values are untouched. This matches the `godotenv`/Docker convention and fixes silent credential corruption causing broker auth failures.
- **Warn on unreadable file** — Only `os.ErrNotExist` is now treated silently. Any other read error (e.g. `permission denied`) logs `slog.Warn("env file unreadable", path=...)` so operators get a pointer to the real cause instead of a confusing downstream "env var not set" error.
- **Guard empty keys** — Lines like `=value` (no key) are now skipped to prevent `os.Setenv("", ...)`.
- **`stripMatchedQuotes` helper** — Extracted as a named function so it's directly unit-testable.

## Test plan

- [ ] `go test -race ./internal/config/... -run TestLoadEnvFile` — all three new tests pass
- [ ] `go test -race ./internal/config/...` — full suite green, no regressions
- [ ] Manual: create a `.env` with `FOO="bar"` and verify `${FOO}` in a broker config resolves to `bar` (not `"bar"`)
- [ ] Manual: create a `.env` with mode `0000` and verify a `WARN env file unreadable` line appears in server logs at startup
- [ ] Manual: remove the `.env` entirely and verify no warning appears (silent skip preserved)

Closes SOL-149664

🤖 Generated with [Claude Code](https://claude.com/claude-code)