### PR TITLE
fix: cap semp.max_concurrent_per_broker at 1024 [SOL-149924]

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -402,8 +402,8 @@ func validate(cfg *ServerConfig) error {
 		errs = append(errs, fmt.Errorf("log_level %q is invalid (must be one of %v)", cfg.LogLevel, validLogLevels))
 	}
 
-	if cfg.SEMP.MaxConcurrentPerBroker < 0 {
-		errs = append(errs, fmt.Errorf("semp.max_concurrent_per_broker must be > 0, got %d", cfg.SEMP.MaxConcurrentPerBroker))
+	if n := cfg.SEMP.MaxConcurrentPerBroker; n < 1 || n > defaults.MaxConcurrentPerBrokerCeiling {
+		errs = append(errs, fmt.Errorf("semp.max_concurrent_per_broker must be between 1 and %d, got %d", defaults.MaxConcurrentPerBrokerCeiling, n))
 	}
 
 	if cfg.SEMP.RequestTimeoutDuration <= 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -769,6 +769,11 @@ func TestLoadConfig_MaxConcurrentPerBroker_OutOfRange(t *testing.T) {
 			value:       "1000000",
 			wantInError: "semp.max_concurrent_per_broker",
 		},
+		{
+			name:        "just above ceiling",
+			value:       "1025",
+			wantInError: "semp.max_concurrent_per_broker",
+		},
 	}
 
 	for _, tc := range cases {
@@ -796,6 +801,28 @@ brokers:
 			}
 		})
 	}
+
+	// Boundary: 1024 must pass (inclusive upper bound). Locks in the
+	// inclusive semantic against future drift.
+	t.Run("at ceiling passes", func(t *testing.T) {
+		yaml := `
+development_mode: true
+client_auth:
+  dev_token: test
+semp:
+  max_concurrent_per_broker: 1024
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+		if _, err := LoadConfig(writeTemp(t, yaml)); err != nil {
+			t.Errorf("max_concurrent_per_broker: 1024 should pass (inclusive upper bound), got: %v", err)
+		}
+	})
 }
 
 func TestLoadConfig_RateLimit_NegativeRetries(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -749,6 +749,55 @@ brokers:
 	}
 }
 
+func TestLoadConfig_MaxConcurrentPerBroker_OutOfRange(t *testing.T) {
+	// Per-broker semaphore size drives both the in-memory semaphore and the
+	// HTTP transport's idle-connection pool (MaxIdleConnsPerHost +
+	// MaxIdleConns × 2). Unbounded above lets a misconfig or compromised
+	// config over-allocate and OOM the process.
+	cases := []struct {
+		name        string
+		value       string
+		wantInError string
+	}{
+		{
+			name:        "negative",
+			value:       "-1",
+			wantInError: "semp.max_concurrent_per_broker",
+		},
+		{
+			name:        "above ceiling",
+			value:       "1000000",
+			wantInError: "semp.max_concurrent_per_broker",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := `
+development_mode: true
+client_auth:
+  dev_token: test
+semp:
+  max_concurrent_per_broker: ` + tc.value + `
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+			_, err := LoadConfig(writeTemp(t, yaml))
+			if err == nil {
+				t.Fatalf("expected error for max_concurrent_per_broker=%s", tc.value)
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Errorf("error should name the offending field, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_RateLimit_NegativeRetries(t *testing.T) {
 	yaml := `
 semp:

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -39,6 +39,15 @@ const DefaultSEMPRequestTimeoutDuration = time.Minute
 // concurrency limit that balances throughput with broker stability.
 const DefaultMaxConcurrentPerBroker = 10
 
+// MaxConcurrentPerBrokerCeiling caps the operator-configurable
+// semp.max_concurrent_per_broker. The value backs a per-broker semaphore plus
+// the HTTP transport's MaxIdleConnsPerHost / MaxIdleConns (×2), so it
+// allocates fixed-size structures proportional to itself × the broker count.
+// 1024 leaves ~100× headroom above the documented typical 1-10 range while
+// rejecting pathological configurations (e.g. a million) that would OOM the
+// process.
+const MaxConcurrentPerBrokerCeiling = 1024
+
 // DefaultInsecureSkipVerify controls whether TLS certificate verification is
 // skipped when connecting to brokers. Must be false in production. Only set
 // to true in development environments with self-signed certificates. Matches


### PR DESCRIPTION
## What was wrong

`internal/config/config.go:405-407` only rejected negative values for `semp.max_concurrent_per_broker`:

```go
if cfg.SEMP.MaxConcurrentPerBroker < 0 {
    errs = append(errs, fmt.Errorf("semp.max_concurrent_per_broker must be > 0, got %d", ...))
}
```

The value drives the per-broker semaphore **and** the HTTP transport's `MaxIdleConnsPerHost` plus `MaxIdleConns` (×2). Each broker gets its own transport, so the total allocation scales linearly with the broker count too. An operator setting `max_concurrent_per_broker: 1000000` (intentional misconfig, typo, or compromised config) would over-allocate fixed-size structures and OOM the process at startup or first broker access.

## What the fix does

- Adds `MaxConcurrentPerBrokerCeiling = 1024` in `internal/defaults` with a comment explaining the choice. The documented typical usage is 1–10 (per `DefaultMaxConcurrentPerBroker`); 1024 gives ~100× headroom for legitimate high-throughput scenarios while rejecting pathological values.
- Replaces the one-sided check in `validate()` with a single bounded check (`< 1 || > ceiling`). The error message names both bounds via the constant so a future change to the ceiling automatically updates the message.

## Tests

- Added `TestLoadConfig_MaxConcurrentPerBroker_OutOfRange` — table test with two sub-cases:
  - `negative` — `max_concurrent_per_broker: -1`, asserts the error names the field. (This subcase passes both before and after the fix; it's regression protection for the existing negative-rejection behavior.)
  - `above_ceiling` — `max_concurrent_per_broker: 1000000`, asserts the error names the field. (This subcase is red before the fix, green after.)
- Revert-verify confirmed: stash `config.go` → upper-bound subcase fails; restore → it passes.
- Full suite stays green: `go build ./... && go vet ./...` clean; `go test ./...` passes all 12 packages.

## Behavior change (operator-visible)

Configs setting `semp.max_concurrent_per_broker > 1024` will now fail at startup with:

```
validating config: semp.max_concurrent_per_broker must be between 1 and 1024, got <value>
```

This is the intended fix. Real-world configurations should comfortably stay below 1024 given the documented typical range. Same EA-release migration-note flavor as SOL-149927 / SOL-149921.

## Edge cases verified

- `max_concurrent_per_broker: 0` (or field omitted): `applyDefaults` rewrites to 10 (existing behavior, untouched). Passes validation.
- `1`, `1024` (inclusive boundary): pass.
- `0` (after applyDefaults: 10), `-1`, `1025`, `1000000`: fail with the new bounded error.

## Jira

[SOL-149924](https://sol-jira.atlassian.net/browse/SOL-149924) — May 2026 robustness/security sweep, epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480).

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149924]: https://sol-jira.atlassian.net/browse/SOL-149924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ