### PR TITLE
SOL-149669: Pin floating solace-public-workflows reusable workflow refs to SHA

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   fossa_scan:
     name: FOSSA Scan
-    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       use_vault: true
       config_file: '.github/workflow-config.json'

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   fossa_scan:
     name: FOSSA Scan
-    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       git_ref: ${{ inputs.git_ref }}
       use_vault: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
   fossa_scan:
     name: FOSSA Scan
-    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       git_ref: ${{ github.ref_name }}
       use_vault: true


### PR DESCRIPTION
## Summary

- Pins all three `SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main` references to SHA `fc521b087f780457f92d4cb46038184e92ad2fbc` (main as of 2026-05-12)
- Affects `ci-pr.yaml`, `release.yml`, and `fossa-scan.yaml`
- Floating `@main` refs mean a force-push or compromise of the upstream repo would execute arbitrary code with this repo's CI token

## Test plan

- [ ] FOSSA scan job runs successfully in CI on this PR
- [ ] Release workflow FOSSA scan job passes on a test tag push (or verify in CI-PR)
- [ ] Manual fossa-scan.yaml dispatch runs successfully

**To update the pin in future:** Run `gh api repos/SolaceDev/solace-public-workflows/commits/main --jq '.sha'` and replace the SHA in all three files.

Fixes [SOL-149669](https://sol-jira.atlassian.net/browse/SOL-149669)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-149669]: https://sol-jira.atlassian.net/browse/SOL-149669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ