### PR TITLE
SOL-149478: MCP minimum documentation to support release

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -128,7 +128,7 @@ Before starting, decide how your MCP client will register with your identity pro
 | IdP requirements | Standard OAuth client setup | Must support anonymous DCR (RFC 7591) |
 | Best for | Most setups; more control | Zero-config end-user experience |
 
-Both options use the same browser-based OAuth 2.1 Authorization Code flow with PKCE. The difference is only in how the MCP client obtains its client ID.
+Both options use the same browser-based OAuth 2.1 Authorization Code flow with PKCE. The difference is in how the MCP client obtains its client credentials (and whether it uses DCR) — Option A may also involve a client secret for confidential clients, while Option B never does.
 
 ### Step 1: Set up your identity provider
 
@@ -169,12 +169,13 @@ Skip this step if you are using Option B (Dynamic Client Registration).
 
 Create a client in your IdP with the following settings:
 
+- **Client ID:** any name (e.g. `mcp-client`) — you will pass this as `--client-id` in step 4
 - **Flow:** Authorization Code with PKCE
 - **PKCE challenge method:** `S256`
 - **Client type:** Public (no secret) or Confidential (with secret) — a public client is recommended for MCP clients like Claude Code and Claude Desktop, since they run on a user's machine where a client secret cannot be stored securely. For Option B (Dynamic Client Registration), the MCP client should always be registered as public.
 - **Redirect URI:** `http://localhost:<port>/callback`, where `<port>` matches the `--callback-port` you will use when adding the server to Claude Code
 
-> **Keycloak:** **Clients** → **Create client** → set a **Client ID** → click **Next**.
+> **Keycloak:** **Clients** → **Create client** → set a **Client ID** (e.g. `mcp-client`) → click **Next**.
 > - **Client authentication:** leave **OFF** for a public client (no secret required); turn **ON** for a confidential client (requires `--client-secret`)
 >
 > Enable **Standard flow**, disable all other flows → **Next** → **Save**. Under **Access settings**, set **Valid redirect URIs** to `http://localhost:*`. Under **Advanced**, set **Proof Key for Code Exchange Code Challenge Method** to `S256` → **Save**.
@@ -198,7 +199,9 @@ client_auth:
   resource_url: "https://your-mcp-server.example.com/mcp"
 ```
 
-The `audience` value must exactly match what you configured in step 1.2. Adjust `resource_url` to match the URL your MCP server is listening on.
+Refer to the Keycloack configuration below for an example.
+
+The `audience` value must exactly match what you configured in step 1.2. Set `resource_url` to the externally reachable URL of your MCP endpoint — this is advertised to clients for OAuth discovery, so it must be the public-facing URL, not the server's internal bind address (these differ when running behind a reverse proxy or ingress).
 
 | Field | Description |
 |-------|-------------|

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -116,20 +116,82 @@ Authorization: Bearer my-secret-dev-token-123
 
 ## Mode 3: OAuth / JWT (Production Authentication)
 
-**When to use:** Production deployments or any environment where you need browser-based authentication with an identity provider (IdP). This mode uses the OAuth 2.1 Authorization Code flow, allowing MCP clients (like Claude) to authenticate users via a browser login.
+**When to use:** Production deployments or any environment where you need browser-based authentication with an identity provider (IdP). This mode uses the OAuth 2.1 Authorization Code flow with PKCE, allowing MCP clients (like Claude) to authenticate users via a browser login.
 
-### Prerequisites
+### Choose a client registration method
 
-You need an OAuth 2.1 / OpenID Connect identity provider. Any OIDC-compliant provider will work:
-- Keycloak
-- Auth0
-- Okta
+Before starting, decide how your MCP client will register with your identity provider:
 
-### Configuration
+| | Option A: Client pre-registration | Option B: Dynamic Client Registration |
+|---|---|---|
+| User setup | Provide `--client-id` when adding the server | Just add the server URL — no credentials needed |
+| IdP requirements | Standard OAuth client setup | Must support anonymous DCR (RFC 7591) |
+| Best for | Most setups; more control | Zero-config end-user experience |
 
-1. Open your configuration file (`broker-config.yaml`)
+Both options use the same browser-based OAuth 2.1 Authorization Code flow with PKCE. The difference is only in how the MCP client obtains its client ID.
 
-2. Set the following values:
+### Step 1: Set up your identity provider
+
+You need an OAuth 2.1 / OpenID Connect identity provider. Any OIDC-compliant provider will work (Keycloak, Auth0, Okta, etc.).
+
+#### 1.1 Create a realm or tenant
+
+Most IdPs organize clients and users into an isolated namespace — called a realm, tenant, or organization depending on the provider. Create one dedicated to your MCP server deployment.
+
+> **Keycloak:** Start a local instance with Docker:
+> ```bash
+> docker run -p 127.0.0.1:8080:8080 \
+>   -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+>   -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+>   quay.io/keycloak/keycloak:latest start-dev
+> ```
+> Then open the Admin Console at `http://localhost:8080/admin`, log in with `admin` / `admin`, click the realm dropdown in the top-left → **Create realm** → set a **Realm name** → **Create**. You can use the built-in `master` realm for quick local testing, but a dedicated realm is recommended.
+>
+> **Tip:** To automate steps 1.1–1.4, the project includes a setup script at `test/e2e/oauth/setup-keycloak.sh` that starts Keycloak, creates the realm, and configures the audience mapper, OAuth clients, DCR policies, and a test user — all via Terraform. Run it from the project root: `cd test/e2e/oauth && ./setup-keycloak.sh`.
+
+#### 1.2 Configure an audience mapper
+
+The MCP server validates the `aud` claim in every access token. Configure your IdP to include your chosen audience value in issued tokens.
+
+The mapper must apply globally to all clients — not just specific pre-registered ones. This is especially important for Option B (Dynamic Client Registration): a mapper scoped to a single client will not apply to tokens issued to dynamically registered clients.
+
+> **Keycloak:** Add the mapper to the built-in `basic` client scope, which Keycloak assigns to all clients regardless of how they were registered. Go to **Client Scopes** → **basic** → **Mappers** tab → **Add mapper** → **By configuration** → **Audience**. Fill in:
+> - **Name:** any descriptive name (e.g., `solace-mcp-audience`)
+> - **Included Custom Audience:** your chosen audience value (e.g., `solace-mcp-server`)
+> - **Included Client Audience:** leave empty
+> - **Add to access token:** ON
+>
+> Use **Included Custom Audience** for a free-form string. **Included Client Audience** is only for referencing an existing Keycloak client by its Client ID.
+
+> **Auth0:** Configure the audience as an API resource (**APIs** → **Create API**). Tokens issued for that API include the audience claim automatically.
+
+> **Okta:** Configure the audience in the authorization server settings under **Security** → **API** → **Authorization Servers**.
+
+#### 1.3 Register an OAuth client (Option A only)
+
+Skip this step if you are using Option B (Dynamic Client Registration).
+
+Create a client in your IdP with the following settings:
+
+- **Flow:** Authorization Code with PKCE
+- **PKCE challenge method:** `S256`
+- **Client type:** Public (no secret) or Confidential (with secret) — a public client is recommended for MCP clients like Claude Code and Claude Desktop, since they run on a user's machine where a client secret cannot be stored securely. For Option B (Dynamic Client Registration), the MCP client should always be registered as public.
+- **Redirect URI:** `http://localhost:<port>/callback`, where `<port>` matches the `--callback-port` you will use when adding the server to Claude Code
+
+> **Keycloak:** **Clients** → **Create client** → set a **Client ID** → click **Next**.
+> - **Client authentication:** leave **OFF** for a public client (no secret required); turn **ON** for a confidential client (requires `--client-secret`)
+>
+> Enable **Standard flow**, disable all other flows → **Next** → **Save**. Under **Access settings**, set **Valid redirect URIs** to `http://localhost:*`. Under **Advanced**, set **Proof Key for Code Exchange Code Challenge Method** to `S256` → **Save**.
+
+#### 1.4 Create users
+
+Create user accounts in your IdP. These users will log in via the browser window that opens during the OAuth flow.
+
+> **Keycloak:** **Users** → **Create new user** → enter a username → **Create**. Go to the **Credentials** tab → **Set password**, enter a password, and turn **Temporary** off.
+
+### Step 2: Configure the MCP server
+
+Open your `broker-config.yaml` and set:
 
 ```yaml
 development_mode: false
@@ -140,43 +202,46 @@ client_auth:
   resource_url: "https://your-mcp-server.example.com/mcp"
 ```
 
-3. Start the MCP server
+The `audience` value must exactly match what you configured in step 1.2. Adjust `resource_url` to match the URL your MCP server is listening on.
 
-### Configuration fields
+| Field | Description |
+|-------|-------------|
+| `issuer` | The OIDC issuer URL of your IdP. The server fetches JWKS keys from here for token validation. |
+| `audience` | Must exactly match the audience value configured in your IdP in step 1.2. |
+| `resource_url` | The public URL of your MCP server endpoint, advertised to MCP clients for OAuth discovery. |
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `issuer` | Yes | The OIDC issuer URL of your identity provider. The server uses this to fetch the `.well-known/openid-configuration` and JWKS keys for token validation. |
-| `audience` | Yes | The expected `aud` claim in access tokens. Tokens without this audience are rejected. Must match what your IdP includes in issued tokens. |
-| `resource_url` | Yes | The public URL of your MCP server endpoint. Used in the OAuth Protected Resource Metadata response to tell clients where the protected resource lives. |
+> **Keycloak:** The issuer URL follows the pattern `http://<host>:<port>/realms/<realm-name>`. For example, Keycloak running locally on port 8080 with a realm named `solace`:
+> ```yaml
+> development_mode: false
+>
+> client_auth:
+>   issuer: "http://localhost:8080/realms/solace"
+>   audience: "solace-mcp-server"
+>   resource_url: "http://localhost:9090/mcp"
+> ```
 
-### Client registration methods
+### Step 3: Start the MCP server
 
-There are two ways for MCP clients to register with your identity provider. Both use the browser-based OAuth 2.1 Authorization Code flow with PKCE — the user authenticates via browser in both cases. The difference is how the MCP client obtains its OAuth client credentials.
+```bash
+go run ./cmd/server
+```
 
-| | Client Pre-Registration | Dynamic Client Registration |
-|---|---|---|
-| User setup | Provide client_id when adding the server | Just add the server URL |
-| IdP requirements | Standard OAuth client setup | Must allow anonymous client registration |
-| Best for | Locked-down IdPs, enterprise environments | Zero-config end-user experience |
+### Step 4: Add the server to Claude Code
 
 #### Option A: Client pre-registration
 
-Pre-register an OAuth client in your IdP and provide the credentials to the MCP client. This avoids the need for your IdP to support Dynamic Client Registration.
-
-##### Claude Code
+If your MCP server is already running on `http://localhost:9090`, you can add it using the Claude Code CLI:
 
 ```bash
 claude mcp add --transport http \
-  --client-id your-client-id \
-  --client-secret \
-  --callback-port 8080 \
-  solace-broker https://your-mcp-server.example.com/mcp
+  --client-id mcp-client \
+  --callback-port 8081 \
+  solace-broker http://localhost:9090/mcp
 ```
 
-- `--client-id` — the client ID from your IdP
-- `--client-secret` — prompts for masked input; stored securely in the system keychain
-- `--callback-port` — must match a redirect URI registered in your IdP (e.g., `http://localhost:8080/callback`)
+- `--client-id` — the client ID you registered in step 1.3
+- `--callback-port` — any free port; `http://localhost:<port>/callback` must be in the client's registered redirect URIs
+- `--client-secret` — add this flag only if you created a confidential client in step 1.3; prompts for masked input and stores the secret in the system keychain
 
 Alternatively, configure via `.mcp.json` in your project root:
 
@@ -185,116 +250,45 @@ Alternatively, configure via `.mcp.json` in your project root:
   "mcpServers": {
     "solace-broker": {
       "type": "http",
-      "url": "https://your-mcp-server.example.com/mcp",
+      "url": "http://localhost:9090/mcp",
       "oauth": {
-        "clientId": "your-client-id",
-        "callbackPort": 8080
+        "clientId": "mcp-client",
+        "callbackPort": 8081
       }
     }
   }
 }
 ```
 
-Then set the client secret via the CLI:
+#### Option B: Dynamic Client Registration
+
+If your MCP server is already running on `http://localhost:9090`, you can add it using the Claude Code CLI:
 
 ```bash
-claude mcp add-json solace-broker \
-  '{"type":"http","url":"https://your-mcp-server.example.com/mcp","oauth":{"clientId":"your-client-id","callbackPort":8080}}' \
-  --client-secret
+claude mcp add --transport http solace-broker http://localhost:9090/mcp
 ```
 
-The `--client-secret` flag prompts for masked input and stores the secret securely in the system keychain.
+A browser window will open for you to log in on first use. Your IdP must support anonymous Dynamic Client Registration (RFC 7591).
 
-##### What happens
+> **Keycloak:** Keycloak requires three additional policy changes to allow DCR.
+>
+> **1. Create an `openid` client scope placeholder** — Keycloak handles `openid` at the protocol level but its DCR policy checks for a scope by that name. Go to **Client Scopes** → **Create client scope** → **Name:** `openid`, **Protocol:** `openid-connect` → **Save**.
+>
+> **2. Update the Allowed Client Scopes policy** — Go to **Realm Settings** → **Client Registration** → **Client Registration Policies** tab → under **Anonymous Access Policies**, click **Allowed Client Scopes** → add `openid` and `service_account` to the allowed list → **Save**.
+>
+> **3. Update the Trusted Hosts policy** — If Keycloak is running in a container, DCR requests arrive from the container bridge IP rather than `localhost`. Go to **Realm Settings** → **Client Registration** → **Client Registration Policies** tab → under **Anonymous Access Policies**, click **Trusted Hosts** → turn off **Host Sending Registration Request Must Match** → **Save**.
 
-1. The MCP client connects to the server and receives a `401 Unauthorized` response
-2. The client fetches the OAuth Protected Resource Metadata to discover the authorization server
-3. The client **skips DCR** — it already has client credentials from your configuration
-4. The client initiates an OAuth 2.1 Authorization Code flow (with PKCE) — a browser window opens for the user to log in
-5. After successful login, the client receives a JWT access token and includes it in subsequent requests
-6. The MCP server validates each token's signature (via the IdP's JWKS endpoint), issuer, audience, and expiry
-- Tokens are automatically refreshed by the client when they expire
-- You'll see a log message: `"using JWT token for authentication — production mode"`
+### How it works
 
-##### IdP requirements
+1. Claude Code connects to the MCP server and receives a `401 Unauthorized` response
+2. Claude Code fetches the OAuth Protected Resource Metadata from `/.well-known/oauth-protected-resource` to discover the authorization server
+3. **Option A:** Claude Code uses the pre-registered client credentials and skips DCR
+   **Option B:** Claude Code performs Dynamic Client Registration (RFC 7591) to obtain a client ID at runtime
+4. A browser window opens for the user to log in with their IdP credentials
+5. After login, Claude Code receives a JWT access token and includes it in all subsequent requests
+6. The MCP server validates each token's signature (via JWKS), issuer, audience, and expiry — tokens are automatically refreshed when they expire
 
-Create an OAuth client in your IdP with the following settings:
-
-- **Client type:** Confidential (with client secret) or Public (PKCE-only, no secret)
-- **Flow:** Authorization Code (also called "Standard flow" in Keycloak)
-- **PKCE:** Required, with `S256` challenge method
-- **Redirect URI:** `http://localhost:<port>/callback` — must match the `--callback-port` used in the CLI command
-- **Scopes:** At minimum, `openid`
-
-#### Option B: Dynamic Client Registration (zero-config)
-
-The MCP client discovers the authorization server automatically and registers itself at runtime. No pre-shared client credentials are needed.
-
-##### Claude Code
-
-```bash
-claude mcp add solace-broker --transport http https://your-mcp-server.example.com/mcp
-```
-
-When you first use the server, Claude will open a browser window for you to authenticate with your identity provider.
-
-##### What happens
-
-1. The MCP client connects to the server and receives a `401 Unauthorized` response with a `WWW-Authenticate` header containing a `resource_metadata` URL
-2. The client fetches the OAuth Protected Resource Metadata (RFC 9728) from `/.well-known/oauth-protected-resource`
-3. The metadata tells the client which authorization server to use
-4. The client performs Dynamic Client Registration (RFC 7591) with the authorization server to register itself as an OAuth client
-5. The client initiates an OAuth 2.1 Authorization Code flow (with PKCE) — a browser window opens for the user to log in with the identity provider
-6. After successful login, the client receives a JWT access token and includes it in subsequent requests
-7. The MCP server validates each token's signature (via the IdP's JWKS endpoint), issuer, audience, and expiry
-- Tokens are automatically refreshed by the client when they expire
-- You'll see a log message: `"using JWT token for authentication — production mode"`
-
-##### IdP requirements
-
-Your IdP must support anonymous Dynamic Client Registration (RFC 7591):
-
-- **Expose a registration endpoint** — typically at `<issuer>/clients-registrations/openid-connect` or similar (advertised in the authorization server metadata as `registration_endpoint`)
-- **Allow anonymous registration** — the MCP client has no pre-existing credentials with the IdP
-- **Allow localhost redirect URIs** — the MCP client uses ephemeral localhost ports (e.g., `http://localhost:<port>/callback`) to receive authorization codes
-- **Support PKCE** with `S256` challenge method (required by OAuth 2.1)
-
-##### Client registration policies
-
-Most IdPs enforce policies on what dynamically registered clients can do. The following must be permitted:
-
-| Policy area | Requirement |
-|-------------|-------------|
-| **Allowed scopes** | The IdP must allow the scopes that get assigned to dynamically registered clients. At minimum, `openid` must be permitted. If your IdP has internal scopes (e.g., `service_account` in Keycloak), those must also be allowed. |
-| **Trusted hosts** | If your IdP runs in a container or on a different network, ensure the host trust policy does not reject registration requests based on source IP. The request may arrive from a container bridge IP rather than localhost. |
-| **Redirect URI validation** | Dynamically registered clients specify `http://localhost:*` redirect URIs. The IdP must allow these. |
-
-### Setting up your identity provider
-
-The steps below apply to both registration methods. Refer to your IdP's documentation for specifics.
-
-#### 1. Configure an audience mapper
-
-The MCP server validates the `aud` (audience) claim in every access token. Your IdP must include your configured `audience` value in issued tokens.
-
-If you use DCR, the audience mapper must be attached to a scope or mechanism that applies to **all clients in the realm** — not just specific pre-registered ones. This is the most common pitfall: audience mappers configured only on one client will not apply to tokens issued to dynamically registered clients.
-
-How to achieve this depends on your IdP:
-
-- **Keycloak:** Add an audience protocol mapper to a built-in client scope (e.g., `basic`) that Keycloak assigns to all clients regardless of registration method.
-- **Auth0:** Configure the audience as an API resource. Tokens issued for that API will include the audience automatically.
-- **Okta:** Configure the audience in the authorization server settings.
-
-For example, if your MCP server config has `audience: "solace-mcp-server"`, the issued JWT must contain:
-```json
-{
-  "aud": "solace-mcp-server"
-}
-```
-
-#### 2. Create users
-
-Create user accounts in your IdP that will authenticate via the browser login flow. These users will log in with their individual credentials when the MCP client opens a browser window during the OAuth flow.
+You'll see this in the server logs on success: `"using JWT token for authentication — production mode"`
 
 ---
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -132,7 +132,7 @@ Both options use the same browser-based OAuth 2.1 Authorization Code flow with P
 
 ### Step 1: Set up your identity provider
 
-You need an OAuth 2.1 / OpenID Connect identity provider. Any OIDC-compliant provider will work (Keycloak, Auth0, Okta, etc.).
+You need an OAuth 2.1 / OpenID Connect identity provider. Note that any OIDC-compliant provider will work (configuration examples specific to Keycloak are provided).
 
 #### 1.1 Create a realm or tenant
 
@@ -162,10 +162,6 @@ The mapper must apply globally to all clients — not just specific pre-register
 > - **Add to access token:** ON
 >
 > Use **Included Custom Audience** for a free-form string. **Included Client Audience** is only for referencing an existing Keycloak client by its Client ID.
-
-> **Auth0:** Configure the audience as an API resource (**APIs** → **Create API**). Tokens issued for that API include the audience claim automatically.
-
-> **Okta:** Configure the audience in the authorization server settings under **Security** → **API** → **Authorization Servers**.
 
 #### 1.3 Register an OAuth client (Option A only)
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -178,7 +178,7 @@ Create a client in your IdP with the following settings:
 > **Keycloak:** **Clients** → **Create client** → set a **Client ID** (e.g. `mcp-client`) → click **Next**.
 > - **Client authentication:** leave **OFF** for a public client (no secret required); turn **ON** for a confidential client (requires `--client-secret`)
 >
-> Enable **Standard flow**, disable all other flows → **Next** → **Save**. Under **Access settings**, set **Valid redirect URIs** to `http://localhost:*`. Under **Advanced**, set **Proof Key for Code Exchange Code Challenge Method** to `S256` → **Save**.
+> Enable **Standard flow** and disable all other flows. Enable **Require PKCE** and set the **PKCE Method** to `S256` → click **Next**. Under **Login settings**, set **Valid redirect URIs** to `http://localhost:*` → **Save**.
 
 #### 1.4 Create users
 
@@ -273,7 +273,7 @@ A browser window will open for you to log in on first use. Your IdP must support
 >
 > **1. Create an `openid` client scope placeholder** — Keycloak handles `openid` at the protocol level but its DCR policy checks for a scope by that name. Go to **Client Scopes** → **Create client scope** → **Name:** `openid`, **Protocol:** `openid-connect` → **Save**.
 >
-> **2. Update the Allowed Client Scopes policy** — Go to **Realm Settings** → **Client Registration** → **Client Registration Policies** tab → under **Anonymous Access Policies**, click **Allowed Client Scopes** → add `openid` and `service_account` to the allowed list → **Save**.
+> **2. Update the Allowed Client Scopes policy** — Go to **Clients** → **Client Registration**  tab → under **Anonymous Access Policies**, click **Allowed Client Scopes** → add `openid` and `service_account` to the allowed list → **Save**.
 >
 > **3. Update the Trusted Hosts policy** — If Keycloak is running in a container, DCR requests arrive from the container bridge IP rather than `localhost`. Go to **Realm Settings** → **Client Registration** → **Client Registration Policies** tab → under **Anonymous Access Policies**, click **Trusted Hosts** → turn off **Host Sending Registration Request Must Match** → **Save**.
 


### PR DESCRIPTION
## Summary

Restructures and expands the authentication documentation (docs/authentication.md) to make Mode 3 (OAuth/JWT) easier to follow for new users, with step-by-step setup instructions and Keycloak-specific examples.    

Fixes SOL-149478

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

The existing Mode 3 documentation was structured in a non-linear way — IdP setup instructions appeared after server configuration, making it difficult for new users to follow. Keycloak-specific steps were also missing.

## Changes Made

- Restructured Mode 3 into a linear step-by-step flow: IdP setup → server config → start server → add to Claude Code                                     
- Made all instructions generic (any OIDC provider) with Keycloak-specific callouts inline at each step                                                

## Testing

**Test Environment:**
- Go version: 1.26.2
- OS: macOS
- Broker version (if applicable): N/A

## Breaking Changes

N/A - documentation only.