### PR TITLE
fix(server): close broker pool on graceful shutdown [SOL-149926]

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -254,6 +254,14 @@ func main() {
 
 	// 3. Create broker pool
 	pool := semp.NewBrokerPool(cfg)
+	// Release per-broker rate-limiter tickers (and any other client-held
+	// resources) on the normal shutdown path. The defer fires after main()
+	// returns — i.e. after httpServer.Shutdown completes — so no in-flight
+	// tool call holds a Sender when pool.Close iterates clients. Earlier
+	// os.Exit(1) paths in main() bypass this defer; that is acceptable
+	// because process exit reaps the resources anyway. Close is idempotent
+	// (see TestBrokerPool_Close_*).
+	defer pool.Close()
 	slog.Info("created broker pool",
 		slog.Any("broker_aliases", pool.Aliases()))
 

--- a/internal/semp/pool_test.go
+++ b/internal/semp/pool_test.go
@@ -323,6 +323,45 @@ func TestBrokerPool_GetSEMPv1_ConcurrentFirstAccess(t *testing.T) {
 	}
 }
 
+// TestBrokerPool_Close_BeforeAnyAccess confirms Close is safe to call on a
+// freshly constructed pool that never had a client created. With no lazy
+// creations, the iteration loop in Close has nothing to do; it must not
+// panic.
+func TestBrokerPool_Close_BeforeAnyAccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	pool := semp.NewBrokerPool(newTestServerConfig(server.URL))
+	pool.Close() // must not panic
+}
+
+// TestBrokerPool_Close_AfterLazyCreation exercises the production path that
+// matters for cmd/server/main.go's shutdown defer: lazily create a client
+// (which spins up a rate-limiter ticker inside the Sender), then Close the
+// pool. The ticker is internal, so we verify the observable contract: no
+// panic, and Close is idempotent — calling it twice must remain safe.
+func TestBrokerPool_Close_AfterLazyCreation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer server.Close()
+
+	pool := semp.NewBrokerPool(newTestServerConfig(server.URL))
+
+	// Force one client into existence (lazy creation path).
+	if _, err := pool.GetSEMPv2("prod-us"); err != nil {
+		t.Fatalf("GetSEMPv2: %v", err)
+	}
+
+	// First Close: shuts down the broker client(s) that exist.
+	pool.Close()
+	// Second Close: must remain safe — main()'s defer fires once, but
+	// future call sites or test helpers may exercise multi-close. The
+	// per-broker Sender.Close is documented as safe to call multiple times.
+	pool.Close()
+}
+
 // TestBrokerPool_SharedBrokerClientAcrossProtocols is the structural proof
 // of the "log once per alias" invariant from T4's Definition of Done. Both
 // GetSEMPv1 and GetSEMPv2 route through getOrCreate and must operate on the


### PR DESCRIPTION
## What was wrong

`internal/semp/pool.go:111-118` exposes a working `BrokerPool.Close()` that iterates cached clients and calls each `BrokerClient.Close()` → `Sender.Close()` → `time.Ticker.Stop()`. `cmd/server/main.go` never called it. On signal-driven graceful shutdown the HTTP server stopped cleanly but the per-broker rate-limiter tickers leaked until `os.Exit` reaped the process — bounded in normal operation (process exit reclaims everything), but a real correctness gap and a foot-gun for any future code that re-enters server lifecycle (in-process server restarts, integration tests that embed `main`, etc.).

## What the fix does

- `defer pool.Close()` immediately after pool creation in `main()`. Position matters: the defer fires after `main()` returns, so it runs **after** `httpServer.Shutdown(ctx)` completes — by which time no in-flight tool call still holds a `Sender`. Earlier `os.Exit(1)` paths in `main()` (config load failure, OpenAPI spec failure, etc.) bypass the defer; that's acceptable because process exit reaps the resources anyway. The in-code comment captures this trade-off.
- The skill rule "Don't keep dead defensive code" doesn't apply here — `BrokerPool.Close()` is reachable in tests and in any future lifecycle code, and the new tests exercise it.

## Tests

- `TestBrokerPool_Close_BeforeAnyAccess`: Close on a pool with zero created clients (the iteration is a no-op). Asserts no panic.
- `TestBrokerPool_Close_AfterLazyCreation`: forces a lazy client creation (which spins up a `Sender` and its rate-limiter `time.Ticker`), then closes the pool. Calls `Close()` a second time to pin that it's idempotent (safe across the multi-close scenarios future call sites or test helpers may produce).
- Revert-verify implicit: the new tests pass with or without the `main()` change because they exercise the pool directly. The `main()` change itself is one line + a positional comment; reviewer-verifiable.
- Full suite green: `go build ./... && go vet ./...` clean; `go test ./...` passes all 12 packages.

## Behavior change

None operator-visible. Cleaner shutdown for embedded/in-process use cases; identical behaviour for the standard `os.Exit`-terminated server.

## Jira

[SOL-149926](https://sol-jira.atlassian.net/browse/SOL-149926) — May 2026 robustness/security sweep, epic [SOL-149480](https://sol-jira.atlassian.net/browse/SOL-149480). **Last of the sweep — all 10 tickets PR'd.**

🤖 Generated with [fix:bug](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-149926]: https://sol-jira.atlassian.net/browse/SOL-149926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ