### PR TITLE
fix(server): set ReadTimeout and IdleTimeout on the MCP HTTP server [SOL-149914]

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -134,6 +134,22 @@ func healthConfigFromFile() healthConfig {
 	return healthConfig{Port: cfg.Port, Scheme: scheme}
 }
 
+// newHTTPServer builds the MCP server's *http.Server with the production
+// timeout posture from internal/defaults. Extracted so timeout fields can be
+// asserted in a unit test without spinning up a real listener. See the
+// constants in internal/defaults for the rationale on each timeout value;
+// WriteTimeout is deliberately zero to preserve long-lived MCP streamable
+// HTTP / SSE responses.
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: time.Duration(defaults.DefaultReadHeaderTimeoutSeconds) * time.Second,
+		ReadTimeout:       time.Duration(defaults.DefaultReadTimeoutSeconds) * time.Second,
+		IdleTimeout:       time.Duration(defaults.DefaultIdleTimeoutSeconds) * time.Second,
+	}
+}
+
 // startServer starts httpServer in a background goroutine and returns a channel
 // that receives any startup/runtime error (excluding http.ErrServerClosed, which
 // is the normal result of Shutdown). The channel is buffered so the goroutine
@@ -328,11 +344,7 @@ func main() {
 
 	// 9. Start server with graceful shutdown
 	addr := fmt.Sprintf(":%d", cfg.Port)
-	httpServer := &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: time.Duration(defaults.DefaultReadHeaderTimeoutSeconds) * time.Second,
-	}
+	httpServer := newHTTPServer(addr, mux)
 
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -92,6 +92,27 @@ func TestMCPEndpoint_POST_ReachesMCPHandler(t *testing.T) {
 	}
 }
 
+func TestNewHTTPServer_TimeoutsAreSet(t *testing.T) {
+	// Asserts the production timeout posture: ReadHeaderTimeout / ReadTimeout
+	// / IdleTimeout are all non-zero (close Slowloris-class and idle
+	// keep-alive exhaustion vectors), and WriteTimeout is deliberately zero
+	// (preserves long-lived MCP streamable HTTP / SSE responses).
+	srv := newHTTPServer(":0", http.NewServeMux())
+
+	if want := 10 * time.Second; srv.ReadHeaderTimeout != want {
+		t.Errorf("ReadHeaderTimeout = %s, want %s", srv.ReadHeaderTimeout, want)
+	}
+	if want := 30 * time.Second; srv.ReadTimeout != want {
+		t.Errorf("ReadTimeout = %s, want %s", srv.ReadTimeout, want)
+	}
+	if want := 120 * time.Second; srv.IdleTimeout != want {
+		t.Errorf("IdleTimeout = %s, want %s", srv.IdleTimeout, want)
+	}
+	if srv.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %s, want 0 (intentional — preserves SSE streams)", srv.WriteTimeout)
+	}
+}
+
 func TestUnknownRoute_Returns404(t *testing.T) {
 	mux := testMux()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/unknown", nil)

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -58,6 +58,36 @@ const DefaultInsecureSkipVerify = false
 // this value is not too aggressive for real-world network conditions.
 const DefaultReadHeaderTimeoutSeconds = 10
 
+// DefaultReadTimeoutSeconds bounds the time from accepting a connection to
+// finishing the request body. Together with DefaultReadHeaderTimeoutSeconds
+// it closes the slow-body variant of the Slowloris attack: a client that
+// sends headers in time but then trickles the body forever.
+//
+// Assumption: 30 seconds is generous for MCP request bodies.
+// Reasoning: MCP tool calls carry JSON-RPC payloads that are typically a few
+// KB. 30s tolerates congested networks while bounding the worst case.
+// Trade-off: a request that legitimately takes >30s to send its body will
+// be dropped. Accepted — MCP clients do not stream the request body.
+const DefaultReadTimeoutSeconds = 30
+
+// DefaultIdleTimeoutSeconds bounds how long an idle HTTP/1.1 keep-alive
+// connection sits open after a request completes before the server closes it.
+// Prevents idle-connection exhaustion: without this, an attacker can open
+// thousands of sockets, send one request each, and hold them open until the
+// kernel reaps the file descriptors.
+//
+// Assumption: 120 seconds balances reuse with resource bounds.
+// Reasoning: 2 minutes lets a chatty MCP client reuse the connection for
+// follow-up calls while bounding worst-case fd usage to (concurrent clients)
+// × 2 minutes of idle slots.
+//
+// NOTE: WriteTimeout is intentionally NOT set on the MCP server. The /mcp
+// endpoint serves long-lived MCP streamable HTTP / SSE responses; a server-
+// wide write deadline would cut legitimate streams. The slow-read attack
+// surface is mitigated by the OS's TCP send buffer plus IdleTimeout reaping
+// idle sockets — neither perfect, but the alternative breaks the product.
+const DefaultIdleTimeoutSeconds = 120
+
 // DefaultConfigPathSystem is the production-install location for the config
 // file. Tried when CONFIG_FILE is not set. Follows the conventional Linux
 // /etc/<app>/config.yaml layout used by Linux services, K8s, and Docker.


### PR DESCRIPTION
## What was wrong

The MCP server's HTTP listener (`cmd/server/main.go:331-335`) was configured with only `ReadHeaderTimeout`. Two attack/exhaustion vectors remained open:

- **Slow body**: a client can send headers within 10 s, then trickle the request body forever. Goroutine + connection held indefinitely.
- **Idle keep-alive exhaustion**: after a response completes, an idle HTTP/1.1 keep-alive connection sits open until the kernel reaps the fd. A modest attacker can open thousands of idle sockets, send one request each, and exhaust the server's fd budget.

## What the fix does

- Adds `DefaultReadTimeoutSeconds = 30` and `DefaultIdleTimeoutSeconds = 120` to `internal/defaults/defaults.go` with documented-decision comments (assumption / reasoning / trade-off, matching the existing style).
- Extracts `newHTTPServer(addr, handler)` in `cmd/server/main.go` so the production timeout posture is in one testable place. `main()` now calls it instead of building `&http.Server{...}` inline.
- Wires up all three timeouts: `ReadHeaderTimeout`, `ReadTimeout`, `IdleTimeout`. **`WriteTimeout` is deliberately not set** — the `/mcp` endpoint serves long-lived MCP streamable HTTP / SSE responses, and a server-wide write deadline would cut legitimate streams. The trade-off is captured in the constant's doc comment.

## Tests

- Added `TestNewHTTPServer_TimeoutsAreSet`: locks in the posture (`ReadHeaderTimeout=10s`, `ReadTimeout=30s`, `IdleTimeout=120s`, `WriteTimeout=0`). If a future change removes a timeout or sets `WriteTimeout`, this fails loudly.
- Revert-verify confirmed: stash `cmd/server/main.go` → test build-fails (proves the test couples to the new function); restore → it passes.
- Full suite green: `go build ./... && go vet ./...` clean; `go test ./...` passes all 12 packages.

## Behavior change (operator-visible)

- A client whose request body takes longer than 30 s will be dropped. MCP request bodies are JSON-RPC payloads of a few KB; this is generous in practice.
- An idle keep-alive connection is closed after 120 s. MCP clients that reuse connections within that window are unaffected; clients past 120 s will reconnect.

Same EA-CHANGELOG flavor as the other tickets in this sweep.

## Why no WriteTimeout

`http.Server.WriteTimeout` bounds the entire response duration (from when reading the request body finishes to when the response write completes). For SSE / MCP streamable HTTP, the response is long-lived by design — a 1 minute or 5 minute deadline would cut active sessions. Mitigations for the slow-read attack on streaming endpoints would need to be per-handler via `http.ResponseController` rather than a blanket server setting; out of scope for this ticket.

## Jira

[SOL-149914](https://sol-jira.atlassian.net/browse/SOL-149914) — May 2026 robustness/security sweep, epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480).

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149914]: https://sol-jira.atlassian.net/browse/SOL-149914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ