### PR TITLE
test(config): add client_auth.mode to PR 51's max-concurrent fixtures [SOL-150117]

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1010,6 +1010,7 @@ func TestLoadConfig_MaxConcurrentPerBroker_OutOfRange(t *testing.T) {
 			yaml := `
 development_mode: true
 client_auth:
+  mode: static
   dev_token: test
 semp:
   max_concurrent_per_broker: ` + tc.value + `
@@ -1037,6 +1038,7 @@ brokers:
 		yaml := `
 development_mode: true
 client_auth:
+  mode: static
   dev_token: test
 semp:
   max_concurrent_per_broker: 1024


### PR DESCRIPTION
## Summary

- Restores `TestLoadConfig_MaxConcurrentPerBroker_OutOfRange` on `main` (it broke when PR 51 and PR 62 landed back-to-back on Friday).
- Adds `mode: static` to the two YAML fixtures that were missing it — the same mechanical edit PR 62 (`SOL-149989`) applied to every other fixture in commit `422a35d`.
- Test-only — no production code changed.

## Root cause

PR 51 (`SOL-149924`) was branched 2026-05-19, two days before PR 62 (`SOL-149989`) merged on 2026-05-21. PR 62 made `client_auth.mode` a required config field and mechanically updated every existing fixture. PR 51 was developed in parallel and added new YAML fixtures that never picked up that sweep, so they fail validation once both PRs are on `main`.

Visible symptom:

```
--- FAIL: TestLoadConfig_MaxConcurrentPerBroker_OutOfRange/at_ceiling_passes
    config_test.go:1052: max_concurrent_per_broker: 1024 should pass
    (inclusive upper bound), got: validating config: client_auth.mode is
    required (must be one of [disabled static oauth])
```

The negative subcases (`negative`, `above_ceiling`, `just_above_ceiling`) still produced the expected error string only because the `max_concurrent_per_broker` validator happened to fire before the `client_auth.mode` check. Adding `mode: static` to those fixtures too hardens them against future validator-order changes.

Tracked in [SOL-150117](https://sol-jira.atlassian.net/browse/SOL-150117).

## Test plan

- [x] `go test -run TestLoadConfig_MaxConcurrentPerBroker_OutOfRange -v ./internal/config/` — all 4 subtests PASS
- [x] `go test -count=1 ./...` — all packages green, no FAIL
- [x] `go vet ./...` — clean
- [x] `/check-logs` scoped scan of the modified file — clean (no log calls touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150117]: https://sol-jira.atlassian.net/browse/SOL-150117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ