### PR TITLE
SOL-149904: Skip env var substitution in YAML comments

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -353,28 +354,70 @@ func stripMatchedQuotes(s string) string {
 var envVarPattern = regexp.MustCompile(`\$\{([A-Z0-9_]+)\}`)
 
 // substituteEnvVars replaces all ${VAR_NAME} occurrences in raw YAML bytes with
-// the corresponding environment variable values. Returns an error if any
-// referenced env var is not set. This runs before YAML parsing so any field
-// can reference env vars.
+// the corresponding environment variable values. YAML comments are skipped —
+// a ${VAR} reference inside a # comment has no effect on the parsed config and
+// must not cause loading to fail (SOL-149904). Returns an error listing any
+// referenced env vars that are not set (comments excluded). This runs before
+// YAML parsing so any field can reference env vars.
 func substituteEnvVars(data []byte) ([]byte, error) {
 	var missing []string
+	var result bytes.Buffer
+	result.Grow(len(data))
 
-	result := envVarPattern.ReplaceAllFunc(data, func(match []byte) []byte {
-		// Extract var name from ${VAR_NAME}
-		varName := string(envVarPattern.FindSubmatch(match)[1])
-		value, exists := os.LookupEnv(varName)
-		if !exists {
-			missing = append(missing, varName)
-			return match // leave as-is, error reported after
-		}
-		return []byte(value)
-	})
+	for _, line := range bytes.SplitAfter(data, []byte("\n")) {
+		active, comment := splitYAMLComment(line)
+		substituted := envVarPattern.ReplaceAllFunc(active, func(match []byte) []byte {
+			varName := string(envVarPattern.FindSubmatch(match)[1])
+			value, exists := os.LookupEnv(varName)
+			if !exists {
+				missing = append(missing, varName)
+				return match // leave as-is, error reported after
+			}
+			return []byte(value)
+		})
+		result.Write(substituted)
+		result.Write(comment)
+	}
 
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("environment variables not set: %s", strings.Join(missing, ", "))
 	}
 
-	return result, nil
+	return result.Bytes(), nil
+}
+
+// splitYAMLComment returns (active, comment) where active is the portion of
+// line before any unquoted YAML comment marker (#) and comment is the rest
+// (including the # itself). A # starts a comment when it is at the start of
+// the line OR preceded by whitespace, AND not inside a single- or
+// double-quoted string on the same line.
+//
+// Limitations: block scalars (|, >) treat # as literal text — this helper
+// does not track block-scalar context. The broker MCP config schema uses only
+// scalar values and nested structs, never block scalars, so this is acceptable.
+// If a block-scalar field is ever added, extend this helper accordingly.
+func splitYAMLComment(line []byte) (active, comment []byte) {
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case c == '"' && !inSingle:
+			// Treat a preceding backslash as escaping the quote (heuristic,
+			// not a full YAML lexer — double-backslash isn't unescaped here).
+			if !inDouble || i == 0 || line[i-1] != '\\' {
+				inDouble = !inDouble
+			}
+		case c == '\'' && !inDouble:
+			// YAML escapes ' inside a single-quoted string as ''. A naive
+			// toggle re-enters the string at the second quote, which leaves
+			// the in/out state correct at any later #.
+			inSingle = !inSingle
+		case c == '#' && !inSingle && !inDouble && (i == 0 || line[i-1] == ' ' || line[i-1] == '\t'):
+			return line[:i], line[i:]
+		}
+	}
+	return line, nil
 }
 
 // validate checks that the config has all required fields and that values are

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -261,6 +261,78 @@ brokers:
 	}
 }
 
+// ${VAR} references inside YAML comments must NOT trigger env var lookups —
+// the line is inert at parse time and has no effect on the loaded config.
+func TestLoadConfig_EnvVarInWholeLineComment(t *testing.T) {
+	yaml := `
+development_mode: true
+brokers:
+  prod:
+    url: "https://broker.example.com:1943"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+      # token: ${UNSET_BEARER_TOKEN}  # alternate bearer-auth example
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("commented-out ${UNSET_BEARER_TOKEN} must not fail load: %v", err)
+	}
+	if cfg.Brokers["prod"].Auth.Token != "" {
+		t.Errorf("expected token unset for commented-out line, got %q", cfg.Brokers["prod"].Auth.Token)
+	}
+}
+
+// Trailing inline comments must also be skipped, while ${VAR} in the live
+// portion of the same line is still substituted.
+func TestLoadConfig_EnvVarInInlineComment(t *testing.T) {
+	t.Setenv("INLINE_PASSWORD", "live-secret")
+
+	yaml := `
+development_mode: true
+brokers:
+  prod:
+    url: "https://broker.example.com:1943"
+    auth:
+      mode: basic
+      username: admin
+      password: ${INLINE_PASSWORD}  # was ${UNSET_OLD_PASSWORD}
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("inline comment ${UNSET_OLD_PASSWORD} must not fail load: %v", err)
+	}
+	if cfg.Brokers["prod"].Auth.Password != "live-secret" {
+		t.Errorf("expected password substituted to %q, got %q", "live-secret", cfg.Brokers["prod"].Auth.Password)
+	}
+}
+
+// A # character that appears inside a quoted string is part of the value, not
+// a comment marker. ${VAR} on the same line must still be substituted and the
+// # preserved in the parsed value.
+func TestLoadConfig_HashInsideQuotedValue(t *testing.T) {
+	t.Setenv("PWD_HEAD", "live")
+
+	yaml := `
+development_mode: true
+brokers:
+  prod:
+    url: "https://broker.example.com:1943"
+    auth:
+      mode: basic
+      username: admin
+      password: "${PWD_HEAD}#tail"
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cfg.Brokers["prod"].Auth.Password; got != "live#tail" {
+		t.Errorf("expected password %q, got %q", "live#tail", got)
+	}
+}
+
 func TestLoadConfig_PortOutOfRange(t *testing.T) {
 	yaml := `
 port: 99999


### PR DESCRIPTION
## Summary

Jira: [SOL-149904](https://sol-jira.atlassian.net/browse/SOL-149904)

`substituteEnvVars` ran the `${VAR_NAME}` regex against raw YAML bytes via `regexp.ReplaceAllFunc`, with no awareness of YAML comment syntax. A `${VAR}` reference inside a `#` comment was treated identically to a live field, so an unset env var on a commented-out line aborted config loading even though the line has no effect on the parsed config.

Example: the shipped `broker-config.example.yaml` itself triggers this — an operator copying the example and using basic auth would still see config loading fail with `environment variables not set: BROKER_TOKEN` because line 50 of the example file contains the commented-out bearer-token reference.

## Approach

Process input line by line. Run the existing regex only on the portion of each line before any unquoted `#` comment marker. Add a small `splitYAMLComment` helper that tracks single/double quote state so a `#` inside a quoted value remains part of the value.

- Pure byte transformation — no behavior change for live fields.
- Block scalars (`|`, `>`) are not handled by the heuristic; the config schema doesn't use them. Documented inline.
- No new dependencies. No public API change. No logging change.

## Files changed

- `internal/config/config.go` — modified `substituteEnvVars`; added `splitYAMLComment` helper. (+58, -15)
- `internal/config/config_test.go` — added 3 tests. (+72)

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — all 12 packages green
- [x] New tests for whole-line and inline comment cases (failing before the fix, passing after)
- [x] Regression guard test for `#` inside a quoted value (passing before and after)
- [x] Revert-verify performed: stashed implementation → new tests went red; restored → green
- [x] `/check-logs` on the diff — 0 violations
- [x] `gofmt` / `go vet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-149904]: https://sol-jira.atlassian.net/browse/SOL-149904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ