### PR TITLE
fix(config): redact userinfo in broker-URL validation errors [SOL-149923]

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,10 +98,13 @@ func (a AuthConfig) LogValue() slog.Value {
 
 // LogValue implements slog.LogValuer for BrokerConfig. It exposes connection
 // metadata (URL, TLS settings, auth method) but excludes credentials.
+// The URL is routed through sanitizeURLString so any userinfo is stripped
+// before reaching the log — defense in depth against logging a BrokerConfig
+// before validateBrokerURL has had a chance to reject credentialed URLs.
 // See docs/secure-logging-rules.md Rule 2.
 func (b BrokerConfig) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("url", b.URL),
+		slog.String("url", sanitizeURLString(b.URL)),
 		slog.Bool("insecure_skip_verify", b.InsecureSkipVerify),
 		slog.String("auth_mode", b.Auth.Mode),
 	)
@@ -109,12 +112,14 @@ func (b BrokerConfig) LogValue() slog.Value {
 
 // LogValue implements slog.LogValuer for ClientAuthConfig. It exposes OAuth
 // configuration (issuer, audience, resource URL) but excludes DevToken
-// to prevent credential leaks in log output. See docs/secure-logging-rules.md Rule 2.
+// to prevent credential leaks in log output. Issuer and ResourceURL are
+// routed through sanitizeURLString for the same defense-in-depth reason
+// as BrokerConfig.LogValue. See docs/secure-logging-rules.md Rule 2.
 func (c ClientAuthConfig) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("issuer", c.Issuer),
+		slog.String("issuer", sanitizeURLString(c.Issuer)),
 		slog.String("audience", c.Audience),
-		slog.String("resource_url", c.ResourceURL),
+		slog.String("resource_url", sanitizeURLString(c.ResourceURL)),
 	)
 }
 
@@ -567,6 +572,22 @@ func sanitizeURL(u *url.URL) string {
 	cp := *u
 	cp.User = nil
 	return cp.String()
+}
+
+// sanitizeURLString parses s and returns the URL with any userinfo stripped.
+// Empty input passes through unchanged. Unparseable input is replaced with
+// "<unparseable url>" rather than echoed back: we cannot prove the original
+// string is credential-free, so the safe default is to drop it. Used by the
+// LogValuer implementations on BrokerConfig and ClientAuthConfig.
+func sanitizeURLString(s string) string {
+	if s == "" {
+		return ""
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "<unparseable url>"
+	}
+	return sanitizeURL(u)
 }
 
 // applyEnvOverrides checks for environment variable overrides and applies them

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -527,6 +527,11 @@ func ValidatePort(port int) error {
 // endpoint. Those are deliberately runtime concerns surfaced on the first
 // tool call. When productionMode is true, http:// is rejected — credentials
 // would otherwise be transmitted in plaintext.
+//
+// URLs with embedded userinfo (e.g. "https://user:pass@host") are rejected:
+// credentials belong in the auth block, not the URL, and accepting them
+// invites disclosure via logs, error messages, and any future field that
+// echoes the URL back to operators.
 func validateBrokerURL(s string, productionMode bool) error {
 	u, err := url.Parse(s)
 	if err != nil {
@@ -535,13 +540,33 @@ func validateBrokerURL(s string, productionMode bool) error {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("url scheme must be http or https, got %q", u.Scheme)
 	}
+	if u.User != nil {
+		// Surface a clear error WITHOUT echoing the userinfo. Operators get
+		// directed to the auth block; logs do not capture the credential.
+		return fmt.Errorf("url must not include credentials (use the auth block instead), got %q", sanitizeURL(u))
+	}
 	if productionMode && u.Scheme == "http" {
-		return fmt.Errorf("url scheme must be https to protect credentials in transit (got %q)", s)
+		return fmt.Errorf("url scheme must be https to protect credentials in transit (got %q)", sanitizeURL(u))
 	}
 	if u.Host == "" {
-		return fmt.Errorf("url must include a host, got %q", s)
+		return fmt.Errorf("url must include a host, got %q", sanitizeURL(u))
 	}
 	return nil
+}
+
+// sanitizeURL returns u's string form with any userinfo stripped, so the
+// result is safe to embed in error messages and log lines. The previous
+// validateBrokerURL implementation formatted the raw URL via %q, which
+// would have leaked any user:pass@ portion through the config-load error
+// to slog.Error and onward to any log aggregator the operator forgot was
+// retained. Defense in depth alongside the userinfo rejection above.
+func sanitizeURL(u *url.URL) string {
+	if u.User == nil {
+		return u.String()
+	}
+	cp := *u
+	cp.User = nil
+	return cp.String()
 }
 
 // applyEnvOverrides checks for environment variable overrides and applies them

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -569,6 +569,46 @@ brokers:
 	}
 }
 
+// TestLoadConfig_RejectsBrokerURLWithCredentials_AndRedactsThemInError pins
+// two related behaviours: (a) an inline user:pass URL in a broker entry is
+// rejected at validation, and (b) the password never appears in the error
+// message — even though the offending URL is part of the error context.
+// Together they prevent the disclosure path from validation errors through
+// slog.Error("failed to load config", err) at startup.
+func TestLoadConfig_RejectsBrokerURLWithCredentials_AndRedactsThemInError(t *testing.T) {
+	const inlinePassword = "hunter2-super-secret-must-not-leak"
+	yaml := `
+development_mode: true
+client_auth:
+  dev_token: test
+brokers:
+  prod-us:
+    url: "https://admin:` + inlinePassword + `@broker.example.com:1943"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	_, err := LoadConfig(writeTemp(t, yaml))
+	if err == nil {
+		t.Fatal("expected error for broker URL with embedded credentials")
+	}
+
+	// The full error string is what main() will log via slog.Error — that
+	// is the disclosure surface. Assert the password is NOT present anywhere
+	// in it (case-sensitive: the literal would survive %q escaping).
+	if strings.Contains(err.Error(), inlinePassword) {
+		t.Errorf("password leaked through validation error\nfull error: %v", err)
+	}
+	// Operator-friendly: the error should point at the right place to fix.
+	if !strings.Contains(err.Error(), "auth block") {
+		t.Errorf("error should steer operator to the auth block, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "prod-us") {
+		t.Errorf("error should name the broker alias, got: %v", err)
+	}
+}
+
 func TestLoadConfig_LogLevel_Default(t *testing.T) {
 	yaml := `
 development_mode: true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -609,6 +609,63 @@ brokers:
 	}
 }
 
+// TestBrokerConfig_LogValue_RedactsURLCredentials pins that the LogValuer
+// itself strips userinfo from the URL — independent of whether validation
+// has run. validateBrokerURL already rejects credentialed URLs, but
+// LogValue should not assume that: any future code path that logs a
+// BrokerConfig before validation (e.g., a debug line in LoadConfig itself)
+// would otherwise echo the credential to slog.
+func TestBrokerConfig_LogValue_RedactsURLCredentials(t *testing.T) {
+	const inlinePassword = "hunter2-super-secret-must-not-leak"
+	b := BrokerConfig{
+		URL: "https://admin:" + inlinePassword + "@broker.example.com:1943",
+		Auth: AuthConfig{
+			Mode:     "basic",
+			Username: "admin",
+			Password: "irrelevant-to-this-test",
+		},
+	}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.Info("broker config", slog.Any("broker", b))
+
+	out := buf.String()
+	if strings.Contains(out, inlinePassword) {
+		t.Errorf("password leaked through BrokerConfig.LogValue output:\n%s", out)
+	}
+	// Sanity: the host must still be present so logs remain useful.
+	if !strings.Contains(out, "broker.example.com") {
+		t.Errorf("host stripped from LogValue output (sanitization too aggressive):\n%s", out)
+	}
+}
+
+// TestClientAuthConfig_LogValue_RedactsURLCredentials applies the same
+// LogValue-level defense in depth to ClientAuthConfig. Issuer and
+// ResourceURL both go through validateBrokerURL, but LogValue should not
+// rely on that ordering.
+func TestClientAuthConfig_LogValue_RedactsURLCredentials(t *testing.T) {
+	const inlinePassword = "hunter2-issuer-secret-must-not-leak"
+	c := ClientAuthConfig{
+		Issuer:      "https://admin:" + inlinePassword + "@idp.example.com/realms/main",
+		Audience:    "mcp",
+		ResourceURL: "https://admin:" + inlinePassword + "@mcp.example.com/mcp",
+	}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.Info("client auth config", slog.Any("client_auth", c))
+
+	out := buf.String()
+	if strings.Contains(out, inlinePassword) {
+		t.Errorf("password leaked through ClientAuthConfig.LogValue output:\n%s", out)
+	}
+	if !strings.Contains(out, "idp.example.com") {
+		t.Errorf("issuer host stripped from LogValue output (sanitization too aggressive):\n%s", out)
+	}
+	if !strings.Contains(out, "mcp.example.com") {
+		t.Errorf("resource_url host stripped from LogValue output (sanitization too aggressive):\n%s", out)
+	}
+}
+
 func TestLoadConfig_LogLevel_Default(t *testing.T) {
 	yaml := `
 development_mode: true


### PR DESCRIPTION
## What was wrong

`internal/config/config.go:539, 542` formatted the raw broker URL into validation errors via `%q`. A misconfigured broker URL like `https://admin:hunter2@broker.example.com:1943` wrote the password into the error message. That error propagated through `errors.Join` to `cmd/server/main.go:231` and was logged via `slog.Error("failed to load config", slog.String("error", err.Error()))`. The slog handler's `ReplaceAttr` redactor matches on attribute *key* (`"error"`), not on value content, so the credential passed through untouched and landed in stderr → journald → log aggregators → SIEM, with retention windows that typically outlive operator awareness.

## What the fix does

- `validateBrokerURL` rejects URLs with non-empty `u.User` with a clear error directing operators to the `auth` block. Credentials belong in `AuthConfig`, never inline in the URL. The error itself names the broker alias and the right fix location, with the URL routed through `sanitizeURL` so the userinfo never reaches the message.
- The two existing `%q` formatters (http-scheme-in-production, missing-host) now also route the URL through the new `sanitizeURL(u *url.URL)` helper. Defense in depth: even if the userinfo-rejection path is ever changed or bypassed, the user:pass component never reaches the error message.

## Tests

- `TestLoadConfig_RejectsBrokerURLWithCredentials_AndRedactsThemInError`: feeds a broker URL with `admin:hunter2-super-secret-must-not-leak@…`, asserts (a) validation fails, (b) the password substring does **not** appear anywhere in `err.Error()`, and (c) the error mentions both `prod-us` (the broker alias) and `auth block` (the right place to put credentials).
- Revert-verify confirmed: stash `config.go` → the test fails on "expected error for broker URL with embedded credentials"; restore → it passes.
- Full suite green: `go build ./... && go vet ./...` clean; `go test ./...` passes all 12 packages.

## Behavior change (operator-visible)

Configs that currently embed `user:pass@` in a broker URL will now fail at startup with:

```
validating config: broker "<alias>": url must not include credentials (use the auth block instead), got "<sanitized URL>"
```

Operators should move credentials into the broker's `auth` block. Same EA-CHANGELOG flavor as the rest of the sweep.

## Jira

[SOL-149923](https://sol-jira.atlassian.net/browse/SOL-149923) — May 2026 robustness/security sweep, epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480).

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149923]: https://sol-jira.atlassian.net/browse/SOL-149923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ