### PR TITLE
chore: add Makefile with build/test/lint/docker targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+# Solace Broker MCP — convenience targets.
+# Thin wrappers around the same commands CI runs. CI (.github/workflows/build-and-test.yml)
+# remains the source of truth; if a target here drifts from CI, CI wins.
+
+BINARY      := solace-broker-mcp
+PKG         := ./cmd/server
+VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS     := -s -w -X github.com/SolaceDev/solace-broker-mcp/internal/version.version=$(VERSION)
+IMAGE       ?= solace-broker-mcp
+IMAGE_TAG   ?= dev
+COMPOSE_E2E := docker compose -f test/e2e/docker-compose.yml
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# ── Build ────────────────────────────────────────────────────────────────────
+
+.PHONY: build
+build: ## Build the server binary
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(PKG)
+
+.PHONY: run
+run: ## Run the server from source (uses ./broker-config.yaml)
+	go run $(PKG)
+
+.PHONY: clean
+clean: ## Remove build artifacts
+	rm -f $(BINARY)
+
+# ── Test & lint ──────────────────────────────────────────────────────────────
+
+.PHONY: test
+test: ## Run unit tests
+	go test -v ./...
+
+.PHONY: test-race
+test-race: ## Run unit tests with the race detector (matches CI)
+	go test -race -v ./...
+
+.PHONY: vet
+vet: ## go vet
+	go vet ./...
+
+.PHONY: lint
+lint: ## golangci-lint (CI pins v2.11.4)
+	golangci-lint run
+
+.PHONY: check
+check: vet lint test-race ## Run vet, lint, and race-enabled tests
+
+# ── E2E ──────────────────────────────────────────────────────────────────────
+
+.PHONY: e2e-up
+e2e-up: ## Start Solace brokers for E2E tests
+	$(COMPOSE_E2E) up -d
+
+.PHONY: e2e
+e2e: ## Run the E2E suite (requires brokers from `make e2e-up`)
+	bash test/e2e/run_all.sh
+
+.PHONY: e2e-down
+e2e-down: ## Stop and remove E2E brokers
+	$(COMPOSE_E2E) down -v
+
+# ── Docker ───────────────────────────────────────────────────────────────────
+
+.PHONY: docker
+docker: ## Build the Docker image (override with IMAGE=, IMAGE_TAG=, VERSION=)
+	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE):$(IMAGE_TAG) .

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,15 @@
 
 BINARY      := solace-broker-mcp
 PKG         := ./cmd/server
-VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+# Filter VERSION through a safe-character regex so a poisoned git tag cannot
+# inject shell when spliced into -ldflags or docker build-args.
+VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null | grep -E '^[A-Za-z0-9._+-]+$$' || echo dev)
 # Deferred (=) so $(shell git describe) only runs for targets that actually use LDFLAGS.
 LDFLAGS      = -s -w -X github.com/SolaceDev/solace-broker-mcp/internal/version.version=$(VERSION)
 IMAGE       ?= solace-broker-mcp
 IMAGE_TAG   ?= dev
-COMPOSE_E2E := docker compose -f test/e2e/docker-compose.yml
+E2E_DIR     := test/e2e-basic-mcp
+COMPOSE_E2E := docker compose -f $(E2E_DIR)/docker-compose.yml
 
 .DEFAULT_GOAL := help
 
@@ -59,24 +62,26 @@ check: build-all vet lint test-race ## Run build, vet, lint, and race-enabled te
 # ── E2E ──────────────────────────────────────────────────────────────────────
 
 .PHONY: e2e-up
-e2e-up: ## Start Solace brokers for E2E tests
+e2e-up: ## Start Solace brokers for E2E tests (does not wait for health — use `e2e-all` for the full cycle)
 	$(COMPOSE_E2E) up -d
 
 .PHONY: e2e
 e2e: ## Run the E2E suite (requires brokers from `make e2e-up`)
-	bash test/e2e/run_all.sh
+	bash $(E2E_DIR)/run_all.sh
 
 .PHONY: e2e-down
 e2e-down: ## Stop and remove E2E brokers
 	$(COMPOSE_E2E) down -v
 
 .PHONY: e2e-all
-e2e-all: ## Full E2E cycle: bring brokers up, run suite, tear down (tears down even on failure)
+e2e-all: ## Full E2E cycle: brokers up, wait for health, run suite, tear down (tears down even on failure)
 	$(COMPOSE_E2E) up -d
-	bash test/e2e/run_all.sh; status=$$?; $(COMPOSE_E2E) down -v; exit $$status
+	@. $(E2E_DIR)/helpers.sh && wait_for_all_brokers 120 && bash $(E2E_DIR)/run_all.sh; t=$$?; \
+	$(COMPOSE_E2E) down -v || echo "WARN: e2e-all teardown failed"; \
+	exit $$t
 
 # ── Docker ───────────────────────────────────────────────────────────────────
 
 .PHONY: docker
 docker: ## Build the Docker image (override with IMAGE=, IMAGE_TAG=, VERSION=)
-	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE):$(IMAGE_TAG) .
+	docker build --build-arg VERSION="$(VERSION)" -t "$(IMAGE):$(IMAGE_TAG)" .

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@
 BINARY      := solace-broker-mcp
 PKG         := ./cmd/server
 VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS     := -s -w -X github.com/SolaceDev/solace-broker-mcp/internal/version.version=$(VERSION)
+# Deferred (=) so $(shell git describe) only runs for targets that actually use LDFLAGS.
+LDFLAGS      = -s -w -X github.com/SolaceDev/solace-broker-mcp/internal/version.version=$(VERSION)
 IMAGE       ?= solace-broker-mcp
 IMAGE_TAG   ?= dev
 COMPOSE_E2E := docker compose -f test/e2e/docker-compose.yml
@@ -19,8 +20,12 @@ help: ## Show this help
 # ── Build ────────────────────────────────────────────────────────────────────
 
 .PHONY: build
-build: ## Build the server binary
+build: ## Build the server binary (version-stamped, matches Dockerfile)
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(PKG)
+
+.PHONY: build-all
+build-all: ## Build every package (matches CI's `go build -v ./...`)
+	go build -v ./...
 
 .PHONY: run
 run: ## Run the server from source (uses ./broker-config.yaml)
@@ -49,7 +54,7 @@ lint: ## golangci-lint (CI pins v2.11.4)
 	golangci-lint run
 
 .PHONY: check
-check: vet lint test-race ## Run vet, lint, and race-enabled tests
+check: build-all vet lint test-race ## Run build, vet, lint, and race-enabled tests (full CI parity)
 
 # ── E2E ──────────────────────────────────────────────────────────────────────
 
@@ -64,6 +69,11 @@ e2e: ## Run the E2E suite (requires brokers from `make e2e-up`)
 .PHONY: e2e-down
 e2e-down: ## Stop and remove E2E brokers
 	$(COMPOSE_E2E) down -v
+
+.PHONY: e2e-all
+e2e-all: ## Full E2E cycle: bring brokers up, run suite, tear down (tears down even on failure)
+	$(COMPOSE_E2E) up -d
+	bash test/e2e/run_all.sh; status=$$?; $(COMPOSE_E2E) down -v; exit $$status
 
 # ── Docker ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds a top-level `Makefile` providing convenience targets for everyday development tasks (build, test, lint, E2E, docker). The Makefile is a thin wrapper around the same commands `.github/workflows/build-and-test.yml` runs — **CI remains the source of truth**; the Makefile exists so contributors don't have to dig through CI YAML to find the canonical incantations.

No code, CI, or release behavior changes. No new tooling required (only `make`, which is universally available).

## Motivation

- Lower the discovery cost for new contributors: `make help` lists every entry point.
- Codify non-obvious commands that already live in CI: the `-race` flag, the pinned `golangci-lint` version, the `VERSION` build-arg for the Docker image, the E2E up/run/down dance.
- Give people who prefer `make build` muscle-memory a first-class path that produces the same artifacts as the Dockerfile.

## Targets

| Target | Maps to | Notes |
|---|---|---|
| `build` | `CGO_ENABLED=0 go build -ldflags ...` | Version-stamped binary. **Matches `Dockerfile`.** |
| `build-all` | `go build -v ./...` | Compiles every package. **Matches CI's build job.** |
| `run` | `go run ./cmd/server` | Reads `./broker-config.yaml`. |
| `clean` | `rm -f solace-broker-mcp` | Intentionally minimal — does not touch Docker images or test cache. |
| `test` | `go test -v ./...` | No race detector. |
| `test-race` | `go test -race -v ./...` | **Matches CI.** |
| `vet` | `go vet ./...` | **Matches CI.** |
| `lint` | `golangci-lint run` | Local install must be **v2.11.4** to match CI. |
| `check` | `build-all` + `vet` + `lint` + `test-race` | Full local CI parity. |
| `e2e-up` | `docker compose -f test/e2e/docker-compose.yml up -d` | Starts Solace brokers. |
| `e2e` | `bash test/e2e/run_all.sh` | Requires `e2e-up` first. |
| `e2e-down` | `docker compose ... down -v` | Tears brokers down. |
| `e2e-all` | up + suite + down | Tears down even on failure. **Do not use if brokers are already up for unrelated purposes** — `down -v` removes volumes. |
| `docker` | `docker build --build-arg VERSION=... -t IMAGE:IMAGE_TAG .` | Override via `make docker IMAGE_TAG=v0.3.0`. |
| `help` | (default goal) | Self-documenting target listing. |

## Overridable variables

| Var | Default | Purpose |
|---|---|---|
| `VERSION` | `git describe --tags --always --dirty`, falling back to `dev` | Stamped into the binary via `-ldflags`. |
| `IMAGE` | `solace-broker-mcp` | Docker image repository. |
| `IMAGE_TAG` | `dev` | Docker image tag. |

`LDFLAGS` uses deferred (`=`) expansion so `git describe` only runs for targets that actually need it (not for `make help`/`make clean`).

## Test plan

Verified locally on this branch:
- [x] `make help` lists all 15 targets with descriptions
- [x] `make build` produces a version-stamped binary (`v0.2.0-58-g622706f`)
- [x] `make build-all` compiles every package
- [x] `make vet` runs clean
- [x] `make clean` removes the binary (safe when absent)

Exercised by CI on this PR (no need to run locally):
- [ ] `make test-race` — same command as CI's test step
- [ ] `make lint` — CI runs golangci-lint v2.11.4 via the action
- [ ] `make e2e-up && make e2e && make e2e-down` — CI's E2E job runs the equivalent sequence
- [ ] `make docker` — release workflow builds the same image

## Risks & rollback

- **Risk: drift between Makefile and CI.** Mitigation: Makefile targets are intentionally thin wrappers around the same commands CI runs, with a header comment stating "CI remains the source of truth." Drift would be obvious in PR review.
- **Risk: `make e2e-all` removes volumes from already-running brokers.** Documented in the target's doc string and in this PR description.
- **Rollback:** This PR adds a single new file (`Makefile`). Reverting is `git revert`; no migrations, no state, no consumers.

## Out of scope / follow-ups

- `clean-e2e` and `clean-docker` targets — left out so that routine `make clean` does not surprise contributors by tearing down containers or deleting images.
- `install` target — not added; the binary is consumed via Docker or release archives.
- `tidy` target wrapping `go mod tidy` — could add if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)