### PR TITLE
SOL-149790: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+
+* @SolaceDev/dax-developers


### PR DESCRIPTION
## What is the purpose of this change?
- Add a `CODEOWNERS` file so reviewers are automatically requested on every PR.

## How is this accomplished?
- Created `.github/CODEOWNERS` with a single global rule assigning `@SolaceDev/dax-developers` as the default owner for the entire repository.

## Anything reviewers should focus on/be aware of?
- The `dax-developers` team must have at least **write access** to this repo, or GitHub will silently ignore the entry.
- To enforce code-owner review on merge, enable **Require review from Code Owners** in `main` branch protection.

## What testing if any was performed?
- No code changes; configuration-only. The pattern follows the [GitHub CODEOWNERS spec](https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners).