### PR TITLE
SOL-150440: Add 4 new tools to README and user-guide tools reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ The server exposes read-only tools grouped by what they inspect. Every tool exce
 |---|---|---|
 | Discovery | `list-brokers` | List configured broker aliases for use as the `broker` parameter |
 | Broker health | `get-broker-health`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA and mate-link state |
+| Replication | `get-replication-status` | Replication role, sync eligibility, bridge status, transaction mode, and queued-message counts |
 | Message VPN | `list-vpns`, `get-vpn-health`, `get-message-rates` | List VPNs, check per-VPN service health, read message and byte rates |
 | Queues | `list-queues`, `get-queue-metrics` | List queues with depth and throughput; drill into spool, bindings, consumers |
-| Clients | `list-clients`, `get-client-details`, `list-client-subscriptions` | List connections, inspect per-client rates and discards, list subscriptions |
+| Clients | `list-clients`, `get-client-details`, `list-client-subscriptions`, `list-slow-subscribers` | List connections, inspect per-client rates and discards, list subscriptions, filter for slow-subscriber-flagged clients |
 | REST Delivery Points | `list-rdps`, `get-rdp-status` | List RDPs; inspect bindings, REST consumers, and last failure reason |
+| Discards | `get-discard-stats`, `list-queue-discards` | Broker-wide and per-VPN discard aggregates; per-queue discard counters |
 
 ## Guides
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -91,7 +91,7 @@ What are the current message rates for default VPN on my-broker?
 
 ## Tools Reference
 
-The server exposes 13 read-only tools. All broker-querying tools require a `broker` parameter to identify which configured event broker to query; `list-brokers` is the exception and returns the available event broker aliases.
+The server exposes 17 read-only tools. All broker-querying tools require a `broker` parameter to identify which configured event broker to query; `list-brokers` is the exception and returns the available event broker aliases.
 
 ### Discovery
 
@@ -105,6 +105,12 @@ The server exposes 13 read-only tools. All broker-querying tools require a `brok
 |---|---|
 | `get-broker-health` | Curated event broker health snapshot: version, uptime, restart reason, broker-tier scaling limits, system resources, subscription memory, and message-spool state with HA roles and disk utilization. |
 | `get-redundancy-status` | Event broker redundancy and high-availability status: config/operational status, active-standby role, mate router name, mate link state, and per-virtual-router activity. |
+
+### Replication
+
+| Tool | Description |
+|---|---|
+| `get-replication-status` | Replication state for a Message VPN: role, sync eligibility, bridge status, transaction mode, and queued-message counts. |
 
 ### Message VPN
 
@@ -128,6 +134,7 @@ The server exposes 13 read-only tools. All broker-querying tools require a `brok
 | `list-clients` | List active client connections in a VPN with connection details, uptime, and slow subscriber status. Default 100 results, max 500. |
 | `get-client-details` | Performance metrics for a specific connected client: message rates, slow subscriber status, and egress discard counts. Use to diagnose slow consumers. |
 | `list-client-subscriptions` | Topic subscriptions for a specific client. Default 100 results, max 500. |
+| `list-slow-subscribers` | Filtered list of clients in a VPN flagged with the broker's slow-subscriber field (server-side `where` filter). Narrow signal — catches direct-messaging or replication-bridge backpressure; does NOT flip for slow guaranteed-message consumers (slow to ACK). For those, use `list-queues` / `get-queue-metrics`. Default 100 results, max 500. |
 
 ### REST Delivery Points
 
@@ -135,6 +142,13 @@ The server exposes 13 read-only tools. All broker-querying tools require a `brok
 |---|---|
 | `list-rdps` | List all RDPs in a VPN with enabled state, up/down status, and last failure reason. Default 100 results, max 500. |
 | `get-rdp-status` | Detailed RDP status: enabled state, up/down status, client name, last failure reason, queue bindings, and REST consumer status. |
+
+### Discards
+
+| Tool | Description |
+|---|---|
+| `get-discard-stats` | Broker-wide or per-VPN discard aggregates: client-level ingress/egress discards plus broker-wide spool discards (native SEMPv1). Per-VPN scope returns client-level discards only — the broker exposes no per-VPN spool breakdown via SEMPv1. |
+| `list-queue-discards` | Per-queue discard counters for a VPN: TTL-expired, max-redelivery, spool-quota-exceeded, and other discard categories. Complements `get-discard-stats` with queue-level granularity. Default 100 results, max 500. |
 
 ## Recommended Environments
 


### PR DESCRIPTION
## Summary

Documents the four new tools shipped by SOL-148432 (`get-replication-status`, `list-slow-subscribers`, `list-queue-discards`, `get-discard-stats`) in both the README and the user-guide tools reference.

Closes SOL-150440.

## Type of Change

- [x] Documentation update

## Motivation and Context

The four tools landed via SOL-148432 but the user-facing docs (README `## Tools` table and `docs/user-guide.md` Tools Reference) were not updated at the same time. Without this, users have no visibility into the new tools outside the FD doc.

## Changes Made

- **`README.md`** — added `Replication` row, added `Discards` row, added `list-slow-subscribers` to the `Clients` row.
- **`docs/user-guide.md`** — bumped tool count (13 → 17), added `### Replication` subsection, added `### Discards` subsection, added `list-slow-subscribers` to `### Clients`.
- Short descriptions sourced from the FD doc (`broker-mcp-ai-ops-sol-147161-FD.md#key-components`) and existing tool descriptions in `tools.yaml` / `discardstats/handler.go`.
- Format matches existing pattern (markdown tables, pagination notes for `list-*` tools).
- Verified no prior mentions of the 4 tools in either file before the edit.

