### PR TITLE
SOL-149670: Reject unknown fields in composite YAML loader

### DIFF
--- a/internal/composite/loader.go
+++ b/internal/composite/loader.go
@@ -15,6 +15,7 @@
 package composite
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 
@@ -32,7 +33,9 @@ func LoadTools(fsys fs.FS, filename string) ([]CompositeTool, error) {
 	}
 
 	var file CompositeToolsFile
-	if err := yaml.Unmarshal(data, &file); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&file); err != nil {
 		return nil, fmt.Errorf("parsing composite tool file %q: %w", filename, err)
 	}
 

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -844,6 +844,54 @@ tools:
 	}
 }
 
+func TestLoadTools_UnknownFieldRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "unknown top-level tool field",
+			yaml: `
+tools:
+  - name: test-tool
+    description: A test tool
+    bogusField: oops
+    steps:
+      - id: s1
+        operation: monitor/getVpn
+    result:
+      strategy: collect
+`,
+		},
+		{
+			name: "unknown step field",
+			yaml: `
+tools:
+  - name: test-tool
+    description: A test tool
+    steps:
+      - id: s1
+        operation: monitor/getVpn
+        paralel: true
+    result:
+      strategy: collect
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsys := fstest.MapFS{
+				"tools.yaml": &fstest.MapFile{Data: []byte(tc.yaml)},
+			}
+			_, err := LoadTools(fsys, "tools.yaml")
+			if err == nil {
+				t.Fatal("expected error for unknown field, got nil")
+			}
+		})
+	}
+}
+
 func TestLoadTools_ListRDPs(t *testing.T) {
 	yaml := `
 tools:


### PR DESCRIPTION
## Summary

- Switches `yaml.Unmarshal` to `yaml.NewDecoder` + `KnownFields(true)` in `internal/composite/loader.go`
- Typos in tool YAML (e.g. `paralel: true` instead of `parallel: true`) were previously silently dropped; they now return a clear parse error at server startup
- Adds `TestLoadTools_UnknownFieldRejected` covering both top-level and step-level unknown keys (two sub-tests)

## Test plan

- [ ] `go test -race ./internal/composite/...` passes
- [ ] Verify a tool YAML with a deliberate typo (e.g. `bogusField: oops`) causes startup to fail with a descriptive error
- [ ] Existing composite tool YAML (`internal/composite/definitions/`) loads without error

Fixes [SOL-149670](https://sol-jira.atlassian.net/browse/SOL-149670)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-149670]: https://sol-jira.atlassian.net/browse/SOL-149670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ