### PR TITLE
fix(config): reject unknown YAML fields in config decoder [SOL-149927]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Tracked under SOL-149789.
 
+- Config loader now rejects unknown YAML fields at startup instead of silently ignoring them. Previously, a typo like `developmnet_mode` or `insecure_skip_verfy` was accepted and the operator's intended override became a no-op. The loader now fails fast with an error naming the offending field. Existing configs with stale or misspelled keys will fail to start until the typo is corrected; configs with only valid keys are unaffected. Tracked under SOL-149927.
+
 ## [0.1.0] - 2026-04-24
 
 ### Added

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -287,7 +287,9 @@ func LoadConfig(path string) (*ServerConfig, error) {
 	}
 
 	var raw yamlConfig
-	if err := yaml.Unmarshal(data, &raw); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
 		return nil, fmt.Errorf("parsing config YAML: %w", err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -185,7 +185,6 @@ func TestLoadConfig_RejectsUnknownFields(t *testing.T) {
 		{
 			name: "top-level typo",
 			yaml: `
-development_mode: true
 developmnet_mode: true
 brokers:
   dev:
@@ -200,7 +199,6 @@ brokers:
 		{
 			name: "nested broker typo",
 			yaml: `
-development_mode: true
 brokers:
   dev:
     url: "http://localhost:8080"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,6 +172,61 @@ func TestLoadConfig_MalformedYAML(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_RejectsUnknownFields(t *testing.T) {
+	// Unknown YAML keys are a foot-gun: a typo like `developmnet_mode` or
+	// `max_concurrent_per_brokr` was previously accepted silently, leaving
+	// the operator's override as a no-op. KnownFields(true) on the YAML
+	// decoder forces typos to surface at config load.
+	cases := []struct {
+		name        string
+		yaml        string
+		wantInError string
+	}{
+		{
+			name: "top-level typo",
+			yaml: `
+development_mode: true
+developmnet_mode: true
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`,
+			wantInError: "developmnet_mode",
+		},
+		{
+			name: "nested broker typo",
+			yaml: `
+development_mode: true
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    insecure_skip_verfy: true
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`,
+			wantInError: "insecure_skip_verfy",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadConfig(writeTemp(t, tc.yaml))
+			if err == nil {
+				t.Fatal("expected error for unknown YAML field")
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Errorf("error should name the offending field %q, got: %v", tc.wantInError, err)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_DefaultsApplied(t *testing.T) {
 	yaml := `
 client_auth:


### PR DESCRIPTION
## What was wrong

`internal/config/config.go:230-233` decoded the main YAML config via `yaml.Unmarshal`, which silently ignores unknown fields. Operator typos like `developmnet_mode: true` or `max_concurrent_per_brokr: 200` were accepted; the default was applied and the operator's override became a no-op. The composite-tool loader (`internal/composite/loader.go:36-38`) already uses the strict pattern — main loader didn't.

## What the fix does

Swaps `yaml.Unmarshal(data, &raw)` for `yaml.NewDecoder(bytes.NewReader(data))` + `dec.KnownFields(true)` + `dec.Decode(&raw)`, mirroring the composite loader. Configs with unknown YAML keys now fail at startup with an error naming the offending field. The error wrapping (`"parsing config YAML: %w"`) is unchanged.

## Tests

- Added `TestLoadConfig_RejectsUnknownFields` — table test with two sub-cases:
  - `top-level typo` — feeds `developmnet_mode: true` alongside the real field, asserts the error names the typo.
  - `nested broker typo` — feeds `insecure_skip_verfy: true` inside a broker, asserts the error names the typo.
- All existing tests still pass; full suite is green.
- Revert-verify confirmed the new test couples to the fix (stash the config.go change → test fails; restore → test passes).

## Behavior change (operator-visible)

Any deployed config that currently contains a stale or misspelled field — silently ignored before — will now fail at startup. This is the intended outcome of the fix. Operators should run their config through a quick validation pass before upgrading. The error message names the offending field so the source of the failure is obvious.

## Scope

Two yaml decode sites are NOT touched:

- `internal/composite/loader.go:36-38` — already uses the strict pattern.
- `cmd/server/main.go:127` — `healthConfigFromFile()` is a deliberately partial decode into a 3-field struct (`port`, `tls_cert_file`, `tls_key_file`) for the `--health` CLI probe. Enabling `KnownFields(true)` here would fail on every other config key. Intentional asymmetry.

## Jira

[SOL-149927](https://sol-jira.atlassian.net/browse/SOL-149927) — part of the May 2026 robustness/security sweep tracked under epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480).

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149927]: https://sol-jira.atlassian.net/browse/SOL-149927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ