### PR TITLE
SOL-149749: buildURL errors on unfilled path parameter placeholders

### DIFF
--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -121,7 +121,10 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (
 // Rate limiting is enforced before the request (new requests only, not retries).
 // Retry logic is handled by the shared resilience.Sender.
 func (c *HTTPClient) Execute(ctx context.Context, op *Operation, args map[string]any) (*Result, error) {
-	reqURL := c.buildURL(op, args)
+	reqURL, err := c.buildURL(op, args)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := c.buildRequest(ctx, op, reqURL, args)
 	if err != nil {
@@ -164,7 +167,10 @@ func (c *HTTPClient) Execute(ctx context.Context, op *Operation, args map[string
 
 // buildURL substitutes path parameter placeholders in the operation's path
 // template with values from args and prepends the broker's base URL.
-func (c *HTTPClient) buildURL(op *Operation, args map[string]any) string {
+// Returns an error if any {placeholder} tokens remain unfilled after
+// substitution — this catches missing required path parameters before a
+// silently-wrong HTTP call is made.
+func (c *HTTPClient) buildURL(op *Operation, args map[string]any) (string, error) {
 	path := op.Path
 
 	for key, value := range args {
@@ -174,7 +180,25 @@ func (c *HTTPClient) buildURL(op *Operation, args map[string]any) string {
 		}
 	}
 
-	return c.baseURL + "/" + strings.TrimPrefix(path, "/")
+	// Detect any unfilled {placeholder} tokens left in the path.
+	if strings.Contains(path, "{") {
+		var missing []string
+		for rest := path; len(rest) > 0; {
+			start := strings.Index(rest, "{")
+			if start < 0 {
+				break
+			}
+			end := strings.Index(rest[start:], "}")
+			if end < 0 {
+				break
+			}
+			missing = append(missing, rest[start:start+end+1])
+			rest = rest[start+end+1:]
+		}
+		return "", fmt.Errorf("operation %s: unfilled path parameters: %s", op.ID, strings.Join(missing, ", "))
+	}
+
+	return c.baseURL + "/" + strings.TrimPrefix(path, "/"), nil
 }
 
 // buildRequest constructs the HTTP request with query parameters and JSON body

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -180,25 +180,41 @@ func (c *HTTPClient) buildURL(op *Operation, args map[string]any) (string, error
 		}
 	}
 
-	// Detect any unfilled {placeholder} tokens left in the path.
-	if strings.Contains(path, "{") {
-		var missing []string
-		for rest := path; len(rest) > 0; {
-			start := strings.Index(rest, "{")
-			if start < 0 {
-				break
-			}
-			end := strings.Index(rest[start:], "}")
-			if end < 0 {
-				break
-			}
-			missing = append(missing, rest[start:start+end+1])
-			rest = rest[start+end+1:]
-		}
-		return "", fmt.Errorf("operation %s: unfilled path parameters: %s", op.ID, strings.Join(missing, ", "))
+	// Detect any unfilled {placeholder} tokens left in the path. A "{" with no
+	// matching "}" means the path template itself is malformed — in that case
+	// fall through and let the broker surface the bad URL via a 4xx, since the
+	// problem isn't a missing argument.
+	missing := unfilledPlaceholders(path)
+	if len(missing) > 0 {
+		return "", fmt.Errorf("operation %s (path %q): unfilled path parameters: %s", op.ID, op.Path, strings.Join(missing, ", "))
 	}
 
 	return c.baseURL + "/" + strings.TrimPrefix(path, "/"), nil
+}
+
+// unfilledPlaceholders returns the de-duplicated list of "{name}" tokens
+// remaining in path after argument substitution. Each placeholder is reported
+// once even if it appears multiple times in the template.
+func unfilledPlaceholders(path string) []string {
+	var missing []string
+	seen := make(map[string]struct{})
+	for rest := path; len(rest) > 0; {
+		start := strings.Index(rest, "{")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(rest[start:], "}")
+		if end < 0 {
+			break
+		}
+		placeholder := rest[start : start+end+1]
+		if _, dup := seen[placeholder]; !dup {
+			seen[placeholder] = struct{}{}
+			missing = append(missing, placeholder)
+		}
+		rest = rest[start+end+1:]
+	}
+	return missing
 }
 
 // buildRequest constructs the HTTP request with query parameters and JSON body

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -83,6 +83,53 @@ func TestClient_Execute_Success(t *testing.T) {
 	}
 }
 
+func TestClient_Execute_MissingPathParam_ReturnsError(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// Should never be reached — buildURL should return an error before any HTTP call.
+		t.Error("handler called unexpectedly; buildURL should have errored")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	op := testOp("GET",
+		sempv2.Parameter{Name: "msgVpnName", In: "path"},
+		sempv2.Parameter{Name: "queueName", In: "path"},
+	)
+
+	// Provide msgVpnName but omit queueName — {queueName} stays unfilled.
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"msgVpnName": "default",
+		// queueName intentionally absent
+	})
+	if err == nil {
+		t.Fatal("expected error for missing path parameter, got nil")
+	}
+	if !strings.Contains(err.Error(), "{queueName}") {
+		t.Errorf("error = %q, expected it to name the missing placeholder {queueName}", err.Error())
+	}
+}
+
+func TestClient_Execute_AllPathParamsProvided_NoError(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer server.Close()
+
+	op := testOp("GET",
+		sempv2.Parameter{Name: "msgVpnName", In: "path"},
+		sempv2.Parameter{Name: "queueName", In: "path"},
+	)
+
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"msgVpnName": "default",
+		"queueName":  "q1",
+	})
+	if err != nil {
+		t.Fatalf("Execute() with all path params: unexpected error: %v", err)
+	}
+}
+
 func TestClient_Execute_PathParams(t *testing.T) {
 	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "/msgVpns/my-vpn/queues/my-queue") {

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -107,6 +107,50 @@ func TestClient_Execute_MissingPathParam_ReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "{queueName}") {
 		t.Errorf("error = %q, expected it to name the missing placeholder {queueName}", err.Error())
 	}
+	// Error message should include the operation's path template so an operator
+	// can correlate the error to the spec.
+	if !strings.Contains(err.Error(), op.Path) {
+		t.Errorf("error = %q, expected it to include op.Path %q for debuggability", err.Error(), op.Path)
+	}
+}
+
+// TestClient_Execute_MissingPathParam_DeduplicatedInError ensures a repeated
+// placeholder appears only once in the error message even when the template
+// references it multiple times.
+func TestClient_Execute_MissingPathParam_DeduplicatedInError(t *testing.T) {
+	client, server := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("handler called unexpectedly; buildURL should have errored")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	op := &sempv2.Operation{
+		ID:     "testOp",
+		Method: "GET",
+		// {vpn} appears twice in the template; should be reported once.
+		Path: "/v2/x/{vpn}/y/{vpn}/z",
+		Parameters: []sempv2.Parameter{
+			{Name: "vpn", In: "path"},
+		},
+	}
+
+	_, err := client.Execute(context.Background(), op, map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing path parameter")
+	}
+	// The error embeds op.Path (which contains {vpn} twice) plus the
+	// deduplicated list of unfilled placeholders. Inspect only the list
+	// portion after "unfilled path parameters:" to verify dedupe.
+	const marker = "unfilled path parameters:"
+	idx := strings.Index(err.Error(), marker)
+	if idx < 0 {
+		t.Fatalf("error message missing %q section: %q", marker, err.Error())
+	}
+	listPortion := err.Error()[idx+len(marker):]
+	occurrences := strings.Count(listPortion, "{vpn}")
+	if occurrences != 1 {
+		t.Errorf("expected {vpn} to appear exactly once in the unfilled-params list, got %d (list: %q)", occurrences, listPortion)
+	}
 }
 
 func TestClient_Execute_AllPathParamsProvided_NoError(t *testing.T) {

--- a/internal/semp/sempv2/operation_test.go
+++ b/internal/semp/sempv2/operation_test.go
@@ -77,6 +77,7 @@ func TestParseSpecs_RefParametersResolved(t *testing.T) {
 	op := ops["monitor/getMsgVpnQueue"]
 	if op == nil {
 		t.Fatal("monitor/getMsgVpnQueue not found")
+		return
 	}
 
 	found := false
@@ -132,6 +133,7 @@ func TestParseSpecs_PathIncludesBasePath(t *testing.T) {
 	op := ops["monitor/getMsgVpnQueue"]
 	if op == nil {
 		t.Fatal("monitor/getMsgVpnQueue not found")
+		return
 	}
 
 	if !strings.HasPrefix(op.Path, "/SEMP/v2/__private_monitor__/") {


### PR DESCRIPTION
## Summary
- `buildURL` previously substituted `{placeholder}` tokens from args but never checked whether any remained unfilled — a missing required path param would silently produce a wrong URL
- `buildURL` now returns `(string, error)`; after substitution it scans the path for any remaining `{...}` tokens and returns a descriptive error naming them
- `Execute` propagates the error before making any HTTP call
- Also fixed pre-existing `SA5011` staticcheck violations in `operation_test.go`

## Test plan
- [x] `TestClient_Execute_MissingPathParam_ReturnsError` — omitting `queueName` returns error mentioning `{queueName}`; server is never called
- [x] `TestClient_Execute_AllPathParamsProvided_NoError` — all params present succeeds as before
- [x] All existing path/query/body param tests pass
- [x] `go test -race ./internal/semp/sempv2/...` passes
- [x] `golangci-lint run ./internal/semp/sempv2/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)