### PR TITLE
fix(semp): wrap cookie jar in atomic SafeCookieJar to remove 401 race [SOL-149922]

### DIFF
--- a/internal/semp/resilience/cookiejar.go
+++ b/internal/semp/resilience/cookiejar.go
@@ -1,0 +1,90 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resilience
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"sync/atomic"
+)
+
+// SafeCookieJar is a thread-safe wrapper around *cookiejar.Jar that supports
+// concurrent SetCookies / Cookies calls plus an atomic Clear() that swaps the
+// inner jar.
+//
+// The standard library jar is itself thread-safe for read/write operations
+// but exposes no way to clear stored cookies. The 401 re-auth path in the
+// Sender wants to drop session state and force fresh credentials on the
+// retry. Replacing the entire jar via direct assignment to
+// http.Client.Jar — the previous implementation — races with concurrent
+// http.Client.Do reads of the interface value (two-word: type pointer + data
+// pointer). The data race detector flags it, and even on architectures where
+// torn interface reads do not panic, callers may observe inconsistent jar
+// state across a swap.
+//
+// This type pins the http.Client.Jar slot to a stable *SafeCookieJar
+// instance — never re-assigned — and routes the actual jar replacement
+// through an atomic.Pointer swap. http.Client.Do always sees the same
+// SafeCookieJar value; concurrent SetCookies/Cookies calls always read a
+// consistent *cookiejar.Jar via atomic.Load.
+type SafeCookieJar struct {
+	inner atomic.Pointer[cookiejar.Jar]
+}
+
+// Compile-time assertion that SafeCookieJar satisfies the http.CookieJar
+// interface required by http.Client.Jar.
+var _ http.CookieJar = (*SafeCookieJar)(nil)
+
+// NewSafeCookieJar constructs an empty jar. The underlying cookiejar.New
+// only returns an error for a non-nil *cookiejar.Options with bad fields;
+// passing nil here cannot fail in practice, but the error is propagated for
+// surface parity with cookiejar.New.
+func NewSafeCookieJar() (*SafeCookieJar, error) {
+	inner, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+	j := &SafeCookieJar{}
+	j.inner.Store(inner)
+	return j, nil
+}
+
+// SetCookies implements http.CookieJar.
+func (s *SafeCookieJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
+	s.inner.Load().SetCookies(u, cookies)
+}
+
+// Cookies implements http.CookieJar.
+func (s *SafeCookieJar) Cookies(u *url.URL) []*http.Cookie {
+	return s.inner.Load().Cookies(u)
+}
+
+// Clear replaces the inner jar with a fresh, empty one. Concurrent
+// SetCookies/Cookies calls in flight observe either the old jar (if they
+// loaded the pointer before this Store) or the new one — never a torn read.
+// In-flight cookie operations against the old jar complete normally; their
+// side effects are then discarded with that jar instance.
+//
+// cookiejar.New(nil) never returns a non-nil error in practice; the error
+// path here is unreachable defensively rather than because it can fire.
+func (s *SafeCookieJar) Clear() error {
+	fresh, err := cookiejar.New(nil)
+	if err != nil {
+		return err
+	}
+	s.inner.Store(fresh)
+	return nil
+}

--- a/internal/semp/resilience/cookiejar_test.go
+++ b/internal/semp/resilience/cookiejar_test.go
@@ -1,0 +1,132 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resilience
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", raw, err)
+	}
+	return u
+}
+
+func TestSafeCookieJar_SetAndGet(t *testing.T) {
+	jar, err := NewSafeCookieJar()
+	if err != nil {
+		t.Fatalf("NewSafeCookieJar: %v", err)
+	}
+	u := mustURL(t, "https://broker.example.com/SEMP")
+
+	jar.SetCookies(u, []*http.Cookie{{Name: "session", Value: "abc"}})
+
+	got := jar.Cookies(u)
+	if len(got) != 1 || got[0].Name != "session" || got[0].Value != "abc" {
+		t.Errorf("Cookies = %+v, want one cookie session=abc", got)
+	}
+}
+
+func TestSafeCookieJar_Clear_EmptiesTheJar(t *testing.T) {
+	jar, err := NewSafeCookieJar()
+	if err != nil {
+		t.Fatalf("NewSafeCookieJar: %v", err)
+	}
+	u := mustURL(t, "https://broker.example.com/SEMP")
+
+	jar.SetCookies(u, []*http.Cookie{{Name: "session", Value: "abc"}})
+	if len(jar.Cookies(u)) != 1 {
+		t.Fatal("precondition: expected 1 cookie before Clear")
+	}
+
+	if err := jar.Clear(); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if got := jar.Cookies(u); len(got) != 0 {
+		t.Errorf("after Clear: Cookies = %+v, want empty", got)
+	}
+}
+
+// TestSafeCookieJar_ConcurrentSetClear hammers SetCookies, Cookies, and Clear
+// from many goroutines. Run under `go test -race`: a torn read or unguarded
+// write on the inner jar pointer would surface here.
+func TestSafeCookieJar_ConcurrentSetClear(t *testing.T) {
+	jar, err := NewSafeCookieJar()
+	if err != nil {
+		t.Fatalf("NewSafeCookieJar: %v", err)
+	}
+	u := mustURL(t, "https://broker.example.com/SEMP")
+
+	const (
+		readers = 8
+		writers = 8
+		clears  = 4
+		iters   = 200
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(readers + writers + clears)
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				jar.SetCookies(u, []*http.Cookie{{Name: "session", Value: "abc"}})
+			}
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_ = jar.Cookies(u)
+			}
+		}()
+	}
+	for i := 0; i < clears; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				if err := jar.Clear(); err != nil {
+					t.Errorf("Clear: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSafeCookieJar_ImplementsHTTPCookieJar is satisfied at compile time by
+// the package-level interface assertion in cookiejar.go. This runtime test
+// pins the contract for readers and runs the round trip through an actual
+// http.Client.Jar field assignment, which is what the production code does.
+func TestSafeCookieJar_ImplementsHTTPCookieJar(t *testing.T) {
+	jar, err := NewSafeCookieJar()
+	if err != nil {
+		t.Fatalf("NewSafeCookieJar: %v", err)
+	}
+	client := &http.Client{Jar: jar} // type-checked assignment
+	if client.Jar == nil {
+		t.Fatal("http.Client.Jar must be assignable to *SafeCookieJar")
+	}
+}

--- a/internal/semp/resilience/retry.go
+++ b/internal/semp/resilience/retry.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
-	"net/http/cookiejar"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/hashicorp/go-retryablehttp"
@@ -85,10 +84,15 @@ func (d *Sender) checkRetry(ctx context.Context, resp *http.Response, err error)
 			state.auth401Retried = true
 			// Stale session cookie is the most likely cause. Clear the jar so
 			// the retried request re-sends Basic Auth credentials from scratch.
-			// This assignment races with http.Client.Do reads of the Jar field
-			// (see Sender doc comment) but is benign.
-			jar, _ := cookiejar.New(nil)
-			d.httpClient.Jar = jar
+			// SafeCookieJar.Clear performs an atomic swap of the inner jar,
+			// so concurrent http.Client.Do reads see either the old jar or
+			// the new one — never a torn read.
+			if err := d.cookieJar.Clear(); err != nil {
+				slog.Warn("retrying: 401 received but failed to clear cookie jar",
+					slog.String("broker", d.brokerURL),
+					slog.String("error", err.Error()))
+				return false, nil
+			}
 			slog.Warn("retrying: 401 received, clearing session cookies",
 				slog.String("broker", d.brokerURL),
 				slog.String("auth_mode", d.authCfg.Mode))

--- a/internal/semp/resilience/sender.go
+++ b/internal/semp/resilience/sender.go
@@ -35,14 +35,15 @@ func (e *RetriesExhaustedError) Unwrap() error { return e.Err }
 // shared HTTP resilience without duplication.
 //
 // Sender is safe for concurrent use from multiple goroutines. The cookie jar
-// replacement in checkRetry (401 re-auth) races with http.Client.Do reads of
-// the Jar field, but this is benign: the worst case is one retry using a stale
-// jar while fresh Basic Auth credentials in the header still succeed.
-// NOTE: if per-user broker sessions are introduced, jar replacement will need
-// to be scoped per user.
+// is wrapped in a *SafeCookieJar so the 401 re-auth path can clear session
+// state via an atomic swap without racing concurrent http.Client.Do reads
+// of the Jar field.
+//
+// NOTE: if per-user broker sessions are introduced, jar replacement will
+// need to be scoped per user.
 type Sender struct {
 	retryClient *retryablehttp.Client
-	httpClient  *http.Client      // underlying client for cookie jar access
+	cookieJar   *SafeCookieJar    // for 401 re-auth: Clear() swaps in a fresh inner jar atomically
 	authCfg     config.AuthConfig // for 401 auth-mode check
 	rateLimiter <-chan time.Time
 	rateTicker  *time.Ticker // non-nil when rate limiting enabled; stopped by Close()
@@ -50,13 +51,16 @@ type Sender struct {
 }
 
 // New creates a Sender configured for a specific broker. It sets up retryablehttp
-// with the retry policy from SEMPConfig and a per-broker rate limiter.
+// with the retry policy from SEMPConfig and a per-broker rate limiter. The
+// caller is expected to have set httpClient.Jar to the same *SafeCookieJar so
+// 401 re-auth (Clear) and the cookie attachment in http.Client.Do operate on
+// the same jar instance.
 // sempCfg.Retries and sempCfg.RequestMinInterval must be non-nil.
-func New(httpClient *http.Client, sempCfg *config.SEMPConfig, authCfg config.AuthConfig, brokerURL string) *Sender {
+func New(httpClient *http.Client, cookieJar *SafeCookieJar, sempCfg *config.SEMPConfig, authCfg config.AuthConfig, brokerURL string) *Sender {
 	d := &Sender{
-		httpClient: httpClient,
-		authCfg:    authCfg,
-		brokerURL:  brokerURL,
+		cookieJar: cookieJar,
+		authCfg:   authCfg,
+		brokerURL: brokerURL,
 	}
 
 	// Configure retryablehttp client with the underlying http.Client.

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -13,6 +13,17 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 )
 
+// mustNewSafeCookieJar creates an empty SafeCookieJar for tests; fails the
+// test on the (unreachable in practice) error path.
+func mustNewSafeCookieJar(t *testing.T) *SafeCookieJar {
+	t.Helper()
+	jar, err := NewSafeCookieJar()
+	if err != nil {
+		t.Fatalf("NewSafeCookieJar: %v", err)
+	}
+	return jar
+}
+
 // newTestSender creates a Sender configured for testing with the given auth mode and retry count.
 func newTestSender(t *testing.T, httpClient *http.Client, authMode string, retries int) *Sender {
 	t.Helper()
@@ -29,7 +40,9 @@ func newTestSender(t *testing.T, httpClient *http.Client, authMode string, retri
 		Password: "secret",
 		Token:    "static-token",
 	}
-	return New(httpClient, sempCfg, authCfg, "http://test-broker")
+	jar := mustNewSafeCookieJar(t)
+	httpClient.Jar = jar
+	return New(httpClient, jar, sempCfg, authCfg, "http://test-broker")
 }
 
 // newTestSenderWithServer creates a test server and a Sender pointed at it.
@@ -529,7 +542,8 @@ func TestSender_ErrorHandler_NetworkError_ProducesRetriesExhaustedError(t *testi
 		RetryMaxInterval:   10 * time.Millisecond,
 	}
 	authCfg := config.AuthConfig{Mode: "basic", Username: "admin", Password: "secret"}
-	sender := New(&http.Client{}, sempCfg, authCfg, serverURL)
+	jar := mustNewSafeCookieJar(t)
+	sender := New(&http.Client{Jar: jar}, jar, sempCfg, authCfg, serverURL)
 
 	req := newGetRequest(t, serverURL)
 	resp, err := sender.Do(context.Background(), req)
@@ -674,7 +688,8 @@ func TestSender_NoRetry_POST_ConnectionError(t *testing.T) {
 		RetryMaxInterval:   10 * time.Millisecond,
 	}
 	authCfg := config.AuthConfig{Mode: "basic", Username: "admin", Password: "secret"}
-	sender := New(&http.Client{}, sempCfg, authCfg, serverURL)
+	jar := mustNewSafeCookieJar(t)
+	sender := New(&http.Client{Jar: jar}, jar, sempCfg, authCfg, serverURL)
 
 	req := newMethodRequest(t, http.MethodPost, serverURL)
 	resp, err := sender.Do(context.Background(), req)
@@ -713,7 +728,8 @@ func TestSender_NoRetry_PATCH_ConnectionError(t *testing.T) {
 		RetryMaxInterval:   10 * time.Millisecond,
 	}
 	authCfg := config.AuthConfig{Mode: "basic", Username: "admin", Password: "secret"}
-	sender := New(&http.Client{}, sempCfg, authCfg, serverURL)
+	jar := mustNewSafeCookieJar(t)
+	sender := New(&http.Client{Jar: jar}, jar, sempCfg, authCfg, serverURL)
 
 	req := newMethodRequest(t, http.MethodPatch, serverURL)
 	resp, err := sender.Do(context.Background(), req)

--- a/internal/semp/sempv1/client.go
+++ b/internal/semp/sempv1/client.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/http/cookiejar"
 	"strings"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
@@ -62,7 +61,7 @@ func (c *HTTPClient) Close() {
 // I/O happens here — connection setup is lazy on the first Execute call.
 func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (*HTTPClient, error) {
 	transport := resilience.NewTunedTransport(brokerCfg, sempCfg)
-	jar, err := cookiejar.New(nil)
+	jar, err := resilience.NewSafeCookieJar()
 	if err != nil {
 		return nil, fmt.Errorf("creating cookie jar: %w", err)
 	}
@@ -80,7 +79,7 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (
 	baseURL := strings.TrimSuffix(brokerCfg.URL, "/")
 
 	return &HTTPClient{
-		sender:    resilience.New(httpClient, sempCfg, brokerCfg.Auth, baseURL),
+		sender:    resilience.New(httpClient, jar, sempCfg, brokerCfg.Auth, baseURL),
 		baseURL: baseURL,
 		authCfg: brokerCfg.Auth,
 	}, nil

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"strings"
 
@@ -84,7 +83,7 @@ func (c *HTTPClient) Close() {
 func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (*HTTPClient, error) {
 	transport := resilience.NewTunedTransport(brokerCfg, sempCfg)
 
-	jar, err := cookiejar.New(nil)
+	jar, err := resilience.NewSafeCookieJar()
 	if err != nil {
 		return nil, fmt.Errorf("creating cookie jar: %w", err)
 	}
@@ -103,7 +102,7 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (
 	baseURL := strings.TrimSuffix(brokerCfg.URL, "/")
 
 	return &HTTPClient{
-		sender:    resilience.New(httpClient, sempCfg, brokerCfg.Auth, baseURL),
+		sender:    resilience.New(httpClient, jar, sempCfg, brokerCfg.Auth, baseURL),
 		baseURL: baseURL,
 		authCfg: brokerCfg.Auth,
 	}, nil


### PR DESCRIPTION
## What was wrong

`internal/semp/resilience/retry.go:88-91` cleared session cookies on a 401 by allocating a fresh `*cookiejar.Jar` and assigning it directly to `httpClient.Jar`:

```go
jar, _ := cookiejar.New(nil)
d.httpClient.Jar = jar
```

This races concurrent `http.Client.Do` reads of the `Jar` field. The interface value is a two-word (type pointer + data pointer); Go's memory model makes torn reads undefined. The Sender's own doc comment characterised the race as "benign", but that was speculative — `go test -race` flags it, and even on architectures where torn reads do not panic, callers may observe inconsistent jar state across a swap.

## What the fix does

Adds `resilience.SafeCookieJar` (new file `cookiejar.go`): an `http.CookieJar` wrapper around `*cookiejar.Jar` whose inner pointer is stored in an `atomic.Pointer`. `http.Client.Jar` is pinned to a stable `*SafeCookieJar` value for the lifetime of the client, so concurrent `http.Client.Do` reads always see the same interface value. The inner jar is swapped atomically when `Clear()` runs — concurrent `SetCookies`/`Cookies` calls load the pointer via `atomic.Load` and observe a consistent jar.

Plumbs the jar through `resilience.New`: callers (the SEMPv1 and SEMPv2 client constructors) build the `*SafeCookieJar` once, set it on `http.Client.Jar`, and pass it to `resilience.New(...)` so the `Sender` can call `Clear()` during the 401 re-auth path.

`retry.go` now calls `d.cookieJar.Clear()` instead of swapping the `Jar` field directly. The (unreachable) error path is logged with a WARN and short-circuits the retry rather than silently dropping it.

## Tests

- `internal/semp/resilience/cookiejar_test.go` (new):
  - `SetAndGet` / `Clear_EmptiesTheJar` — basic semantics.
  - `ConcurrentSetClear` — hammers SetCookies, Cookies, and Clear from many goroutines. Designed to fail under `go test -race` if the wrapper ever permits a torn read.
  - `ImplementsHTTPCookieJar` — runtime assertion that pairs with the compile-time `var _ http.CookieJar = (*SafeCookieJar)(nil)` interface assertion in `cookiejar.go`.
- Updated `sender_test.go` helper to construct a `*SafeCookieJar`, set it on `httpClient.Jar`, and pass it to `resilience.New`. Inline test sites that constructed bare clients are updated for the new signature.
- Full suite passes under `go test -race ./...`. The existing `TestSender_Retry_401_BasicAuth_ClearsCookiesAndRetries` still exercises the end-to-end 401 retry behaviour and still passes; the implementation of "clearing" is now atomic.

## Behavior change

None operator-visible. The cookie-clearing semantic is unchanged; only the underlying mechanism is now race-free.

## Jira

[SOL-149922](https://sol-jira.atlassian.net/browse/SOL-149922) — May 2026 robustness/security sweep, epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480).

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149922]: https://sol-jira.atlassian.net/browse/SOL-149922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ