### PR TITLE
SOL-149668: Add explicit permissions block to build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,12 @@ on:
       - 'v*'
   workflow_call:
 
+# Minimal token permissions — read-only access to repo contents.
+# golangci-lint-action uses checks: write to post inline annotations on PRs.
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` + `checks: write` to `.github/workflows/build-and-test.yml`
- Without an explicit block the workflow inherits repo-wide token defaults (often `contents: write`)
- `checks: write` is required for `golangci-lint-action` to post inline annotations on PRs

## Test plan

- [ ] Workflow triggers on push and passes all jobs (lint, build, test, e2e)
- [ ] golangci-lint annotations still appear on PRs

Fixes [SOL-149668](https://sol-jira.atlassian.net/browse/SOL-149668)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-149668]: https://sol-jira.atlassian.net/browse/SOL-149668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ