### PR TITLE
fix: require dev_token when development_mode is true [SOL-149921]

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -31,11 +31,6 @@ import (
 )
 
 func NewAuthMiddleware(cfg *config.ServerConfig, next http.Handler) (http.Handler, error) {
-	if cfg.DevelopmentMode && cfg.ClientAuth.DevToken == "" {
-		slog.Warn("authentication disabled — development mode with no dev token — not for production use")
-		return next, nil
-	}
-
 	verifier, err := NewTokenVerifier(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create token verifier: %w", err)
@@ -144,11 +139,6 @@ func createOIDCTokenVerifier(cfg *config.ServerConfig) (sdkauth.TokenVerifier, e
 // and initiate browser-based OAuth flows (Authorization Code + PKCE).
 // Returns nil when there's no OAuth configuration to advertise.
 func NewProtectedResourceMetadataHandler(cfg *config.ServerConfig) http.Handler {
-	// Only provide metadata endpoint when JWT validation is active
-	if cfg.DevelopmentMode && cfg.ClientAuth.DevToken == "" {
-		return nil
-	}
-
 	// Skip metadata endpoint when there's no issuer configured.
 	// The endpoint's purpose is to advertise the OAuth authorization server,
 	// so serving it with an empty issuer would be misleading to clients.

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -37,61 +37,6 @@ var dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request)
 	w.Write([]byte("OK"))
 })
 
-// Test_AuthDisabled tests that all requests pass through when development_mode=true and dev_token=""
-func Test_AuthDisabled(t *testing.T) {
-	cfg := &config.ServerConfig{
-		Port:            9090,
-		DevelopmentMode: true,
-		ClientAuth: config.ClientAuthConfig{
-			DevToken: "", // Empty dev token means auth disabled
-		},
-	}
-
-	middleware, err := NewAuthMiddleware(cfg, dummyHandler)
-	if err != nil {
-		t.Fatalf("failed to create middleware: %v", err)
-	}
-
-	tests := []struct {
-		name         string
-		authHeader   string
-		expectedCode int
-		expectedBody string
-	}{
-		{
-			name:         "no auth header",
-			authHeader:   "",
-			expectedCode: http.StatusOK,
-			expectedBody: "OK",
-		},
-		{
-			name:         "with bearer token",
-			authHeader:   "Bearer some-random-token",
-			expectedCode: http.StatusOK,
-			expectedBody: "OK",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
-			if tt.authHeader != "" {
-				req.Header.Set("Authorization", tt.authHeader)
-			}
-
-			rec := httptest.NewRecorder()
-			middleware.ServeHTTP(rec, req)
-
-			if rec.Code != tt.expectedCode {
-				t.Errorf("expected status %d, got %d", tt.expectedCode, rec.Code)
-			}
-			if strings.TrimSpace(rec.Body.String()) != tt.expectedBody {
-				t.Errorf("expected body %q, got %q", tt.expectedBody, rec.Body.String())
-			}
-		})
-	}
-}
-
 // Test_StaticDevToken tests static token validation in development mode
 func Test_StaticDevToken(t *testing.T) {
 	const validToken = "dev-secret-token-12345"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -432,9 +432,15 @@ func validate(cfg *ServerConfig) error {
 	}
 
 	// Validate client authentication configuration based on development mode.
-	// Note that no validation is needed when development mode is enabled, as DevToken
-	// can be set or empty. When DevToken is empty, all requests pass through
-	if !cfg.DevelopmentMode {
+	// Production mode requires the OIDC fields. Development mode requires a
+	// static dev_token — an empty token used to silently disable client auth
+	// entirely (auth bypass via a single blank YAML field), which the
+	// validator must reject.
+	if cfg.DevelopmentMode {
+		if cfg.ClientAuth.DevToken == "" {
+			errs = append(errs, fmt.Errorf("client_auth.dev_token is required when development_mode is true (set a non-empty token to enable static auth)"))
+		}
+	} else {
 		// Production mode: require JWT validation fields
 		if cfg.ClientAuth.Issuer == "" {
 			errs = append(errs, fmt.Errorf("client_auth.issuer is required when development_mode is false"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,8 @@ func TestLoadConfig_SingleBroker(t *testing.T) {
 
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   prod-us:
     url: "https://broker-us.example.com:1943"
@@ -87,6 +89,8 @@ func TestLoadConfig_MultiBroker(t *testing.T) {
 
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   prod-us:
     url: "https://broker-us.example.com:1943"
@@ -121,6 +125,8 @@ brokers:
 func TestLoadConfig_MissingBrokerURL(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     auth:
@@ -140,6 +146,8 @@ brokers:
 func TestLoadConfig_MissingBasicAuthCreds(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "https://broker.example.com:1943"
@@ -162,9 +170,38 @@ func TestLoadConfig_MalformedYAML(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_DevModeRequiresDevToken(t *testing.T) {
+	// development_mode: true with an empty dev_token used to silently disable
+	// all client authentication and pass every request through. That is an
+	// auth bypass triggered by a one-line config omission — the validator
+	// must reject it instead.
+	yaml := `
+development_mode: true
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error when development_mode is true and dev_token is empty")
+	}
+	if !strings.Contains(err.Error(), "dev_token") {
+		t.Errorf("error should name the offending field (dev_token), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "development_mode") {
+		t.Errorf("error should mention development_mode for operator context, got: %v", err)
+	}
+}
+
 func TestLoadConfig_DefaultsApplied(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "https://broker.example.com:1943"
@@ -192,6 +229,8 @@ brokers:
 func TestLoadConfig_InvalidAuthMethod(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "https://broker.example.com:1943"
@@ -216,6 +255,8 @@ func TestLoadConfig_EnvVarSubstitution(t *testing.T) {
 
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   prod:
     url: ${BROKER_URL}
@@ -244,6 +285,8 @@ brokers:
 func TestLoadConfig_EnvVarMissing(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   prod:
     url: ${MISSING_URL}
@@ -284,6 +327,8 @@ brokers:
 func TestLoadConfig_TLSOnlyCert_ReturnsError(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 tls_cert_file: "/tmp/cert.pem"
 brokers:
   dev:
@@ -305,6 +350,8 @@ brokers:
 func TestLoadConfig_TLSBothFields_Valid(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 tls_cert_file: "/tmp/cert.pem"
 tls_key_file: "/tmp/key.pem"
 brokers:
@@ -332,6 +379,8 @@ func TestLoadConfig_EnvOverridePort(t *testing.T) {
 
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 port: 8080
 brokers:
   dev:
@@ -355,6 +404,8 @@ func TestLoadConfig_BearerAuth(t *testing.T) {
 
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   prod:
     url: "https://broker.example.com:8080"
@@ -379,6 +430,8 @@ brokers:
 func TestLoadConfig_BearerAuth_MissingToken(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   prod:
     url: "https://broker.example.com:8080"
@@ -397,6 +450,8 @@ brokers:
 func TestLoadConfig_MissingAuthMode(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "http://localhost:8080"
@@ -416,6 +471,8 @@ brokers:
 func TestLoadConfig_AuthModeCaseInsensitive(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "http://localhost:8080"
@@ -436,6 +493,8 @@ brokers:
 func TestLoadConfig_InvalidURLScheme(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "ftp://broker.example.com"
@@ -510,6 +569,8 @@ client_auth:
 func TestLoadConfig_AllowsHTTPBrokerInDevelopmentMode(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "http://localhost:8080"
@@ -527,6 +588,8 @@ brokers:
 func TestLoadConfig_URLMissingHost(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "http://"
@@ -549,6 +612,8 @@ func TestLoadConfig_URLEmpty_ReportsRequired(t *testing.T) {
 	// structure-validation branch — verifying we don't double-report.
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: ""
@@ -572,6 +637,8 @@ brokers:
 func TestLoadConfig_LogLevel_Default(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "http://localhost:8080"
@@ -594,6 +661,8 @@ func TestLoadConfig_LogLevel_ValidValues(t *testing.T) {
 		t.Run(level, func(t *testing.T) {
 			yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 log_level: ` + level + `
 brokers:
   dev:
@@ -617,6 +686,8 @@ brokers:
 func TestLoadConfig_LogLevel_CaseInsensitive(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 log_level: DEBUG
 brokers:
   dev:
@@ -658,6 +729,8 @@ brokers:
 func TestLoadConfig_RateLimit_Defaults(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "http://localhost:8080"
@@ -687,6 +760,8 @@ brokers:
 func TestLoadConfig_RateLimit_ValidValues(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 semp:
   request_min_interval: 50ms
   retries: 5
@@ -726,6 +801,8 @@ func TestLoadConfig_RateLimit_ExplicitZeroHonored(t *testing.T) {
 	// "0 in YAML" is indistinguishable from "omitted from YAML".
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 semp:
   request_min_interval: 0s
   retries: 0
@@ -852,6 +929,8 @@ func TestValidate_BrokerErrorsAreSorted(t *testing.T) {
 	// joined error string always lists errors in alphabetical alias order.
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   zebra:
     auth:
@@ -883,6 +962,8 @@ brokers:
 func TestLoad_UsesConfigFileEnv(t *testing.T) {
 	yaml := `
 development_mode: true
+client_auth:
+  dev_token: test
 brokers:
   dev:
     url: "http://localhost:8080"

--- a/test/e2e/agent/main.go
+++ b/test/e2e/agent/main.go
@@ -17,18 +17,39 @@
 // the registered tools with hardcoded calls against both configured brokers.
 //
 // Usage: agent <server-url>
+//
+// The agent reads MCP_DEV_TOKEN from the environment and attaches it as a
+// Bearer Authorization header on every request via a custom RoundTripper.
+// This matches the dev_token configured in test/e2e/helpers.sh write_config()
+// so the broker MCP server's static dev-token verifier accepts the agent.
 package main
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// bearerRoundTripper wraps http.DefaultTransport to add a Bearer Authorization
+// header to every outbound request. Used by the e2e agent so the broker MCP
+// server's auth middleware accepts our session-initialize and tool calls.
+type bearerRoundTripper struct {
+	token string
+	rt    http.RoundTripper
+}
+
+func (b *bearerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request so we do not mutate the caller's copy.
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set("Authorization", "Bearer "+b.token)
+	return b.rt.RoundTrip(cloned)
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -48,15 +69,24 @@ func main() {
 }
 
 func run(ctx context.Context, serverURL string) error {
-	// Connect to the MCP server
+	// Connect to the MCP server with a Bearer token attached to every request.
 	fmt.Printf("Connecting to %s ...\n", serverURL)
 	client := mcp.NewClient(&mcp.Implementation{
 		Name:    "e2e-agent",
 		Version: "1.0.0",
 	}, nil)
 
+	token := os.Getenv("MCP_DEV_TOKEN")
+	if token == "" {
+		return fmt.Errorf("MCP_DEV_TOKEN env var is required (set by test harness; matches dev_token in broker config)")
+	}
+	httpClient := &http.Client{
+		Transport: &bearerRoundTripper{token: token, rt: http.DefaultTransport},
+	}
+
 	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: serverURL + "/mcp",
+		Endpoint:   serverURL + "/mcp",
+		HTTPClient: httpClient,
 	}, nil)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)

--- a/test/e2e/broker-config.yaml
+++ b/test/e2e/broker-config.yaml
@@ -10,7 +10,9 @@
 
 # ── Auth settings ───────────────────────────────────────────────────────────
 development_mode: true                # Skip OAuth validation (uses static dev token)
-# client_auth:                        # Required when development_mode is false:
+client_auth:
+  dev_token: e2e-static-dev-token     # Required when development_mode is true.
+# client_auth:                        # When development_mode is false, set these instead:
 #   issuer: "https://idp.example.com" #   IdP issuer URL
 #   audience: "solace-mcp"            #   Expected 'aud' claim
 #   resource_url: "https://mcp.example.com/mcp"  # OAuth resource URL

--- a/test/e2e/helpers.sh
+++ b/test/e2e/helpers.sh
@@ -160,7 +160,8 @@ write_config() {
     # Credentials use ${VAR_NAME} substitution — resolved by the server via ENV_FILE.
     cat > "$config_file" <<EOF
 development_mode: true
-
+client_auth:
+  dev_token: e2e-static-dev-token
 brokers:
   broker-a:
     url: "${BROKER_A_URL}"

--- a/test/e2e/helpers.sh
+++ b/test/e2e/helpers.sh
@@ -29,6 +29,13 @@ SEMP_CONFIG="$BROKER_A_SEMP_CONFIG"
 MCP_PORT=9090
 MCP_URL="http://localhost:$MCP_PORT"
 MCP_SERVER_PID=""
+# Static dev token injected into the broker MCP server config by write_config().
+# Every curl to $MCP_URL/mcp authenticates with this token via Bearer header
+# so the static-dev-token verifier (development_mode: true path) accepts
+# the request. Must match the dev_token value in write_config(). Exported
+# so the Go agent in test/e2e/agent reads it from the environment and attaches
+# it to its outgoing requests via a custom RoundTripper.
+export MCP_DEV_TOKEN="e2e-static-dev-token"
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
@@ -284,6 +291,7 @@ mcp_initialize() {
     response=$(curl -sf -D - -X POST "$MCP_URL/mcp" \
         -H "Content-Type: application/json" \
         -H "Accept: application/json, text/event-stream" \
+        -H "Authorization: Bearer $MCP_DEV_TOKEN" \
         -d '{
             "jsonrpc": "2.0",
             "id": 1,
@@ -308,6 +316,7 @@ mcp_initialize() {
     curl -sf -X POST "$MCP_URL/mcp" \
         -H "Content-Type: application/json" \
         -H "Accept: application/json, text/event-stream" \
+        -H "Authorization: Bearer $MCP_DEV_TOKEN" \
         -H "Mcp-Session-Id: $session_id" \
         -d '{
             "jsonrpc": "2.0",
@@ -327,6 +336,7 @@ mcp_request() {
     raw=$(curl -s -X POST "$MCP_URL/mcp" \
         -H "Content-Type: application/json" \
         -H "Accept: application/json, text/event-stream" \
+        -H "Authorization: Bearer $MCP_DEV_TOKEN" \
         -H "Mcp-Session-Id: $session_id" \
         -d "$body")
 

--- a/test/e2e/oauth/test-config.yaml
+++ b/test/e2e/oauth/test-config.yaml
@@ -13,10 +13,19 @@ port: 9091
 development_mode: true  # localhost http:// URLs are intentional for this e2e test environment
 
 # OAuth configuration - values are injected by setup-keycloak.sh into test/e2e/oauth/.env
+#
+# NOTE: With development_mode: true the static dev_token verifier is used at
+# runtime (not OIDC), so the issuer/audience fields are effectively unused
+# for actual JWT verification. The OAuth test in this directory exercised
+# the pre-SOL-149921 auth-bypass path (dev_mode + empty dev_token = pass
+# everything through), which is no longer permitted. To run a true OIDC
+# test path, this config needs to be switched to development_mode: false
+# with https:// URLs — out of scope for SOL-149921, tracked separately.
 client_auth:
   issuer: "http://localhost:8090/realms/solace"
   audience: "solace-mcp-server"
   resource_url: "http://localhost:9091/mcp"
+  dev_token: oauth-test-static-dev-token
 
 # Broker configuration
 # Note: This broker is only needed for config validation.


### PR DESCRIPTION
## What was wrong

`internal/auth/middleware.go:34-37` short-circuited the auth chain and returned the unprotected next handler whenever `cfg.DevelopmentMode == true && cfg.ClientAuth.DevToken == ""`. The config validator (`internal/config/config.go:434-448`) documented this state as intentional via a comment ("When DevToken is empty, all requests pass through"). A single blank YAML field — `dev_token: ""`, or no `dev_token` line at all — silently removed client authentication, with only a WARN log to flag it. Exploitable auth bypass triggered by a one-line config omission.

## What the fix does

- Extends `validate()` to require `cfg.ClientAuth.DevToken != ""` whenever `cfg.DevelopmentMode == true`. The error names the offending field and the trigger condition.
- Removes the now-unreachable bypass branch in `NewAuthMiddleware` and the matching dead branch in `NewProtectedResourceMetadataHandler`. The downstream `Issuer == ""` check at `middleware.go:150` covers any state that bypasses validation.
- Updates 27 existing test fixtures that used `development_mode: true` without a `dev_token` so they continue to exercise their intended assertions under the stricter validator.
- Removes `Test_AuthDisabled` — it directly asserted the bypass behaviour we removed. Keeping it would defend a state that can no longer exist (skill guidance: don't keep dead defensive code).

## Tests

- Added `TestLoadConfig_DevModeRequiresDevToken` — feeds `development_mode: true` with no `client_auth` block, asserts the validation error mentions both `dev_token` and `development_mode`.
- Existing fixture updates: mechanical addition of `client_auth.dev_token: test` to YAML strings that used dev mode without a token. The bulk-update was done by a script that explicitly skipped the new failure-case test.
- Removed `Test_AuthDisabled` (was asserting `200 OK` for every request when `dev_token` is empty — the exact behaviour the fix removes).
- Revert-verify confirmed: stash the `config.go` change → new test fails; restore → it passes. The `middleware.go` changes are dead-code removal post-fix, so they don't have their own coupled test.
- Full suite green: `go build ./... && go vet ./...` clean; `go test ./...` passes all 12 packages.

## Behavior change (operator-visible)

Deployments with `development_mode: true` and a missing or empty `dev_token` will now fail at startup with:

```
validating config: client_auth.dev_token is required when development_mode is true (set a non-empty token to enable static auth)
```

This is the intended outcome of the fix. Same severity / migration flavor as SOL-149927. Worth a CHANGELOG line for the EA.

## Choice of fix

The ticket sketched two options:
- **A.** Require `dev_token` non-empty in dev mode.
- **B.** Add an `allow_anonymous: true` opt-in flag for intentional no-auth dev mode.

Going with A — smallest possible diff for the security fix. If anyone genuinely needs anonymous-auth dev mode, B can be a separate feature ticket.

## Jira

[SOL-149921](https://sol-jira.atlassian.net/browse/SOL-149921) — part of the May 2026 robustness/security sweep tracked under epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480).

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149921]: https://sol-jira.atlassian.net/browse/SOL-149921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ