### PR TITLE
chore: ignore git worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ vendor/
 *.swo
 *~
 
+# Git worktrees
+.worktrees/
+.claude/worktrees/
+
 # OS files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- Add `.worktrees/` and `.claude/worktrees/` to `.gitignore` so local worktree checkouts (from native git worktrees and Claude Code's worktree tooling) don't show up as untracked files.

## Test plan
- [x] `git status` no longer lists `.worktrees/` or `.claude/worktrees/` when those directories exist locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)