### PR TITLE
docs(readme): add scannable tools table after Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ Then ask Claude to interact with your brokers:
 List queues in the default VPN on the dev broker
 ```
 
+## Tools
+
+The server exposes 14 read-only tools grouped by what they inspect. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See [the user guide](docs/user-guide.md#tools) for per-tool descriptions, parameters, and pagination defaults.
+
+| Category | Tools | What it does |
+|---|---|---|
+| Discovery | `list-brokers` | List configured broker aliases for use as the `broker` parameter |
+| Broker health | `get-broker-health`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA / mate-link state |
+| Message VPN | `list-vpns`, `get-vpn-health`, `get-message-rates` | List VPNs, check per-VPN service health, read message and byte rates |
+| Queues | `list-queues`, `get-queue-metrics` | List queues with depth and throughput; drill into spool, bindings, consumers |
+| Clients | `list-clients`, `get-client-details`, `list-client-subscriptions` | List connections, inspect per-client rates and discards, list subscriptions |
+| REST Delivery Points | `list-rdps`, `get-rdp-status` | List RDPs; inspect bindings, REST consumers, and last failure reason |
+| DMR | `get-dmr-status` | Inspect DMR cluster and link status for mesh connectivity issues |
+
 ## Development Setup
 
 ### 1. Clone and install dependencies

--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ List queues in the default VPN on the dev broker
 
 ## Tools
 
-The server exposes 14 read-only tools grouped by what they inspect. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See [the user guide](docs/user-guide.md#tools) for per-tool descriptions, parameters, and pagination defaults.
+The server exposes read-only tools grouped by what they inspect. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See the [user guide](docs/user-guide.md#tools) for per-tool descriptions, parameters, and pagination defaults.
 
-| Category | Tools | What it does |
+| Category | Tools | Description |
 |---|---|---|
 | Discovery | `list-brokers` | List configured broker aliases for use as the `broker` parameter |
-| Broker health | `get-broker-health`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA / mate-link state |
+| Broker health | `get-broker-health`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA and mate-link state |
 | Message VPN | `list-vpns`, `get-vpn-health`, `get-message-rates` | List VPNs, check per-VPN service health, read message and byte rates |
 | Queues | `list-queues`, `get-queue-metrics` | List queues with depth and throughput; drill into spool, bindings, consumers |
 | Clients | `list-clients`, `get-client-details`, `list-client-subscriptions` | List connections, inspect per-client rates and discards, list subscriptions |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ An MCP (Model Context Protocol) server for Solace broker, built with Go using th
 └──────────────────┘                    └──────────────────────────┘   basic / bearer     └──────────────────┘
 ```
 
+## Tools
+
+The server exposes read-only tools grouped by what they inspect. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See the [user guide](docs/user-guide.md#tools) for per-tool descriptions, parameters, and pagination defaults.
+
+| Category | Tools | Description |
+|---|---|---|
+| Discovery | `list-brokers` | List configured broker aliases for use as the `broker` parameter |
+| Broker health | `get-broker-health`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA and mate-link state |
+| Message VPN | `list-vpns`, `get-vpn-health`, `get-message-rates` | List VPNs, check per-VPN service health, read message and byte rates |
+| Queues | `list-queues`, `get-queue-metrics` | List queues with depth and throughput; drill into spool, bindings, consumers |
+| Clients | `list-clients`, `get-client-details`, `list-client-subscriptions` | List connections, inspect per-client rates and discards, list subscriptions |
+| REST Delivery Points | `list-rdps`, `get-rdp-status` | List RDPs; inspect bindings, REST consumers, and last failure reason |
+| DMR | `get-dmr-status` | Inspect DMR cluster and link status for mesh connectivity issues |
+
 ## Documentation
 
 - [User Guide](docs/user-guide.md) — overview, tools reference, deployment, and troubleshooting
@@ -161,20 +175,6 @@ Then ask Claude to interact with your brokers:
 ```
 List queues in the default VPN on the dev broker
 ```
-
-## Tools
-
-The server exposes read-only tools grouped by what they inspect. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See the [user guide](docs/user-guide.md#tools) for per-tool descriptions, parameters, and pagination defaults.
-
-| Category | Tools | Description |
-|---|---|---|
-| Discovery | `list-brokers` | List configured broker aliases for use as the `broker` parameter |
-| Broker health | `get-broker-health`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA and mate-link state |
-| Message VPN | `list-vpns`, `get-vpn-health`, `get-message-rates` | List VPNs, check per-VPN service health, read message and byte rates |
-| Queues | `list-queues`, `get-queue-metrics` | List queues with depth and throughput; drill into spool, bindings, consumers |
-| Clients | `list-clients`, `get-client-details`, `list-client-subscriptions` | List connections, inspect per-client rates and discards, list subscriptions |
-| REST Delivery Points | `list-rdps`, `get-rdp-status` | List RDPs; inspect bindings, REST consumers, and last failure reason |
-| DMR | `get-dmr-status` | Inspect DMR cluster and link status for mesh connectivity issues |
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary

Adds a new `## Tools` section to the README right after Architecture. The section lists all 14 read-only tools grouped by category in a 7-row Confluent-style table (Category, Tools, Description) and links to the user guide for per-tool detail.

## Why

The README previously named "14 read-only tools" only inside the architecture ASCII diagram, with no breakdown. Anyone evaluating the server had to open `docs/user-guide.md` to see what it does. The new section surfaces that capability list at a glance without duplicating the user-guide's authoritative per-tool reference. Placing it directly after Architecture keeps the "what is this" story together: diagram, then the tool inventory, before deployment detail.

Modelled on https://github.com/confluentinc/mcp-confluent#available-tools.

## Changes

- `README.md`: new `## Tools` section between Architecture and Documentation, 7 categories covering all 14 tools (Discovery, Broker health, Message VPN, Queues, Clients, REST Delivery Points, DMR). No code, tests, or other docs touched.

## Test plan

- [x] Open the rendered README on GitHub and confirm the `## Tools` section sits between Architecture and Documentation, with the table rendering cleanly.
- [x] Click the `user guide` link and confirm it resolves to the user-guide's `## Tools` heading.
- [x] Spot-check that every backticked tool name in the table is defined in `internal/composite/definitions/tools.yaml` or `internal/tools/`.