### PR TITLE
SOL-149747: Replace os.Exit(1) in ListenAndServe goroutine with error channel

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -154,7 +155,7 @@ func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error 
 				slog.String("addr", srv.Addr))
 			listenErr = srv.ListenAndServe()
 		}
-		if listenErr != nil && listenErr != http.ErrServerClosed {
+		if listenErr != nil && !errors.Is(listenErr, http.ErrServerClosed) {
 			slog.Error("server failed", slog.String("error", listenErr.Error()))
 			errCh <- listenErr
 		}
@@ -326,13 +327,14 @@ func main() {
 
 	serverErr := startServer(httpServer, cfg.TLSCertFile, cfg.TLSKeyFile)
 
-	startupFailed := false
+	var startupErr error
 	select {
 	case <-done:
 		slog.Info("server shutting down", slog.String("reason", "signal"))
-	case <-serverErr:
-		// Error already logged in startServer. Run cleanup before exiting.
-		startupFailed = true
+	case startupErr = <-serverErr:
+		// Error already logged in startServer. Capture it so future telemetry
+		// hooks (e.g., metrics flush, error reporting) have access to the value,
+		// then run cleanup before exiting non-zero.
 	}
 
 	shutdownTimeout := time.Duration(defaults.DefaultShutdownTimeoutSeconds) * time.Second
@@ -347,7 +349,7 @@ func main() {
 	}
 
 	slog.Info("server stopped")
-	if startupFailed {
+	if startupErr != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -133,6 +133,35 @@ func healthConfigFromFile() healthConfig {
 	return healthConfig{Port: cfg.Port, Scheme: scheme}
 }
 
+// startServer starts httpServer in a background goroutine and returns a channel
+// that receives any startup/runtime error (excluding http.ErrServerClosed, which
+// is the normal result of Shutdown). The channel is buffered so the goroutine
+// never blocks if the receiver is gone.
+//
+// This replaces the previous pattern of calling os.Exit(1) inside the goroutine,
+// which bypassed all deferred cleanup and the graceful-shutdown path.
+func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		var listenErr error
+		if tlsCertFile != "" && tlsKeyFile != "" {
+			slog.Info("server listening with TLS",
+				slog.String("addr", srv.Addr),
+				slog.String("cert", tlsCertFile))
+			listenErr = srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
+		} else {
+			slog.Info("server listening",
+				slog.String("addr", srv.Addr))
+			listenErr = srv.ListenAndServe()
+		}
+		if listenErr != nil && listenErr != http.ErrServerClosed {
+			slog.Error("server failed", slog.String("error", listenErr.Error()))
+			errCh <- listenErr
+		}
+	}()
+	return errCh
+}
+
 // registerSEMPv1Tools attaches every Go-native SEMPv1 tool handler to mgr.
 // New SEMPv1 tools should be added here as they land — this is the single
 // source of truth for which v1 tools the server exposes. The handlers flow
@@ -295,26 +324,16 @@ func main() {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
 
-	go func() {
-		var err error
-		if cfg.TLSCertFile != "" && cfg.TLSKeyFile != "" {
-			slog.Info("server listening with TLS",
-				slog.String("addr", addr),
-				slog.String("cert", cfg.TLSCertFile))
-			err = httpServer.ListenAndServeTLS(cfg.TLSCertFile, cfg.TLSKeyFile)
-		} else {
-			slog.Info("server listening",
-				slog.String("addr", addr))
-			err = httpServer.ListenAndServe()
-		}
-		if err != nil && err != http.ErrServerClosed {
-			slog.Error("server failed", slog.String("error", err.Error()))
-			os.Exit(1)
-		}
-	}()
+	serverErr := startServer(httpServer, cfg.TLSCertFile, cfg.TLSKeyFile)
 
-	<-done
-	slog.Info("server shutting down", slog.String("reason", "signal"))
+	startupFailed := false
+	select {
+	case <-done:
+		slog.Info("server shutting down", slog.String("reason", "signal"))
+	case <-serverErr:
+		// Error already logged in startServer. Run cleanup before exiting.
+		startupFailed = true
+	}
 
 	shutdownTimeout := time.Duration(defaults.DefaultShutdownTimeoutSeconds) * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
@@ -328,4 +347,7 @@ func main() {
 	}
 
 	slog.Info("server stopped")
+	if startupFailed {
+		os.Exit(1)
+	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -16,11 +16,13 @@ package main
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -99,6 +101,61 @@ func TestUnknownRoute_Returns404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("GET /unknown status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestStartServer_PortConflict_SendsToChannel(t *testing.T) {
+	// Occupy a port to force an "address already in use" startup error.
+	lc := &net.ListenConfig{}
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	srv := &http.Server{
+		Addr:    l.Addr().String(),
+		Handler: http.NewServeMux(),
+	}
+
+	errCh := startServer(srv, "", "")
+
+	select {
+	case startErr := <-errCh:
+		if startErr == nil {
+			t.Fatal("expected error for port conflict, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: expected startup error to be sent to channel, not os.Exit")
+	}
+}
+
+func TestStartServer_NormalShutdown_NoErrorSent(t *testing.T) {
+	// A server that is shut down cleanly should not send to the error channel.
+	lc := &net.ListenConfig{}
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	l.Close() // release port so startServer can bind
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: http.NewServeMux(),
+	}
+
+	errCh := startServer(srv, "", "")
+	// Immediately shut down — this produces ErrServerClosed, not an error.
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case startErr := <-errCh:
+		t.Errorf("expected no error on clean shutdown, got: %v", startErr)
+	case <-time.After(200 * time.Millisecond):
+		// expected: no error sent for ErrServerClosed
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -131,31 +131,28 @@ func TestStartServer_PortConflict_SendsToChannel(t *testing.T) {
 }
 
 func TestStartServer_NormalShutdown_NoErrorSent(t *testing.T) {
-	// A server that is shut down cleanly should not send to the error channel.
-	lc := &net.ListenConfig{}
-	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := l.Addr().String()
-	l.Close() // release port so startServer can bind
-
+	// Verify that ErrServerClosed (the result of a clean Shutdown) is filtered
+	// out and not sent to the error channel.
+	//
+	// We call Shutdown before startServer so http.Server.ListenAndServe sees
+	// shuttingDown=true on entry and returns ErrServerClosed without binding
+	// any port. This exercises the same filter path without the port-reuse
+	// race of binding-then-rebinding to the same address.
 	srv := &http.Server{
-		Addr:    addr,
+		Addr:    "127.0.0.1:0",
 		Handler: http.NewServeMux(),
 	}
-
-	errCh := startServer(srv, "", "")
-	// Immediately shut down — this produces ErrServerClosed, not an error.
 	if err := srv.Shutdown(context.Background()); err != nil {
 		t.Fatalf("Shutdown: %v", err)
 	}
 
+	errCh := startServer(srv, "", "")
+
 	select {
 	case startErr := <-errCh:
-		t.Errorf("expected no error on clean shutdown, got: %v", startErr)
+		t.Errorf("expected no error for ErrServerClosed, got: %v", startErr)
 	case <-time.After(200 * time.Millisecond):
-		// expected: no error sent for ErrServerClosed
+		// expected: ListenAndServe returned ErrServerClosed and was filtered out
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ListenAndServe` goroutine previously called `os.Exit(1)` on startup failure (port conflict, TLS error), bypassing graceful shutdown and any future deferred cleanup
- Extracted `startServer()` helper that returns a `<-chan error`; errors are sent to the channel instead of calling `os.Exit`
- `main()` now selects on both OS signal and server error; `httpServer.Shutdown()` runs in both cases before the process exits

## Test plan
- [x] `TestStartServer_PortConflict_SendsToChannel` — port conflict error arrives on channel (not os.Exit)
- [x] `TestStartServer_NormalShutdown_NoErrorSent` — clean Shutdown produces no error on channel
- [x] All existing health/route tests pass
- [x] `go test -race ./cmd/server/...` passes
- [x] `golangci-lint run ./cmd/server/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)