### PR TITLE
SOL-149672: Fix sempv2 HTTP headers: omit Content-Type on bodyless requests, add Accept

### DIFF
--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -221,7 +221,10 @@ func (c *HTTPClient) buildRequest(ctx context.Context, op *Operation, reqURL str
 		return nil, err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	if bodyData != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "solace/broker-mcp-server/"+version.Version())
 
 	return req, nil

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -544,6 +544,52 @@ func TestClient_Execute_UserAgent(t *testing.T) {
 	}
 }
 
+func TestClient_Execute_NoBody_NoContentType(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			t.Errorf("Content-Type = %q, want empty for GET request with no body", ct)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/test",
+	}
+
+	if _, err := client.Execute(context.Background(), op, map[string]any{}); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestClient_Execute_AcceptHeader(t *testing.T) {
+	for _, method := range []string{"GET", "PUT", "DELETE"} {
+		t.Run(method, func(t *testing.T) {
+			client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if accept := r.Header.Get("Accept"); accept != "application/json" {
+					t.Errorf("Accept = %q, want application/json", accept)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{})
+			})
+			defer server.Close()
+
+			op := &sempv2.Operation{
+				ID:     "testOp",
+				Method: method,
+				Path:   "/SEMP/v2/monitor/test",
+			}
+
+			if _, err := client.Execute(context.Background(), op, map[string]any{}); err != nil {
+				t.Fatalf("Execute() method=%s error: %v", method, err)
+			}
+		})
+	}
+}
+
 func TestClient_Execute_Timeout(t *testing.T) {
 	_, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Second)


### PR DESCRIPTION
## Summary

- **Content-Type**: wrapped in `if bodyData != nil` — GET/DELETE requests no longer set `Content-Type: application/json` (RFC 7231 §3.1.1.5 compliance)
- **Accept**: always sets `Accept: application/json` — explicit is correct even though SEMPv2 only emits JSON
- Both changes are in `internal/semp/sempv2/client.go`

## Test plan

- [ ] `go test -race ./internal/semp/sempv2/...` passes
- [ ] `TestClient_Execute_NoBody_NoContentType` — verifies GET has no `Content-Type`
- [ ] `TestClient_Execute_AcceptHeader` — parametric over GET/PUT/DELETE, verifies `Accept: application/json` on all
- [ ] `TestClient_Execute_RequestBody` — existing test still asserts `Content-Type: application/json` is set when body is present

Fixes [SOL-149672](https://sol-jira.atlassian.net/browse/SOL-149672)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-149672]: https://sol-jira.atlassian.net/browse/SOL-149672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ