### PR TITLE
SOL-150167: fix broken broker healthcheck in e2e-basic-mcp

### DIFF
--- a/test/e2e-basic-mcp/docker-compose.yml
+++ b/test/e2e-basic-mcp/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         soft: 1048576
         hard: 1048576
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf -u admin:${BROKER_PASSWORD:-admin} http://localhost:8080/SEMP/v2/config/about || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 30
@@ -35,7 +35,7 @@ services:
         soft: 1048576
         hard: 1048576
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf -u admin:${BROKER_PASSWORD:-admin} http://localhost:8080/SEMP/v2/config/about || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 30


### PR DESCRIPTION
## Summary

Fix the broker healthcheck in `test/e2e-basic-mcp/docker-compose.yml` so containers correctly report `(healthy)` instead of permanently `(unhealthy)`. The probe was targeting a URL that no longer exists on current Solace images.

Fixes [SOL-150167](https://sol-jira.atlassian.net/browse/SOL-150167)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

The current healthcheck in both broker services targets /health on port 8080:

```test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]```
`/health` is not served on port 8080 by current Solace PubSub+ images — the broker's nginx tries to serve it as a static file from `/usr/sw/loads/currentload/www/health` (which doesn't exist) and returns 404. The healthcheck never passes, and containers stay in`(unhealthy)` state for their entire lifetime.

This was discovered while working on SOL-150024 (the new e2e-monitoring suite), which inherited the same broken healthcheck via copy from this suite. The fix was applied to e2e-monitoring as part of that ticket; this PR closes the gap on e2e-basic-mcp.

Today's impact is cosmetic, not functional: the suite scripts `(helpers.sh::wait_for_all_brokers)` do their own SEMP-based readiness probe and ignore Docker's health status, so tests still pass. But `docker compose ps` permanently lies (debugging trap), the broker's nginx logs a `/health` 404 every interval, and any future use of `depends_on: condition: service_healthy` would hang forever.

## Changes Made
- Updated the healthcheck.test line for both solace-a and solace-b services in test/e2e-basic-mcp/docker-compose.yml to probe /SEMP/v2/config/about (a real authenticated endpoint) instead of the nonexistent /health.


## Testing
**Test Environment:**
- Go version: go version go1.25.0 linux/amd64
- OS:  Linux 6.14.5-100.fc40.x86_64
- Broker version (if applicable): solace/solace-pubsub-standard:latest


**Tests Performed:**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**
- Verified docker compose -f test/e2e-basic-mcp/docker-compose.yml up -d brings both containers to (healthy) within ~90 s.
- Confirmed no /health 404 entries appear in docker logs solace-e2e-a after the change.
- Re-ran bash test/e2e-basic-mcp/run_all.sh — all existing scenarios still pass; no regression.


## Checklist

<!-- Ensure all items are completed before requesting review -->

### Code Quality
- [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [ ] Code is well-commented (explains "why", not "what")
- [ ] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (checked all files, commits, and logs)
- [x] Followed [secure logging rules](../docs/secure-logging-rules.md)
- [x] Credential-carrying types implement `slog.LogValuer`
- [x] No security vulnerabilities introduced (checked with golangci-lint/gosec)

### Testing
- [ ] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [x] Error paths tested
- [ ] Test names clearly describe what is being tested

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

## Related Issues/PRs
- Related to [SOL-150024](https://sol-jira.atlassian.net/browse/SOL-150024)



[SOL-150167]: https://sol-jira.atlassian.net/browse/SOL-150167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-150024]: https://sol-jira.atlassian.net/browse/SOL-150024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ