### PR TITLE
SOL-150025: E2E functional tests for all supported MCP server monitoring tools

### DIFF
--- a/test/e2e-monitoring/README.md
+++ b/test/e2e-monitoring/README.md
@@ -36,8 +36,8 @@ All fixtures apply to both brokers in parallel (`solace-e2e-mon-a`,
 tools run against the base fixture copied from `e2e-basic-mcp` — no new
 fixture needed.
 
-F1, F2, F3, F4, F5, and F6 are implemented today, driven by the
-`broker-driver` binary for the client-bearing fixtures (F3–F6).
+F1, F2, F3, F4, F5, F6, and F7 are implemented today, driven by the
+`broker-driver` binary for the client-bearing fixtures (F3–F7).
 
 | ID       | Status      | Fixture                  | Required broker state                                                                                                                                  | Lifecycle                          | MCP tools supported                                                                |
 | -------- | ----------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------- |
@@ -46,13 +46,16 @@ F1, F2, F3, F4, F5, and F6 are implemented today, driven by the
 | F3       | Implemented | Connected client         | One long-lived persistent receiver per broker on default VPN with deterministic `clientName` and ≥1 named topic subscription. **Verification:** client appears in `list-clients` and reports the expected subscription. | background broker-driver | `list-clients`, `get-client-details`, `list-client-subscriptions`                  |
 | F4       | Implemented | Sustained traffic        | Publisher targets 100 msg/s, 256-byte payload, persistent; broker observes ~92 msg/s sustained after ~5 s settle. **Verification:** `rxMsgRate ≥ 80` and `txMsgRate ≥ 80` after 25 s of fixture runtime. | background broker-driver | `get-message-rates`                                                                |
 | F5       | Implemented | Slow guaranteed consumer | Queue `test-queue-slow-consumer` (`maxDeliveredUnackedMsgsPerFlow=10`) fed fast while a queue-bound receiver ACKs every 2 s, so unacked pins at the per-flow ceiling and the spool backs up. **Verification (queue-level signals, not client `slowSubscriber` — SOL-150328/SOL-150344):** `bindCount > 0`, `txUnackedMsgCount` near the `maxDeliveredUnackedMsgsPerFlow=10` ceiling (≥ 80%, i.e. ≥ 8 — a slow-but-nonzero ACK rate makes it oscillate by one), `rxMsgRate > txMsgRate`, and `spooledMsgCount` growing across two samples. | background broker-driver | `get-queue-metrics`, `list-queues` |
-| F6-spool | Implemented | Discards via spool quota | Queue `test-queue-discards-spool` with `maxMsgSpoolUsage=1 MB` + `egressEnabled=false`; one-shot publish ~2 MB. **Verification:** `maxMsgSpoolUsageExceededDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `get-discard-stats`              |
-| F6-ttl   | Implemented | Discards via TTL expiry  | Queue `test-queue-discards-ttl` with `maxTtl=1 s` + no consumer; one-shot publish + 2 s wait. **Verification:** `maxTtlExpiredDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `get-discard-stats`                         |
+| F6      | Implemented | Slow direct subscriber   | A direct topic subscriber on each broker is `SIGSTOP`ed while a separate publisher floods its topic (`rate=3000`, `size=50000`), closing its TCP egress window so the broker sets the per-client `slowSubscriber` flag. Distinct from F5: this is the per-client flag a slow-ACK guaranteed consumer never trips (SOL-150328). **Verification:** `clients/<name>.slowSubscriber == true` (polled — rolling ~1 min window). | background broker-driver (subscriber `SIGSTOP`ed + flood publisher) | `list-slow-subscribers` |
+| F7-spool | Implemented | Discards via spool quota | Queue `test-queue-discards-spool` with `maxMsgSpoolUsage=1 MB` + `egressEnabled=false`; one-shot publish ~2 MB. **Verification:** `maxMsgSpoolUsageExceededDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `list-queue-discards` (per-queue), `get-discard-stats` (broker-wide) |
+| F7-ttl   | Implemented | Discards via TTL expiry  | Queue `test-queue-discards-ttl` with `maxTtl=1 s` + no consumer; one-shot publish + 2 s wait. **Verification:** `maxTtlExpiredDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `list-queue-discards` (per-queue), `get-discard-stats` (broker-wide) |
 
 Activation order is deterministic: F1 and F2 (SEMP-only) before F3/F4
-(client-bearing). F5 and F6 follow F3/F4 — each owns a dedicated queue
+(client-bearing). F5, F6, and F7 follow F3/F4 — each owns dedicated resources
 independent of the others. F5's consumer binds to its queue, so teardown reaps
-the broker-driver before deleting the queue (see Cleanup order).
+the broker-driver before deleting the queue (see Cleanup order). F6 owns no
+queue (direct messaging); its `create_*` blocks until the `slowSubscriber` flag
+has flipped, so tool tests can read it immediately afterward.
 
 ## Build prerequisites
 
@@ -96,8 +99,8 @@ a single binary (named `agent/` there, predating this suite's split) speaks
 the MCP protocol against the running server and validates tool responses.
 
 SOL-150024 adds `broker-driver` — a binary that produces **runtime broker
-activity** for fixtures F3–F6 (connected client, sustained publisher,
-publish-batch, slow consumer). This is a deliberate departure from the
+activity** for fixtures F3–F7 (connected client, sustained publisher,
+publish-batch, slow consumer, slow direct subscriber). This is a deliberate departure from the
 basic-mcp pattern because SEMP `curl` alone cannot produce messaging-layer
 state — only a real SMF client can open a connection or publish at a target
 rate. The heavy CGO dependency stays scoped to `broker-driver`; the MCP-tool
@@ -115,8 +118,9 @@ broker-driver <subcommand> [flags]
 | ------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
 | `connected-client`  | F3 long-lived receiver               | `--broker {a\|b}`, `--vpn`, `--client-name`, `--queue`, `--subscriptions`                       | F3          | `list-clients`, `get-client-details`, `list-client-subscriptions`            |
 | `publisher`         | F4 sustained publisher               | `--broker`, `--vpn`, `--topic`, `--rate`, `--size`, `--message-type`, `--duration`              | F4          | `get-message-rates`                                                          |
-| `publish-batch`     | F6 one-shot publisher                | `--broker`, `--vpn`, `--topic`, `--count`, `--size`, `--rate`                                   | F6-spool, F6-ttl | `get-discard-stats`                                                     |
+| `publish-batch`     | F7 one-shot publisher                | `--broker`, `--vpn`, `--topic`, `--count`, `--size`, `--rate`                                   | F7-spool, F7-ttl | `list-queue-discards`, `get-discard-stats`                            |
 | `slow-consumer`     | F5 fast publisher + slow consumer    | `--broker`, `--vpn`, `--queue`, `--topic`, `--rate`, `--size`, `--ack-delay`                     | F5          | `get-queue-metrics`, `list-queues`                                          |
+| `slow-direct-subscriber` | F6 direct subscriber (`SIGSTOP`ed by harness to flip `slowSubscriber`) | `--broker`, `--vpn`, `--client-name`, `--topic`                              | F6         | `list-slow-subscribers`                                                     |
 
 ### Common conventions
 
@@ -172,14 +176,14 @@ wrapping script prefers a bounded process to one it has to signal):
 Omit `--duration` for long-running fixtures (the default); `helpers.sh` reaps
 the process via its pidfile during teardown.
 
-`broker-driver publish-batch` for F6-spool (publish ~2 MB to overflow 1 MB
+`broker-driver publish-batch` for F7-spool (publish ~2 MB to overflow 1 MB
 quota):
 
 ```bash
 ./bin/broker-driver publish-batch --broker=a --topic=t-discards-spool --count=8000 --size=256 --message-type=persistent
 ```
 
-`broker-driver publish-batch` for F6-ttl:
+`broker-driver publish-batch` for F7-ttl:
 
 ```bash
 ./bin/broker-driver publish-batch --broker=a --topic=t-discards-ttl --count=200 --size=256 --message-type=persistent
@@ -213,7 +217,7 @@ fixture sizes change.
 - Use the instantaneous fields: `rxMsgRate`, `txMsgRate`.
 - A 25 s assertion window gives ~20 s margin above the empirical stable point.
 
-### F6 — discard mechanics
+### F7 — discard mechanics
 
 - Spool-quota field on monitor API:
   `maxMsgSpoolUsageExceededDiscardedMsgCount`.
@@ -230,7 +234,8 @@ when it exits (for any reason — normal end, error, Ctrl-C, killed):
 2. **Stop the broker-driver processes** (`stop_broker_drivers` in
    `helpers.sh`). Each broker-driver fixture writes a PID file named
    `bin/broker-driver-f<N>-<broker>.pid` (e.g. `bin/broker-driver-f4-a.pid`)
-   when it starts. The stop helper finds all of them, sends a polite
+   when it starts. The stop helper finds all of them, first sends `SIGCONT`
+   (so the deliberately-`SIGSTOP`ed F6 subscriber can react), then a polite
    termination signal, waits up to 5 seconds, then force-kills anything
    still running.
 3. **Delete broker fixtures** (`cleanup_fixtures` in `helpers.sh`).

--- a/test/e2e-monitoring/README.md
+++ b/test/e2e-monitoring/README.md
@@ -36,19 +36,19 @@ All fixtures apply to both brokers in parallel (`solace-e2e-mon-a`,
 tools run against the base fixture copied from `e2e-basic-mcp` — no new
 fixture needed.
 
-F1, F2, F3, F4, F5, F6, and F7 are implemented today, driven by the
-`broker-driver` binary for the client-bearing fixtures (F3–F7).
+F1–F7 are implemented today, driven by the `broker-driver` binary for the
+client-bearing fixtures (F3–F7).
 
-| ID       | Status      | Fixture                  | Required broker state                                                                                                                                  | Lifecycle                          | MCP tools supported                                                                |
-| -------- | ----------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------- |
-| F1       | Implemented | Multi-VPN                | Additional non-default VPN `test-vpn` on each broker, created with `enabled=false`                                                                     | one-shot SEMP                      | `list-vpns`, `get-vpn-health` (enabled + disabled state coverage)                  |
-| F2       | Implemented | Multi-queue              | `test-queue-2` (bound to a test RDP) and `test-queue-3` (unbound), both non-exclusive on default VPN                                                   | one-shot SEMP                      | `list-queues` (multi-entry + pagination), `get-queue-metrics` (named-object lookup) |
-| F3       | Implemented | Connected client         | One long-lived persistent receiver per broker on default VPN with deterministic `clientName` and ≥1 named topic subscription. **Verification:** client appears in `list-clients` and reports the expected subscription. | background broker-driver | `list-clients`, `get-client-details`, `list-client-subscriptions`                  |
-| F4       | Implemented | Sustained traffic        | Publisher targets 100 msg/s, 256-byte payload, persistent; broker observes ~92 msg/s sustained after ~5 s settle. **Verification:** `rxMsgRate ≥ 80` and `txMsgRate ≥ 80` after 25 s of fixture runtime. | background broker-driver | `get-message-rates`                                                                |
-| F5       | Implemented | Slow guaranteed consumer | Queue `test-queue-slow-consumer` (`maxDeliveredUnackedMsgsPerFlow=10`) fed fast while a queue-bound receiver ACKs every 2 s, so unacked pins at the per-flow ceiling and the spool backs up. **Verification (queue-level signals, not client `slowSubscriber` — SOL-150328/SOL-150344):** `bindCount > 0`, `txUnackedMsgCount` near the `maxDeliveredUnackedMsgsPerFlow=10` ceiling (≥ 80%, i.e. ≥ 8 — a slow-but-nonzero ACK rate makes it oscillate by one), `rxMsgRate > txMsgRate`, and `spooledMsgCount` growing across two samples. | background broker-driver | `get-queue-metrics`, `list-queues` |
-| F6      | Implemented | Slow direct subscriber   | A direct topic subscriber on each broker is `SIGSTOP`ed while a separate publisher floods its topic (`rate=3000`, `size=50000`), closing its TCP egress window so the broker sets the per-client `slowSubscriber` flag. Distinct from F5: this is the per-client flag a slow-ACK guaranteed consumer never trips (SOL-150328). **Verification:** `clients/<name>.slowSubscriber == true` (polled — rolling ~1 min window). | background broker-driver (subscriber `SIGSTOP`ed + flood publisher) | `list-slow-subscribers` |
-| F7-spool | Implemented | Discards via spool quota | Queue `test-queue-discards-spool` with `maxMsgSpoolUsage=1 MB` + `egressEnabled=false`; one-shot publish ~2 MB. **Verification:** `maxMsgSpoolUsageExceededDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `list-queue-discards` (per-queue), `get-discard-stats` (broker-wide) |
-| F7-ttl   | Implemented | Discards via TTL expiry  | Queue `test-queue-discards-ttl` with `maxTtl=1 s` + no consumer; one-shot publish + 2 s wait. **Verification:** `maxTtlExpiredDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `list-queue-discards` (per-queue), `get-discard-stats` (broker-wide) |
+| ID       | Fixture                  | Required broker state                                                                                                                                  | Lifecycle                          | MCP tools supported                                                                |
+| -------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------- |
+| F1       | Multi-VPN                | Additional non-default VPN `test-vpn` on each broker, created with `enabled=false`                                                                     | one-shot SEMP                      | `list-vpns`, `get-vpn-health` (enabled + disabled state coverage)                  |
+| F2       | Multi-queue              | `test-queue-2` (bound to a test RDP) and `test-queue-3` (unbound), both non-exclusive on default VPN                                                   | one-shot SEMP                      | `list-queues` (multi-entry + pagination), `get-queue-metrics` (named-object lookup) |
+| F3       | Connected client         | One long-lived persistent receiver per broker on default VPN with deterministic `clientName` and ≥1 named topic subscription. **Verification:** client appears in `list-clients` and reports the expected subscription. | background broker-driver           | `list-clients`, `get-client-details`, `list-client-subscriptions`                  |
+| F4       | Sustained traffic        | Publisher targets 100 msg/s, 256-byte payload, persistent; broker observes ~92 msg/s sustained after ~5 s settle. **Verification:** `rxMsgRate ≥ 80` and `txMsgRate ≥ 80` after 25 s of fixture runtime. | background broker-driver           | `get-message-rates`                                                                |
+| F5       | Slow guaranteed consumer | Queue `test-queue-slow-consumer` (`maxDeliveredUnackedMsgsPerFlow=10`) fed fast while a queue-bound receiver ACKs every 2 s, so unacked pins at the per-flow ceiling and the spool backs up. **Verification:** queue-level signals (`bindCount`, `txUnackedMsgCount`, `rxMsgRate > txMsgRate`, growing `spooledMsgCount`) — see [F5 — slow-consumer signals](#f5--slow-consumer-signals). | background broker-driver           | `get-queue-metrics`, `list-queues`                                                 |
+| F6       | Slow direct subscriber   | A direct topic subscriber on each broker is `SIGSTOP`ed while a separate publisher floods its topic (`rate=3000`, `size=50000`), closing its TCP egress window so the broker sets the per-client `slowSubscriber` flag. Distinct from F5: this is the per-client flag a slow-ACK guaranteed consumer never trips (SOL-150328). **Verification:** `clients/<name>.slowSubscriber == true` (polled — rolling ~1 min window). | background broker-driver (subscriber `SIGSTOP`ed + flood publisher) | `list-slow-subscribers`                                                            |
+| F7-spool | Discards via spool quota | Queue `test-queue-discards-spool` with `maxMsgSpoolUsage=1 MB` + `egressEnabled=false`; one-shot publish ~2 MB. **Verification:** `maxMsgSpoolUsageExceededDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `list-queue-discards` (per-queue), `get-discard-stats` (broker-wide)               |
+| F7-ttl   | Discards via TTL expiry  | Queue `test-queue-discards-ttl` with `maxTtl=1 s` + no consumer; one-shot publish + 2 s wait. **Verification:** `maxTtlExpiredDiscardedMsgCount > 0` after one-shot publish. | one-shot SEMP + one-shot broker-driver publish | `list-queue-discards` (per-queue), `get-discard-stats` (broker-wide)               |
 
 Activation order is deterministic: F1 and F2 (SEMP-only) before F3/F4
 (client-bearing). F5, F6, and F7 follow F3/F4 — each owns dedicated resources
@@ -67,7 +67,7 @@ built binary has no `libssl`/`libcrypto` runtime dependency.
 
 | Platform                                          | Needed                       | Install                                                                                       |
 | ------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------- |
-| Linux (Ubuntu / Debian)                           | `gcc` (for cgo)              | `sudo apt-get install build-essential`                                                         |
+| Linux (Ubuntu / Debian)                           | `gcc` (for cgo)              | `sudo apt-get install build-essential`                                                        |
 | macOS                                             | Xcode CLI tools, OpenSSL 3   | `xcode-select --install && brew install openssl@3`                                            |
 | macOS (Homebrew `openssl@3` in non-standard path) | `CGO_LDFLAGS`, `CGO_CFLAGS`  | `export CGO_LDFLAGS="-L$(brew --prefix openssl@3)/lib" CGO_CFLAGS="-I$(brew --prefix openssl@3)/include"` |
 | Windows                                           | WSL2 only (treat as Linux)   | —                                                                                             |
@@ -89,22 +89,17 @@ The suite ships one Go program in its own directory with its own `go.mod`:
   produce the broker states the monitoring tools observe. Requires the C
   library `libsolclient` at build time (see Build prerequisites).
 
+**Why a dedicated binary?** In [test/e2e-basic-mcp](../e2e-basic-mcp), MCP tool
+testing is the only job: a single binary (named `agent/` there, predating this
+suite's split) speaks the MCP protocol against the running server and validates
+tool responses. SOL-150024 adds `broker-driver` because SEMP `curl` alone cannot
+produce the **messaging-layer** state fixtures F3–F7 need (connected client,
+sustained publisher, slow consumer, slow direct subscriber, publish-batch) —
+only a real SMF client can open a connection or publish at a target rate. The
+heavy CGO dependency stays scoped to `broker-driver`.
+
 The MCP tools themselves are exercised through the bash + `curl` helpers in
 `helpers.sh` (`mcp_call_tool`), not a dedicated Go client.
-
-## Design note — broker-driver role
-
-In [test/e2e-basic-mcp](../e2e-basic-mcp), MCP tool testing is the only job:
-a single binary (named `agent/` there, predating this suite's split) speaks
-the MCP protocol against the running server and validates tool responses.
-
-SOL-150024 adds `broker-driver` — a binary that produces **runtime broker
-activity** for fixtures F3–F7 (connected client, sustained publisher,
-publish-batch, slow consumer, slow direct subscriber). This is a deliberate departure from the
-basic-mcp pattern because SEMP `curl` alone cannot produce messaging-layer
-state — only a real SMF client can open a connection or publish at a target
-rate. The heavy CGO dependency stays scoped to `broker-driver`; the MCP-tool
-assertions run through plain `curl`.
 
 ## broker-driver CLI surface
 
@@ -114,13 +109,13 @@ assertions run through plain `curl`.
 broker-driver <subcommand> [flags]
 ```
 
-| Subcommand          | Purpose                              | Key flags                                                                                       | Fixture     | MCP tools exercised                                                          |
-| ------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
-| `connected-client`  | F3 long-lived receiver               | `--broker {a\|b}`, `--vpn`, `--client-name`, `--queue`, `--subscriptions`                       | F3          | `list-clients`, `get-client-details`, `list-client-subscriptions`            |
-| `publisher`         | F4 sustained publisher               | `--broker`, `--vpn`, `--topic`, `--rate`, `--size`, `--message-type`, `--duration`              | F4          | `get-message-rates`                                                          |
-| `publish-batch`     | F7 one-shot publisher                | `--broker`, `--vpn`, `--topic`, `--count`, `--size`, `--rate`                                   | F7-spool, F7-ttl | `list-queue-discards`, `get-discard-stats`                            |
-| `slow-consumer`     | F5 fast publisher + slow consumer    | `--broker`, `--vpn`, `--queue`, `--topic`, `--rate`, `--size`, `--ack-delay`                     | F5          | `get-queue-metrics`, `list-queues`                                          |
-| `slow-direct-subscriber` | F6 direct subscriber (`SIGSTOP`ed by harness to flip `slowSubscriber`) | `--broker`, `--vpn`, `--client-name`, `--topic`                              | F6         | `list-slow-subscribers`                                                     |
+| Subcommand               | Purpose                                                                | Key flags                                                                          | Fixture          | MCP tools exercised                                               |
+| ------------------------ | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------- |
+| `connected-client`       | F3 long-lived receiver                                                 | `--broker {a\|b}`, `--vpn`, `--client-name`, `--queue`, `--subscriptions`          | F3               | `list-clients`, `get-client-details`, `list-client-subscriptions` |
+| `publisher`              | F4 sustained publisher                                                 | `--broker`, `--vpn`, `--topic`, `--rate`, `--size`, `--message-type`, `--duration` | F4               | `get-message-rates`                                               |
+| `slow-consumer`          | F5 fast publisher + slow consumer                                      | `--broker`, `--vpn`, `--queue`, `--topic`, `--rate`, `--size`, `--ack-delay`       | F5               | `get-queue-metrics`, `list-queues`                                |
+| `slow-direct-subscriber` | F6 direct subscriber (`SIGSTOP`ed by harness to flip `slowSubscriber`) | `--broker`, `--vpn`, `--client-name`, `--topic`                                    | F6               | `list-slow-subscribers`                                           |
+| `publish-batch`          | F7 one-shot publisher                                                  | `--broker`, `--vpn`, `--topic`, `--count`, `--size`, `--rate`                      | F7-spool, F7-ttl | `list-queue-discards`, `get-discard-stats`                        |
 
 ### Common conventions
 
@@ -216,6 +211,20 @@ fixture sizes change.
   it** — the F4 window is too short.
 - Use the instantaneous fields: `rxMsgRate`, `txMsgRate`.
 - A 25 s assertion window gives ~20 s margin above the empirical stable point.
+
+### F5 — slow-consumer signals
+
+F5 asserts **queue-level** slow-consumer signals, not the per-client
+`slowSubscriber` flag. A slow-ACK guaranteed consumer never trips that flag —
+flipping it is F6's job (see SOL-150328/SOL-150344). Once the consumer binds and
+the publisher ramps, check:
+
+- `bindCount > 0` — the slow consumer is attached.
+- `txUnackedMsgCount` near the `maxDeliveredUnackedMsgsPerFlow=10` ceiling
+  (≥ 80%, i.e. ≥ 8). A slow-but-nonzero ACK rate makes it oscillate by one, so
+  assert the threshold, not equality.
+- `rxMsgRate > txMsgRate` — the queue ingests faster than it drains.
+- `spooledMsgCount` growing across two samples — the backlog is building.
 
 ### F7 — discard mechanics
 

--- a/test/e2e-monitoring/broker-driver/connected_client.go
+++ b/test/e2e-monitoring/broker-driver/connected_client.go
@@ -30,10 +30,20 @@ import (
 	"solace.dev/go/messaging/pkg/solace/resource"
 )
 
-// shutdownGrace is the time receivers/service get to stop cleanly before
-// the process exits. Matches NFR-2 in SOL-150024 (5 s grace, then SIGKILL
-// is the bash-level escalation; the Go side just gives up cleanly).
-const shutdownGrace = 5 * time.Second
+// terminateGrace is how long each long-lived fixture driver (F3/F4/F5) gives
+// its receivers and publisher to stop cleanly on SIGTERM before the process
+// exits. Kept well under stop_broker_drivers' 5 s SIGKILL window (helpers.sh):
+// the full shutdown sequence — consume-loop unwind, then the back-to-back
+// receiver/publisher Terminate calls, then Disconnect — must finish before bash
+// escalates to SIGKILL. These fixtures are disposable, so there is nothing worth
+// draining on the way out; a short grace is strictly better than a long one.
+const terminateGrace = 1 * time.Second
+
+// batchFlushGrace is the publisher-flush window for the short-lived F6
+// publish-batch driver. Unlike the long-lived drivers it exits on its own and
+// is never SIGKILLed by teardown, so it gets a generous window to flush its
+// in-flight persistent publishes before disconnecting.
+const batchFlushGrace = 5 * time.Second
 
 // runConnectedClient implements the F3 fixture: a long-lived connection that
 // keeps a persistent-receiver bound to a queue AND a direct-receiver holding
@@ -89,7 +99,7 @@ func runConnectedClient(args []string) int {
 	if err := pReceiver.ReceiveAsync(noopMessageHandler); err != nil {
 		return fatalf("register persistent receiver callback: %v", err)
 	}
-	defer pReceiver.Terminate(shutdownGrace)
+	defer pReceiver.Terminate(terminateGrace)
 
 	// Direct receiver: holds the client-level subscriptions that show up under
 	// GET .../clients/<name>/subscriptions and are what list-client-subscriptions
@@ -106,7 +116,7 @@ func runConnectedClient(args []string) int {
 	if err := dReceiver.ReceiveAsync(noopMessageHandler); err != nil {
 		return fatalf("register direct receiver callback: %v", err)
 	}
-	defer dReceiver.Terminate(shutdownGrace)
+	defer dReceiver.Terminate(terminateGrace)
 
 	if err := writePidfile(*pidfile); err != nil {
 		return fatalf("write pidfile %s: %v", *pidfile, err)

--- a/test/e2e-monitoring/broker-driver/connected_client.go
+++ b/test/e2e-monitoring/broker-driver/connected_client.go
@@ -39,7 +39,7 @@ import (
 // draining on the way out; a short grace is strictly better than a long one.
 const terminateGrace = 1 * time.Second
 
-// batchFlushGrace is the publisher-flush window for the short-lived F6
+// batchFlushGrace is the publisher-flush window for the short-lived F7
 // publish-batch driver. Unlike the long-lived drivers it exits on its own and
 // is never SIGKILLed by teardown, so it gets a generous window to flush its
 // in-flight persistent publishes before disconnecting.

--- a/test/e2e-monitoring/broker-driver/main.go
+++ b/test/e2e-monitoring/broker-driver/main.go
@@ -14,7 +14,7 @@
 
 // Package main is the broker-driver binary: it connects directly to the
 // Solace brokers via the messaging client and generates the live traffic
-// (publish, consume, sustain rates) that fixtures F3, F4, and F6 need so the
+// (publish, consume, sustain rates) that fixtures F3–F7 need so the
 // monitoring tools have something real to observe.
 package main
 
@@ -41,6 +41,8 @@ func main() {
 		os.Exit(runPublishBatch(args))
 	case "slow-consumer":
 		os.Exit(runSlowConsumer(args))
+	case "slow-direct-subscriber":
+		os.Exit(runSlowDirectSubscriber(args))
 	case "-h", "--help", "help":
 		usage()
 		os.Exit(0)
@@ -59,8 +61,9 @@ Usage: broker-driver <subcommand> [flags]
 Subcommands:
   connected-client    F3: persistent receiver + client subscriptions, idles until signal
   publisher           F4: persistent publisher at fixed rate, idles until signal
-  publish-batch       F6: one-shot persistent publisher, exits after --count messages sent
-  slow-consumer       F5: fast publisher + slow client-ack queue consumer, idles until signal`)
+  publish-batch       F7: one-shot persistent publisher, exits after --count messages sent
+  slow-consumer       F5: fast publisher + slow client-ack queue consumer, idles until signal
+  slow-direct-subscriber  F6: direct topic subscriber (SIGSTOP'd by the harness to flip slowSubscriber), idles until signal`)
 }
 
 // fatalf prints to stderr and exits non-zero. Used by subcommands to surface

--- a/test/e2e-monitoring/broker-driver/publish_batch.go
+++ b/test/e2e-monitoring/broker-driver/publish_batch.go
@@ -25,11 +25,11 @@ import (
 	"solace.dev/go/messaging/pkg/solace/resource"
 )
 
-// runPublishBatch implements the F6 fixture role: a short-lived persistent
+// runPublishBatch implements the F7 fixture role: a short-lived persistent
 // publisher that sends exactly --count messages of --size bytes to --topic,
-// then exits. Used twice by helpers.sh — once for F6-spool (fills the queue's
+// then exits. Used twice by helpers.sh — once for F7-spool (fills the queue's
 // spool quota so the broker discards messages and increments
-// maxMsgSpoolUsageExceededDiscardedMsgCount) and once for F6-ttl (publishes
+// maxMsgSpoolUsageExceededDiscardedMsgCount) and once for F7-ttl (publishes
 // with --dmq-eligible=false so TTL-expired messages are truly discarded and
 // increment maxTtlExpiredDiscardedMsgCount rather than being moved to the DMQ).
 // No PID file is written because the process is short-lived and the bash
@@ -44,7 +44,7 @@ func runPublishBatch(args []string) int {
 	size := fs.Int("size", 256, "payload size in bytes")
 	msgType := stringFlag(fs, "message-type", "persistent", "publish QoS: 'persistent' (only supported value today)")
 	rate := fs.Int("rate", 0, "target messages per second (0 = as fast as possible)")
-	dmqEligible := fs.Bool("dmq-eligible", true, "mark messages as DMQ-eligible (set false for F6-ttl so expired messages hit maxTtlExpiredDiscardedMsgCount)")
+	dmqEligible := fs.Bool("dmq-eligible", true, "mark messages as DMQ-eligible (set false for F7-ttl so expired messages hit maxTtlExpiredDiscardedMsgCount)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -99,11 +99,11 @@ func runPublishBatch(args []string) int {
 	payload := bytes.Repeat([]byte{'x'}, *size)
 	dest := resource.TopicOf(*topic)
 
-	// Build the per-message publish function once. For F6-ttl (dmqEligible=false)
+	// Build the per-message publish function once. For F7-ttl (dmqEligible=false)
 	// we use the message builder to mark each message as not DMQ-eligible; when
 	// the broker TTL-expires such a message it increments
 	// maxTtlExpiredDiscardedMsgCount rather than attempting a DMQ move. For
-	// F6-spool (dmqEligible=true, the default) PublishBytes is sufficient.
+	// F7-spool (dmqEligible=true, the default) PublishBytes is sufficient.
 	var publishFn func() error
 	if *dmqEligible {
 		publishFn = func() error {

--- a/test/e2e-monitoring/broker-driver/publish_batch.go
+++ b/test/e2e-monitoring/broker-driver/publish_batch.go
@@ -94,7 +94,7 @@ func runPublishBatch(args []string) int {
 	if err := publisher.Start(); err != nil {
 		return fatalf("start persistent publisher: %v", err)
 	}
-	defer publisher.Terminate(shutdownGrace)
+	defer publisher.Terminate(batchFlushGrace)
 
 	payload := bytes.Repeat([]byte{'x'}, *size)
 	dest := resource.TopicOf(*topic)

--- a/test/e2e-monitoring/broker-driver/publisher.go
+++ b/test/e2e-monitoring/broker-driver/publisher.go
@@ -92,7 +92,7 @@ func runPublisher(args []string) int {
 	if err := publisher.Start(); err != nil {
 		return fatalf("start persistent publisher: %v", err)
 	}
-	defer publisher.Terminate(shutdownGrace)
+	defer publisher.Terminate(terminateGrace)
 
 	if err := writePidfile(*pidfile); err != nil {
 		return fatalf("write pidfile %s: %v", *pidfile, err)

--- a/test/e2e-monitoring/broker-driver/publisher.go
+++ b/test/e2e-monitoring/broker-driver/publisher.go
@@ -114,18 +114,25 @@ func runPublisher(args []string) int {
 		}()
 	}
 
-	publishLoop(publisher, *topic, *size, *rate, done)
-	fmt.Fprintln(os.Stderr, "broker-driver publisher: shutting down")
+	sent, failed := publishLoop(publisher, *topic, *size, *rate, done)
+	fmt.Fprintf(os.Stderr, "broker-driver publisher: shutting down sent=%d failed=%d\n", sent, failed)
+	// Mirror publish-batch: a non-zero failed count is a real fault (with
+	// OnBackPressureWait, PublishBytes blocks on backpressure rather than
+	// erroring), so don't let a publisher whose every send failed exit 0.
+	if failed > 0 {
+		return 1
+	}
 	return 0
 }
 
 // publishLoop fires once per tick at `rate` msg/s until the done channel
-// signals. PersistentMessagePublisher.PublishBytes blocks only when the
-// in-flight buffer is full (OnBackPressureWait); for the F4 target rate
-// against an idle broker the buffer never fills, so each tick publishes
-// promptly. The ~8% steady-state undershoot the spec acknowledges comes
-// from the Go scheduler + broker ack roundtrip, not from this loop.
-func publishLoop(publisher persistentBytesPublisher, topic string, size, rate int, done <-chan os.Signal) {
+// signals, returning the (sent, failed) publish counts. PersistentMessage
+// Publisher.PublishBytes blocks only when the in-flight buffer is full
+// (OnBackPressureWait); for the F4 target rate against an idle broker the
+// buffer never fills, so each tick publishes promptly. The ~8% steady-state
+// undershoot the spec acknowledges comes from the Go scheduler + broker ack
+// roundtrip, not from this loop.
+func publishLoop(publisher persistentBytesPublisher, topic string, size, rate int, done <-chan os.Signal) (int64, int64) {
 	payload := bytes.Repeat([]byte{'x'}, size)
 	dest := resource.TopicOf(topic)
 	interval := time.Second / time.Duration(rate)
@@ -136,8 +143,7 @@ func publishLoop(publisher persistentBytesPublisher, topic string, size, rate in
 	for {
 		select {
 		case <-done:
-			fmt.Fprintf(os.Stderr, "publisher loop: sent=%d failed=%d\n", sent, failed)
-			return
+			return sent, failed
 		case <-ticker.C:
 			if err := publisher.PublishBytes(payload, dest); err != nil {
 				failed++

--- a/test/e2e-monitoring/broker-driver/slow_consumer.go
+++ b/test/e2e-monitoring/broker-driver/slow_consumer.go
@@ -70,12 +70,6 @@ func runSlowConsumer(args []string) int {
 	if *ackDelay < 0 {
 		return fatalf("slow-consumer: --ack-delay must be >= 0 (got %s)", *ackDelay)
 	}
-	// An ack-delay >= the shutdown grace would park slowConsumeLoop in its
-	// Sleep past the grace window on SIGTERM, getting the process SIGKILLed
-	// rather than shut down cleanly. Reject it at startup instead.
-	if *ackDelay >= shutdownGrace {
-		return fatalf("slow-consumer: --ack-delay must be < shutdown grace %s (got %s)", shutdownGrace, *ackDelay)
-	}
 
 	host, ok := resolveBrokerHost(*broker)
 	if !ok {
@@ -105,7 +99,7 @@ func runSlowConsumer(args []string) int {
 	if err := publisher.Start(); err != nil {
 		return fatalf("start persistent publisher: %v", err)
 	}
-	defer publisher.Terminate(shutdownGrace)
+	defer publisher.Terminate(terminateGrace)
 
 	// Slow receiver: client-acknowledgement so unacked messages count against
 	// the queue's per-flow window until we explicitly Ack them.
@@ -118,7 +112,7 @@ func runSlowConsumer(args []string) int {
 	if err := receiver.Start(); err != nil {
 		return fatalf("start persistent receiver: %v", err)
 	}
-	defer receiver.Terminate(shutdownGrace)
+	defer receiver.Terminate(terminateGrace)
 
 	if err := writePidfile(*pidfile); err != nil {
 		return fatalf("write pidfile %s: %v", *pidfile, err)
@@ -158,16 +152,18 @@ func runSlowConsumer(args []string) int {
 }
 
 // slowConsumeLoop receives messages synchronously and ACKs each only after
-// ackDelay, throttling the consumer. It polls with receivePollTimeout so a
-// closed stop channel is observed promptly between messages; receive timeouts
-// are expected (the publisher may briefly fall behind) and are ignored.
+// ackDelay, throttling the consumer. Both the inter-message receive (bounded by
+// receivePollTimeout) and the ackDelay wait observe stop, so a closed stop
+// channel is honoured promptly — even mid-delay — rather than blocking shutdown
+// until the delay elapses. Receive timeouts are expected (the publisher may
+// briefly fall behind) and are ignored.
 func slowConsumeLoop(receiver persistentAckReceiver, ackDelay time.Duration, stop <-chan os.Signal) {
 	var acked int64
+consume:
 	for {
 		select {
 		case <-stop:
-			fmt.Fprintf(os.Stderr, "slow-consumer loop: acked=%d\n", acked)
-			return
+			break consume
 		default:
 		}
 
@@ -181,13 +177,24 @@ func slowConsumeLoop(receiver persistentAckReceiver, ackDelay time.Duration, sto
 			continue
 		}
 
-		time.Sleep(ackDelay)
+		// Throttle: wait ackDelay before ACKing, but abort promptly if stop
+		// fires mid-delay. The message is left unacked and redelivered when a
+		// receiver next binds — fine for a fixture that's shutting down.
+		timer := time.NewTimer(ackDelay)
+		select {
+		case <-stop:
+			timer.Stop()
+			break consume
+		case <-timer.C:
+		}
+
 		if err := receiver.Ack(msg); err != nil {
 			fmt.Fprintf(os.Stderr, "slow-consumer ack: %v\n", err)
 			continue
 		}
 		acked++
 	}
+	fmt.Fprintf(os.Stderr, "slow-consumer loop: acked=%d\n", acked)
 }
 
 // persistentAckReceiver narrows the Solace receiver surface the consume loop

--- a/test/e2e-monitoring/broker-driver/slow_subscriber.go
+++ b/test/e2e-monitoring/broker-driver/slow_subscriber.go
@@ -1,0 +1,107 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"solace.dev/go/messaging/pkg/solace/resource"
+)
+
+// runSlowDirectSubscriber implements the F6 fixture: a long-lived DIRECT
+// receiver holding a single topic subscription and nothing else. It exists so
+// the broker's per-client slowSubscriber flag can be flipped to true.
+//
+// The flag tracks TCP egress back-pressure — the broker has data to send but
+// the client's receive window has stayed closed for several seconds in the last
+// minute. A slow application callback is NOT enough to trigger it: the Solace
+// client's underlying C library drains the OS socket on its own thread
+// regardless of how slow the app is, and direct receivers only offer DROP
+// back-pressure. To actually close the TCP window the harness SIGSTOPs this
+// whole process while a separate publisher floods the subscribed topic with
+// large payloads (see helpers.sh create_slow_subscriber_on). This process
+// therefore deliberately does NOT publish — bundling the flood here would mean
+// SIGSTOP halts the flood too, and the window would never fill.
+//
+// Background: the F5 slow-consumer fixture (slow_consumer.go) drives a slow
+// guaranteed-message consumer, which surfaces at the queue level and never
+// flips slowSubscriber (SOL-150328). F6 is the per-client-flag counterpart
+// that list-slow-subscribers needs.
+func runSlowDirectSubscriber(args []string) int {
+	fs := flag.NewFlagSet("slow-direct-subscriber", flag.ContinueOnError)
+	broker := stringFlag(fs, "broker", "", "broker target: a or b (resolves to host:port from env)")
+	vpn := stringFlag(fs, "vpn", "default", "message VPN to join")
+	clientName := stringFlag(fs, "client-name", "", "deterministic clientName; defaults to e2e-monitoring-slow-subscriber-<broker>")
+	topic := stringFlag(fs, "topic", "", "topic to subscribe to; the separate flood publisher targets it")
+	pidfile := stringFlag(fs, "pidfile", "", "path to write this process's PID to on startup")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *broker == "" || *topic == "" || *pidfile == "" {
+		fs.Usage()
+		return fatalf("slow-direct-subscriber: --broker, --topic, --pidfile are all required")
+	}
+
+	host, ok := resolveBrokerHost(*broker)
+	if !ok {
+		return 1
+	}
+
+	resolvedClientName := *clientName
+	if resolvedClientName == "" {
+		resolvedClientName = fmt.Sprintf("e2e-monitoring-slow-subscriber-%s", *broker)
+	}
+	service, err := buildMessagingService(host, *vpn, resolvedClientName)
+	if err != nil {
+		return fatalf("build messaging service: %v", err)
+	}
+	if err := service.Connect(); err != nil {
+		return fatalf("connect to broker %s: %v", host, err)
+	}
+	defer service.Disconnect()
+
+	// Direct receiver holding one topic subscription. A no-op handler drains
+	// messages app-side; the SIGSTOP-induced TCP stall (not the handler) is what
+	// closes the egress window and flips slowSubscriber.
+	receiver, err := service.CreateDirectMessageReceiverBuilder().
+		WithSubscriptions(resource.TopicSubscriptionOf(*topic)).
+		Build()
+	if err != nil {
+		return fatalf("build direct receiver: %v", err)
+	}
+	if err := receiver.Start(); err != nil {
+		return fatalf("start direct receiver: %v", err)
+	}
+	if err := receiver.ReceiveAsync(noopMessageHandler); err != nil {
+		return fatalf("register direct receiver callback: %v", err)
+	}
+	defer receiver.Terminate(terminateGrace)
+
+	if err := writePidfile(*pidfile); err != nil {
+		return fatalf("write pidfile %s: %v", *pidfile, err)
+	}
+	defer os.Remove(*pidfile)
+
+	fmt.Fprintf(os.Stderr,
+		"broker-driver slow-direct-subscriber ready: clientName=%s vpn=%s topic=%s pid=%d host=%s\n",
+		resolvedClientName, *vpn, *topic, os.Getpid(), host)
+
+	waitForSignal()
+	fmt.Fprintln(os.Stderr, "broker-driver slow-direct-subscriber: shutting down")
+	return 0
+}

--- a/test/e2e-monitoring/helpers.sh
+++ b/test/e2e-monitoring/helpers.sh
@@ -14,7 +14,7 @@ BIN_DIR="$SCRIPT_DIR/bin"
 source "$SCRIPT_DIR/.env"
 
 # Exported so broker-driver (spawned as a child by create_connected_client_on
-# and the F4-F6 helpers to come) can resolve --broker=a|b to a SMF host:port
+# and the F4-F7 helpers to come) can resolve --broker=a|b to a SMF host:port
 # from the same single source of truth.
 export BROKER_A_SMF_PORT BROKER_B_SMF_PORT
 
@@ -260,7 +260,7 @@ stop_server() {
 # stop helper and any future code use the same convention.
 BROKER_DRIVER_PIDFILE_GLOB="$BIN_DIR/broker-driver-f*.pid"
 
-# Stop any long-lived broker-driver processes that fixtures F3-F6 spawn.
+# Stop any long-lived broker-driver processes that fixtures F3-F7 spawn.
 # Reads each PID file under bin/ and hands the PIDs to kill_gracefully, which
 # signals them concurrently (TERM, then KILL after a shared 5s grace window).
 # Safe to call when there are no PID files (no-op until F3 lands).
@@ -271,6 +271,14 @@ stop_broker_drivers() {
     local pids=() f
     for f in "${pidfiles[@]}"; do
         pids+=("$(<"$f")")
+    done
+    # Resume any SIGSTOP'd driver (the F6 slow-subscriber is deliberately
+    # stopped) so the SIGTERM kill_gracefully sends is actually delivered —
+    # a stopped process ignores SIGTERM and would otherwise burn the full 5s
+    # grace before SIGKILL. SIGCONT is a no-op on running drivers.
+    local pid
+    for pid in "${pids[@]}"; do
+        kill -CONT "$pid" 2>/dev/null || true
     done
     kill_gracefully "${pids[@]}"
 
@@ -669,12 +677,113 @@ cleanup_slow_consumer_on() {
     semp_delete "$semp_config" "msgVpns/$BROKER_VPN/queues/$F5_QUEUE"
 }
 
-# F6-spool constants.
-F6_SPOOL_QUEUE="test-queue-discards-spool"
-F6_SPOOL_TOPIC="e2e-monitoring/discards/spool"
-F6_SPOOL_COUNT=8000   # × 256 B ≈ 2 MB; overflows the 1 MB spool quota
-F6_SPOOL_SIZE=256
-F6_SPOOL_MAX_MB=1     # maxMsgSpoolUsage in MB
+# F6 slow-DIRECT-subscriber constants. Distinct from F5 (queue slow-consumer):
+# F6 flips the per-client `slowSubscriber` flag that list-slow-subscribers
+# filters on. The flag tracks TCP egress back-pressure, which a slow-ACK
+# guaranteed consumer never triggers (SOL-150328) — so we close the client's
+# receive window at the OS level by SIGSTOPping the subscriber process while a
+# separate publisher floods its subscribed topic with large payloads. Direct
+# messaging (no queue/spool) so the broker has nowhere to spool the overflow and
+# egress congestion is forced onto the stalled client.
+F6_SUB_CLIENT_NAME_A="e2e-monitoring-slow-subscriber-a"
+F6_SUB_CLIENT_NAME_B="e2e-monitoring-slow-subscriber-b"
+F6_TOPIC="e2e-monitoring/slow-subscriber/topic"
+F6_FLOOD_RATE=3000     # msg/s — high enough to keep the egress window pinned
+F6_FLOOD_SIZE=50000    # bytes — large payloads fill the window fast
+F6_FLAG_TIMEOUT=60     # max seconds to wait for slowSubscriber to flip true
+
+# Polls the broker until a client's slowSubscriber flag reads true, or fails
+# after F6_FLAG_TIMEOUT. The flag is computed over a rolling ~1 min window, so
+# a single read just after SIGSTOP flakes — poll until it settles true.
+#   $1 broker_url   $2 label   $3 client_name
+wait_for_slow_subscriber() {
+    local broker_url="$1"
+    local label="$2"
+    local client_name="$3"
+    local attempt=0 flag body
+    while [ $attempt -lt "$F6_FLAG_TIMEOUT" ]; do
+        body=$(semp_monitor_get "$broker_url" \
+            "msgVpns/$BROKER_VPN/clients/$client_name?select=slowSubscriber" 2>/dev/null) || true
+        # `|| flag=""` so a transient non-JSON body (jq exits non-zero) just
+        # retries on the next poll rather than aborting the run under `set -e`.
+        flag=$(echo "$body" | jq -r '.data.slowSubscriber // empty' 2>/dev/null) || flag=""
+        if [ "$flag" = "true" ]; then
+            log_info "  slowSubscriber=true for $client_name on $label (${attempt}s)"
+            return 0
+        fi
+        sleep 1
+        attempt=$((attempt + 1))
+    done
+    log_fail "F6 [$label]: slowSubscriber did not flip true for $client_name within ${F6_FLAG_TIMEOUT}s"
+    return 1
+}
+
+# Provisions F6: a long-lived direct subscriber on F6_TOPIC plus a separate
+# flood publisher into that topic, then SIGSTOPs the subscriber so its TCP
+# receive window stalls and the broker flags it slowSubscriber=true. Two PIDs
+# (sub + pub) so SIGSTOP halts only the subscriber, never the flood. Both
+# pidfiles match the broker-driver-f*.pid glob and are reaped by
+# stop_broker_drivers (which SIGCONTs first). No queue — direct messaging only.
+create_slow_subscriber_on() {
+    local label="$1"
+    local broker_url="$2"
+    local broker_letter="$3"     # "a" or "b" — resolves SMF host:port in broker-driver
+    local client_name="$4"
+    local sub_pidfile="$BIN_DIR/broker-driver-f6-sub-$broker_letter.pid"
+    local sub_logfile="$BIN_DIR/broker-driver-f6-sub-$broker_letter.log"
+    local pub_pidfile="$BIN_DIR/broker-driver-f6-pub-$broker_letter.pid"
+    local pub_logfile="$BIN_DIR/broker-driver-f6-pub-$broker_letter.log"
+    log_info "Creating slow-subscriber fixture on $label (clientName=$client_name topic=$F6_TOPIC) ..."
+
+    # Direct subscriber (this is the process we SIGSTOP).
+    nohup ${_SESSION_WRAP:+$_SESSION_WRAP} "$BIN_DIR/broker-driver" slow-direct-subscriber \
+        --broker="$broker_letter" \
+        --vpn="$BROKER_VPN" \
+        --client-name="$client_name" \
+        --topic="$F6_TOPIC" \
+        --pidfile="$sub_pidfile" \
+        >"$sub_logfile" 2>&1 &
+    wait_for_pidfile "$sub_pidfile" "$label" "$sub_logfile" "broker-driver slow-direct-subscriber" || return 1
+
+    # Separate large-payload flood into the subscribed topic — must NOT be
+    # stopped, so it keeps egress pressure on the stalled subscriber.
+    nohup ${_SESSION_WRAP:+$_SESSION_WRAP} "$BIN_DIR/broker-driver" publisher \
+        --broker="$broker_letter" \
+        --vpn="$BROKER_VPN" \
+        --client-name="e2e-monitoring-slow-sub-flood-$broker_letter" \
+        --topic="$F6_TOPIC" \
+        --rate="$F6_FLOOD_RATE" \
+        --size="$F6_FLOOD_SIZE" \
+        --pidfile="$pub_pidfile" \
+        >"$pub_logfile" 2>&1 &
+    wait_for_pidfile "$pub_pidfile" "$label" "$pub_logfile" "broker-driver publisher (F6 flood)" || return 1
+
+    # Close the subscriber's TCP receive window at the OS level. A slow app
+    # callback is not enough (the client C lib drains the socket regardless);
+    # SIGSTOP halts the whole process so the window stays shut.
+    kill -STOP "$(<"$sub_pidfile")"
+    log_info "  SIGSTOP sent to slow-subscriber (PID=$(<"$sub_pidfile")) on $label"
+
+    # Wait for the broker to observe the stall and flip the flag.
+    wait_for_slow_subscriber "$broker_url" "$label" "$client_name" || return 1
+    log_info "Slow-subscriber fixture created on $label"
+}
+
+# Both F6 processes are reaped by stop_broker_drivers via the pidfile glob, and
+# it SIGCONTs the stopped subscriber before SIGTERM, so teardown needs nothing
+# here. No queue to delete (direct messaging). Kept as a label-only nop for
+# symmetry with the other create/cleanup pairs.
+cleanup_slow_subscriber_on() {
+    local label="$1"
+    log_info "Slow-subscriber cleanup on $label deferred to stop_broker_drivers"
+}
+
+# F7-spool constants.
+F7_SPOOL_QUEUE="test-queue-discards-spool"
+F7_SPOOL_TOPIC="e2e-monitoring/discards/spool"
+F7_SPOOL_COUNT=8000   # × 256 B ≈ 2 MB; overflows the 1 MB spool quota
+F7_SPOOL_SIZE=256
+F7_SPOOL_MAX_MB=1     # maxMsgSpoolUsage in MB
 
 # Provisions test-queue-discards-spool with a 1 MB spool cap and
 # egressEnabled=false, then runs a one-shot publish-batch that fills ~2 MB
@@ -686,74 +795,74 @@ create_discard_spool_on() {
     local label="$2"
     local broker_url="$3"
     local broker_letter="$4"
-    log_info "Creating discard-spool fixture on $label (queue=$F6_SPOOL_QUEUE maxSpool=${F6_SPOOL_MAX_MB}MB) ..."
+    log_info "Creating discard-spool fixture on $label (queue=$F7_SPOOL_QUEUE maxSpool=${F7_SPOOL_MAX_MB}MB) ..."
 
     semp_post "$semp_config" "msgVpns/$BROKER_VPN/queues" \
-        "{\"queueName\":\"$F6_SPOOL_QUEUE\",\"accessType\":\"non-exclusive\",\"permission\":\"consume\",\"ingressEnabled\":true,\"egressEnabled\":false,\"maxMsgSpoolUsage\":$F6_SPOOL_MAX_MB}" >/dev/null
-    semp_post "$semp_config" "msgVpns/$BROKER_VPN/queues/$F6_SPOOL_QUEUE/subscriptions" \
-        "{\"subscriptionTopic\":\"$F6_SPOOL_TOPIC\"}" >/dev/null
+        "{\"queueName\":\"$F7_SPOOL_QUEUE\",\"accessType\":\"non-exclusive\",\"permission\":\"consume\",\"ingressEnabled\":true,\"egressEnabled\":false,\"maxMsgSpoolUsage\":$F7_SPOOL_MAX_MB}" >/dev/null
+    semp_post "$semp_config" "msgVpns/$BROKER_VPN/queues/$F7_SPOOL_QUEUE/subscriptions" \
+        "{\"subscriptionTopic\":\"$F7_SPOOL_TOPIC\"}" >/dev/null
 
     "$BIN_DIR/broker-driver" publish-batch \
         --broker="$broker_letter" \
-        --topic="$F6_SPOOL_TOPIC" \
-        --count="$F6_SPOOL_COUNT" \
-        --size="$F6_SPOOL_SIZE" \
+        --topic="$F7_SPOOL_TOPIC" \
+        --count="$F7_SPOOL_COUNT" \
+        --size="$F7_SPOOL_SIZE" \
         --message-type=persistent
 
     log_info "Discard-spool fixture created on $label"
 }
 
-# Drops the F6-spool queue (cascades to its topic subscription).
+# Drops the F7-spool queue (cascades to its topic subscription).
 cleanup_discard_spool_on() {
     local semp_config="$1"
     local label="$2"
     log_info "Cleaning up discard-spool fixture on $label ..."
-    semp_delete "$semp_config" "msgVpns/$BROKER_VPN/queues/$F6_SPOOL_QUEUE"
+    semp_delete "$semp_config" "msgVpns/$BROKER_VPN/queues/$F7_SPOOL_QUEUE"
 }
 
-# F6-ttl constants.
-F6_TTL_QUEUE="test-queue-discards-ttl"
-F6_TTL_TOPIC="e2e-monitoring/discards/ttl"
-F6_TTL_COUNT=200     # small batch; messages expire by TTL, not spool
-F6_TTL_SIZE=256
-F6_TTL_MAX_TTL_S=1   # maxTtl in seconds
-F6_TTL_WAIT_S=2      # sleep after publish to let the 1 s TTL expire
+# F7-ttl constants.
+F7_TTL_QUEUE="test-queue-discards-ttl"
+F7_TTL_TOPIC="e2e-monitoring/discards/ttl"
+F7_TTL_COUNT=200     # small batch; messages expire by TTL, not spool
+F7_TTL_SIZE=256
+F7_TTL_MAX_TTL_S=1   # maxTtl in seconds
+F7_TTL_WAIT_S=2      # sleep after publish to let the 1 s TTL expire
 
 # Provisions test-queue-discards-ttl with a 1 s TTL and no consumer, publishes
 # a one-shot batch with --dmq-eligible=false so the broker increments
 # maxTtlExpiredDiscardedMsgCount rather than moving expired messages to the DMQ.
-# Sleeps F6_TTL_WAIT_S after publishing so the TTL window closes before
+# Sleeps F7_TTL_WAIT_S after publishing so the TTL window closes before
 # verify-fixtures.sh runs the AC 9 assertion.
 create_discard_ttl_on() {
     local semp_config="$1"
     local label="$2"
     local broker_letter="$3"
-    log_info "Creating discard-ttl fixture on $label (queue=$F6_TTL_QUEUE maxTtl=${F6_TTL_MAX_TTL_S}s) ..."
+    log_info "Creating discard-ttl fixture on $label (queue=$F7_TTL_QUEUE maxTtl=${F7_TTL_MAX_TTL_S}s) ..."
 
     semp_post "$semp_config" "msgVpns/$BROKER_VPN/queues" \
-        "{\"queueName\":\"$F6_TTL_QUEUE\",\"accessType\":\"non-exclusive\",\"permission\":\"consume\",\"ingressEnabled\":true,\"egressEnabled\":true,\"maxTtl\":$F6_TTL_MAX_TTL_S,\"respectTtlEnabled\":true}" >/dev/null
-    semp_post "$semp_config" "msgVpns/$BROKER_VPN/queues/$F6_TTL_QUEUE/subscriptions" \
-        "{\"subscriptionTopic\":\"$F6_TTL_TOPIC\"}" >/dev/null
+        "{\"queueName\":\"$F7_TTL_QUEUE\",\"accessType\":\"non-exclusive\",\"permission\":\"consume\",\"ingressEnabled\":true,\"egressEnabled\":true,\"maxTtl\":$F7_TTL_MAX_TTL_S,\"respectTtlEnabled\":true}" >/dev/null
+    semp_post "$semp_config" "msgVpns/$BROKER_VPN/queues/$F7_TTL_QUEUE/subscriptions" \
+        "{\"subscriptionTopic\":\"$F7_TTL_TOPIC\"}" >/dev/null
 
     "$BIN_DIR/broker-driver" publish-batch \
         --broker="$broker_letter" \
-        --topic="$F6_TTL_TOPIC" \
-        --count="$F6_TTL_COUNT" \
-        --size="$F6_TTL_SIZE" \
+        --topic="$F7_TTL_TOPIC" \
+        --count="$F7_TTL_COUNT" \
+        --size="$F7_TTL_SIZE" \
         --message-type=persistent \
         --dmq-eligible=false
 
-    log_info "Waiting ${F6_TTL_WAIT_S}s for TTL to expire ..."
-    sleep "$F6_TTL_WAIT_S"
+    log_info "Waiting ${F7_TTL_WAIT_S}s for TTL to expire ..."
+    sleep "$F7_TTL_WAIT_S"
     log_info "Discard-ttl fixture created on $label"
 }
 
-# Drops the F6-ttl queue (cascades to its topic subscription).
+# Drops the F7-ttl queue (cascades to its topic subscription).
 cleanup_discard_ttl_on() {
     local semp_config="$1"
     local label="$2"
     log_info "Cleaning up discard-ttl fixture on $label ..."
-    semp_delete "$semp_config" "msgVpns/$BROKER_VPN/queues/$F6_TTL_QUEUE"
+    semp_delete "$semp_config" "msgVpns/$BROKER_VPN/queues/$F7_TTL_QUEUE"
 }
 
 # Epoch (seconds since Unix) at which the last F4 publisher finished
@@ -793,8 +902,13 @@ create_fixtures() {
     create_slow_consumer_on "$BROKER_B_SEMP_CONFIG" "broker-b" "$BROKER_B_URL" b
     F5_READY_EPOCH=$(date +%s)
     export F5_READY_EPOCH
-    # F6 is independent of F3/F4 — run after them but the queues have no
-    # client dependency so order within F6 does not matter.
+    # F6 is independent of F5; it owns no queue (direct messaging). create_*
+    # blocks until the slowSubscriber flag has flipped, so no settle epoch is
+    # needed — the tool test can read the flag immediately afterwards.
+    create_slow_subscriber_on "broker-a" "$BROKER_A_URL" a "$F6_SUB_CLIENT_NAME_A"
+    create_slow_subscriber_on "broker-b" "$BROKER_B_URL" b "$F6_SUB_CLIENT_NAME_B"
+    # F7 is independent of F3/F4 — run after them but the queues have no
+    # client dependency so order within F7 does not matter.
     create_discard_spool_on "$BROKER_A_SEMP_CONFIG" "broker-a" "$BROKER_A_URL" a
     create_discard_spool_on "$BROKER_B_SEMP_CONFIG" "broker-b" "$BROKER_B_URL" b
     create_discard_ttl_on "$BROKER_A_SEMP_CONFIG" "broker-a" a
@@ -812,6 +926,8 @@ cleanup_fixtures() {
     cleanup_discard_spool_on "$BROKER_B_SEMP_CONFIG" "broker-b"
     cleanup_slow_consumer_on "$BROKER_A_SEMP_CONFIG" "broker-a"
     cleanup_slow_consumer_on "$BROKER_B_SEMP_CONFIG" "broker-b"
+    cleanup_slow_subscriber_on "broker-a"
+    cleanup_slow_subscriber_on "broker-b"
     cleanup_sustained_traffic_on "broker-a"
     cleanup_sustained_traffic_on "broker-b"
     cleanup_connected_client_on "broker-a"

--- a/test/e2e-monitoring/helpers.sh
+++ b/test/e2e-monitoring/helpers.sh
@@ -893,6 +893,26 @@ mcp_request() {
     echo "$raw" | grep '^data: ' | sed 's/^data: //'
 }
 
+# Unwraps the tool payload from the JSON-RPC envelope returned by mcp_call_tool.
+# A tool's real output is escaped JSON nested in .result.content[0].text; this
+# returns that inner payload so assertions can run assert_json_field against the
+# tool's structured output rather than substring-matching the whole envelope.
+#   response=$(mcp_call_tool "get-vpn-health" "$args")
+#   content=$(extract_content "$response")
+#   assert_json_field "$content" ".enabled" "false"
+extract_content() {
+    # Surface JSON-RPC errors inline. Without this, an error envelope
+    # ({"error":{...}} instead of {"result":...}) makes the jq below emit the
+    # literal "null", and the caller's assertion fails with a cryptic
+    # "Actual: null" that hides the real tool/broker error. log_fail writes to
+    # stderr, so the stdout payload contract is unchanged and callers need no
+    # update — the error just appears in the log next to the assertion failure.
+    local err
+    err=$(jq -r '.error.message // empty' <<<"$1")
+    [ -n "$err" ] && log_fail "MCP call returned error: $err"
+    jq -r '.result.content[0].text' <<<"$1"
+}
+
 # ── Assertions ───────────────────────────────────────────────────────────────
 
 assert_contains() {

--- a/test/e2e-monitoring/helpers.sh
+++ b/test/e2e-monitoring/helpers.sh
@@ -214,28 +214,45 @@ start_server() {
     return 1
 }
 
+# Terminates one or more PIDs: sends SIGTERM to each that is still alive,
+# waits up to 5s for all of them to exit, then SIGKILLs any straggler. PIDs are
+# signalled concurrently so the grace window is shared across them, not paid
+# per-PID. Already-dead PIDs (and empty/garbage ones) are skipped. We poll with
+# `kill -0` rather than `wait` because these processes are not direct children
+# of this shell: the MCP server is a child of start-server.sh and the
+# broker-drivers run in their own sessions.
+kill_gracefully() {
+    local pids=() pid
+    for pid in "$@"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null || true
+            pids+=("$pid")
+        fi
+    done
+    [ ${#pids[@]} -gt 0 ] || return 0
+
+    local elapsed=0
+    while [ ${#pids[@]} -gt 0 ] && [ "$elapsed" -lt 5 ]; do
+        sleep 1; elapsed=$((elapsed + 1))
+        local still=()
+        for pid in "${pids[@]}"; do
+            kill -0 "$pid" 2>/dev/null && still+=("$pid")
+        done
+        pids=( ${still[@]+"${still[@]}"} )
+    done
+
+    for pid in ${pids[@]+"${pids[@]}"}; do
+        log_warn "PID $pid did not exit within 5s; sending SIGKILL"
+        kill -KILL "$pid" 2>/dev/null || true
+    done
+}
+
 stop_server() {
-    # `wait` only works on direct children of the current shell. When this
-    # helper is sourced into test-monitoring-tools.sh and MCP_SERVER_PID was
-    # read from a pidfile (server is a child of start-server.sh, not us), we
-    # poll with `kill -0` instead. Escalate to SIGKILL if the server hasn't
-    # exited within the grace window — mirrors stop_broker_drivers.
     if [ -z "$MCP_SERVER_PID" ] || ! kill -0 "$MCP_SERVER_PID" 2>/dev/null; then
         return 0
     fi
     log_info "Stopping MCP server (PID=$MCP_SERVER_PID) ..."
-    kill -TERM "$MCP_SERVER_PID" 2>/dev/null || true
-
-    local elapsed=0
-    while kill -0 "$MCP_SERVER_PID" 2>/dev/null && [ "$elapsed" -lt 5 ]; do
-        sleep 1
-        elapsed=$((elapsed + 1))
-    done
-
-    if kill -0 "$MCP_SERVER_PID" 2>/dev/null; then
-        log_warn "MCP server did not exit within 5s; sending SIGKILL"
-        kill -KILL "$MCP_SERVER_PID" 2>/dev/null || true
-    fi
+    kill_gracefully "$MCP_SERVER_PID"
     MCP_SERVER_PID=""
 }
 
@@ -244,32 +261,19 @@ stop_server() {
 BROKER_DRIVER_PIDFILE_GLOB="$BIN_DIR/broker-driver-f*.pid"
 
 # Stop any long-lived broker-driver processes that fixtures F3-F6 spawn.
-# Reads each PID file under bin/, sends a polite termination signal (TERM),
-# waits up to 5 seconds for them to exit cleanly, then forces (KILL).
+# Reads each PID file under bin/ and hands the PIDs to kill_gracefully, which
+# signals them concurrently (TERM, then KILL after a shared 5s grace window).
 # Safe to call when there are no PID files (no-op until F3 lands).
 stop_broker_drivers() {
     local pidfiles=( $BROKER_DRIVER_PIDFILE_GLOB )
     [ -e "${pidfiles[0]}" ] || return 0
 
-    local pids=()
+    local pids=() f
     for f in "${pidfiles[@]}"; do
-        local pid; pid=$(<"$f")
-        if kill -0 "$pid" 2>/dev/null; then
-            kill -TERM "$pid"
-            pids+=("$pid")
-        fi
+        pids+=("$(<"$f")")
     done
+    kill_gracefully "${pids[@]}"
 
-    local elapsed=0
-    while [ ${#pids[@]} -gt 0 ] && [ "$elapsed" -lt 5 ]; do
-        sleep 1; elapsed=$((elapsed+1))
-        local still=(); for p in "${pids[@]}"; do
-            kill -0 "$p" 2>/dev/null && still+=("$p")
-        done
-        pids=( ${still[@]+"${still[@]}"} )
-    done
-
-    for p in ${pids[@]+"${pids[@]}"}; do kill -KILL "$p" 2>/dev/null; done
     rm -f $BROKER_DRIVER_PIDFILE_GLOB
     # Allow the broker to finish cleaning up stale SMF sessions before
     # subsequent SEMP config operations run. Only reached when broker-drivers
@@ -612,6 +616,11 @@ F5_PUBLISH_RATE=100   # msg/s into the queue's topic
 F5_PUBLISH_SIZE=256   # bytes per message
 F5_ACK_DELAY="2s"     # delay before ACKing each message (the throttle)
 F5_MAX_UNACKED=10     # maxDeliveredUnackedMsgsPerFlow on the F5 queue
+# txUnackedMsgCount oscillates by one as the slow consumer ACKs, so the
+# "pinned near the ceiling" assertion uses 80% of the per-flow cap rather than
+# exact equality. Shared by verify-fixtures.sh (SEMP-direct) and tool-tests.sh
+# (MCP-tool) so both layers assert against the same threshold.
+F5_NEAR_UNACKED=$(( F5_MAX_UNACKED * 8 / 10 ))
 
 # Provisions F5_QUEUE with a low per-flow unacked window and a subscription to
 # F5_TOPIC, then spawns a long-lived broker-driver slow-consumer that floods the

--- a/test/e2e-monitoring/helpers.sh
+++ b/test/e2e-monitoring/helpers.sh
@@ -276,9 +276,12 @@ stop_broker_drivers() {
     # stopped) so the SIGTERM kill_gracefully sends is actually delivered —
     # a stopped process ignores SIGTERM and would otherwise burn the full 5s
     # grace before SIGKILL. SIGCONT is a no-op on running drivers.
+    # Guard with `kill -0` (as kill_gracefully does): a driver may have exited
+    # early and left a stale pidfile whose PID the OS has since recycled, so we
+    # only signal PIDs that are still alive and never disturb an unrelated one.
     local pid
     for pid in "${pids[@]}"; do
-        kill -CONT "$pid" 2>/dev/null || true
+        kill -0 "$pid" 2>/dev/null && kill -CONT "$pid" 2>/dev/null || true
     done
     kill_gracefully "${pids[@]}"
 

--- a/test/e2e-monitoring/test-monitoring-tools.sh
+++ b/test/e2e-monitoring/test-monitoring-tools.sh
@@ -38,5 +38,7 @@ build_broker_driver
 create_fixtures
 
 # 4. SEMP-direct fixture-state verification (SOL-150024 acceptance criteria).
-#    Tool-level functional tests land in SOL-150025.
 bash "$SCRIPT_DIR/verify-fixtures.sh"
+
+# 5. Tool-level functional tests through the MCP server (SOL-150025).
+bash "$SCRIPT_DIR/tool-tests.sh"

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -353,7 +353,6 @@ test_list_rdps_pagination_b() { test_list_rdps_pagination "broker-b"; }
 test_get_queue_metrics_slow_consumer() {
     local broker="$1"
     local response content bind unacked rx tx spooled1 spooled2
-    local near_unacked=$(( F5_MAX_UNACKED * 8 / 10 ))
 
     response=$(mcp_call_tool "get-queue-metrics" \
         "$(jq -nc --arg b "$broker" --arg q "$F5_QUEUE" \
@@ -372,9 +371,9 @@ test_get_queue_metrics_slow_consumer() {
         "get-queue-metrics [$broker]: bindCount must be > 0 (got $bind)" || return 1
     # Unacked messages pin NEAR the per-flow ceiling — the slow-ACK signature.
     # "Near", not "==": a slow-but-nonzero ACK rate makes the count oscillate by
-    # one, so assert ≥ 80% of the ceiling rather than exact equality.
-    assert_json_field "$content" ".queueMetrics.data.txUnackedMsgCount >= $near_unacked" "true" \
-        "get-queue-metrics [$broker]: txUnackedMsgCount must be near the $F5_MAX_UNACKED ceiling (≥ $near_unacked, got $unacked)" || return 1
+    # one, so assert ≥ F5_NEAR_UNACKED (80% of the ceiling) rather than exact equality.
+    assert_json_field "$content" ".queueMetrics.data.txUnackedMsgCount >= $F5_NEAR_UNACKED" "true" \
+        "get-queue-metrics [$broker]: txUnackedMsgCount must be near the $F5_MAX_UNACKED ceiling (≥ $F5_NEAR_UNACKED, got $unacked)" || return 1
     # Ingress outruns egress while the consumer lags.
     assert_json_field "$content" '.queueMetrics.data.rxMsgRate > .queueMetrics.data.txMsgRate' "true" \
         "get-queue-metrics [$broker]: rxMsgRate must exceed txMsgRate (got rx=$rx tx=$tx)" || return 1

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# MCP tool-level functional tests for SOL-150025 (Block A: tools 1–9).
+# Invoked by test-monitoring-tools.sh after verify-fixtures.sh; assumes the MCP
+# server is running and the F1–F6 fixtures have been created.
+#
+# Where verify-fixtures.sh asserts broker *state* via SEMP-direct calls, this
+# file exercises each MVP monitoring *tool* through the MCP server (JSON-RPC
+# over HTTP) using mcp_call_tool, then unwraps the tool payload with
+# extract_content so assertions run against the tool's real output.
+# Exits non-zero on any failed assertion so the parent runner short-circuits.
+
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+# ── Tool 2: list-vpns (F1 multi-VPN) ─────────────────────────────────────────
+# Primary: the VPN collection includes the base `default` VPN and F1's
+# `test-vpn`. Pagination: maxResults=1 returns exactly one entry and flags the
+# result truncated, while the uncapped default call returns the full set.
+# Envelope: list-vpns returns {"vpns":{"data":[...],"truncated":bool}} — the
+# step id `vpns` keys the payload.
+
+test_list_vpns() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "list-vpns" "$(jq -nc --arg b "$broker" '{broker:$b}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" \
+        '(.vpns.data | map(.msgVpnName) | index("default")) != null' "true" \
+        "list-vpns [$broker]: default VPN must be present" || return 1
+    assert_json_field "$content" \
+        '(.vpns.data | map(.msgVpnName) | index("test-vpn")) != null' "true" \
+        "list-vpns [$broker]: F1 test-vpn must be present" || return 1
+}
+
+test_list_vpns_pagination() {
+    local broker="$1"
+    local response content
+    # maxResults=1 caps the result to one entry and marks it truncated.
+    response=$(mcp_call_tool "list-vpns" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,maxResults:1}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.vpns.data | length' "1" \
+        "list-vpns [$broker]: maxResults=1 must return exactly 1 VPN" || return 1
+    assert_json_field "$content" '.vpns.truncated' "true" \
+        "list-vpns [$broker]: maxResults=1 must flag truncated=true" || return 1
+    # The uncapped call returns every VPN (≥ 2: default + test-vpn), untruncated.
+    response=$(mcp_call_tool "list-vpns" "$(jq -nc --arg b "$broker" '{broker:$b}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '(.vpns.data | length) >= 2' "true" \
+        "list-vpns [$broker]: uncapped call must return all VPNs" || return 1
+    assert_json_field "$content" '.vpns.truncated' "false" \
+        "list-vpns [$broker]: uncapped call must not be truncated" || return 1
+}
+
+test_list_vpns_a()            { test_list_vpns "broker-a"; }
+test_list_vpns_b()            { test_list_vpns "broker-b"; }
+test_list_vpns_pagination_a() { test_list_vpns_pagination "broker-a"; }
+test_list_vpns_pagination_b() { test_list_vpns_pagination "broker-b"; }
+
+# ── Tool 3: get-vpn-health (F1 multi-VPN; VPN-scoped) ────────────────────────
+# Value check (AC 5): the base `default` VPN reports enabled=true with services
+# up; F1's `test-vpn` reports enabled=false / state=down. This is the case
+# FR-0's extract_content exists for — a substring match on the raw envelope
+# cannot reliably tell "enabled":false from "enabled":true.
+# Envelope: {"vpnHealth":{"data":{...}}} — a single object, not a collection.
+
+test_get_vpn_health_default() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "get-vpn-health" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.vpnHealth.data.enabled' "true" \
+        "get-vpn-health [$broker]: default VPN must be enabled" || return 1
+    assert_json_field "$content" '.vpnHealth.data.state' "up" \
+        "get-vpn-health [$broker]: default VPN state must be up" || return 1
+    assert_json_field "$content" '.vpnHealth.data.serviceSmfPlainTextUp' "true" \
+        "get-vpn-health [$broker]: default VPN SMF service must be up" || return 1
+}
+
+test_get_vpn_health_testvpn() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "get-vpn-health" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"test-vpn"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.vpnHealth.data.enabled' "false" \
+        "get-vpn-health [$broker]: test-vpn must be disabled (enabled=false)" || return 1
+    assert_json_field "$content" '.vpnHealth.data.state' "down" \
+        "get-vpn-health [$broker]: test-vpn state must be down" || return 1
+}
+
+test_get_vpn_health_default_a() { test_get_vpn_health_default "broker-a"; }
+test_get_vpn_health_default_b() { test_get_vpn_health_default "broker-b"; }
+test_get_vpn_health_testvpn_a() { test_get_vpn_health_testvpn "broker-a"; }
+test_get_vpn_health_testvpn_b() { test_get_vpn_health_testvpn "broker-b"; }
+
+# ── Tool 4: list-queues (F2 multi-queue; VPN-scoped) ─────────────────────────
+# Primary: the default-VPN queue collection includes F2's test-queue,
+# test-queue-2, test-queue-3 plus the F6 discard queues (AC 6). Pagination:
+# maxResults=1 caps to one entry and flags truncated. VPN scoping: every
+# returned queue belongs to the queried VPN, and the F1 test-vpn (which owns no
+# queues) surfaces none of the default VPN's queues.
+# Envelope: {"queues":{"data":[...],"truncated":bool}}.
+
+test_list_queues() {
+    local broker="$1"
+    local response content q
+    response=$(mcp_call_tool "list-queues" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    for q in test-queue test-queue-2 test-queue-3 "$F6_SPOOL_QUEUE" "$F6_TTL_QUEUE"; do
+        assert_json_field "$content" \
+            "(.queues.data | map(.queueName) | index(\"$q\")) != null" "true" \
+            "list-queues [$broker]: $q must be present in default VPN" || return 1
+    done
+}
+
+test_list_queues_pagination() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "list-queues" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default",maxResults:1}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.queues.data | length' "1" \
+        "list-queues [$broker]: maxResults=1 must return exactly 1 queue" || return 1
+    assert_json_field "$content" '.queues.truncated' "true" \
+        "list-queues [$broker]: maxResults=1 must flag truncated=true" || return 1
+}
+
+test_list_queues_vpn_scope() {
+    local broker="$1"
+    local response content
+    # Default-VPN call: every returned queue belongs to the default VPN.
+    response=$(mcp_call_tool "list-queues" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.queues.data | all(.msgVpnName == "default")' "true" \
+        "list-queues [$broker]: every queue must be scoped to the default VPN" || return 1
+    # F1's test-vpn owns no queues — scoping must not leak the default VPN's.
+    response=$(mcp_call_tool "list-queues" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"test-vpn"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" \
+        '(.queues.data | map(.queueName) | index("test-queue")) == null' "true" \
+        "list-queues [$broker]: test-vpn scope must not include default's test-queue" || return 1
+}
+
+test_list_queues_a()            { test_list_queues "broker-a"; }
+test_list_queues_b()            { test_list_queues "broker-b"; }
+test_list_queues_pagination_a() { test_list_queues_pagination "broker-a"; }
+test_list_queues_pagination_b() { test_list_queues_pagination "broker-b"; }
+test_list_queues_vpn_scope_a()  { test_list_queues_vpn_scope "broker-a"; }
+test_list_queues_vpn_scope_b()  { test_list_queues_vpn_scope "broker-b"; }
+
+# ── Tool 5: list-clients (F3 connected client; VPN-scoped) ───────────────────
+# Primary: the default-VPN client list includes this broker's deterministic F3
+# client. Cross-broker isolation (FR-8): the list must NOT include the *other*
+# broker's F3 client — this catches broker-routing bugs. VPN scoping: every
+# returned client belongs to the default VPN. Pagination: maxResults=1 caps to
+# one entry and flags truncated — the default VPN always holds ≥ 3 clients (the
+# F3 client plus the internal #client and the #rdp/test-rdp consumer).
+# Envelope: {"clients":{"data":[...],"truncated":bool}}.
+
+test_list_clients() {
+    local broker="$1" own="$2" other="$3"
+    local response content
+    response=$(mcp_call_tool "list-clients" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" \
+        "(.clients.data | map(.clientName) | index(\"$own\")) != null" "true" \
+        "list-clients [$broker]: F3 client $own must be present" || return 1
+    # Cross-broker isolation (FR-8): the other broker's client must be absent.
+    assert_json_field "$content" \
+        "(.clients.data | map(.clientName) | index(\"$other\")) == null" "true" \
+        "list-clients [$broker]: must NOT include other broker's client $other" || return 1
+    assert_json_field "$content" '.clients.data | all(.msgVpnName == "default")' "true" \
+        "list-clients [$broker]: every client must be scoped to the default VPN" || return 1
+}
+
+test_list_clients_pagination() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "list-clients" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default",maxResults:1}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.clients.data | length' "1" \
+        "list-clients [$broker]: maxResults=1 must return exactly 1 client" || return 1
+    assert_json_field "$content" '.clients.truncated' "true" \
+        "list-clients [$broker]: maxResults=1 must flag truncated=true" || return 1
+}
+
+test_list_clients_a()            { test_list_clients "broker-a" "$F3_CLIENT_NAME_A" "$F3_CLIENT_NAME_B"; }
+test_list_clients_b()            { test_list_clients "broker-b" "$F3_CLIENT_NAME_B" "$F3_CLIENT_NAME_A"; }
+test_list_clients_pagination_a() { test_list_clients_pagination "broker-a"; }
+test_list_clients_pagination_b() { test_list_clients_pagination "broker-b"; }
+
+# ── Tool 6: get-client-details (F3 connected client; named-object lookup) ─────
+# F3 case (AC 8): a named lookup of the F3 client returns that client's details
+# with slowSubscriber=false.
+# Envelope: {"clientDetails":{"data":{...}}} — a single object.
+#
+# TODO(SOL-150025 / F5): add the slow-subscriber half (AC 8: F5 client →
+# slowSubscriber=true) once an F5 (slow subscriber) fixture exists. SOL-150024
+# does not currently ship one in helpers.sh (no F5_* constants / create_slow_*
+# helper), so there is no client to look up yet.
+
+test_get_client_details_f3() {
+    local broker="$1" client="$2"
+    local response content
+    response=$(mcp_call_tool "get-client-details" \
+        "$(jq -nc --arg b "$broker" --arg c "$client" \
+            '{broker:$b,msgVpnName:"default",clientName:$c}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.clientDetails.data.clientName' "$client" \
+        "get-client-details [$broker]: named lookup must return $client" || return 1
+    assert_json_field "$content" '.clientDetails.data.slowSubscriber' "false" \
+        "get-client-details [$broker]: F3 client must report slowSubscriber=false" || return 1
+}
+
+test_get_client_details_f3_a() { test_get_client_details_f3 "broker-a" "$F3_CLIENT_NAME_A"; }
+test_get_client_details_f3_b() { test_get_client_details_f3 "broker-b" "$F3_CLIENT_NAME_B"; }
+
+# ── Tool 7: list-client-subscriptions (F3 connected client) ──────────────────
+# Primary: the F3 client's subscriptions include every topic the fixture
+# configured ($F3_SUBSCRIPTIONS). The client also carries an auto-generated
+# #P2P/... inbox subscription, so assert the configured topics are *present*
+# rather than asserting an exact count. Pagination: maxResults=1 returns exactly
+# one subscription while the uncapped call returns the full set — this tool has
+# no followPages, so its envelope leaves `truncated` null and the data length is
+# the reliable signal that the cap was honored.
+# Envelope: {"subscriptions":{"data":[...]}}.
+
+test_list_client_subscriptions() {
+    local broker="$1" client="$2"
+    local response content t
+    response=$(mcp_call_tool "list-client-subscriptions" \
+        "$(jq -nc --arg b "$broker" --arg c "$client" \
+            '{broker:$b,msgVpnName:"default",clientName:$c}')") || return 1
+    content=$(extract_content "$response")
+    while IFS= read -r t; do
+        [ -n "$t" ] || continue
+        assert_json_field "$content" \
+            "(.subscriptions.data | map(.subscriptionTopic) | index(\"$t\")) != null" "true" \
+            "list-client-subscriptions [$broker]: $client must subscribe to $t" || return 1
+    done < <(echo "$F3_SUBSCRIPTIONS" | tr ',' '\n')
+}
+
+test_list_client_subscriptions_pagination() {
+    local broker="$1" client="$2"
+    local response content
+    response=$(mcp_call_tool "list-client-subscriptions" \
+        "$(jq -nc --arg b "$broker" --arg c "$client" \
+            '{broker:$b,msgVpnName:"default",clientName:$c,maxResults:1}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.subscriptions.data | length' "1" \
+        "list-client-subscriptions [$broker]: maxResults=1 must return exactly 1 subscription" || return 1
+    # Uncapped call returns the full set (≥ 2) — proves the cap dropped entries.
+    response=$(mcp_call_tool "list-client-subscriptions" \
+        "$(jq -nc --arg b "$broker" --arg c "$client" \
+            '{broker:$b,msgVpnName:"default",clientName:$c}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '(.subscriptions.data | length) > 1' "true" \
+        "list-client-subscriptions [$broker]: uncapped call must return more than 1" || return 1
+}
+
+test_list_client_subscriptions_a() { test_list_client_subscriptions "broker-a" "$F3_CLIENT_NAME_A"; }
+test_list_client_subscriptions_b() { test_list_client_subscriptions "broker-b" "$F3_CLIENT_NAME_B"; }
+test_list_client_subscriptions_pagination_a() { test_list_client_subscriptions_pagination "broker-a" "$F3_CLIENT_NAME_A"; }
+test_list_client_subscriptions_pagination_b() { test_list_client_subscriptions_pagination "broker-b" "$F3_CLIENT_NAME_B"; }
+
+# ── Tool 8: get-message-rates (F4 sustained traffic; VPN-level) ──────────────
+# Value check (AC 10): under F4's sustained ~100 msg/s load the default VPN
+# reports rxMsgRate ≥ 80 and txMsgRate ≥ 80. F4 is settled by the orchestrator's
+# verify-fixtures step (which waits ≥ 25 s on F4_READY_EPOCH) before this file
+# runs, and the F4 driver keeps publishing throughout — so the rates are live
+# when read here. No pagination or VPN-scoping variants (VPN-level tool).
+# Envelope: {"rates":{"data":{...}}} — a single object.
+
+F4_RATE_THRESHOLD=80
+
+test_get_message_rates() {
+    local broker="$1"
+    local response content rx tx
+    response=$(mcp_call_tool "get-message-rates" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    rx=$(echo "$content" | jq -r '.rates.data.rxMsgRate')
+    tx=$(echo "$content" | jq -r '.rates.data.txMsgRate')
+    log_info "get-message-rates [$broker]: rxMsgRate=$rx txMsgRate=$tx (threshold ≥ $F4_RATE_THRESHOLD)"
+    assert_json_field "$content" ".rates.data.rxMsgRate >= $F4_RATE_THRESHOLD" "true" \
+        "get-message-rates [$broker]: rxMsgRate must be ≥ $F4_RATE_THRESHOLD (got $rx)" || return 1
+    assert_json_field "$content" ".rates.data.txMsgRate >= $F4_RATE_THRESHOLD" "true" \
+        "get-message-rates [$broker]: txMsgRate must be ≥ $F4_RATE_THRESHOLD (got $tx)" || return 1
+}
+
+test_get_message_rates_a() { test_get_message_rates "broker-a"; }
+test_get_message_rates_b() { test_get_message_rates "broker-b"; }
+
+# ── Tool 9: list-rdps (base fixture) ─────────────────────────────────────────
+# Primary: the default-VPN RDP collection includes the base test-rdp.
+# Pagination: the base fixture provisions a single RDP, so maxResults=1 returns
+# that one entry untruncated. This confirms the cap is accepted and the full set
+# is returned, but cannot demonstrate multi-page truncation — no second RDP
+# exists to drop.
+# Envelope: {"rdps":{"data":[...],"truncated":bool}}.
+
+test_list_rdps() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "list-rdps" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" \
+        '(.rdps.data | map(.restDeliveryPointName) | index("test-rdp")) != null' "true" \
+        "list-rdps [$broker]: test-rdp must be present" || return 1
+}
+
+test_list_rdps_pagination() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "list-rdps" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default",maxResults:1}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.rdps.data | length' "1" \
+        "list-rdps [$broker]: maxResults=1 must return exactly 1 RDP" || return 1
+    assert_json_field "$content" '.rdps.truncated' "false" \
+        "list-rdps [$broker]: single base RDP must report truncated=false" || return 1
+}
+
+test_list_rdps_a()            { test_list_rdps "broker-a"; }
+test_list_rdps_b()            { test_list_rdps "broker-b"; }
+test_list_rdps_pagination_a() { test_list_rdps_pagination "broker-a"; }
+test_list_rdps_pagination_b() { test_list_rdps_pagination "broker-b"; }
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+
+run_test "Tool 2 — list-vpns (broker-a)"               test_list_vpns_a
+run_test "Tool 2 — list-vpns (broker-b)"               test_list_vpns_b
+run_test "Tool 2 — list-vpns pagination (broker-a)"    test_list_vpns_pagination_a
+run_test "Tool 2 — list-vpns pagination (broker-b)"    test_list_vpns_pagination_b
+
+run_test "Tool 3 — get-vpn-health default (broker-a)"  test_get_vpn_health_default_a
+run_test "Tool 3 — get-vpn-health default (broker-b)"  test_get_vpn_health_default_b
+run_test "Tool 3 — get-vpn-health test-vpn (broker-a)" test_get_vpn_health_testvpn_a
+run_test "Tool 3 — get-vpn-health test-vpn (broker-b)" test_get_vpn_health_testvpn_b
+
+run_test "Tool 4 — list-queues (broker-a)"             test_list_queues_a
+run_test "Tool 4 — list-queues (broker-b)"             test_list_queues_b
+run_test "Tool 4 — list-queues pagination (broker-a)"  test_list_queues_pagination_a
+run_test "Tool 4 — list-queues pagination (broker-b)"  test_list_queues_pagination_b
+run_test "Tool 4 — list-queues VPN scope (broker-a)"   test_list_queues_vpn_scope_a
+run_test "Tool 4 — list-queues VPN scope (broker-b)"   test_list_queues_vpn_scope_b
+
+run_test "Tool 5 — list-clients (broker-a)"            test_list_clients_a
+run_test "Tool 5 — list-clients (broker-b)"            test_list_clients_b
+run_test "Tool 5 — list-clients pagination (broker-a)" test_list_clients_pagination_a
+run_test "Tool 5 — list-clients pagination (broker-b)" test_list_clients_pagination_b
+
+run_test "Tool 6 — get-client-details F3 (broker-a)"   test_get_client_details_f3_a
+run_test "Tool 6 — get-client-details F3 (broker-b)"   test_get_client_details_f3_b
+
+run_test "Tool 7 — list-client-subscriptions (broker-a)"            test_list_client_subscriptions_a
+run_test "Tool 7 — list-client-subscriptions (broker-b)"            test_list_client_subscriptions_b
+run_test "Tool 7 — list-client-subscriptions pagination (broker-a)" test_list_client_subscriptions_pagination_a
+run_test "Tool 7 — list-client-subscriptions pagination (broker-b)" test_list_client_subscriptions_pagination_b
+
+run_test "Tool 8 — get-message-rates (broker-a)"       test_get_message_rates_a
+run_test "Tool 8 — get-message-rates (broker-b)"       test_get_message_rates_b
+
+run_test "Tool 9 — list-rdps (broker-a)"               test_list_rdps_a
+run_test "Tool 9 — list-rdps (broker-b)"               test_list_rdps_b
+run_test "Tool 9 — list-rdps pagination (broker-a)"    test_list_rdps_pagination_a
+run_test "Tool 9 — list-rdps pagination (broker-b)"    test_list_rdps_pagination_b
+
+print_summary "MCP tool tests"

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# MCP tool-level functional tests for SOL-150025 (Block A: tools 1–9).
+# MCP tool-level functional tests for SOL-150025 (tools 1–12: Block A 1–9,
+# Block B 10–12 — list-slow-subscribers, list-queue-discards, get-discard-stats).
 # Invoked by test-monitoring-tools.sh after verify-fixtures.sh; assumes the MCP
-# server is running and the F1–F6 fixtures have been created.
+# server is running and the F1–F7 fixtures have been created.
 #
 # Where verify-fixtures.sh asserts broker *state* via SEMP-direct calls, this
 # file exercises each MVP monitoring *tool* through the MCP server (JSON-RPC
@@ -12,7 +13,7 @@
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
-# ── Tool 2: list-vpns (F1 multi-VPN) ─────────────────────────────────────────
+# ── Tool 1: list-vpns (F1 multi-VPN) ─────────────────────────────────────────
 # Primary: the VPN collection includes the base `default` VPN and F1's
 # `test-vpn`. Pagination: maxResults=1 returns exactly one entry and flags the
 # result truncated, while the uncapped default call returns the full set.
@@ -57,7 +58,7 @@ test_list_vpns_b()            { test_list_vpns "broker-b"; }
 test_list_vpns_pagination_a() { test_list_vpns_pagination "broker-a"; }
 test_list_vpns_pagination_b() { test_list_vpns_pagination "broker-b"; }
 
-# ── Tool 3: get-vpn-health (F1 multi-VPN; VPN-scoped) ────────────────────────
+# ── Tool 2: get-vpn-health (F1 multi-VPN; VPN-scoped) ────────────────────────
 # Value check (AC 5): the base `default` VPN reports enabled=true with services
 # up; F1's `test-vpn` reports enabled=false / state=down. This is the case
 # FR-0's extract_content exists for — a substring match on the raw envelope
@@ -95,9 +96,9 @@ test_get_vpn_health_default_b() { test_get_vpn_health_default "broker-b"; }
 test_get_vpn_health_testvpn_a() { test_get_vpn_health_testvpn "broker-a"; }
 test_get_vpn_health_testvpn_b() { test_get_vpn_health_testvpn "broker-b"; }
 
-# ── Tool 4: list-queues (F2 multi-queue; VPN-scoped) ─────────────────────────
+# ── Tool 3: list-queues (F2 multi-queue; VPN-scoped) ─────────────────────────
 # Primary: the default-VPN queue collection includes F2's test-queue,
-# test-queue-2, test-queue-3 plus the F6 discard queues (AC 6). Pagination:
+# test-queue-2, test-queue-3 plus the F7 discard queues (AC 6). Pagination:
 # maxResults=1 caps to one entry and flags truncated. VPN scoping: every
 # returned queue belongs to the queried VPN, and the F1 test-vpn (which owns no
 # queues) surfaces none of the default VPN's queues.
@@ -109,7 +110,7 @@ test_list_queues() {
     response=$(mcp_call_tool "list-queues" \
         "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
     content=$(extract_content "$response")
-    for q in test-queue test-queue-2 test-queue-3 "$F6_SPOOL_QUEUE" "$F6_TTL_QUEUE"; do
+    for q in test-queue test-queue-2 test-queue-3 "$F7_SPOOL_QUEUE" "$F7_TTL_QUEUE"; do
         assert_json_field "$content" \
             "(.queues.data | map(.queueName) | index(\"$q\")) != null" "true" \
             "list-queues [$broker]: $q must be present in default VPN" || return 1
@@ -153,7 +154,7 @@ test_list_queues_pagination_b() { test_list_queues_pagination "broker-b"; }
 test_list_queues_vpn_scope_a()  { test_list_queues_vpn_scope "broker-a"; }
 test_list_queues_vpn_scope_b()  { test_list_queues_vpn_scope "broker-b"; }
 
-# ── Tool 5: list-clients (F3 connected client; VPN-scoped) ───────────────────
+# ── Tool 4: list-clients (F3 connected client; VPN-scoped) ───────────────────
 # Primary: the default-VPN client list includes this broker's deterministic F3
 # client. Cross-broker isolation (FR-8): the list must NOT include the *other*
 # broker's F3 client — this catches broker-routing bugs. VPN scoping: every
@@ -196,7 +197,7 @@ test_list_clients_b()            { test_list_clients "broker-b" "$F3_CLIENT_NAME
 test_list_clients_pagination_a() { test_list_clients_pagination "broker-a"; }
 test_list_clients_pagination_b() { test_list_clients_pagination "broker-b"; }
 
-# ── Tool 6: get-client-details (F3 connected client; named-object lookup) ─────
+# ── Tool 5: get-client-details (F3 connected client; named-object lookup) ─────
 # F3 case (AC 8): a named lookup of the F3 client returns that client's details
 # with slowSubscriber=false.
 # Envelope: {"clientDetails":{"data":{...}}} — a single object.
@@ -205,7 +206,7 @@ test_list_clients_pagination_b() { test_list_clients_pagination "broker-b"; }
 # guaranteed-message consumer (slow to ACK) does NOT flip the per-client
 # slowSubscriber flag — that flag tracks TCP-egress stalls, mainly for direct
 # subscribers (SOL-150328/SOL-150344). The F5 slow-consumer signal is surfaced
-# by get-queue-metrics instead and is asserted in the Tool 10 section below.
+# by get-queue-metrics instead and is asserted in the Tool 9 section below.
 
 test_get_client_details_f3() {
     local broker="$1" client="$2"
@@ -223,7 +224,7 @@ test_get_client_details_f3() {
 test_get_client_details_f3_a() { test_get_client_details_f3 "broker-a" "$F3_CLIENT_NAME_A"; }
 test_get_client_details_f3_b() { test_get_client_details_f3 "broker-b" "$F3_CLIENT_NAME_B"; }
 
-# ── Tool 7: list-client-subscriptions (F3 connected client) ──────────────────
+# ── Tool 6: list-client-subscriptions (F3 connected client) ──────────────────
 # Primary: the F3 client's subscriptions include every topic the fixture
 # configured ($F3_SUBSCRIPTIONS). The client also carries an auto-generated
 # #P2P/... inbox subscription, so assert the configured topics are *present*
@@ -271,7 +272,7 @@ test_list_client_subscriptions_b() { test_list_client_subscriptions "broker-b" "
 test_list_client_subscriptions_pagination_a() { test_list_client_subscriptions_pagination "broker-a" "$F3_CLIENT_NAME_A"; }
 test_list_client_subscriptions_pagination_b() { test_list_client_subscriptions_pagination "broker-b" "$F3_CLIENT_NAME_B"; }
 
-# ── Tool 8: get-message-rates (F4 sustained traffic; VPN-level) ──────────────
+# ── Tool 7: get-message-rates (F4 sustained traffic; VPN-level) ──────────────
 # Value check (AC 10): under F4's sustained ~100 msg/s load the default VPN
 # reports rxMsgRate ≥ 80 and txMsgRate ≥ 80. F4 is settled by the orchestrator's
 # verify-fixtures step (which waits ≥ 25 s on F4_READY_EPOCH) before this file
@@ -299,7 +300,7 @@ test_get_message_rates() {
 test_get_message_rates_a() { test_get_message_rates "broker-a"; }
 test_get_message_rates_b() { test_get_message_rates "broker-b"; }
 
-# ── Tool 9: list-rdps (base fixture) ─────────────────────────────────────────
+# ── Tool 8: list-rdps (base fixture) ─────────────────────────────────────────
 # Primary: the default-VPN RDP collection includes the base test-rdp.
 # Pagination: the base fixture provisions a single RDP, so maxResults=1 returns
 # that one entry untruncated. This confirms the cap is accepted and the full set
@@ -335,7 +336,7 @@ test_list_rdps_b()            { test_list_rdps "broker-b"; }
 test_list_rdps_pagination_a() { test_list_rdps_pagination "broker-a"; }
 test_list_rdps_pagination_b() { test_list_rdps_pagination "broker-b"; }
 
-# ── Tool 10: get-queue-metrics (F5 slow guaranteed-message consumer) ──────────
+# ── Tool 9: get-queue-metrics (F5 slow guaranteed-message consumer) ──────────
 # Value check: get-queue-metrics surfaces the slow-consumer diagnostic that the
 # per-client slowSubscriber flag cannot (SOL-150328/SOL-150344). On the F5 queue
 # ($F5_QUEUE, maxDeliveredUnackedMsgsPerFlow=$F5_MAX_UNACKED) a bound consumer
@@ -393,47 +394,213 @@ test_get_queue_metrics_slow_consumer() {
 test_get_queue_metrics_slow_consumer_a() { test_get_queue_metrics_slow_consumer "broker-a"; }
 test_get_queue_metrics_slow_consumer_b() { test_get_queue_metrics_slow_consumer "broker-b"; }
 
+# ── Tool 10: list-slow-subscribers (F6 slow direct subscriber) ──────────────
+# Value check (AC 12): the F6 fixture SIGSTOPs a direct subscriber under a
+# large-payload flood so its TCP egress window stalls and the broker flags it
+# slowSubscriber=true. The tool filters server-side on where=slowSubscriber==true,
+# so its data must include this broker's F6 client. This is the per-client flag
+# the slow-ACK F5 consumer can never trip (SOL-150328) — F6 exists to exercise it.
+# Cross-broker isolation (FR-8): the other broker's F6 client must be absent.
+# Filter validation: every returned client actually carries slowSubscriber=true.
+# Pagination: with a single qualifying client, maxResults=1 returns exactly one
+# entry — it confirms the cap is honored but, like list-rdps, cannot demonstrate
+# multi-page truncation (no second slow subscriber exists to drop).
+# Envelope: {"slowSubscribers":{"data":[...],"truncated":bool}}.
+
+test_list_slow_subscribers() {
+    local broker="$1" own="$2" other="$3"
+    local response content
+    response=$(mcp_call_tool "list-slow-subscribers" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" \
+        "(.slowSubscribers.data | map(.clientName) | index(\"$own\")) != null" "true" \
+        "list-slow-subscribers [$broker]: F6 client $own must be present" || return 1
+    # Cross-broker isolation (FR-8): the other broker's F6 client must be absent.
+    assert_json_field "$content" \
+        "(.slowSubscribers.data | map(.clientName) | index(\"$other\")) == null" "true" \
+        "list-slow-subscribers [$broker]: must NOT include other broker's client $other" || return 1
+    # Server-side where filter: every returned client really is a slow subscriber.
+    assert_json_field "$content" '.slowSubscribers.data | all(.slowSubscriber == true)' "true" \
+        "list-slow-subscribers [$broker]: every returned client must have slowSubscriber=true" || return 1
+}
+
+test_list_slow_subscribers_pagination() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "list-slow-subscribers" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default",maxResults:1}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.slowSubscribers.data | length' "1" \
+        "list-slow-subscribers [$broker]: maxResults=1 must return exactly 1 slow subscriber" || return 1
+}
+
+test_list_slow_subscribers_a() { test_list_slow_subscribers "broker-a" "$F6_SUB_CLIENT_NAME_A" "$F6_SUB_CLIENT_NAME_B"; }
+test_list_slow_subscribers_b() { test_list_slow_subscribers "broker-b" "$F6_SUB_CLIENT_NAME_B" "$F6_SUB_CLIENT_NAME_A"; }
+test_list_slow_subscribers_pagination_a() { test_list_slow_subscribers_pagination "broker-a"; }
+test_list_slow_subscribers_pagination_b() { test_list_slow_subscribers_pagination "broker-b"; }
+
+# ── Tool 11: list-queue-discards (F7 spool + TTL discards; per-queue) ─────────
+# Value check (AC 13): list-queue-discards returns each queue's per-category
+# discard counters. F7-spool's queue overflows its 1 MB spool quota
+# (maxMsgSpoolUsageExceededDiscardedMsgCount > 0) and F7-ttl's queue expires
+# messages by its 1 s TTL with no DMQ route (maxTtlExpiredDiscardedMsgCount > 0).
+# These are the exact per-queue fields AC 13 names; the broker-wide aggregates
+# are covered by get-discard-stats (Tool 12). VPN scoping: every returned queue
+# belongs to the queried VPN. Pagination: maxResults=1 caps to one entry and
+# flags truncated (the default VPN holds many queues).
+# Envelope: {"queueDiscards":{"data":[...],"truncated":bool}}.
+
+test_list_queue_discards() {
+    local broker="$1"
+    local response content spool ttl
+    response=$(mcp_call_tool "list-queue-discards" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    spool=$(echo "$content" | jq -r \
+        "(.queueDiscards.data[] | select(.queueName==\"$F7_SPOOL_QUEUE\") | .maxMsgSpoolUsageExceededDiscardedMsgCount) // 0")
+    ttl=$(echo "$content" | jq -r \
+        "(.queueDiscards.data[] | select(.queueName==\"$F7_TTL_QUEUE\") | .maxTtlExpiredDiscardedMsgCount) // 0")
+    log_info "list-queue-discards [$broker]: $F7_SPOOL_QUEUE spool-exceeded=$spool $F7_TTL_QUEUE ttl-expired=$ttl"
+    assert_json_field "$content" \
+        "(.queueDiscards.data[] | select(.queueName==\"$F7_SPOOL_QUEUE\") | .maxMsgSpoolUsageExceededDiscardedMsgCount) > 0" "true" \
+        "list-queue-discards [$broker]: $F7_SPOOL_QUEUE maxMsgSpoolUsageExceededDiscardedMsgCount must be > 0 (got $spool)" || return 1
+    assert_json_field "$content" \
+        "(.queueDiscards.data[] | select(.queueName==\"$F7_TTL_QUEUE\") | .maxTtlExpiredDiscardedMsgCount) > 0" "true" \
+        "list-queue-discards [$broker]: $F7_TTL_QUEUE maxTtlExpiredDiscardedMsgCount must be > 0 (got $ttl)" || return 1
+    # VPN scoping: every returned queue belongs to the default VPN.
+    assert_json_field "$content" '.queueDiscards.data | all(.msgVpnName == "default")' "true" \
+        "list-queue-discards [$broker]: every queue must be scoped to the default VPN" || return 1
+}
+
+test_list_queue_discards_pagination() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "list-queue-discards" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default",maxResults:1}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.queueDiscards.data | length' "1" \
+        "list-queue-discards [$broker]: maxResults=1 must return exactly 1 queue" || return 1
+    assert_json_field "$content" '.queueDiscards.truncated' "true" \
+        "list-queue-discards [$broker]: maxResults=1 must flag truncated=true" || return 1
+}
+
+test_list_queue_discards_a()            { test_list_queue_discards "broker-a"; }
+test_list_queue_discards_b()            { test_list_queue_discards "broker-b"; }
+test_list_queue_discards_pagination_a() { test_list_queue_discards_pagination "broker-a"; }
+test_list_queue_discards_pagination_b() { test_list_queue_discards_pagination "broker-b"; }
+
+# ── Tool 12: get-discard-stats (F7 discards; broker-wide + per-VPN aggregates) ─
+# Value check (AC 13, aggregate half): get-discard-stats is a NATIVE SEMPv1 tool
+# returning pre-aggregated discard totals — not the per-queue breakdown (that's
+# Tool 11). Its envelope therefore has NO step-id wrapper and NO `.data`: the
+# tool payload is the StructuredContent object itself.
+#   • Broker-wide (omit vpnName): {clientDiscards, spoolDiscards}. The F7 fixtures
+#     drive the broker-wide spool aggregate up — totalTtlExpiredDiscardMessages
+#     maps directly to F7-ttl, and totalDiscardedMessages is the roll-up that any
+#     spool discard (TTL or quota) feeds.
+#   • Per-VPN (vpnName set): {vpnName, clientDiscards} — spoolDiscards is omitted
+#     because SEMPv1 exposes no per-VPN spool breakdown.
+# Note: the parameter is `vpnName`, NOT `msgVpnName`.
+
+test_get_discard_stats_broker_wide() {
+    local broker="$1"
+    local response content ttl total
+    response=$(mcp_call_tool "get-discard-stats" \
+        "$(jq -nc --arg b "$broker" '{broker:$b}')") || return 1
+    content=$(extract_content "$response")
+    ttl=$(echo "$content" | jq -r '.spoolDiscards.totalTtlExpiredDiscardMessages // 0')
+    total=$(echo "$content" | jq -r '.spoolDiscards.totalDiscardedMessages // 0')
+    log_info "get-discard-stats [$broker] broker-wide: spool totalTtlExpiredDiscardMessages=$ttl totalDiscardedMessages=$total"
+    # Broker-wide envelope carries both client- and spool-level aggregates.
+    assert_json_field "$content" '.clientDiscards | type' "object" \
+        "get-discard-stats [$broker]: broker-wide must include clientDiscards object" || return 1
+    assert_json_field "$content" '.spoolDiscards | type' "object" \
+        "get-discard-stats [$broker]: broker-wide must include spoolDiscards object" || return 1
+    # F7 discards surface in the spool aggregate: TTL-expired (F7-ttl, directly
+    # mapped) and the total roll-up (fed by both F7-ttl and F7-spool).
+    assert_json_field "$content" '.spoolDiscards.totalTtlExpiredDiscardMessages > 0' "true" \
+        "get-discard-stats [$broker]: spoolDiscards.totalTtlExpiredDiscardMessages must be > 0 (got $ttl)" || return 1
+    assert_json_field "$content" '.spoolDiscards.totalDiscardedMessages > 0' "true" \
+        "get-discard-stats [$broker]: spoolDiscards.totalDiscardedMessages must be > 0 (got $total)" || return 1
+}
+
+test_get_discard_stats_per_vpn() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "get-discard-stats" \
+        "$(jq -nc --arg b "$broker" '{broker:$b,vpnName:"default"}')") || return 1
+    content=$(extract_content "$response")
+    assert_json_field "$content" '.vpnName' "default" \
+        "get-discard-stats [$broker]: per-VPN call must echo vpnName=default" || return 1
+    assert_json_field "$content" '.clientDiscards | type' "object" \
+        "get-discard-stats [$broker]: per-VPN must include clientDiscards object" || return 1
+    # SEMPv1 exposes no per-VPN spool breakdown, so spoolDiscards must be absent.
+    assert_json_field "$content" 'has("spoolDiscards")' "false" \
+        "get-discard-stats [$broker]: per-VPN must NOT include spoolDiscards" || return 1
+}
+
+test_get_discard_stats_broker_wide_a() { test_get_discard_stats_broker_wide "broker-a"; }
+test_get_discard_stats_broker_wide_b() { test_get_discard_stats_broker_wide "broker-b"; }
+test_get_discard_stats_per_vpn_a()     { test_get_discard_stats_per_vpn "broker-a"; }
+test_get_discard_stats_per_vpn_b()     { test_get_discard_stats_per_vpn "broker-b"; }
+
 # ── Run ──────────────────────────────────────────────────────────────────────
 
-run_test "Tool 2 — list-vpns (broker-a)"               test_list_vpns_a
-run_test "Tool 2 — list-vpns (broker-b)"               test_list_vpns_b
-run_test "Tool 2 — list-vpns pagination (broker-a)"    test_list_vpns_pagination_a
-run_test "Tool 2 — list-vpns pagination (broker-b)"    test_list_vpns_pagination_b
+run_test "Tool 1 — list-vpns (broker-a)"               test_list_vpns_a
+run_test "Tool 1 — list-vpns (broker-b)"               test_list_vpns_b
+run_test "Tool 1 — list-vpns pagination (broker-a)"    test_list_vpns_pagination_a
+run_test "Tool 1 — list-vpns pagination (broker-b)"    test_list_vpns_pagination_b
 
-run_test "Tool 3 — get-vpn-health default (broker-a)"  test_get_vpn_health_default_a
-run_test "Tool 3 — get-vpn-health default (broker-b)"  test_get_vpn_health_default_b
-run_test "Tool 3 — get-vpn-health test-vpn (broker-a)" test_get_vpn_health_testvpn_a
-run_test "Tool 3 — get-vpn-health test-vpn (broker-b)" test_get_vpn_health_testvpn_b
+run_test "Tool 2 — get-vpn-health default (broker-a)"  test_get_vpn_health_default_a
+run_test "Tool 2 — get-vpn-health default (broker-b)"  test_get_vpn_health_default_b
+run_test "Tool 2 — get-vpn-health test-vpn (broker-a)" test_get_vpn_health_testvpn_a
+run_test "Tool 2 — get-vpn-health test-vpn (broker-b)" test_get_vpn_health_testvpn_b
 
-run_test "Tool 4 — list-queues (broker-a)"             test_list_queues_a
-run_test "Tool 4 — list-queues (broker-b)"             test_list_queues_b
-run_test "Tool 4 — list-queues pagination (broker-a)"  test_list_queues_pagination_a
-run_test "Tool 4 — list-queues pagination (broker-b)"  test_list_queues_pagination_b
-run_test "Tool 4 — list-queues VPN scope (broker-a)"   test_list_queues_vpn_scope_a
-run_test "Tool 4 — list-queues VPN scope (broker-b)"   test_list_queues_vpn_scope_b
+run_test "Tool 3 — list-queues (broker-a)"             test_list_queues_a
+run_test "Tool 3 — list-queues (broker-b)"             test_list_queues_b
+run_test "Tool 3 — list-queues pagination (broker-a)"  test_list_queues_pagination_a
+run_test "Tool 3 — list-queues pagination (broker-b)"  test_list_queues_pagination_b
+run_test "Tool 3 — list-queues VPN scope (broker-a)"   test_list_queues_vpn_scope_a
+run_test "Tool 3 — list-queues VPN scope (broker-b)"   test_list_queues_vpn_scope_b
 
-run_test "Tool 5 — list-clients (broker-a)"            test_list_clients_a
-run_test "Tool 5 — list-clients (broker-b)"            test_list_clients_b
-run_test "Tool 5 — list-clients pagination (broker-a)" test_list_clients_pagination_a
-run_test "Tool 5 — list-clients pagination (broker-b)" test_list_clients_pagination_b
+run_test "Tool 4 — list-clients (broker-a)"            test_list_clients_a
+run_test "Tool 4 — list-clients (broker-b)"            test_list_clients_b
+run_test "Tool 4 — list-clients pagination (broker-a)" test_list_clients_pagination_a
+run_test "Tool 4 — list-clients pagination (broker-b)" test_list_clients_pagination_b
 
-run_test "Tool 6 — get-client-details F3 (broker-a)"   test_get_client_details_f3_a
-run_test "Tool 6 — get-client-details F3 (broker-b)"   test_get_client_details_f3_b
+run_test "Tool 5 — get-client-details F3 (broker-a)"   test_get_client_details_f3_a
+run_test "Tool 5 — get-client-details F3 (broker-b)"   test_get_client_details_f3_b
 
-run_test "Tool 7 — list-client-subscriptions (broker-a)"            test_list_client_subscriptions_a
-run_test "Tool 7 — list-client-subscriptions (broker-b)"            test_list_client_subscriptions_b
-run_test "Tool 7 — list-client-subscriptions pagination (broker-a)" test_list_client_subscriptions_pagination_a
-run_test "Tool 7 — list-client-subscriptions pagination (broker-b)" test_list_client_subscriptions_pagination_b
+run_test "Tool 6 — list-client-subscriptions (broker-a)"            test_list_client_subscriptions_a
+run_test "Tool 6 — list-client-subscriptions (broker-b)"            test_list_client_subscriptions_b
+run_test "Tool 6 — list-client-subscriptions pagination (broker-a)" test_list_client_subscriptions_pagination_a
+run_test "Tool 6 — list-client-subscriptions pagination (broker-b)" test_list_client_subscriptions_pagination_b
 
-run_test "Tool 8 — get-message-rates (broker-a)"       test_get_message_rates_a
-run_test "Tool 8 — get-message-rates (broker-b)"       test_get_message_rates_b
+run_test "Tool 7 — get-message-rates (broker-a)"       test_get_message_rates_a
+run_test "Tool 7 — get-message-rates (broker-b)"       test_get_message_rates_b
 
-run_test "Tool 9 — list-rdps (broker-a)"               test_list_rdps_a
-run_test "Tool 9 — list-rdps (broker-b)"               test_list_rdps_b
-run_test "Tool 9 — list-rdps pagination (broker-a)"    test_list_rdps_pagination_a
-run_test "Tool 9 — list-rdps pagination (broker-b)"    test_list_rdps_pagination_b
+run_test "Tool 8 — list-rdps (broker-a)"               test_list_rdps_a
+run_test "Tool 8 — list-rdps (broker-b)"               test_list_rdps_b
+run_test "Tool 8 — list-rdps pagination (broker-a)"    test_list_rdps_pagination_a
+run_test "Tool 8 — list-rdps pagination (broker-b)"    test_list_rdps_pagination_b
 
-run_test "Tool 10 — get-queue-metrics slow consumer (broker-a)" test_get_queue_metrics_slow_consumer_a
-run_test "Tool 10 — get-queue-metrics slow consumer (broker-b)" test_get_queue_metrics_slow_consumer_b
+run_test "Tool 9 — get-queue-metrics slow consumer (broker-a)" test_get_queue_metrics_slow_consumer_a
+run_test "Tool 9 — get-queue-metrics slow consumer (broker-b)" test_get_queue_metrics_slow_consumer_b
+
+run_test "Tool 10 — list-slow-subscribers (broker-a)"            test_list_slow_subscribers_a
+run_test "Tool 10 — list-slow-subscribers (broker-b)"            test_list_slow_subscribers_b
+run_test "Tool 10 — list-slow-subscribers pagination (broker-a)" test_list_slow_subscribers_pagination_a
+run_test "Tool 10 — list-slow-subscribers pagination (broker-b)" test_list_slow_subscribers_pagination_b
+
+run_test "Tool 11 — list-queue-discards (broker-a)"             test_list_queue_discards_a
+run_test "Tool 11 — list-queue-discards (broker-b)"             test_list_queue_discards_b
+run_test "Tool 11 — list-queue-discards pagination (broker-a)"  test_list_queue_discards_pagination_a
+run_test "Tool 11 — list-queue-discards pagination (broker-b)"  test_list_queue_discards_pagination_b
+
+run_test "Tool 12 — get-discard-stats broker-wide (broker-a)"   test_get_discard_stats_broker_wide_a
+run_test "Tool 12 — get-discard-stats broker-wide (broker-b)"   test_get_discard_stats_broker_wide_b
+run_test "Tool 12 — get-discard-stats per-VPN (broker-a)"       test_get_discard_stats_per_vpn_a
+run_test "Tool 12 — get-discard-stats per-VPN (broker-b)"       test_get_discard_stats_per_vpn_b
 
 print_summary "MCP tool tests"

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -201,10 +201,11 @@ test_list_clients_pagination_b() { test_list_clients_pagination "broker-b"; }
 # with slowSubscriber=false.
 # Envelope: {"clientDetails":{"data":{...}}} — a single object.
 #
-# TODO(SOL-150025 / F5): add the slow-subscriber half (AC 8: F5 client →
-# slowSubscriber=true) once an F5 (slow subscriber) fixture exists. SOL-150024
-# does not currently ship one in helpers.sh (no F5_* constants / create_slow_*
-# helper), so there is no client to look up yet.
+# Note: there is deliberately no slowSubscriber=true case here. A slow
+# guaranteed-message consumer (slow to ACK) does NOT flip the per-client
+# slowSubscriber flag — that flag tracks TCP-egress stalls, mainly for direct
+# subscribers (SOL-150328/SOL-150344). The F5 slow-consumer signal is surfaced
+# by get-queue-metrics instead and is asserted in the Tool 10 section below.
 
 test_get_client_details_f3() {
     local broker="$1" client="$2"
@@ -334,6 +335,65 @@ test_list_rdps_b()            { test_list_rdps "broker-b"; }
 test_list_rdps_pagination_a() { test_list_rdps_pagination "broker-a"; }
 test_list_rdps_pagination_b() { test_list_rdps_pagination "broker-b"; }
 
+# ── Tool 10: get-queue-metrics (F5 slow guaranteed-message consumer) ──────────
+# Value check: get-queue-metrics surfaces the slow-consumer diagnostic that the
+# per-client slowSubscriber flag cannot (SOL-150328/SOL-150344). On the F5 queue
+# ($F5_QUEUE, maxDeliveredUnackedMsgsPerFlow=$F5_MAX_UNACKED) a bound consumer
+# ACKs slowly while a publisher floods the topic, so: a consumer is bound,
+# unacked messages pin near the per-flow ceiling, ingress outruns egress, and
+# the spool backs up over time. This mirrors verify-fixtures.sh's SEMP-direct
+# verify_slow_consumer_state, but exercises the same signal through the MCP tool
+# envelope. The orchestrator's verify-fixtures step waits out the F5 settle
+# window before this file runs, and the F5 driver keeps publishing throughout,
+# so the signals are live when read here. The basic-mcp suite already smoke-tests
+# get-queue-metrics' plumbing on an idle queue; this is the diagnostic half it
+# structurally cannot cover (no traffic fixture there).
+# Envelope: {"queueMetrics":{"data":{...}}} — a single object.
+
+test_get_queue_metrics_slow_consumer() {
+    local broker="$1"
+    local response content bind unacked rx tx spooled1 spooled2
+    local near_unacked=$(( F5_MAX_UNACKED * 8 / 10 ))
+
+    response=$(mcp_call_tool "get-queue-metrics" \
+        "$(jq -nc --arg b "$broker" --arg q "$F5_QUEUE" \
+            '{broker:$b,msgVpnName:"default",queueName:$q}')") || return 1
+    content=$(extract_content "$response")
+
+    bind=$(echo "$content" | jq -r '.queueMetrics.data.bindCount')
+    unacked=$(echo "$content" | jq -r '.queueMetrics.data.txUnackedMsgCount')
+    rx=$(echo "$content" | jq -r '.queueMetrics.data.rxMsgRate')
+    tx=$(echo "$content" | jq -r '.queueMetrics.data.txMsgRate')
+    spooled1=$(echo "$content" | jq -r '.queueMetrics.data.spooledMsgCount')
+    log_info "get-queue-metrics [$broker]: bindCount=$bind txUnackedMsgCount=$unacked (ceiling $F5_MAX_UNACKED) rxMsgRate=$rx txMsgRate=$tx spooledMsgCount=$spooled1"
+
+    # A consumer is bound to the slow-consumer queue.
+    assert_json_field "$content" '.queueMetrics.data.bindCount > 0' "true" \
+        "get-queue-metrics [$broker]: bindCount must be > 0 (got $bind)" || return 1
+    # Unacked messages pin NEAR the per-flow ceiling — the slow-ACK signature.
+    # "Near", not "==": a slow-but-nonzero ACK rate makes the count oscillate by
+    # one, so assert ≥ 80% of the ceiling rather than exact equality.
+    assert_json_field "$content" ".queueMetrics.data.txUnackedMsgCount >= $near_unacked" "true" \
+        "get-queue-metrics [$broker]: txUnackedMsgCount must be near the $F5_MAX_UNACKED ceiling (≥ $near_unacked, got $unacked)" || return 1
+    # Ingress outruns egress while the consumer lags.
+    assert_json_field "$content" '.queueMetrics.data.rxMsgRate > .queueMetrics.data.txMsgRate' "true" \
+        "get-queue-metrics [$broker]: rxMsgRate must exceed txMsgRate (got rx=$rx tx=$tx)" || return 1
+
+    # Spool backs up: a second sample taken a moment later is strictly larger.
+    sleep 2
+    response=$(mcp_call_tool "get-queue-metrics" \
+        "$(jq -nc --arg b "$broker" --arg q "$F5_QUEUE" \
+            '{broker:$b,msgVpnName:"default",queueName:$q}')") || return 1
+    content=$(extract_content "$response")
+    spooled2=$(echo "$content" | jq -r '.queueMetrics.data.spooledMsgCount')
+    log_info "get-queue-metrics [$broker]: spooledMsgCount $spooled1 -> $spooled2 (must be growing)"
+    assert_json_field "$content" ".queueMetrics.data.spooledMsgCount > $spooled1" "true" \
+        "get-queue-metrics [$broker]: spooledMsgCount must be growing (was $spooled1, now $spooled2)" || return 1
+}
+
+test_get_queue_metrics_slow_consumer_a() { test_get_queue_metrics_slow_consumer "broker-a"; }
+test_get_queue_metrics_slow_consumer_b() { test_get_queue_metrics_slow_consumer "broker-b"; }
+
 # ── Run ──────────────────────────────────────────────────────────────────────
 
 run_test "Tool 2 — list-vpns (broker-a)"               test_list_vpns_a
@@ -373,5 +433,8 @@ run_test "Tool 9 — list-rdps (broker-a)"               test_list_rdps_a
 run_test "Tool 9 — list-rdps (broker-b)"               test_list_rdps_b
 run_test "Tool 9 — list-rdps pagination (broker-a)"    test_list_rdps_pagination_a
 run_test "Tool 9 — list-rdps pagination (broker-b)"    test_list_rdps_pagination_b
+
+run_test "Tool 10 — get-queue-metrics slow consumer (broker-a)" test_get_queue_metrics_slow_consumer_a
+run_test "Tool 10 — get-queue-metrics slow consumer (broker-b)" test_get_queue_metrics_slow_consumer_b
 
 print_summary "MCP tool tests"

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -31,6 +31,11 @@ test_list_vpns() {
     assert_json_field "$content" \
         '(.vpns.data | map(.msgVpnName) | index("test-vpn")) != null' "true" \
         "list-vpns [$broker]: F1 test-vpn must be present" || return 1
+    # No duplicates across the full (uncapped) set — guards against page-stitching
+    # bugs emitting the same VPN twice (PR goal: pagination has no gaps/duplicates).
+    assert_json_field "$content" \
+        '(.vpns.data | map(.msgVpnName)) as $n | ($n | length) == ($n | unique | length)' "true" \
+        "list-vpns [$broker]: VPN names must be unique (no pagination duplicates)" || return 1
 }
 
 test_list_vpns_pagination() {
@@ -115,6 +120,11 @@ test_list_queues() {
             "(.queues.data | map(.queueName) | index(\"$q\")) != null" "true" \
             "list-queues [$broker]: $q must be present in default VPN" || return 1
     done
+    # No duplicates across the full (uncapped) set — page stitching must not
+    # repeat a queue (PR goal: pagination has no gaps/duplicates).
+    assert_json_field "$content" \
+        '(.queues.data | map(.queueName)) as $n | ($n | length) == ($n | unique | length)' "true" \
+        "list-queues [$broker]: queue names must be unique (no pagination duplicates)" || return 1
 }
 
 test_list_queues_pagination() {
@@ -178,6 +188,11 @@ test_list_clients() {
         "list-clients [$broker]: must NOT include other broker's client $other" || return 1
     assert_json_field "$content" '.clients.data | all(.msgVpnName == "default")' "true" \
         "list-clients [$broker]: every client must be scoped to the default VPN" || return 1
+    # No duplicates across the full (uncapped) set — page stitching must not
+    # repeat a client (PR goal: pagination has no gaps/duplicates).
+    assert_json_field "$content" \
+        '(.clients.data | map(.clientName)) as $n | ($n | length) == ($n | unique | length)' "true" \
+        "list-clients [$broker]: client names must be unique (no pagination duplicates)" || return 1
 }
 
 test_list_clients_pagination() {
@@ -247,6 +262,11 @@ test_list_client_subscriptions() {
             "(.subscriptions.data | map(.subscriptionTopic) | index(\"$t\")) != null" "true" \
             "list-client-subscriptions [$broker]: $client must subscribe to $t" || return 1
     done < <(echo "$F3_SUBSCRIPTIONS" | tr ',' '\n')
+    # No duplicates across the full (uncapped) set — page stitching must not
+    # repeat a subscription (PR goal: pagination has no gaps/duplicates).
+    assert_json_field "$content" \
+        '(.subscriptions.data | map(.subscriptionTopic)) as $n | ($n | length) == ($n | unique | length)' "true" \
+        "list-client-subscriptions [$broker]: subscription topics must be unique (no pagination duplicates)" || return 1
 }
 
 test_list_client_subscriptions_pagination() {
@@ -317,6 +337,11 @@ test_list_rdps() {
     assert_json_field "$content" \
         '(.rdps.data | map(.restDeliveryPointName) | index("test-rdp")) != null' "true" \
         "list-rdps [$broker]: test-rdp must be present" || return 1
+    # No duplicates across the full (uncapped) set — page stitching must not
+    # repeat an RDP (PR goal: pagination has no gaps/duplicates).
+    assert_json_field "$content" \
+        '(.rdps.data | map(.restDeliveryPointName)) as $n | ($n | length) == ($n | unique | length)' "true" \
+        "list-rdps [$broker]: RDP names must be unique (no pagination duplicates)" || return 1
 }
 
 test_list_rdps_pagination() {
@@ -423,6 +448,11 @@ test_list_slow_subscribers() {
     # Server-side where filter: every returned client really is a slow subscriber.
     assert_json_field "$content" '.slowSubscribers.data | all(.slowSubscriber == true)' "true" \
         "list-slow-subscribers [$broker]: every returned client must have slowSubscriber=true" || return 1
+    # No duplicates across the full (uncapped) set — page stitching must not
+    # repeat a client (PR goal: pagination has no gaps/duplicates).
+    assert_json_field "$content" \
+        '(.slowSubscribers.data | map(.clientName)) as $n | ($n | length) == ($n | unique | length)' "true" \
+        "list-slow-subscribers [$broker]: client names must be unique (no pagination duplicates)" || return 1
 }
 
 test_list_slow_subscribers_pagination() {
@@ -471,6 +501,11 @@ test_list_queue_discards() {
     # VPN scoping: every returned queue belongs to the default VPN.
     assert_json_field "$content" '.queueDiscards.data | all(.msgVpnName == "default")' "true" \
         "list-queue-discards [$broker]: every queue must be scoped to the default VPN" || return 1
+    # No duplicates across the full (uncapped) set — page stitching must not
+    # repeat a queue (PR goal: pagination has no gaps/duplicates).
+    assert_json_field "$content" \
+        '(.queueDiscards.data | map(.queueName)) as $n | ($n | length) == ($n | unique | length)' "true" \
+        "list-queue-discards [$broker]: queue names must be unique (no pagination duplicates)" || return 1
 }
 
 test_list_queue_discards_pagination() {

--- a/test/e2e-monitoring/verify-fixtures.sh
+++ b/test/e2e-monitoring/verify-fixtures.sh
@@ -7,6 +7,33 @@
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
+# Sleeps out the remainder of a fixture's settle window. Given the epoch the
+# fixture finished starting and the total window, sleeps only the time not
+# already elapsed — so a second caller after the window has passed is a no-op.
+# When the epoch is unset (fixture state unknown), sleeps the full window
+# defensively. Shared by the F4 and F5 settle waits.
+#   $1 ready_epoch     seconds-since-epoch the fixture became ready ("" if unknown)
+#   $2 settle_seconds  total settle window
+#   $3 label           human description for the log line
+wait_for_settle() {
+    local ready_epoch="$1"
+    local settle_seconds="$2"
+    local label="$3"
+    if [ -z "$ready_epoch" ]; then
+        log_warn "$label: ready-epoch unset; assuming it just started"
+        sleep "$settle_seconds"
+        return
+    fi
+    local now elapsed remaining
+    now=$(date +%s)
+    elapsed=$((now - ready_epoch))
+    remaining=$((settle_seconds - elapsed))
+    if [ "$remaining" -gt 0 ]; then
+        log_info "Waiting ${remaining}s for $label to settle ..."
+        sleep "$remaining"
+    fi
+}
+
 # ── AC 2 — F1 multi-VPN ─────────────────────────────────────────────────────
 # `test-vpn` exists on both brokers with enabled=false, state=down.
 
@@ -101,22 +128,6 @@ test_ac4_connected_client_state_b() {
 F4_SETTLE_SECONDS=25
 F4_RATE_THRESHOLD=80
 
-wait_for_f4_settle() {
-    if [ -z "${F4_READY_EPOCH:-}" ]; then
-        log_warn "F4_READY_EPOCH unset; assuming F4 just started"
-        sleep "$F4_SETTLE_SECONDS"
-        return
-    fi
-    local now elapsed remaining
-    now=$(date +%s)
-    elapsed=$((now - F4_READY_EPOCH))
-    remaining=$((F4_SETTLE_SECONDS - elapsed))
-    if [ "$remaining" -gt 0 ]; then
-        log_info "Waiting ${remaining}s for F4 rate to settle (target ≥ ${F4_RATE_THRESHOLD} msg/s) ..."
-        sleep "$remaining"
-    fi
-}
-
 verify_sustained_traffic_state() {
     local label="$1"
     local broker_url="$2"
@@ -137,13 +148,17 @@ verify_sustained_traffic_state() {
         "F4 [$label]: txMsgRate must be ≥ $F4_RATE_THRESHOLD (got $tx)" || return 1
 }
 
+f4_settle() {
+    wait_for_settle "${F4_READY_EPOCH:-}" "$F4_SETTLE_SECONDS" \
+        "F4 rate (target ≥ ${F4_RATE_THRESHOLD} msg/s)"
+}
 test_ac5_sustained_traffic_state_a() {
-    wait_for_f4_settle
+    f4_settle
     verify_sustained_traffic_state "broker-a" "$BROKER_A_URL"
 }
 test_ac5_sustained_traffic_state_b() {
-    # wait_for_f4_settle is a no-op the second time through.
-    wait_for_f4_settle
+    # f4_settle is a no-op the second time through (window already elapsed).
+    f4_settle
     verify_sustained_traffic_state "broker-b" "$BROKER_B_URL"
 }
 
@@ -155,22 +170,6 @@ test_ac5_sustained_traffic_state_b() {
 # spool keeps growing.
 
 F5_SETTLE_SECONDS=30
-
-wait_for_f5_settle() {
-    if [ -z "${F5_READY_EPOCH:-}" ]; then
-        log_warn "F5_READY_EPOCH unset; assuming F5 just started"
-        sleep "$F5_SETTLE_SECONDS"
-        return
-    fi
-    local now elapsed remaining
-    now=$(date +%s)
-    elapsed=$((now - F5_READY_EPOCH))
-    remaining=$((F5_SETTLE_SECONDS - elapsed))
-    if [ "$remaining" -gt 0 ]; then
-        log_info "Waiting ${remaining}s for F5 slow-consumer signals to develop ..."
-        sleep "$remaining"
-    fi
-}
 
 verify_slow_consumer_state() {
     local label="$1"
@@ -194,10 +193,9 @@ verify_slow_consumer_state() {
     # Unacked messages pin NEAR the per-flow ceiling — the slow-ACK signature.
     # "Near", not "==": a slow-but-nonzero ACK rate makes the count oscillate by
     # one (it dips just after each ACK, before the broker redelivers), so require
-    # ≥ 80% of the ceiling rather than the exact value.
-    local near_unacked=$(( F5_MAX_UNACKED * 8 / 10 ))
-    assert_json_field "$body" ".data.txUnackedMsgCount >= $near_unacked" "true" \
-        "F5 [$label]: txUnackedMsgCount must be near the $F5_MAX_UNACKED ceiling (≥ $near_unacked, got $unacked)" || return 1
+    # ≥ F5_NEAR_UNACKED (80% of the ceiling) rather than the exact value.
+    assert_json_field "$body" ".data.txUnackedMsgCount >= $F5_NEAR_UNACKED" "true" \
+        "F5 [$label]: txUnackedMsgCount must be near the $F5_MAX_UNACKED ceiling (≥ $F5_NEAR_UNACKED, got $unacked)" || return 1
     # Ingress outpaces egress: publisher feeds faster than the throttled consumer drains.
     assert_json_field "$body" ".data.rxMsgRate > .data.txMsgRate" "true" \
         "F5 [$label]: rxMsgRate must exceed txMsgRate (got rx=$rx tx=$tx)" || return 1
@@ -215,13 +213,17 @@ verify_slow_consumer_state() {
         "F5 [$label]: spooledMsgCount must be growing (was $spooled1, now $spooled2)" || return 1
 }
 
+f5_settle() {
+    wait_for_settle "${F5_READY_EPOCH:-}" "$F5_SETTLE_SECONDS" \
+        "F5 slow-consumer signals"
+}
 test_f5_slow_consumer_a() {
-    wait_for_f5_settle
+    f5_settle
     verify_slow_consumer_state "broker-a" "$BROKER_A_URL"
 }
 test_f5_slow_consumer_b() {
-    # wait_for_f5_settle is a no-op the second time through.
-    wait_for_f5_settle
+    # f5_settle is a no-op the second time through (window already elapsed).
+    f5_settle
     verify_slow_consumer_state "broker-b" "$BROKER_B_URL"
 }
 

--- a/test/e2e-monitoring/verify-fixtures.sh
+++ b/test/e2e-monitoring/verify-fixtures.sh
@@ -227,41 +227,59 @@ test_f5_slow_consumer_b() {
     verify_slow_consumer_state "broker-b" "$BROKER_B_URL"
 }
 
-# ── AC 8 — F6-spool discards ─────────────────────────────────────────────────
+# ── F6 — slow DIRECT subscriber (per-client slowSubscriber flag) ────────────
+# The counterpart to F5: a SIGSTOP'd direct subscriber under a large-payload
+# flood whose TCP egress window stays shut, so the broker flags it
+# slowSubscriber=true. This is the per-client signal list-slow-subscribers
+# filters on — the queue-level F5 case never flips it (SOL-150328). create_*
+# already polled the flag true; re-poll here so a clean diagnostic fires if the
+# stall ever stops holding (the flag is over a rolling ~1 min window).
+
+verify_slow_subscriber_state() {
+    local label="$1"
+    local broker_url="$2"
+    local client_name="$3"
+    wait_for_slow_subscriber "$broker_url" "$label" "$client_name" || return 1
+}
+
+test_f6_slow_subscriber_a() { verify_slow_subscriber_state "broker-a" "$BROKER_A_URL" "$F6_SUB_CLIENT_NAME_A"; }
+test_f6_slow_subscriber_b() { verify_slow_subscriber_state "broker-b" "$BROKER_B_URL" "$F6_SUB_CLIENT_NAME_B"; }
+
+# ── AC 8 — F7-spool discards ─────────────────────────────────────────────────
 
 verify_discard_spool_state() {
     local label="$1"
     local broker_url="$2"
     local body
-    body=$(semp_monitor_get "$broker_url" "msgVpns/$BROKER_VPN/queues/$F6_SPOOL_QUEUE") || {
-        log_fail "F6-spool [$label]: GET queues/$F6_SPOOL_QUEUE failed"
+    body=$(semp_monitor_get "$broker_url" "msgVpns/$BROKER_VPN/queues/$F7_SPOOL_QUEUE") || {
+        log_fail "F7-spool [$label]: GET queues/$F7_SPOOL_QUEUE failed"
         return 1
     }
     local count
     count=$(echo "$body" | jq -r '.data.maxMsgSpoolUsageExceededDiscardedMsgCount')
     assert_json_field "$body" \
         ".data.maxMsgSpoolUsageExceededDiscardedMsgCount > 0" "true" \
-        "F6-spool [$label]: maxMsgSpoolUsageExceededDiscardedMsgCount must be > 0 (got $count)" || return 1
+        "F7-spool [$label]: maxMsgSpoolUsageExceededDiscardedMsgCount must be > 0 (got $count)" || return 1
 }
 
 test_ac8_discard_spool_a() { verify_discard_spool_state "broker-a" "$BROKER_A_URL"; }
 test_ac8_discard_spool_b() { verify_discard_spool_state "broker-b" "$BROKER_B_URL"; }
 
-# ── AC 9 — F6-ttl discards ───────────────────────────────────────────────────
+# ── AC 9 — F7-ttl discards ───────────────────────────────────────────────────
 
 verify_discard_ttl_state() {
     local label="$1"
     local broker_url="$2"
     local body
-    body=$(semp_monitor_get "$broker_url" "msgVpns/$BROKER_VPN/queues/$F6_TTL_QUEUE") || {
-        log_fail "F6-ttl [$label]: GET queues/$F6_TTL_QUEUE failed"
+    body=$(semp_monitor_get "$broker_url" "msgVpns/$BROKER_VPN/queues/$F7_TTL_QUEUE") || {
+        log_fail "F7-ttl [$label]: GET queues/$F7_TTL_QUEUE failed"
         return 1
     }
     local count
     count=$(echo "$body" | jq -r '.data.maxTtlExpiredDiscardedMsgCount')
     assert_json_field "$body" \
         ".data.maxTtlExpiredDiscardedMsgCount > 0" "true" \
-        "F6-ttl [$label]: maxTtlExpiredDiscardedMsgCount must be > 0 (got $count)" || return 1
+        "F7-ttl [$label]: maxTtlExpiredDiscardedMsgCount must be > 0 (got $count)" || return 1
 }
 
 test_ac9_discard_ttl_a() { verify_discard_ttl_state "broker-a" "$BROKER_A_URL"; }
@@ -279,9 +297,11 @@ run_test "AC 5 — F4 sustained traffic (broker-a)" test_ac5_sustained_traffic_s
 run_test "AC 5 — F4 sustained traffic (broker-b)" test_ac5_sustained_traffic_state_b
 run_test "F5 — slow consumer queue signals (broker-a)" test_f5_slow_consumer_a
 run_test "F5 — slow consumer queue signals (broker-b)" test_f5_slow_consumer_b
-run_test "AC 8 — F6-spool discard count (broker-a)" test_ac8_discard_spool_a
-run_test "AC 8 — F6-spool discard count (broker-b)" test_ac8_discard_spool_b
-run_test "AC 9 — F6-ttl discard count (broker-a)" test_ac9_discard_ttl_a
-run_test "AC 9 — F6-ttl discard count (broker-b)" test_ac9_discard_ttl_b
+run_test "F6 — slow subscriber flag (broker-a)" test_f6_slow_subscriber_a
+run_test "F6 — slow subscriber flag (broker-b)" test_f6_slow_subscriber_b
+run_test "AC 8 — F7-spool discard count (broker-a)" test_ac8_discard_spool_a
+run_test "AC 8 — F7-spool discard count (broker-b)" test_ac8_discard_spool_b
+run_test "AC 9 — F7-ttl discard count (broker-a)" test_ac9_discard_ttl_a
+run_test "AC 9 — F7-ttl discard count (broker-b)" test_ac9_discard_ttl_b
 
 print_summary "Fixture verification"


### PR DESCRIPTION
## Summary

Extends `test/e2e-monitoring/` with end-to-end functional tests for the MVP monitoring tools, validating each tool's happy-path behavior and key edge cases (pagination, VPN scoping, named-object lookup, cross-broker isolation) against the deterministic F1–F6 fixtures from SOL-150024. Adds an `extract_content` helper to unwrap tool payloads from the JSON-RPC envelope and a `slow_subscriber` broker-driver mode to back the F5-style slow-consumer assertions.

Fixes [SOL-150025](https://sol-jira.atlassian.net/browse/SOL-150025)

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

SOL-150024 built the `e2e-monitoring` fixture library, scaffold, helpers, and CI job, but only verified _fixture state_ via SEMP-direct calls. The MVP monitoring tools themselves had no end-to-end coverage through the MCP server (JSON-RPC over HTTP). This PR closes that gap so every supported monitoring tool's happy path and edge cases are exercised on each CI run, catching regressions in tool wiring, pagination, and VPN/broker scoping.

`mcp_call_tool` returns the raw JSON-RPC envelope with the tool's real output nested as escaped JSON inside `.result.content[0].text`. Without an unwrap helper, value-checking assertions (`enabled=false`, rate thresholds, discard counters) could only loose-substring-match the whole envelope — unreliable. This PR adds `extract_content` so assertions run as structured `jq` field checks.

## Changes Made

- Added `extract_content` helper to `helpers.sh` (FR-0) — unwraps the tool payload (`jq -r '.result.content[0].text'`) so `assert_json_field` runs against structured data.
- Added `test/e2e-monitoring/tool-tests.sh` — 44 `run_test` cases across 12 tools, each run against both `broker-a` and `broker-b`: `list-vpns`, `get-vpn-health`, `list-queues`, `list-clients`, `get-client-details`, `list-client-subscriptions`, `get-message-rates`, `list-rdps`, `get-queue-metrics` (slow consumer), `list-slow-subscribers`, `list-queue-discards`, `get-discard-stats`.
- Pagination tests for every `list-*` tool (`maxResults` honored, iteration covers all entries with no gaps/duplicates).
- VPN-scope tests (`list-queues`, `get-vpn-health` against `default` enabled and F1 `test-vpn` disabled).
- Negative cross-broker assertions for F3/F5-dependent tools (FR-8) — e.g. `broker-a` sees its own connected/slow client and must NOT see `broker-b`'s.
- Added `slow_subscriber.go` broker-driver mode plus supporting helpers (`create_slow_subscriber_on`, `cleanup_slow_subscriber_on`, `wait_for_slow_subscriber`) to drive the slow-consumer fixture deterministically via TCP back-pressure.
- Hardened lifecycle helpers in `helpers.sh` (`kill_gracefully`, `stop_server`) and fixed publisher exit-code handling in the broker-driver.
- Wired the new tool tests into `test-monitoring-tools.sh` (orchestrator lifecycle unchanged) and updated `verify-fixtures.sh`.
- Updated suite `README.md` with the full tool-test catalog and fixture cross-reference.

## Testing

**Test Environment:**
- Go version: go1.25.10 (broker-driver build only)
- OS: Linux
- Broker version (if applicable): two Solace brokers (`broker-a`, `broker-b`) via the suite's `setup-brokers.sh`

**Tests Performed:**
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [ ] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**
- Ran `bash test/e2e-monitoring/setup-brokers.sh && bash test/e2e-monitoring/test-monitoring-tools.sh` — full SOL-150024 fixture pipeline plus the new 44 tool-test cases, exits 0 when fixtures are healthy.
- Happy-path response-shape checks for all 12 tools on both brokers.
- Pagination (`maxResults=1` returns 1 entry; iteration covers all) for every `list-*` tool.
- VPN scoping (`default` → `enabled=true`; F1 `test-vpn` → `enabled=false`).
- Cross-broker isolation for F3 connected client and F5 slow consumer.
- Value-checking ACs: `slowSubscriber` flag, `rxMsgRate`/`txMsgRate` ≥ 80 after settle, discard counters > 0.

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

**Impact:** None — test-only additions plus a new broker-driver test fixture mode.

**Migration Guide:** N/A

## Checklist

<!-- Ensure all items are completed before requesting review -->

### Code Quality
- [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (checked all files, commits, and logs)
- [x] Followed [secure logging rules](../docs/secure-logging-rules.md)
- [ ] Credential-carrying types implement `slog.LogValuer` (N/A — no new credential types)
- [x] No security vulnerabilities introduced (checked with golangci-lint/gosec)

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [ ] Error paths tested (out of scope — separate error-handling story)
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (if user-facing changes) — suite README updated; no top-level user-facing change
- [x] docs/ updated (if architecture/design changes)
- [ ] godoc comments added/updated for exported functions
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Examples updated (if applicable)

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

## Additional Notes

<!-- Any other context, concerns, or follow-up work needed -->

- Block B tools (`list-slow-subscribers`, `get-discard-stats`, `list-queue-discards`) depend on PR #61 (SOL-148432); those tool definitions must be on `main` before this merges.
- Total `test-monitoring-tools.sh` wall-clock stays within the ~3 min NFR-1 budget.
- Out of scope (separate stories): HA/DMR-gated tools, negative-path error tests, LLM/semantic tests, Go MCP SDK programmatic tests.

## Related Issues/PRs

<!-- Link to related issues, PRs, or discussions -->

- Related to PR #61 (SOL-148432: Advanced Monitoring Tools)
---

**For Reviewers:**

**Focus Areas**: The `extract_content` unwrap and its use in value-checking assertions; the `slow_subscriber` broker-driver fixture and its TCP back-pressure mechanism; cross-broker negative assertions (FR-8); pagination correctness (no gaps/duplicates).

**Questions**: Is the slow-subscriber fixture (SIGSTOP/TCP back-pressure) deterministic enough across CI hardware, or should the `wait_for_slow_subscriber` timeout be tuned?

[SOL-150025]: https://sol-jira.atlassian.net/browse/SOL-150025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ