### PR TITLE
SOL-149671: Add sync.RWMutex to ToolManager to guard concurrent handlers map access

### DIFF
--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite"
@@ -33,8 +34,11 @@ import (
 
 // ToolManager validates parameters, resolves broker connections, routes tool
 // calls to handlers, and produces structured MCP responses.
+//
+// All public methods are safe for concurrent use.
 type ToolManager struct {
 	pool     *semp.BrokerPool
+	mu       sync.RWMutex
 	handlers map[string]ToolHandler
 }
 
@@ -63,6 +67,8 @@ func NewToolManagerFromComposite(pool *semp.BrokerPool, tools []composite.Compos
 // configuration error that should be caught at startup.
 func (m *ToolManager) Register(handler ToolHandler) {
 	name := handler.Metadata().Name
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if _, exists := m.handlers[name]; exists {
 		panic(fmt.Sprintf("duplicate tool registration: %q", name))
 	}
@@ -72,7 +78,9 @@ func (m *ToolManager) Register(handler ToolHandler) {
 // Route looks up a handler by tool name. Returns an error if the tool is not
 // registered.
 func (m *ToolManager) Route(name string) (ToolHandler, error) {
+	m.mu.RLock()
 	handler, ok := m.handlers[name]
+	m.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("unknown tool %q", name)
 	}
@@ -82,10 +90,12 @@ func (m *ToolManager) Route(name string) (ToolHandler, error) {
 // Handlers returns all registered tool handlers. The returned slice is
 // unordered — callers should sort if deterministic ordering is needed.
 func (m *ToolManager) Handlers() []ToolHandler {
+	m.mu.RLock()
 	handlers := make([]ToolHandler, 0, len(m.handlers))
 	for _, h := range m.handlers {
 		handlers = append(handlers, h)
 	}
+	m.mu.RUnlock()
 	return handlers
 }
 

--- a/internal/tools/manager_test.go
+++ b/internal/tools/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -749,4 +750,47 @@ func TestHandlers_ReturnsAll(t *testing.T) {
 	if !names["tool-a"] || !names["tool-b"] {
 		t.Errorf("expected tool-a and tool-b, got %v", names)
 	}
+}
+
+func TestToolManager_ConcurrentRegisterAndRoute(t *testing.T) {
+	const workers = 20
+	mgr := NewToolManager(newTestPool())
+
+	// Pre-register tools that readers will look up.
+	for i := range workers {
+		mgr.Register(newStubHandler(fmt.Sprintf("pre-tool-%d", i)))
+	}
+
+	var wg sync.WaitGroup
+
+	// Writers: register new tools concurrently.
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			mgr.Register(newStubHandler(fmt.Sprintf("new-tool-%d", i)))
+		}(i)
+	}
+
+	// Readers: call Route, Handlers, and CallTool concurrently with writers.
+	for i := range workers {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = mgr.Route(fmt.Sprintf("pre-tool-%d", i))
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = mgr.Handlers()
+		}()
+		go func(i int) {
+			defer wg.Done()
+			// CallTool exercises Route internally; broker resolution will fail
+			// (no real broker) but the important thing is no data race.
+			_, _ = mgr.CallTool(context.Background(), fmt.Sprintf("pre-tool-%d", i),
+				map[string]any{"broker": "no-such-broker"})
+		}(i)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

- Adds `sync.RWMutex` field to `ToolManager` struct (`internal/tools/manager.go`)
- `Register()` takes a write lock; `Route()` and `Handlers()` take a read lock; `CallTool()` is protected transitively through `Route()`
- The handlers map was safe today only by single-threaded-startup convention — now explicitly safe for any future dynamic registration scenario

## Test plan

- [ ] `go test -race ./internal/tools/...` passes with zero data-race reports
- [ ] New `TestToolManager_ConcurrentRegisterAndRoute` explicitly exercises 20 parallel writers + 60 parallel readers under the race detector
- [ ] All existing `TestToolManager_*` and `TestCallTool_*` tests pass

Fixes [SOL-149671](https://sol-jira.atlassian.net/browse/SOL-149671)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-149671]: https://sol-jira.atlassian.net/browse/SOL-149671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ