### PR TITLE
fix(semp): cap broker response body at 16 MiB [SOL-149920]

### DIFF
--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -29,6 +29,22 @@ const DefaultShutdownTimeoutSeconds = 30
 // Terraform provider convention.
 const DefaultSEMPRequestTimeoutDuration = time.Minute
 
+// MaxSEMPResponseBytes caps the in-memory buffering of a broker's SEMP
+// response body. Without this cap, a misbehaving broker or a man-in-the-
+// middle could stream gigabytes of data within the request timeout and OOM
+// the MCP server.
+//
+// Decided: 16 MiB.
+// Reasoning: SEMPv2 list responses are bounded by the broker's page size
+// (typically 500 items). At an extreme of ~30 KB per item, a single page
+// sits around 15 MB — 16 MiB gives a safety margin above any realistic
+// page response while bounding worst-case allocation to a few percent of
+// process memory.
+// Trade-off: a broker that legitimately returned > 16 MiB in a single
+// response would now fail with a typed "response too large" error. The
+// SEMP pagination contract makes this implausible in practice.
+const MaxSEMPResponseBytes = 16 * 1024 * 1024
+
 // DefaultMaxConcurrentPerBroker is the maximum number of concurrent SEMP
 // requests allowed per broker, enforced via a per-broker semaphore.
 //

--- a/internal/semp/resilience/io.go
+++ b/internal/semp/resilience/io.go
@@ -1,0 +1,44 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resilience
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrResponseTooLarge is returned by ReadCappedBody when the source reader
+// yields more than the configured cap. Callers branch on this with errors.Is
+// to distinguish "broker misbehaved / MITM" from generic I/O errors.
+var ErrResponseTooLarge = errors.New("response body exceeded size cap")
+
+// ReadCappedBody reads from r into memory, capped at limit bytes. Returns
+// ErrResponseTooLarge if r yields more than limit bytes; the body buffer is
+// returned as nil in that case (callers should not consume a partial read).
+//
+// The implementation asks for limit+1 bytes via io.LimitReader. If the
+// result is longer than limit, the source had more data than the cap
+// allowed.
+func ReadCappedBody(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading body: %w", err)
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("%w (cap: %d bytes)", ErrResponseTooLarge, limit)
+	}
+	return body, nil
+}

--- a/internal/semp/resilience/io_test.go
+++ b/internal/semp/resilience/io_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resilience
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadCappedBody_UnderCap(t *testing.T) {
+	body, err := ReadCappedBody(strings.NewReader("hello"), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("body = %q, want %q", body, "hello")
+	}
+}
+
+func TestReadCappedBody_AtCap(t *testing.T) {
+	// A body exactly at the cap must succeed (cap is inclusive).
+	body, err := ReadCappedBody(strings.NewReader("1234567890"), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != "1234567890" {
+		t.Errorf("body = %q, want exact cap content", body)
+	}
+}
+
+func TestReadCappedBody_OverCap(t *testing.T) {
+	// A body one byte past the cap must fail with ErrResponseTooLarge.
+	body, err := ReadCappedBody(strings.NewReader("12345678901"), 10)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("err = %v, want errors.Is(_, ErrResponseTooLarge)", err)
+	}
+	if body != nil {
+		t.Errorf("body = %q, want nil on over-cap read", body)
+	}
+}
+
+func TestReadCappedBody_WellOverCap(t *testing.T) {
+	// Confirm the cap holds when the source is much larger than the limit.
+	large := bytes.Repeat([]byte("x"), 1024*1024) // 1 MiB
+	_, err := ReadCappedBody(bytes.NewReader(large), 1024)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("err = %v, want errors.Is(_, ErrResponseTooLarge)", err)
+	}
+}
+
+// errReader returns a configured error on every Read.
+type errReader struct{ err error }
+
+func (e *errReader) Read([]byte) (int, error) { return 0, e.err }
+
+func TestReadCappedBody_UnderlyingReadError_PropagatesWrapped(t *testing.T) {
+	want := errors.New("nope")
+	_, err := ReadCappedBody(&errReader{err: want}, 100)
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want errors.Is(_, %v)", err, want)
+	}
+	if errors.Is(err, ErrResponseTooLarge) {
+		t.Error("read error should not be classified as ErrResponseTooLarge")
+	}
+}
+
+// Sanity check: io.EOF from the underlying reader is the normal end-of-stream
+// signal and must NOT propagate as an error from ReadCappedBody. io.ReadAll
+// already handles this, but the test pins the behaviour.
+func TestReadCappedBody_EOFIsNotAnError(t *testing.T) {
+	body, err := ReadCappedBody(io.MultiReader(strings.NewReader("abc")), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != "abc" {
+		t.Errorf("body = %q, want %q", body, "abc")
+	}
+}

--- a/internal/semp/sempv1/client.go
+++ b/internal/semp/sempv1/client.go
@@ -3,13 +3,13 @@ package sempv1
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
@@ -134,7 +134,7 @@ func (c *HTTPClient) Execute(ctx context.Context, xml string) (*Result, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := resilience.ReadCappedBody(resp.Body, defaults.MaxSEMPResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading SEMPv1 response body: %w", err)
 	}

--- a/internal/semp/sempv1/client_test.go
+++ b/internal/semp/sempv1/client_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 )
 
@@ -55,6 +57,36 @@ func newTestClient(t *testing.T, srv *httptest.Server) *HTTPClient {
 }
 
 const successEnvelope = `<rpc-reply><rpc><show><version/></show></rpc><execute-result code="ok"/></rpc-reply>`
+
+// TestExecute_OversizedResponseBody_ReturnsTypedError verifies that a broker
+// (or MITM) streaming more than MaxSEMPResponseBytes fails fast with
+// ErrResponseTooLarge rather than OOMing the process.
+func TestExecute_OversizedResponseBody_ReturnsTypedError(t *testing.T) {
+	chunk := bytes.Repeat([]byte("x"), 64*1024) // 64 KiB
+	totalBytes := defaults.MaxSEMPResponseBytes + len(chunk)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Stream chunks until we've sent more than the cap. Using a streaming
+		// write avoids allocating 16+ MiB in a single Go buffer.
+		written := 0
+		for written < totalBytes {
+			n, err := w.Write(chunk)
+			if err != nil {
+				return // client disconnected, which is what we expect
+			}
+			written += n
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.Execute(context.Background(), `<rpc/>`)
+	if err == nil {
+		t.Fatal("expected error for oversized response body, got nil")
+	}
+	if !errors.Is(err, resilience.ErrResponseTooLarge) {
+		t.Errorf("err = %v, want errors.Is(_, resilience.ErrResponseTooLarge)", err)
+	}
+}
 
 // TestExecute_RequestConstruction asserts that Execute builds the HTTP request
 // with the correct method, path, content type, user agent, body, and auth

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
@@ -142,7 +143,7 @@ func (c *HTTPClient) Execute(ctx context.Context, op *Operation, args map[string
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := resilience.ReadCappedBody(resp.Body, defaults.MaxSEMPResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading response for %s: %w", op.ID, err)
 	}

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -1,6 +1,7 @@
 package sempv2_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,8 @@ import (
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 )
 
@@ -50,6 +53,44 @@ func testOp(method string, params ...sempv2.Parameter) *sempv2.Operation {
 		Method:     method,
 		Path:       "/SEMP/v2/monitor/msgVpns/{msgVpnName}/queues/{queueName}",
 		Parameters: params,
+	}
+}
+
+// TestClient_Execute_OversizedResponseBody_ReturnsTypedError verifies that a
+// broker (or MITM) streaming more than MaxSEMPResponseBytes fails fast with
+// ErrResponseTooLarge rather than OOMing the process.
+func TestClient_Execute_OversizedResponseBody_ReturnsTypedError(t *testing.T) {
+	chunk := bytes.Repeat([]byte("x"), 64*1024) // 64 KiB
+	totalBytes := defaults.MaxSEMPResponseBytes + len(chunk)
+	client, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Stream chunks until we've sent more than the cap. Using a streaming
+		// write avoids allocating 16+ MiB in a single Go buffer.
+		written := 0
+		for written < totalBytes {
+			n, err := w.Write(chunk)
+			if err != nil {
+				return
+			}
+			written += n
+		}
+	})
+	defer server.Close()
+
+	op := testOp("GET",
+		sempv2.Parameter{Name: "msgVpnName", In: "path"},
+		sempv2.Parameter{Name: "queueName", In: "path"},
+	)
+
+	_, err := client.Execute(context.Background(), op, map[string]any{
+		"msgVpnName": "default",
+		"queueName":  "test-queue",
+	})
+	if err == nil {
+		t.Fatal("expected error for oversized response body, got nil")
+	}
+	if !errors.Is(err, resilience.ErrResponseTooLarge) {
+		t.Errorf("err = %v, want errors.Is(_, resilience.ErrResponseTooLarge)", err)
 	}
 }
 


### PR DESCRIPTION
## What was wrong

`internal/semp/sempv1/client.go:137` and `internal/semp/sempv2/client.go:145` both read SEMP response bodies with `io.ReadAll(resp.Body)` and no size cap. The `http.Client.Timeout` (60 s default) bounds *duration* but does not bound *bytes* — a peer streaming 100 MB/s for 60 s delivers ~6 GB into the MCP server's heap. A single oversized response is enough to OOM-kill the entire MCP process, taking down all tools across all configured brokers.

The SEMPv2 pagination contract (500 items/page) keeps real responses comfortably small, but a compromised broker, a man-in-the-middle, or a misbehaving build of the broker can sidestep that.

## What the fix does

- Adds `MaxSEMPResponseBytes = 16 * 1024 * 1024` (16 MiB) to `internal/defaults/defaults.go`. Sized to comfortably exceed any realistic SEMPv2 page response (~15 MB at the extreme of 30 KB per item × 500 items) while bounding worst-case heap usage. Documented-decision comment with assumption / reasoning / trade-off, matching the existing style.
- Adds `resilience.ReadCappedBody(r, limit)` plus typed `ErrResponseTooLarge` in a new `internal/semp/resilience/io.go`. The helper reads `limit+1` bytes via `io.LimitReader` and rejects over-cap reads with the typed error so callers can branch via `errors.Is`.
- Swaps the `io.ReadAll(resp.Body)` calls in both SEMP clients for the helper.

## Tests

- `internal/semp/resilience/io_test.go` covers the helper directly: under-cap returns body, at-cap (inclusive) returns body, over-cap returns `ErrResponseTooLarge` and a nil body, well-over-cap (1 MiB source vs 1 KiB cap) is rejected, EOF-is-not-an-error, and underlying read errors are wrapped and not classified as `ErrResponseTooLarge`.
- `internal/semp/sempv1/client_test.go` adds `TestExecute_OversizedResponseBody_ReturnsTypedError`: spins up an `httptest.Server` that streams `> MaxSEMPResponseBytes` bytes (64 KiB chunks) and asserts `errors.Is(err, resilience.ErrResponseTooLarge)` surfaces through the full `Execute` pipeline.
- `internal/semp/sempv2/client_test.go` adds the parallel test.
- Revert-verify confirmed: stash both `client.go` files → both integration tests fail (sempv1 returns `"err = sempv1: unknown (status=200)"` because the old code happily read the oversized body); restore → both pass.
- Full suite green: `go build ./... && go vet ./...` clean; `go test ./...` passes all 12 packages.

## Behavior change (operator-visible)

A broker that ever returns more than 16 MiB in a single response will now produce an error wrapping `resilience.ErrResponseTooLarge` instead of silently buffering the entire payload. The SEMP pagination contract makes this implausible in practice. Same EA-CHANGELOG flavor as the rest of this sweep.

## Jira

[SOL-149920](https://sol-jira.atlassian.net/browse/SOL-149920) — May 2026 robustness/security sweep, epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480).

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149920]: https://sol-jira.atlassian.net/browse/SOL-149920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ