### PR TITLE
SOL-150200: Backport E2E harness cleanups

### DIFF
--- a/test/e2e-basic-mcp/agent/go.mod
+++ b/test/e2e-basic-mcp/agent/go.mod
@@ -1,4 +1,4 @@
-module github.com/SolaceDev/solace-broker-mcp/test/e2e/agent
+module github.com/SolaceDev/solace-broker-mcp/test/e2e-basic-mcp/agent
 
 go 1.25.0
 

--- a/test/e2e-basic-mcp/helpers.sh
+++ b/test/e2e-basic-mcp/helpers.sh
@@ -32,7 +32,7 @@ MCP_SERVER_PID=""
 
 # Static dev token used to authenticate every e2e curl/agent request to the
 # broker MCP server. Must match dev_token in write_config() and broker-config.yaml.
-# Exported so test/e2e/agent reads it from env (see test/e2e/agent/main.go).
+# Exported so test/e2e-basic-mcp/agent reads it from env (see test/e2e-basic-mcp/agent/main.go).
 export MCP_DEV_TOKEN="e2e-static-dev-token"
 
 # ── Colors ───────────────────────────────────────────────────────────────────
@@ -49,10 +49,10 @@ TESTS_FAILED=0
 
 # ── Logging ──────────────────────────────────────────────────────────────────
 
-log_info()  { echo -e "${CYAN}[INFO]${NC}  $*"; }
-log_ok()    { echo -e "${GREEN}[PASS]${NC}  $*"; }
-log_fail()  { echo -e "${RED}[FAIL]${NC}  $*"; }
-log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_info()  { echo -e "${CYAN}[INFO]${NC}  $*" >&2; }
+log_ok()    { echo -e "${GREEN}[PASS]${NC}  $*" >&2; }
+log_fail()  { echo -e "${RED}[FAIL]${NC}  $*" >&2; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*" >&2; }
 
 # ── Broker Readiness ─────────────────────────────────────────────────────────
 
@@ -81,6 +81,13 @@ wait_for_broker() {
     # Phase 2: Wait for message spool to accept queue operations.
     # The monitor API may report spool fields before the spool is actually writable,
     # so we probe with a real queue create/delete to confirm readiness.
+    #
+    # Best-effort cleanup of any probe queue left behind by a previous run that
+    # was killed between create and delete — otherwise every create below would
+    # return HTTP 400 "already exists" and we'd time out blaming the broker.
+    curl -sf -X DELETE -u "$BROKER_USER:$BROKER_PASS" \
+        "$semp_config/msgVpns/$BROKER_VPN/queues/_e2e_spool_probe_" >/dev/null 2>&1 || true
+
     while [ $attempt -lt "$max_attempts" ]; do
         local http_code
         http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
@@ -157,6 +164,11 @@ stop_server() {
         wait "$MCP_SERVER_PID" 2>/dev/null || true
         MCP_SERVER_PID=""
     fi
+    # Remove the temp config written by start_server.sh --bg, if any.
+    local configfile_ref="$BIN_DIR/mcp-server.config"
+    if [ -f "$configfile_ref" ]; then
+        rm -f "$(cat "$configfile_ref")" "$configfile_ref"
+    fi
 }
 
 write_config() {
@@ -191,19 +203,22 @@ semp_post() {
     local semp_config="$1"
     local path="$2"
     local data="$3"
-    local response
-    response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -u "$BROKER_USER:$BROKER_PASS" \
+    local response http_code body
+    # Capture body and HTTP status in a single request — the body is logged on
+    # failure for diagnostics, so we cannot afford to re-issue the (possibly
+    # non-idempotent) POST.
+    response=$(curl -s -X POST -u "$BROKER_USER:$BROKER_PASS" \
         -H "Content-Type: application/json" \
+        -w "\n%{http_code}" \
         "$semp_config/$path" -d "$data")
-    if [ "$response" -ge 200 ] && [ "$response" -lt 300 ]; then
-        return 0
-    else
-        log_fail "SEMP POST $path returned HTTP $response"
-        curl -s -X POST -u "$BROKER_USER:$BROKER_PASS" \
-            -H "Content-Type: application/json" \
-            "$semp_config/$path" -d "$data" >&2
-        return 1
-    fi
+    http_code="${response##*$'\n'}"
+    body="${response%$'\n'*}"
+
+    [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ] && return 0
+
+    log_fail "SEMP POST $path returned HTTP $http_code"
+    echo "$body" >&2
+    return 1
 }
 
 semp_delete() {

--- a/test/e2e-basic-mcp/run_all.sh
+++ b/test/e2e-basic-mcp/run_all.sh
@@ -15,11 +15,9 @@ cleanup() {
     log_info "Running cleanup ..."
     stop_server
     cleanup_fixtures
-    rm -f "$CONFIG_FILE"
     rm -f "$BIN_DIR/mcp-server.pid"
     rm -rf "$E2E_RESULTS_DIR"
 }
-CONFIG_FILE=$(mktemp /tmp/e2e-config-XXXXXX.yaml)
 trap cleanup EXIT
 
 # ── Main ─────────────────────────────────────────────────────────────────────
@@ -43,20 +41,28 @@ create_fixtures
 log_info ""
 log_info "=== Scenario 1: Standalone (curl) ==="
 log_info ""
-bash "$SCRIPT_DIR/test_standalone.sh"
-STANDALONE_EXIT=$?
+if bash "$SCRIPT_DIR/test_standalone.sh"; then
+    STANDALONE_EXIT=0
+else
+    STANDALONE_EXIT=$?
+fi
 
 # 4. Run Scenario 2: Agent
 log_info ""
 log_info "=== Scenario 2: Agent (Go MCP SDK) ==="
 log_info ""
-bash "$SCRIPT_DIR/test_agent.sh"
-AGENT_EXIT=$?
+if bash "$SCRIPT_DIR/test_agent.sh"; then
+    AGENT_EXIT=0
+else
+    AGENT_EXIT=$?
+fi
 
 # 5. Summary table
 TOTAL_RUN=0
 TOTAL_PASSED=0
 TOTAL_FAILED=0
+SAW_STANDALONE=0
+SAW_AGENT=0
 
 echo ""
 echo "┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓"
@@ -69,7 +75,20 @@ if [ -f "$E2E_RESULTS_DIR/results.txt" ]; then
         TOTAL_RUN=$((TOTAL_RUN + run))
         TOTAL_PASSED=$((TOTAL_PASSED + passed))
         TOTAL_FAILED=$((TOTAL_FAILED + failed))
+        case "$label" in
+            "Standalone tests") SAW_STANDALONE=1 ;;
+            "Agent tests")      SAW_AGENT=1      ;;
+        esac
     done < "$E2E_RESULTS_DIR/results.txt"
+fi
+
+# Scenarios that exited non-zero before reaching print_summary leave no line in
+# results.txt — emit a placeholder row so they don't silently vanish from the table.
+if [ "$SAW_STANDALONE" -eq 0 ] && [ "$STANDALONE_EXIT" -ne 0 ]; then
+    printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "Standalone tests" "CRASH" "--" "--"
+fi
+if [ "$SAW_AGENT" -eq 0 ] && [ "$AGENT_EXIT" -ne 0 ]; then
+    printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "Agent tests" "CRASH" "--" "--"
 fi
 
 echo "┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━╋━━━━━━━━━╋━━━━━━━━━┫"

--- a/test/e2e-basic-mcp/start_server.sh
+++ b/test/e2e-basic-mcp/start_server.sh
@@ -2,8 +2,8 @@
 # Build the MCP server from latest source and start it against the E2E broker.
 #
 # Usage:
-#   bash test/e2e/start_server.sh           # foreground (Ctrl-C to stop)
-#   bash test/e2e/start_server.sh --bg      # background (prints PID, writes pidfile)
+#   bash test/e2e-basic-mcp/start_server.sh           # foreground (Ctrl-C to stop)
+#   bash test/e2e-basic-mcp/start_server.sh --bg      # background (prints PID, writes pidfile)
 #
 # The server runs on port 9090 by default. Override with MCP_PORT env var.
 # Requires both Solace brokers to be running (ports 8080 and 8082).
@@ -32,12 +32,14 @@ cleanup_on_exit() {
 }
 
 if [ "$MODE" = "background" ]; then
-    # Start in background, write pidfile for external stop
+    # Start in background, write pidfile + config path for external stop/cleanup
     start_server "$CONFIG_FILE"
     PIDFILE="$BIN_DIR/mcp-server.pid"
+    CONFIGFILE_REF="$BIN_DIR/mcp-server.config"
     echo "$MCP_SERVER_PID" > "$PIDFILE"
+    echo "$CONFIG_FILE" > "$CONFIGFILE_REF"
     log_info "Server running in background (PID=$MCP_SERVER_PID, pidfile=$PIDFILE)"
-    log_info "Stop with: kill \$(cat $PIDFILE)"
+    log_info "Stop with: kill \$(cat $PIDFILE) && rm -f \$(cat $CONFIGFILE_REF) $CONFIGFILE_REF"
 else
     # Foreground: start server, trap Ctrl-C for clean shutdown
     trap cleanup_on_exit EXIT INT TERM


### PR DESCRIPTION
## Summary

Backport of e2e harness cleanups to the `SOL-150200` branch, plus a small set of correctness fixes in `test/e2e-basic-mcp/` discovered during review: stderr-routed logs, single-curl `semp_post`, probe-queue self-heal, and miscellaneous stale-path cleanup.

Fixes [SOL-150200](https://sol-jira.atlassian.net/browse/SOL-150200)

## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [x] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Dependency update

  ## Motivation and Context

  The e2e harness in `test/e2e-basic-mcp/` had several latent issues:

  1. **Log helpers wrote to stdout.** `mcp_initialize` returns its session ID by echoing to stdout, but on the failure path `log_fail` also wrote to stdout — so callers using
  `session_id=$(mcp_initialize)` captured the `[FAIL] No Mcp-Session-Id...` log line *as* the session ID. The `[ -n "$session_id" ]` guard then passed (non-empty string) and the
  test continued with garbage, failing later with a misleading error.

  2. **`semp_post` re-issued failed POSTs.** On non-2xx the function ran a second identical POST just to log the body. Wasteful, and unsafe for non-idempotent endpoints.

  3. **`wait_for_broker` probe queue could leak across runs.** If a previous run was killed between creating and deleting `_e2e_spool_probe_`, the next run's probe-create loop got 
  HTTP 400 ("already exists") forever and timed out after 60s blaming the broker.

  4. **Stale `test/e2e/` paths** in comments after the directory rename to `test/e2e-basic-mcp/`.

  Plus the backported scope: agent module path, `stop_server` temp-config cleanup, exit-code capture in `run_all.sh`, and CRASH placeholder rows so scenarios that crash before 
  `print_summary` don't silently vanish from the summary table.

  ## Changes Made

  - **`helpers.sh`**
    - `log_info` / `log_ok` / `log_fail` / `log_warn` write to stderr. Function return values via `$(...)` are no longer corrupted by log output. Also surfaces previously-swallowed
   errors in code paths like `semp_post ... >/dev/null`.
    - `semp_post` now issues a single curl, parses HTTP status and body from one response via parameter expansion, and uses guard-clause flow (no `else` after `return`, no second 
  non-idempotent POST).
    - `wait_for_broker` deletes any stale `_e2e_spool_probe_` queue before entering the probe loop, mirroring the `create_fixtures` → `cleanup_fixtures` precondition pattern 
  already used elsewhere.
    - `stop_server` also removes the temp config file referenced by `mcp-server.config` (paired with `start_server.sh --bg`).
    - Stale `test/e2e/agent` paths in comments updated to `test/e2e-basic-mcp/agent`.

  - **`run_all.sh`**
    - Capture per-scenario exit codes via `if … then … else $? fi` so `set -e` doesn't kill the script on a scenario failure.
    - Emit a `CRASH` placeholder row when a scenario exited non-zero without reaching `print_summary`.
    - Removed unused top-level `CONFIG_FILE=$(mktemp …)` — `start_server.sh` owns the temp config now.

  - **`start_server.sh`**
    - In `--bg` mode, write the temp config path to `$BIN_DIR/mcp-server.config` so `stop_server` can clean it up later.
    - Updated usage-example paths in the header comment.

  - **`broker-config.yaml`**
    - Updated stale `test/e2e/.env` path in the manual-run example.

  - **`agent/go.mod`**
    - Module path renamed `test/e2e/agent` → `test/e2e-basic-mcp/agent` to match the directory.

  ## Testing

  **Test Environment:**
  - Go version: 1.25.0
  - OS: Fedora 40 (Linux 6.14.5)
  - Broker version: `solace/solace-pubsub-standard:latest` (via `docker compose`)

  **Tests Performed:**
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated (if applicable)
  - [x] E2E tests added/updated (if applicable)
  - [ ] Tested locally with `go test -race ./...`
  - [x] Tested with real Solace broker

  **Test Coverage:**
  - `bash run_all.sh` — green, 10/10 (9 standalone + 1 agent).
  - **Probe-queue self-heal verified end-to-end**: planted `_e2e_spool_probe_` on both brokers (simulating an interrupted prior run), re-ran `run_all.sh`, observed `Broker fully 
  ready after 0s` on both, suite passed 10/10, and post-run state showed the probe queue was `NOT_FOUND`. Without the fix this scenario would have stalled for ~60s per broker and 
  reported a false "broker not ready" failure.
  - **`mcp_initialize` failure path manually reproduced** (ran `test_standalone.sh` with no server up): the `[ -n "$session_id" ]` guard now correctly catches the failure as `Empty
   session ID`, where previously it would have proceeded with the `[FAIL]` log line as the session ID.

  ## Breaking Changes

  None. Test harness only; no public APIs or runtime behavior of the production server are affected.

  **Impact:** N/A

  **Migration Guide:** N/A

  ## Checklist

  ### Code Quality
  - [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
  - [x] Self-review completed (checked for typos, logic errors, edge cases)
  - [x] Code is well-commented (explains "why", not "what")
  - [x] Complex logic has explanatory comments
  - [x] No commented-out code or debug statements left in

  ### Security
  - [x] **No credentials in code** (only the existing `e2e-static-dev-token` and `admin/admin` in `.env`, unchanged by this PR)
  - [x] Followed [secure logging rules](../docs/secure-logging-rules.md) (test scripts only; no Go logging changes)
  - [x] Credential-carrying types implement `slog.LogValuer` (N/A — no Go production code changed)
  - [x] No security vulnerabilities introduced (checked with golangci-lint/gosec)

  ### Testing
  - [x] All tests pass locally: `bash test/e2e-basic-mcp/run_all.sh`
  - [x] No race conditions detected
  - [x] Edge cases covered by tests (probe-queue interrupted-run scenario)
  - [x] Error paths tested (`mcp_initialize` failure, `semp_post` failure)
  - [x] Test names clearly describe what is being tested

  ### Documentation
  - [ ] README.md updated (N/A — no user-facing changes)
  - [ ] docs/ updated (N/A — no architecture changes)
  - [ ] godoc comments added/updated for exported functions (N/A — no exported Go API changes)
  - [ ] CHANGELOG.md updated (N/A — test harness only)
  - [ ] Examples updated (N/A)

  ### Git & CI
  - [ ] All commits are signed off (DCO: `git commit -s`)
  - [x] Commits have clear, descriptive messages
  - [x] Branch is up to date with main (rebased if needed)
  - [x] No merge conflicts
  - [x] CI checks passing (lint, build, test, E2E)

  ### Breaking Changes (if applicable)
  - [ ] Breaking changes documented in commit message (N/A)
  - [ ] Breaking changes documented in PR description (N/A)
  - [ ] Migration guide provided (N/A)
  - [ ] Deprecated functionality marked with comments and deprecation notices (N/A)

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes

  Three issues from the review are intentionally **not** included in this PR — they are latent or hygiene-only and worth a follow-up rather than expanding scope:

  - Cross-script coupling via the `mcp-server.config` filesystem marker.
  - String-duplicated scenario labels (`"Standalone tests"` / `"Agent tests"`) between `run_all.sh` CRASH detection and the `print_summary` calls.
  - `mcp_initialize` greps the full HTTP response for the session header; works today but would break if the body ever echoed that string.
  ---

  **For Reviewers:**

  **Focus Areas**: `helpers.sh` — the four small but load-bearing changes: log routing, `semp_post`, `wait_for_broker` pre-cleanup, `stop_server` temp-config removal. `run_all.sh` 
  — exit-code capture + CRASH-row logic.

  **Questions**: Comfortable leaving the three deferred items (additional notes above) for a follow-up, or want them folded in here?


[SOL-150200]: https://sol-jira.atlassian.net/browse/SOL-150200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ