### PR TITLE
fix(server): renumber skipped step comment in main.go startup sequence [SOL-149771]

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -259,7 +259,7 @@ func main() {
 
 	slog.Info("all tools registered")
 
-	// 9. Set up HTTP routes
+	// 8. Set up HTTP routes
 	mux := buildMux()
 
 	// Create MCP handler
@@ -284,7 +284,7 @@ func main() {
 		slog.Info("registered OAuth protected resource metadata endpoint")
 	}
 
-	// 10. Start server with graceful shutdown
+	// 9. Start server with graceful shutdown
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	httpServer := &http.Server{
 		Addr:              addr,


### PR DESCRIPTION
## Summary

- Step 8 was missing in the `cmd/server/main.go` startup sequence — the numbered comments jumped from `// 7.` to `// 9.` after a prior deletion
- Renumbered `// 9. Set up HTTP routes` → `// 8.` and `// 10. Start server with graceful shutdown` → `// 9.`
- Pure comment change — no logic, no behaviour, no tests needed

## Changes

`cmd/server/main.go`
- Line 262: `// 9.` → `// 8.`
- Line 287: `// 10.` → `// 9.`

## Test plan

- [x] `go test ./...` passes (all packages green, baseline verified before changes)
- [x] `go build ./...` succeeds
- [x] Step sequence is now contiguous: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9

## Jira

[SOL-149771](https://sol-jira.atlassian.net/browse/SOL-149771)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-149771]: https://sol-jira.atlassian.net/browse/SOL-149771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ