### PR TITLE
SOL-149667: Config code quality: sorted errors, comment fix, redundant guard, octal

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -387,8 +388,8 @@ func validate(cfg *ServerConfig) error {
 		errs = append(errs, fmt.Errorf("at least one broker must be configured"))
 	}
 
-	for alias, broker := range cfg.Brokers {
-		errs = append(errs, validateBroker(alias, broker, !cfg.DevelopmentMode)...)
+	for _, alias := range slices.Sorted(maps.Keys(cfg.Brokers)) {
+		errs = append(errs, validateBroker(alias, cfg.Brokers[alias], !cfg.DevelopmentMode)...)
 	}
 
 	if err := ValidatePort(cfg.Port); err != nil {
@@ -426,7 +427,7 @@ func validate(cfg *ServerConfig) error {
 
 	if cfg.SEMP.RetryMaxInterval <= 0 {
 		errs = append(errs, fmt.Errorf("semp.retry_max_interval must be > 0, got %s", cfg.SEMP.RetryMaxInterval))
-	} else if cfg.SEMP.RetryMinInterval > 0 && cfg.SEMP.RetryMaxInterval < cfg.SEMP.RetryMinInterval {
+	} else if cfg.SEMP.RetryMaxInterval < cfg.SEMP.RetryMinInterval {
 		errs = append(errs, fmt.Errorf("semp.retry_max_interval (%s) must be >= semp.retry_min_interval (%s)", cfg.SEMP.RetryMaxInterval, cfg.SEMP.RetryMinInterval))
 	}
 
@@ -544,8 +545,8 @@ func validateBrokerURL(s string, productionMode bool) error {
 }
 
 // applyEnvOverrides checks for environment variable overrides and applies them
-// to the config. This runs after validation and credential resolution. The
-// overridden value is validated via ValidatePort internally.
+// to the config. This runs before validate() so overridden values are still
+// range-checked. The overridden value is validated via ValidatePort internally.
 func applyEnvOverrides(cfg *ServerConfig) error {
 	if envPort := os.Getenv("MCP_SERVER_PORT"); envPort != "" {
 		port, err := strconv.Atoi(envPort)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,6 +63,7 @@ brokers:
 	broker := cfg.Brokers["prod-us"]
 	if broker == nil {
 		t.Fatal("expected broker 'prod-us' to exist")
+		return
 	}
 	if broker.URL != "https://broker-us.example.com:1943" {
 		t.Errorf("unexpected URL: %s", broker.URL)
@@ -873,7 +874,7 @@ brokers:
 	if alphaIdx < 0 || monkeyIdx < 0 || zebraIdx < 0 {
 		t.Fatalf("expected all three aliases in error, got: %s", msg)
 	}
-	if !(alphaIdx < monkeyIdx && monkeyIdx < zebraIdx) {
+	if alphaIdx >= monkeyIdx || monkeyIdx >= zebraIdx {
 		t.Errorf("expected errors in alphabetical order (alpha < monkey < zebra), got positions %d %d %d\nfull error:\n%s",
 			alphaIdx, monkeyIdx, zebraIdx, msg)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,7 @@ func writeTemp(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("writing temp config: %v", err)
 	}
 	return path
@@ -843,6 +843,39 @@ brokers:
 		if !strings.Contains(msg, want) {
 			t.Errorf("combined error missing expected substring %q\nfull error:\n%s", want, msg)
 		}
+	}
+}
+
+func TestValidate_BrokerErrorsAreSorted(t *testing.T) {
+	// Broker map iteration is non-deterministic; sorted aliases ensure the
+	// joined error string always lists errors in alphabetical alias order.
+	yaml := `
+development_mode: true
+brokers:
+  zebra:
+    auth:
+      mode: basic
+  alpha:
+    auth:
+      mode: basic
+  monkey:
+    auth:
+      mode: basic
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected validation errors")
+	}
+	msg := err.Error()
+	alphaIdx := strings.Index(msg, `"alpha"`)
+	monkeyIdx := strings.Index(msg, `"monkey"`)
+	zebraIdx := strings.Index(msg, `"zebra"`)
+	if alphaIdx < 0 || monkeyIdx < 0 || zebraIdx < 0 {
+		t.Fatalf("expected all three aliases in error, got: %s", msg)
+	}
+	if !(alphaIdx < monkeyIdx && monkeyIdx < zebraIdx) {
+		t.Errorf("expected errors in alphabetical order (alpha < monkey < zebra), got positions %d %d %d\nfull error:\n%s",
+			alphaIdx, monkeyIdx, zebraIdx, msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Four mechanical fixes in `internal/config/`, all in the same file area:

- **Sorted broker error ordering** — `validate()` now iterates broker aliases via `slices.Sorted(maps.Keys(...))` so the joined validation error string always lists brokers alphabetically. Previously random map iteration made error messages non-deterministic across runs.
- **Remove redundant guard** — `cfg.SEMP.RetryMinInterval > 0` was checked again in the max-min comparison (`else if` at line 411), despite the preceding check at line 405 already guaranteeing `> 0`. Removed the redundant clause; `TestLoadConfig_RateLimit_MaxSmallerThanMin` still passes.
- **Fix misleading comment** — `applyEnvOverrides` doc said "runs after validation" but it runs *before* `validate()`. Corrected to "runs before validate() so overridden values are still range-checked."
- **Fix unprefixed octal** — `0644` → `0o644` in `config_test.go:32`. Swept rest of repo — this was the only occurrence.

## Test plan

- [ ] `go test -race ./internal/config/... -run TestValidate_BrokerErrorsAreSorted` — passes
- [ ] `go test -race ./internal/config/...` — full suite green
- [ ] `grep -rn --include="*.go" -E '\b0[0-9]{3}\b' .` — returns no matches
- [ ] `grep "after validation" internal/config/config.go` — returns no matches

Closes SOL-149667

🤖 Generated with [Claude Code](https://claude.com/claude-code)