### PR TITLE
SOL-148426: Implement Basic Health Endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,14 +127,20 @@ func buildMux(aliases func() []string, ping func(ctx context.Context, broker str
 		wg.Wait()
 		close(results)
 
-		// reduce: partition into ready brokers and errors
-		var readyBrokers []string
-		var errs []string
+		// Collect goroutine results into a map, then emit in the original broker
+		// order so the JSON response is deterministic regardless of goroutine
+		// scheduling. Initialize as empty slices so they marshal as [] not null.
+		resultsByBroker := make(map[string]error, len(brokers))
 		for res := range results {
-			if res.err != nil {
-				errs = append(errs, fmt.Sprintf("%s: %s", res.broker, res.err.Error()))
+			resultsByBroker[res.broker] = res.err
+		}
+		readyBrokers := []string{}
+		errs := []string{}
+		for _, broker := range brokers {
+			if err := resultsByBroker[broker]; err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %s", broker, err.Error()))
 			} else {
-				readyBrokers = append(readyBrokers, res.broker)
+				readyBrokers = append(readyBrokers, broker)
 			}
 		}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -251,7 +251,7 @@ func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error 
 // production implementation of buildMux's probeBroker parameter.
 func newBrokerReachabilityProbe(cfg *config.ServerConfig) func(context.Context, string) error {
 	return func(ctx context.Context, broker string) error {
-		brokerCfg, ok := cfg.Brokers[broker]
+		brokerCfg, ok := cfg.Broker(broker)
 		if !ok {
 			return fmt.Errorf("unknown broker %q", broker)
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -81,8 +81,8 @@ func newSlogHandler(level slog.Level) slog.Handler {
 // Both main() and tests use this function to avoid route drift.
 //
 // aliases returns the list of broker names to check.
-// ping tests connectivity to a single broker; it returns nil on success.
-func buildMux(aliases func() []string, ping func(ctx context.Context, broker string) error) *http.ServeMux {
+// probeBroker tests connectivity to a single broker; it returns nil on success.
+func buildMux(aliases func() []string, probeBroker func(ctx context.Context, broker string) error) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -104,6 +104,8 @@ func buildMux(aliases func() []string, ping func(ctx context.Context, broker str
 		}
 		w.Header().Set("Content-Type", "application/json")
 
+		// Config validation ensures there is at least one broker configured, so aliases()
+		// is never empty in production.
 		brokers := aliases()
 		type brokerResult struct {
 			broker string
@@ -114,22 +116,20 @@ func buildMux(aliases func() []string, ping func(ctx context.Context, broker str
 		var wg sync.WaitGroup
 		wg.Add(len(brokers))
 
-		// map: ping each broker concurrently
+		// Probe each broker concurrently, then collect in configured order.
 		for _, broker := range brokers {
 			go func(broker string) {
 				defer wg.Done()
-				reqCtx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+				timeout := time.Duration(defaults.DefaultReadinessProbeTimeoutSeconds) * time.Second
+				reqCtx, cancel := context.WithTimeout(r.Context(), timeout)
 				defer cancel()
-				results <- brokerResult{broker: broker, err: ping(reqCtx, broker)}
+				results <- brokerResult{broker: broker, err: probeBroker(reqCtx, broker)}
 			}(broker)
 		}
 
 		wg.Wait()
 		close(results)
 
-		// Collect goroutine results into a map, then emit in the original broker
-		// order so the JSON response is deterministic regardless of goroutine
-		// scheduling. Initialize as empty slices so they marshal as [] not null.
 		resultsByBroker := make(map[string]error, len(brokers))
 		for res := range results {
 			resultsByBroker[res.broker] = res.err
@@ -138,7 +138,7 @@ func buildMux(aliases func() []string, ping func(ctx context.Context, broker str
 		errs := []string{}
 		for _, broker := range brokers {
 			if err := resultsByBroker[broker]; err != nil {
-				errs = append(errs, fmt.Sprintf("%s: %s", broker, err.Error()))
+				errs = append(errs, fmt.Sprintf("%s: unreachable", broker))
 			} else {
 				readyBrokers = append(readyBrokers, broker)
 			}
@@ -242,6 +242,42 @@ func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error 
 		}
 	}()
 	return errCh
+}
+
+// newBrokerReachabilityProbe returns a probe function that checks whether a
+// broker's SEMP port is accepting TCP connections. The returned function
+// resolves the broker alias against cfg, parses the URL, defaults the port
+// (443 for HTTPS, 80 otherwise), and performs a TCP dial. It is the
+// production implementation of buildMux's probeBroker parameter.
+func newBrokerReachabilityProbe(cfg *config.ServerConfig) func(context.Context, string) error {
+	return func(ctx context.Context, broker string) error {
+		brokerCfg, ok := cfg.Brokers[broker]
+		if !ok {
+			return fmt.Errorf("unknown broker %q", broker)
+		}
+		u, err := url.Parse(brokerCfg.URL)
+		if err != nil {
+			return fmt.Errorf("broker %q: invalid URL: %w", broker, err)
+		}
+		host := u.Hostname()
+		port := u.Port()
+		if port == "" {
+			if u.Scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		}
+		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(host, port))
+		if err != nil {
+			slog.Warn("broker TCP connectivity check failed",
+				slog.String("broker", broker),
+				slog.String("error", err.Error()))
+			return err
+		}
+		_ = conn.Close()
+		return nil
+	}
 }
 
 // registerSEMPv1Tools attaches every Go-native SEMPv1 tool handler to mgr.
@@ -386,34 +422,7 @@ func main() {
 	slog.Info("all tools registered")
 
 	// 8. Set up HTTP routes
-	mux := buildMux(pool.Aliases, func(ctx context.Context, broker string) error {
-		brokerCfg, ok := cfg.Brokers[broker]
-		if !ok {
-			return fmt.Errorf("unknown broker %q", broker)
-		}
-		u, err := url.Parse(brokerCfg.URL)
-		if err != nil {
-			return fmt.Errorf("broker %q: invalid URL: %w", broker, err)
-		}
-		host := u.Hostname()
-		port := u.Port()
-		if port == "" {
-			if u.Scheme == "https" {
-				port = "443"
-			} else {
-				port = "80"
-			}
-		}
-		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(host, port))
-		if err != nil {
-			slog.Warn("broker TCP connectivity check failed",
-				slog.String("broker", broker),
-				slog.String("error", err.Error()))
-			return err
-		}
-		_ = conn.Close()
-		return nil
-	})
+	mux := buildMux(pool.Aliases, newBrokerReachabilityProbe(cfg))
 
 	// Create MCP handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,14 +17,18 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -75,7 +79,10 @@ func newSlogHandler(level slog.Level) slog.Handler {
 // buildMux creates the HTTP route multiplexer with basic routes.
 // The /mcp route is registered separately in main() with auth middleware.
 // Both main() and tests use this function to avoid route drift.
-func buildMux() *http.ServeMux {
+//
+// aliases returns the list of broker names to check.
+// ping tests connectivity to a single broker; it returns nil on success.
+func buildMux(aliases func() []string, ping func(ctx context.Context, broker string) error) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -85,9 +92,61 @@ func buildMux() *http.ServeMux {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`{"status": "ok"}`)); err != nil {
+		if _, err := w.Write([]byte(`{"status": "healthy"}`)); err != nil {
 			http.Error(w, "failed to write response", http.StatusInternalServerError)
 		}
+	})
+
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		brokers := aliases()
+		type brokerResult struct {
+			broker string
+			err    error
+		}
+		results := make(chan brokerResult, len(brokers))
+
+		var wg sync.WaitGroup
+		wg.Add(len(brokers))
+
+		// map: ping each broker concurrently
+		for _, broker := range brokers {
+			go func(broker string) {
+				defer wg.Done()
+				reqCtx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+				defer cancel()
+				results <- brokerResult{broker: broker, err: ping(reqCtx, broker)}
+			}(broker)
+		}
+
+		wg.Wait()
+		close(results)
+
+		// reduce: partition into ready brokers and errors
+		var readyBrokers []string
+		var errs []string
+		for res := range results {
+			if res.err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %s", res.broker, res.err.Error()))
+			} else {
+				readyBrokers = append(readyBrokers, res.broker)
+			}
+		}
+
+		if len(errs) > 0 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			resp, _ := json.Marshal(map[string]any{"ready": false, "errors": errs})
+			_, _ = w.Write(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		resp, _ := json.Marshal(map[string]any{"ready": true, "brokers": readyBrokers})
+		_, _ = w.Write(resp)
 	})
 
 	return mux
@@ -321,7 +380,34 @@ func main() {
 	slog.Info("all tools registered")
 
 	// 8. Set up HTTP routes
-	mux := buildMux()
+	mux := buildMux(pool.Aliases, func(ctx context.Context, broker string) error {
+		brokerCfg, ok := cfg.Brokers[broker]
+		if !ok {
+			return fmt.Errorf("unknown broker %q", broker)
+		}
+		u, err := url.Parse(brokerCfg.URL)
+		if err != nil {
+			return fmt.Errorf("broker %q: invalid URL: %w", broker, err)
+		}
+		host := u.Hostname()
+		port := u.Port()
+		if port == "" {
+			if u.Scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		}
+		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(host, port))
+		if err != nil {
+			slog.Warn("broker TCP connectivity check failed",
+				slog.String("broker", broker),
+				slog.String("error", err.Error()))
+			return err
+		}
+		_ = conn.Close()
+		return nil
+	})
 
 	// Create MCP handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +37,7 @@ func testMux() *http.ServeMux {
 		Name:    "solace-broker-mcp",
 		Version: version.Version(),
 	}, nil)
-	mux := buildMux()
+	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil })
 
 	// Register /mcp endpoint for testing (without auth middleware)
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
@@ -56,8 +58,8 @@ func TestHealth_GET_ReturnsOK(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("GET /health status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if rec.Body.String() != `{"status": "ok"}` {
-		t.Errorf("GET /health body = %q, want %q", rec.Body.String(), `{"status": "ok"}`)
+	if rec.Body.String() != `{"status": "healthy"}` {
+		t.Errorf("GET /health body = %q, want %q", rec.Body.String(), `{"status": "healthy"}`)
 	}
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("GET /health Content-Type = %q, want %q", ct, "application/json")
@@ -292,5 +294,68 @@ func TestHealthConfigFromFile_PartialTLSIsHTTP(t *testing.T) {
 	got := healthConfigFromFile()
 	if got.Scheme != "http" {
 		t.Errorf("Scheme = %q, want http (only cert set, no key)", got.Scheme)
+	}
+}
+
+func TestReady_POST_ReturnsMethodNotAllowed(t *testing.T) {
+	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil })
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/ready", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /ready status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestReady_GET_AllBrokersReachable(t *testing.T) {
+	brokers := []string{"prod-1", "prod-2"}
+	mux := buildMux(
+		func() []string { return brokers },
+		func(_ context.Context, _ string) error { return nil },
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /ready status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if body["ready"] != true {
+		t.Errorf("ready = %v, want true", body["ready"])
+	}
+}
+
+func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
+	brokers := []string{"prod-1", "prod-2"}
+	mux := buildMux(
+		func() []string { return brokers },
+		func(_ context.Context, broker string) error {
+			if broker == "prod-2" {
+				return errors.New("connection refused")
+			}
+			return nil
+		},
+	)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("GET /ready status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if body["ready"] != false {
+		t.Errorf("ready = %v, want false", body["ready"])
 	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -23,10 +23,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -379,7 +379,76 @@ func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
 	if len(body.Errors) == 0 {
 		t.Fatal("errors array is empty, want at least one entry")
 	}
-	if !strings.Contains(body.Errors[0], "prod-2") {
-		t.Errorf("errors[0] = %q, want it to reference failing broker %q", body.Errors[0], "prod-2")
+	want := "prod-2: unreachable"
+	if body.Errors[0] != want {
+		t.Errorf("errors[0] = %q, want %q", body.Errors[0], want)
+	}
+}
+
+func TestNewBrokerReachabilityProbe_UnknownBroker(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Brokers: map[string]*config.BrokerConfig{},
+	}
+	probe := newBrokerReachabilityProbe(cfg)
+
+	err := probe(context.Background(), "no-such-broker")
+	if err == nil {
+		t.Fatal("expected error for unknown broker, got nil")
+	}
+	if want := `unknown broker "no-such-broker"`; err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestNewBrokerReachabilityProbe_ExplicitPort(t *testing.T) {
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	addr := l.Addr().String()
+	_, port, _ := net.SplitHostPort(addr)
+	cfg := &config.ServerConfig{
+		Brokers: map[string]*config.BrokerConfig{
+			"broker-a": {URL: "http://127.0.0.1:" + port},
+		},
+	}
+	probe := newBrokerReachabilityProbe(cfg)
+
+	if err := probe(context.Background(), "broker-a"); err != nil {
+		t.Errorf("expected success for reachable broker, got: %v", err)
+	}
+}
+
+func TestNewBrokerReachabilityProbe_HTTPSDefaultsTo443(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Brokers: map[string]*config.BrokerConfig{
+			"broker-a": {URL: "https://192.0.2.1"},
+		},
+	}
+	probe := newBrokerReachabilityProbe(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := probe(ctx, "broker-a")
+	if err == nil {
+		t.Fatal("expected dial error to 192.0.2.1:443, got nil")
+	}
+}
+
+func TestNewBrokerReachabilityProbe_HTTPDefaultsTo80(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Brokers: map[string]*config.BrokerConfig{
+			"broker-a": {URL: "http://192.0.2.1"},
+		},
+	}
+	probe := newBrokerReachabilityProbe(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := probe(ctx, "broker-a")
+	if err == nil {
+		t.Fatal("expected dial error to 192.0.2.1:80, got nil")
 	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -323,12 +324,26 @@ func TestReady_GET_AllBrokersReachable(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("GET /ready status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	var body map[string]any
+	if contentType := rec.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("GET /ready Content-Type = %q, want %q", contentType, "application/json")
+	}
+	var body struct {
+		Ready   bool     `json:"ready"`
+		Brokers []string `json:"brokers"`
+	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("response is not valid JSON: %v", err)
 	}
-	if body["ready"] != true {
-		t.Errorf("ready = %v, want true", body["ready"])
+	if !body.Ready {
+		t.Errorf("ready = %v, want true", body.Ready)
+	}
+	if len(body.Brokers) != len(brokers) {
+		t.Errorf("brokers len = %d, want %d", len(body.Brokers), len(brokers))
+	}
+	for i, expectedBroker := range brokers {
+		if body.Brokers[i] != expectedBroker {
+			t.Errorf("brokers[%d] = %q, want %q", i, body.Brokers[i], expectedBroker)
+		}
 	}
 }
 
@@ -351,11 +366,20 @@ func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("GET /ready status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
 	}
-	var body map[string]any
+	var body struct {
+		Ready  bool     `json:"ready"`
+		Errors []string `json:"errors"`
+	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("response is not valid JSON: %v", err)
 	}
-	if body["ready"] != false {
-		t.Errorf("ready = %v, want false", body["ready"])
+	if body.Ready {
+		t.Errorf("ready = %v, want false", body.Ready)
+	}
+	if len(body.Errors) == 0 {
+		t.Fatal("errors array is empty, want at least one entry")
+	}
+	if !strings.Contains(body.Errors[0], "prod-2") {
+		t.Errorf("errors[0] = %q, want it to reference failing broker %q", body.Errors[0], "prod-2")
 	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -385,10 +386,32 @@ func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
 	}
 }
 
-func TestNewBrokerReachabilityProbe_UnknownBroker(t *testing.T) {
-	cfg := &config.ServerConfig{
-		Brokers: map[string]*config.BrokerConfig{},
+// probeTestConfig writes a minimal YAML config with the given brokers and
+// returns the loaded *config.ServerConfig. Each broker entry is an
+// (alias, url) pair.
+// probeTestConfig writes a minimal YAML config with the given brokers and
+// returns the loaded *config.ServerConfig. Each entry is an [alias, url] pair.
+func probeTestConfig(t *testing.T, brokers ...[2]string) *config.ServerConfig {
+	t.Helper()
+	var yamlContent string
+	yamlContent += "client_auth:\n  mode: disabled\nbrokers:\n"
+	for _, broker := range brokers {
+		alias, brokerURL := broker[0], broker[1]
+		yamlContent += fmt.Sprintf("  %s:\n    url: %s\n    auth:\n      mode: basic\n      username: admin\n      password: secret\n", alias, brokerURL)
 	}
+	path := filepath.Join(t.TempDir(), "broker-config.yaml")
+	if err := os.WriteFile(path, []byte(yamlContent), os.FileMode(0o600)); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+	cfg, err := config.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	return cfg
+}
+
+func TestNewBrokerReachabilityProbe_UnknownBroker(t *testing.T) {
+	cfg := probeTestConfig(t, [2]string{"existing", "http://127.0.0.1:8080"})
 	probe := newBrokerReachabilityProbe(cfg)
 
 	err := probe(context.Background(), "no-such-broker")
@@ -409,11 +432,7 @@ func TestNewBrokerReachabilityProbe_ExplicitPort(t *testing.T) {
 
 	addr := l.Addr().String()
 	_, port, _ := net.SplitHostPort(addr)
-	cfg := &config.ServerConfig{
-		Brokers: map[string]*config.BrokerConfig{
-			"broker-a": {URL: "http://127.0.0.1:" + port},
-		},
-	}
+	cfg := probeTestConfig(t, [2]string{"broker-a", "http://127.0.0.1:" + port})
 	probe := newBrokerReachabilityProbe(cfg)
 
 	if err := probe(context.Background(), "broker-a"); err != nil {
@@ -422,11 +441,7 @@ func TestNewBrokerReachabilityProbe_ExplicitPort(t *testing.T) {
 }
 
 func TestNewBrokerReachabilityProbe_HTTPSDefaultsTo443(t *testing.T) {
-	cfg := &config.ServerConfig{
-		Brokers: map[string]*config.BrokerConfig{
-			"broker-a": {URL: "https://192.0.2.1"},
-		},
-	}
+	cfg := probeTestConfig(t, [2]string{"broker-a", "https://192.0.2.1"})
 	probe := newBrokerReachabilityProbe(cfg)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -438,11 +453,7 @@ func TestNewBrokerReachabilityProbe_HTTPSDefaultsTo443(t *testing.T) {
 }
 
 func TestNewBrokerReachabilityProbe_HTTPDefaultsTo80(t *testing.T) {
-	cfg := &config.ServerConfig{
-		Brokers: map[string]*config.BrokerConfig{
-			"broker-a": {URL: "http://192.0.2.1"},
-		},
-	}
+	cfg := probeTestConfig(t, [2]string{"broker-a", "http://192.0.2.1"})
 	probe := newBrokerReachabilityProbe(cfg)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -113,6 +113,15 @@ const DefaultReadTimeoutSeconds = 30
 // idle sockets — neither perfect, but the alternative breaks the product.
 const DefaultIdleTimeoutSeconds = 120
 
+// DefaultReadinessProbeTimeoutSeconds is the per-broker timeout for the TCP
+// connectivity check performed by the /ready endpoint.
+//
+// Decided: 2 seconds.
+// Reasoning: the probe only opens and closes a TCP connection — no TLS
+// handshake, no SEMP request. 2s is generous for an in-cluster dial while
+// keeping the /ready response snappy for orchestrator liveness probes.
+const DefaultReadinessProbeTimeoutSeconds = 2
+
 // DefaultConfigPathSystem is the production-install location for the config
 // file. Tried when CONFIG_FILE is not set. Follows the conventional Linux
 // /etc/<app>/config.yaml layout used by Linux services, K8s, and Docker.

--- a/test/e2e-basic-mcp/test_standalone.sh
+++ b/test/e2e-basic-mcp/test_standalone.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/helpers.sh"
 test_health_endpoint() {
     local response
     response=$(curl -sf "$MCP_URL/health")
-    assert_json_field "$response" ".status" "ok" "Health endpoint should return status ok"
+    assert_json_field "$response" ".status" "healthy" "Health endpoint should return status healthy"
 }
 
 test_initialize() {

--- a/test/e2e/health/test_health.sh
+++ b/test/e2e/health/test_health.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Standalone e2e tests for /health and /ready endpoints.
+# Manages its own docker containers and MCP server — can be run independently
+# of the full e2e suite.
+
+set -euo pipefail
+source "$(dirname "$0")/../helpers.sh"
+
+STARTED_DOCKER=false
+SECONDARY_MCP_PORT=9091
+SECONDARY_MCP_PID=""
+SECONDARY_CONFIG=""
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Wait for a TCP port to accept connections — mirrors exactly what /ready uses internally.
+wait_for_tcp() {
+    local host="$1" port="$2" label="$3"
+    local max=30
+    local attempt=0
+    log_info "Waiting for TCP $label ($host:$port) ..."
+    while [ $attempt -lt $max ]; do
+        # -z  zero-I/O mode: open the connection and close it immediately without sending data
+        # -w 1  give up after 1 second if the port doesn't respond
+        # 2>/dev/null  suppress per-attempt "connection refused" noise; log_fail handles the timeout case
+        if nc -z -w 1 "$host" "$port" 2>/dev/null; then
+            log_info "TCP $label ready after ${attempt}s"
+            return 0
+        fi
+        sleep 1
+        attempt=$((attempt + 1))
+    done
+    log_fail "TCP $label not ready after ${max}s"
+    return 1
+}
+
+cleanup() {
+    log_info "Running cleanup ..."
+    stop_server
+    if [ -n "$SECONDARY_MCP_PID" ]; then
+        kill "$SECONDARY_MCP_PID" 2>/dev/null || true
+        wait "$SECONDARY_MCP_PID" 2>/dev/null || true
+    fi
+    if [ -n "$SECONDARY_CONFIG" ]; then
+        rm -f "$SECONDARY_CONFIG"
+    fi
+    rm -f "$CONFIG_FILE"
+    if [ "$STARTED_DOCKER" = "true" ]; then
+        log_info "Stopping broker containers ..."
+        docker compose -f "$SCRIPT_DIR/docker-compose.yml" down --timeout 10 >/dev/null 2>&1 || true
+    fi
+}
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+CONFIG_FILE=$(mktemp /tmp/e2e-config-XXXXXX.yaml)
+trap cleanup EXIT
+
+log_info "=== Health/Readiness E2E Tests ==="
+echo ""
+
+# Start broker containers if not already reachable on the configured ports.
+# The health test only needs TCP connectivity — it does not perform SEMP operations.
+if ! nc -z -w 1 localhost "$BROKER_A_SEMP_PORT" 2>/dev/null || \
+   ! nc -z -w 1 localhost "$BROKER_B_SEMP_PORT" 2>/dev/null; then
+    log_info "Starting broker containers ..."
+    docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d >/dev/null 2>&1 || \
+        { log_fail "Failed to start broker containers"; exit 1; }
+    STARTED_DOCKER=true
+fi
+
+wait_for_tcp localhost "$BROKER_A_SEMP_PORT" "broker-a"
+wait_for_tcp localhost "$BROKER_B_SEMP_PORT" "broker-b"
+
+build_server
+write_config "$CONFIG_FILE"
+start_server "$CONFIG_FILE"
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+test_health() {
+    local response
+    response=$(curl -sf "$MCP_URL/health")
+    assert_json_field "$response" ".status" "healthy" "/health should return status=healthy"
+}
+
+test_ready_both_reachable() {
+    local response
+    response=$(curl -sf "$MCP_URL/ready")
+    assert_json_field "$response" ".ready" "true" "/ready should return ready=true" || return 1
+    assert_contains "$response" "broker-a" "/ready should list broker-a" || return 1
+    assert_contains "$response" "broker-b" "/ready should list broker-b" || return 1
+}
+
+test_ready_unreachable_broker() {
+    SECONDARY_CONFIG=$(mktemp /tmp/e2e-secondary-XXXXXX)
+    cat > "$SECONDARY_CONFIG" <<EOF
+development_mode: true
+port: $SECONDARY_MCP_PORT
+brokers:
+  broker-dead:
+    url: "http://localhost:19999"
+    auth:
+      mode: basic
+      username: "admin"
+      password: "admin"
+EOF
+
+    local existing
+    existing=$(lsof -ti:"$SECONDARY_MCP_PORT" 2>/dev/null || true)
+    if [ -n "$existing" ]; then
+        kill "$existing" 2>/dev/null || true
+        sleep 0.5
+    fi
+
+    CONFIG_FILE="$SECONDARY_CONFIG" "$BIN_DIR/mcp-server" 2>/dev/null &
+    SECONDARY_MCP_PID=$!
+
+    local attempt=0 ready=0
+    # 30 attempts × 0.5s = 15s timeout
+    while [ $attempt -lt 30 ]; do
+        if curl -sf "http://localhost:$SECONDARY_MCP_PORT/health" >/dev/null 2>&1; then
+            ready=1; break
+        fi
+        sleep 0.5
+        attempt=$((attempt + 1))
+    done
+
+    local result=0
+    if [ "$ready" -eq 1 ]; then
+        local http_code
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$SECONDARY_MCP_PORT/ready")
+        if [ "$http_code" = "503" ]; then
+            log_info "  /ready correctly returned 503 — TCP dial to localhost:19999 failed as expected"
+        else
+            log_fail "/ready returned HTTP $http_code, want 503 for unreachable broker"
+            result=1
+        fi
+    else
+        log_fail "Secondary MCP server failed to start on port $SECONDARY_MCP_PORT"
+        result=1
+    fi
+
+    kill "$SECONDARY_MCP_PID" 2>/dev/null || true
+    wait "$SECONDARY_MCP_PID" 2>/dev/null || true
+    SECONDARY_MCP_PID=""
+    rm -f "$SECONDARY_CONFIG"
+    SECONDARY_CONFIG=""
+    return "$result"
+}
+
+# ── Run ───────────────────────────────────────────────────────────────────────
+
+run_test "Health endpoint"                     test_health
+run_test "Ready endpoint (brokers reachable)"  test_ready_both_reachable
+run_test "Ready endpoint (broker unreachable)" test_ready_unreachable_broker
+
+print_summary "Health/Readiness"

--- a/test/health/test_health.sh
+++ b/test/health/test_health.sh
@@ -4,7 +4,7 @@
 # of the full e2e suite.
 
 set -euo pipefail
-source "$(dirname "$0")/../helpers.sh"
+source "$(dirname "$0")/../e2e-basic-mcp/helpers.sh"
 
 STARTED_DOCKER=false
 SECONDARY_MCP_PORT=9091
@@ -94,7 +94,8 @@ test_ready_both_reachable() {
 test_ready_unreachable_broker() {
     SECONDARY_CONFIG=$(mktemp /tmp/e2e-secondary-XXXXXX)
     cat > "$SECONDARY_CONFIG" <<EOF
-development_mode: true
+client_auth:
+  mode: disabled
 port: $SECONDARY_MCP_PORT
 brokers:
   broker-dead:


### PR DESCRIPTION
## Summary

Implements /health and /ready HTTP endpoints for MCP server liveness and  broker readiness checks. The readiness probe uses a lightweight TCP dial instead of a full SEMP API call, confirming broker reachability without putting load on the broker. 

Fixes https://sol-jira.atlassian.net/browse/SOL-148426

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

Platform operators deploying the MCP server need health and readiness endpoints to integrate with broker orchestration  and monitor MCP server health. The readiness endpoint must verify broker connectivity, but a full SEMP API call (authentication + HTTP round-trip + broker query) is unnecessarily heavy for a probe that runs on every check interval. A TCP dial to the broker's SEMP port confirms the broker is up and accepting connections with essentially zero load.

## Changes Made

- Added /health endpoint returning {"status":"healthy"} with HTTP 200
- Added /ready endpoint that concurrently TCP-dials each configured broker's SEMP host:port (2s timeout per broker), returning {"ready":true,"brokers":[...]} on HTTP 200 or {"ready":false,"errors":[...]} on HTTP 503
- Refactored buildMux to accept aliases and ping as injected dependencies, decoupling the route logic from broker connectivity implementation and enabling unit testing without a real broker
- Updated /health response body from {"status":"ok"} to {"status":"healthy"} 
-  Added unit and integration tests                        

## Testing

**Test Environment:**
- Go version: 1.26.2
- OS: macOS 26.3.1
- Broker version (if applicable): latest

**Tests Performed:**
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [ ] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**

- Added unit tests for /ready: method not allowed, all brokers reachable (200), one broker unreachable (503)                                       - Added standalone e2e test test/e2e/health/test_health.sh that manages its own docker containers and MCP server, covering: /health happy path, /ready with both brokers reachable, and /ready with an unreachable broker

## Breaking Changes

**Impact:**

None. The /health response body changed from {"status":"ok"} to {"status":"healthy"} — any client already polling /health and parsing the status field will see a different string value. The existing test_standalone.sh assertion has been updated accordingly.