### PR TITLE
SOL-149746: Skip retry for non-idempotent HTTP methods (POST/PATCH)

### DIFF
--- a/internal/semp/resilience/retry.go
+++ b/internal/semp/resilience/retry.go
@@ -20,8 +20,9 @@ type retryStateKey struct{}
 // Each Do() call creates its own instance via context, so concurrent requests
 // to the same Sender are safe.
 type retryState struct {
-	auth401Retried  bool // true after first 401 re-auth attempt (basic auth only)
-	other5xxRetried bool // true after first non-429/503 5xx retry
+	auth401Retried  bool   // true after first 401 re-auth attempt (basic auth only)
+	other5xxRetried bool   // true after first non-429/503 5xx retry
+	method          string // HTTP method captured at Do() time for idempotency check
 }
 
 // OperationIDKey is the context key callers use to attach an operation
@@ -53,6 +54,15 @@ func (d *Sender) checkRetry(ctx context.Context, resp *http.Response, err error)
 		return false, ctx.Err()
 	}
 
+	// Non-idempotent methods are never retried. POST and PATCH can produce
+	// side effects (resource creation, partial config update) that are not safe
+	// to repeat even on transient errors — a double-write is worse than a
+	// visible failure. This check covers both HTTP errors and connection errors.
+	state := getRetryState(ctx)
+	if state.method == http.MethodPost || state.method == http.MethodPatch {
+		return false, nil
+	}
+
 	// Connection errors: delegate to retryablehttp's default policy which
 	// handles network errors, DNS failures, TLS handshake errors, etc.
 	if err != nil {
@@ -62,8 +72,6 @@ func (d *Sender) checkRetry(ctx context.Context, resp *http.Response, err error)
 	if resp == nil {
 		return false, nil
 	}
-
-	state := getRetryState(ctx)
 
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized: // 401

--- a/internal/semp/resilience/retry.go
+++ b/internal/semp/resilience/retry.go
@@ -43,6 +43,7 @@ func getRetryState(ctx context.Context) *retryState {
 }
 
 // checkRetry is the custom retry policy for retryablehttp. It implements:
+//   - POST and PATCH: never retried (non-idempotent — see guard below)
 //   - 401: basic auth → clear cookie jar + retry once; bearer → fail immediately
 //   - 429, 503: full retries with exponential backoff
 //   - Other 5xx: retry once only (likely a bug, not transient)
@@ -58,6 +59,11 @@ func (d *Sender) checkRetry(ctx context.Context, resp *http.Response, err error)
 	// side effects (resource creation, partial config update) that are not safe
 	// to repeat even on transient errors — a double-write is worse than a
 	// visible failure. This check covers both HTTP errors and connection errors.
+	//
+	// PUT and DELETE are deliberately NOT in this guard: RFC 9110 §9.2.2 defines
+	// both as idempotent, so a retry yields the same final state as a single call.
+	// SEMPv2 routes resource replacement through PUT; treating it as non-idempotent
+	// would defeat the retry policy for legitimately transient failures.
 	state := getRetryState(ctx)
 	if state.method == http.MethodPost || state.method == http.MethodPatch {
 		return false, nil

--- a/internal/semp/resilience/sender.go
+++ b/internal/semp/resilience/sender.go
@@ -109,8 +109,10 @@ func (d *Sender) Do(ctx context.Context, req *http.Request) (*http.Response, err
 		return nil, ctx.Err()
 	}
 
-	// Attach per-request retry state for checkRetry.
-	ctx = context.WithValue(ctx, retryStateKey{}, &retryState{})
+	// Attach per-request retry state for checkRetry, including the HTTP method
+	// so the non-idempotent method guard can fire even on connection errors
+	// (where resp is nil and resp.Request.Method is unavailable).
+	ctx = context.WithValue(ctx, retryStateKey{}, &retryState{method: req.Method})
 	req = req.WithContext(ctx)
 
 	retryReq, err := retryablehttp.FromRequest(req)

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -650,6 +650,89 @@ func TestSender_NoRetry_POST_On500(t *testing.T) {
 	}
 }
 
+// TestSender_NoRetry_POST_ConnectionError exercises the reason the HTTP method
+// is captured on retryState: when the server is unreachable, checkRetry receives
+// (nil resp, non-nil err). Without the captured method, the guard couldn't tell
+// it was a POST and would fall through to retryablehttp's default policy, which
+// retries connection errors. We assert exactly one attempt and a wrapped
+// RetriesExhaustedError with Attempts=1.
+func TestSender_NoRetry_POST_ConnectionError(t *testing.T) {
+	// Bring a server up to obtain a URL, then close it so all dials are refused.
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+	}))
+	serverURL := server.URL
+	server.Close()
+
+	retries := 5
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		Retries:            &retries,
+		RequestMinInterval: &minInterval,
+		RetryMinInterval:   1 * time.Millisecond,
+		RetryMaxInterval:   10 * time.Millisecond,
+	}
+	authCfg := config.AuthConfig{Mode: "basic", Username: "admin", Password: "secret"}
+	sender := New(&http.Client{}, sempCfg, authCfg, serverURL)
+
+	req := newMethodRequest(t, http.MethodPost, serverURL)
+	resp, err := sender.Do(context.Background(), req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected connection error for closed server")
+	}
+
+	var exhausted *RetriesExhaustedError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("expected RetriesExhaustedError, got %T: %v", err, err)
+	}
+	if exhausted.Attempts != 1 {
+		t.Errorf("expected exactly 1 attempt for POST connection error (no retry), got %d", exhausted.Attempts)
+	}
+	if requestCount.Load() != 0 {
+		t.Errorf("expected 0 successful requests (server closed), got %d", requestCount.Load())
+	}
+}
+
+// TestSender_NoRetry_PATCH_ConnectionError mirrors the POST connection-error
+// case for PATCH.
+func TestSender_NoRetry_PATCH_ConnectionError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	serverURL := server.URL
+	server.Close()
+
+	retries := 5
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		Retries:            &retries,
+		RequestMinInterval: &minInterval,
+		RetryMinInterval:   1 * time.Millisecond,
+		RetryMaxInterval:   10 * time.Millisecond,
+	}
+	authCfg := config.AuthConfig{Mode: "basic", Username: "admin", Password: "secret"}
+	sender := New(&http.Client{}, sempCfg, authCfg, serverURL)
+
+	req := newMethodRequest(t, http.MethodPatch, serverURL)
+	resp, err := sender.Do(context.Background(), req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected connection error for closed server")
+	}
+
+	var exhausted *RetriesExhaustedError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("expected RetriesExhaustedError, got %T: %v", err, err)
+	}
+	if exhausted.Attempts != 1 {
+		t.Errorf("expected exactly 1 attempt for PATCH connection error (no retry), got %d", exhausted.Attempts)
+	}
+}
+
 func TestSender_NoRetry_400(t *testing.T) {
 	var requestCount atomic.Int32
 	sender, server := newTestSenderWithServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -51,6 +51,15 @@ func newGetRequest(t *testing.T, url string) *http.Request {
 	return req
 }
 
+func newMethodRequest(t *testing.T, method, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), method, url+"/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	return req
+}
+
 func jsonOK(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{}})
@@ -568,6 +577,76 @@ func TestSender_NoRetry_404(t *testing.T) {
 
 	if requestCount.Load() != 1 {
 		t.Errorf("expected 1 request (no retry for 404), got %d", requestCount.Load())
+	}
+}
+
+func TestSender_NoRetry_POST_On503(t *testing.T) {
+	var requestCount atomic.Int32
+	sender, server := newTestSenderWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("unavailable"))
+	}, "basic", 10)
+	defer server.Close()
+
+	req := newMethodRequest(t, http.MethodPost, server.URL)
+	resp, err := sender.Do(context.Background(), req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("expected non-error response, got error: %v", err)
+	}
+
+	// POST must never be retried — exactly 1 request regardless of status.
+	if requestCount.Load() != 1 {
+		t.Errorf("expected 1 request (no retry for POST), got %d", requestCount.Load())
+	}
+}
+
+func TestSender_NoRetry_PATCH_On503(t *testing.T) {
+	var requestCount atomic.Int32
+	sender, server := newTestSenderWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("unavailable"))
+	}, "basic", 10)
+	defer server.Close()
+
+	req := newMethodRequest(t, http.MethodPatch, server.URL)
+	resp, err := sender.Do(context.Background(), req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("expected non-error response, got error: %v", err)
+	}
+
+	// PATCH must never be retried — exactly 1 request regardless of status.
+	if requestCount.Load() != 1 {
+		t.Errorf("expected 1 request (no retry for PATCH), got %d", requestCount.Load())
+	}
+}
+
+func TestSender_NoRetry_POST_On500(t *testing.T) {
+	var requestCount atomic.Int32
+	sender, server := newTestSenderWithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("error"))
+	}, "basic", 10)
+	defer server.Close()
+
+	req := newMethodRequest(t, http.MethodPost, server.URL)
+	resp, err := sender.Do(context.Background(), req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("expected non-error response, got error: %v", err)
+	}
+	if requestCount.Load() != 1 {
+		t.Errorf("expected 1 request (no retry for POST on 500), got %d", requestCount.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary
- `checkRetry` in `resilience/retry.go` previously had no HTTP method guard — POST and PATCH requests would retry on 503/5xx, risking double-writes (e.g. creating a queue twice)
- Added method check before all other retry logic; POST and PATCH return `(false, nil)` immediately regardless of status
- The HTTP method is stored in `retryState` at `Do()` time so the guard fires on connection errors too (where `resp` is nil)

## Test plan
- [x] `TestSender_NoRetry_POST_On503` — POST with 503 makes exactly 1 request
- [x] `TestSender_NoRetry_PATCH_On503` — PATCH with 503 makes exactly 1 request  
- [x] `TestSender_NoRetry_POST_On500` — POST with 500 makes exactly 1 request
- [x] All existing retry tests pass (GET/503, GET/429, 5xx-retry-once, 401 re-auth)
- [x] `go test -race ./internal/semp/resilience/...` passes
- [x] `golangci-lint run ./internal/semp/resilience/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)