### PR TITLE
SOL-149666: Fix k8s nonroot UID, harden secret.yaml warning, gitignore working docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ Thumbs.db
 .env
 broker-config.yaml
 
+# Working documents that must not be committed (see OPEN_SOURCE_STATUS.md)
+Mark2-report.md
+open-source.md
+
 # E2E test config (not secrets — safe to track)
 !test/e2e/.env
 !test/e2e/broker-config.yaml

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
+        runAsUser: 65532  # distroless nonroot UID (gcr.io/distroless/static-debian12:nonroot)
       containers:
         - name: solace-broker-mcp
           image: ghcr.io/solacedev/solace-broker-mcp:latest

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -1,5 +1,14 @@
-# WARNING: Do not commit this file with real credentials.
-# Use a secret manager (Vault, sealed-secrets, External Secrets) in production.
+# ============================================================
+# EXAMPLE ONLY — CHANGE CREDENTIALS BEFORE APPLYING
+# ============================================================
+# This file ships with placeholder credentials. Running
+# `kubectl apply` without replacing them exposes your broker
+# with a well-known password. Options:
+#   - Edit BROKER_USERNAME / BROKER_PASSWORD directly here
+#     (but do NOT commit the edited file)
+#   - Use a secret manager: Vault, Sealed Secrets,
+#     External Secrets Operator, or SOPS
+# ============================================================
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +17,4 @@ metadata:
     app.kubernetes.io/name: solace-broker-mcp
 stringData:
   BROKER_USERNAME: admin
-  BROKER_PASSWORD: changeme
+  BROKER_PASSWORD: changeme  # CHANGE THIS before applying


### PR DESCRIPTION
## Summary

- **deployment.yaml** — `runAsUser` corrected from `65534` → `65532`, the actual UID used by `gcr.io/distroless/static-debian12:nonroot` (confirmed in `Dockerfile` line 17). `65534` is `nobody` on most Linux distros; using the wrong UID with `runAsNonRoot: true` can cause admission failures on strict clusters.
- **secret.yaml** — Replaced the brief one-line warning with a prominent block comment explaining the risk, and added an inline `# CHANGE THIS before applying` annotation on the `changeme` value. Makes it visually impossible to miss before a `kubectl apply`.
- **.gitignore** — Added `Mark2-report.md` and `open-source.md` per `OPEN_SOURCE_STATUS.md` §181; these working documents are intentionally untracked and were showing as untracked noise in `git status`.

## Test plan

- [ ] `grep runAsUser deploy/kubernetes/deployment.yaml` → `65532`
- [ ] Confirm `Dockerfile` uses `gcr.io/distroless/static-debian12:nonroot` (line 17) — UID matches
- [ ] `git status` after this PR merges → `Mark2-report.md` and `open-source.md` no longer appear as untracked
- [ ] Review `secret.yaml` — warning block is prominent and inline annotation is visible

Closes SOL-149666

🤖 Generated with [Claude Code](https://claude.com/claude-code)