### PR TITLE
SOL-148434: Implement Error Translation and Output Sanitization

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -182,17 +182,25 @@ The server supports open access, static token, and OAuth/OIDC authentication for
 
 Tool errors include structured fields to help diagnose the problem:
 
-| Field | Meaning |
-|---|---|
-| `error` | Human-readable error message. |
-| `retryable` | `true` if retrying may succeed (rate limits, transient failures). |
-| `status` | HTTP status code from the SEMP API. |
-| `operation` | The SEMP operation that failed (for example, `monitor/getMsgVpnQueues`). |
+| Field | Meaning | Present when |
+|---|---|---|
+| `error` | Human-readable error message. | Always |
+| `retryable` | `true` if retrying may succeed (rate limits, transient failures). | Always |
+| `status` | HTTP status code from the SEMP API. | SEMPv2, SEMPv1, or retries-exhausted (when non-zero) |
+| `operation` | The SEMP operation that failed (for example, `monitor/getMsgVpnQueues`). | SEMPv2 |
+| `sempStatus` | Broker error status string from `meta.error.status` (for example, `NOT_FOUND`). | SEMPv2, when non-empty |
+| `sempCode` | Broker error code from `meta.error.code` (for example, `6`). | SEMPv2, when non-zero |
+| `kind` | SEMPv1 error classification: `http`, `execute-fail`, `parse`, `permission`, `limit`, or `unknown`. | SEMPv1 |
+| `reasonCode` | SEMPv1 reason code from the broker response. | SEMPv1 `execute-fail` responses |
+| `attempts` | Number of attempts made before retries were exhausted. | Retries exhausted |
+| `suggestions` | Array of actionable hints for resolving the error. | Any source, when available |
 
 Common causes:
 - **404** — The specified VPN, queue, client, or RDP does not exist. Check the name for typos.
 - **401 / 403** — Event broker credentials lack permission for the requested operation. Verify the SEMP user has monitor-level access.
-- **429 / 503** — Rate limiting or event broker overload. These are retryable — the server retries automatically based on the configured retry policy.
+- **429** — Rate limiting from a proxy, gateway, or load balancer in front of the broker. (The broker itself does not emit 429 over SEMP.) Retryable — the server retries automatically based on the configured retry policy.
+- **503** — The broker is overloaded or out of resources. Retryable — the server retries automatically based on the configured retry policy.
+- **529** — No SEMP session available — a Solace-specific status for exhausted management sessions. Retry shortly.
 
 ### "Session not found" errors
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -200,7 +200,6 @@ Common causes:
 - **401 / 403** — Event broker credentials lack permission for the requested operation. Verify the SEMP user has monitor-level access.
 - **429** — Rate limiting from a proxy, gateway, or load balancer in front of the broker. (The broker itself does not emit 429 over SEMP.) Retryable — the server retries automatically based on the configured retry policy.
 - **503** — The broker is overloaded or out of resources. Retryable — the server retries automatically based on the configured retry policy.
-- **529** — No SEMP session available — a Solace-specific status for exhausted management sessions. Retry shortly.
 
 ### "Session not found" errors
 

--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -72,28 +72,21 @@ var fsPrefixPattern = regexp.MustCompile(`(?i)(/opt/|/var/|/usr/|/etc/|/home/|/r
 // log), so we accept the lost debugging signal rather than complicate the regex.
 var ipv4Pattern = regexp.MustCompile(`\b\d{1,3}(\.\d{1,3}){3}\b`)
 
-// ipv6Pattern matches IPv6 addresses in both the broker's observed
-// bracket-wrapped form ("[2001:db8::1]") and bare forms ("2001:db8::1",).
-// The optional brackets ([...]) are consumed as part of the match so the
-// wrapped form is replaced as a whole.
-//
-// The broker is observed to bracket IPv6 peer addresses, but relying on that for
-// a security sanitizer is fragile, so bare forms are matched defensively too.
-// Every branch requires either "::" or a full eight-group form, which keeps it
-// from matching clock times (12:34:56) or MAC addresses (no "::", < 8 groups).
-// As with ipv4Pattern, over-redaction is acceptable: the raw text still survives
-// in the server log.
-//
-// Go's regexp prefers the first matching branch, not the longest, so the
-// IPv4-tailed branch goes first to match v4-mapped addresses whole.
+// ipv6Pattern matches IPv6 addresses, both the broker's bracket-wrapped form
+// ("[2001:db8::1]", brackets consumed) and bare forms matched defensively.
+// Requiring a hextet on both sides of "::" avoids redacting non-address tokens
+// like "foo::bar"; the cost is that bare "::1"/"::" (non-sensitive) are skipped.
+// Over-redaction is otherwise acceptable — the raw text survives in the server log.
+// The IPv4-tailed branch is first because Go's regexp prefers the first matching
+// branch, not the longest, so v4-mapped addresses match whole.
 var ipv6Pattern = regexp.MustCompile(`(?i)\[?(?:` +
-	// IPv6 with an embedded IPv4 tail (v4-mapped/translated), e.g. ::ffff:1.2.3.4
+	// "::" with an embedded IPv4 tail (v4-mapped), e.g. ::ffff:1.2.3.4
 	`(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?::(?:[0-9a-f]{1,4}:)*(?:\d{1,3}\.){3}\d{1,3}` +
 	`|` +
-	// Compressed IPv6 (contains "::"), e.g. 2001:db8::1, ::1, fe80::
-	`(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?` +
+	// Compressed "::", hextet required on both sides, e.g. 2001:db8::1
+	`(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)` +
 	`|` +
-	// Full eight-group IPv6, e.g. 2001:db8:0:0:0:0:2:1
+	// Full eight-group form, e.g. 2001:db8:0:0:0:0:2:1
 	`(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}` +
 	`)(?:%[0-9a-zA-Z._-]+)?\]?`)
 
@@ -276,7 +269,7 @@ func buildSEMPv2Message(err *sempv2.SEMPError) string {
 // isRetryable returns true for errors that represent transient conditions where
 // the same request might succeed later: exhausted internal retries (the
 // resilience layer only exhausts on genuinely transient HTTP statuses, e.g.
-// 429/503), a live HTTP 503, or a transient comRc_t code (229 TIME_OUT).
+// 429/503), a live HTTP 429 or 503, or a transient comRc_t code (229 TIME_OUT).
 // All other SEMP/envelope errors are deterministic and non-retryable.
 func isRetryable(err error) bool {
 	var retriesErr *resilience.RetriesExhaustedError
@@ -285,11 +278,11 @@ func isRetryable(err error) bool {
 	}
 	var sempv2Err *sempv2.SEMPError
 	if errors.As(err, &sempv2Err) {
-		return sempv2Err.StatusCode == 503 || translatedErrorCodes[sempv2Err.SEMPCode].retryable
+		return sempv2Err.StatusCode == 429 || sempv2Err.StatusCode == 503 || translatedErrorCodes[sempv2Err.SEMPCode].retryable
 	}
 	var sempv1Err *sempv1.Error
 	if errors.As(err, &sempv1Err) {
-		return sempv1Err.StatusCode == 503 || translatedErrorCodes[sempv1Err.ReasonCode].retryable
+		return sempv1Err.StatusCode == 429 || sempv1Err.StatusCode == 503 || translatedErrorCodes[sempv1Err.ReasonCode].retryable
 	}
 	return false
 }

--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -35,34 +35,35 @@ const serviceUnavailableMessage = "The broker is temporarily unavailable. Please
 
 // codeInfo struct is used to store a single row of the translatedErrorCodes table
 type codeInfo struct {
-	summary string // short label used when the broker gives no description
-	hint    string // generic actionable hint surfaced to the agent
+	hint string // generic actionable hint surfaced to the agent
 	// retryable marks transient codes where the same request might succeed on
 	// retry (HTTP 503 and exhausted internal retries are handled separately).
 	retryable bool
 }
 
-// translatedErrorCodes maps the comRc_t integer to a short summary and a generic hint.
+// translatedErrorCodes maps the comRc_t integer to a generic actionable hint.
 // Note that the comRc_t code corresponds to the SEMPv2 error.code / SEMPv1 reasonCode.
 var translatedErrorCodes = map[int]codeInfo{
-	6:   {summary: "Object not found", hint: "Verify the name is correct."},
-	10:  {summary: "Object already exists", hint: "Update the existing object or choose a new name."},
-	11:  {summary: "Invalid parameter", hint: "Check attribute values against the SEMP schema."},
-	14:  {summary: "Operation not supported", hint: "Not supported for this object or broker mode."},
-	27:  {summary: "Request parse error", hint: "Check the request/query syntax."},
-	72:  {summary: "Unauthorized", hint: "Credentials lack permission; check the management role/VPN scope."},
-	89:  {summary: "Operation not allowed", hint: "Not allowed in the object's current state."},
-	135: {summary: "Maximum exceeded", hint: "A configured maximum was reached."},
-	228: {summary: "Missing required parameter", hint: "Supply all required fields for this object."},
-	229: {summary: "Operation timed out", hint: "Retry shortly.", retryable: true},
-	256: {summary: "Object not empty", hint: "Drain or remove contained objects before deleting."},
+	6:   {hint: "Verify the name is correct."},
+	10:  {hint: "Update the existing object or choose a new name."},
+	11:  {hint: "Check attribute values against the SEMP schema."},
+	14:  {hint: "Not supported for this object or broker mode."},
+	27:  {hint: "Check the request/query syntax."},
+	72:  {hint: "Credentials lack permission; check the management role/VPN scope."},
+	89:  {hint: "Not allowed in the object's current state."},
+	135: {hint: "A configured maximum was reached."},
+	228: {hint: "Supply all required fields for this object."},
+	229: {hint: "Retry shortly.", retryable: true},
+	256: {hint: "Drain or remove contained objects before deleting."},
 }
 
 // fsPrefixPattern matches filesystem paths by their leading prefix only, so
 // SEMP object paths (e.g. /msgVpns/foo/queues/bar) — which have none of these
 // prefixes — are preserved. This is the load-bearing constraint of the
-// sanitizer.
-var fsPrefixPattern = regexp.MustCompile(`(?i)(/opt/|/var/|/usr/|/etc/|[A-Za-z]:\\)\S*`)
+// sanitizer: every prefix here must be a real OS root that can never collide
+// with a SEMP object collection name. The set covers the common Unix roots that
+// could leak host layout (including /home, /tmp, /root) plus a Windows drive.
+var fsPrefixPattern = regexp.MustCompile(`(?i)(/opt/|/var/|/usr/|/etc/|/home/|/root/|/tmp/|/mnt/|/srv/|[A-Za-z]:\\)\S*`)
 
 // ipv4Pattern matches dotted-quad IPv4 addresses. Known trade-off: a broker
 // version with four dot-separated numbers (e.g. "10.2.1.5") has the same shape
@@ -71,10 +72,30 @@ var fsPrefixPattern = regexp.MustCompile(`(?i)(/opt/|/var/|/usr/|/etc/|[A-Za-z]:
 // log), so we accept the lost debugging signal rather than complicate the regex.
 var ipv4Pattern = regexp.MustCompile(`\b\d{1,3}(\.\d{1,3}){3}\b`)
 
-// ipv6Pattern matches the broker's bracket-wrapped IPv6 form (e.g. "[2001:db8::1]").
-// The broker brackets IPv6 and leaves IPv4 bare, so only the bracketed shape is
-// needed here. The required ':' avoids matching plain bracketed hex tokens.
-var ipv6Pattern = regexp.MustCompile(`\[[0-9a-fA-F:]*:[0-9a-fA-F:]*\]`)
+// ipv6Pattern matches IPv6 addresses in both the broker's observed
+// bracket-wrapped form ("[2001:db8::1]") and bare forms ("2001:db8::1",).
+// The optional brackets ([...]) are consumed as part of the match so the
+// wrapped form is replaced as a whole.
+//
+// The broker is observed to bracket IPv6 peer addresses, but relying on that for
+// a security sanitizer is fragile, so bare forms are matched defensively too.
+// Every branch requires either "::" or a full eight-group form, which keeps it
+// from matching clock times (12:34:56) or MAC addresses (no "::", < 8 groups).
+// As with ipv4Pattern, over-redaction is acceptable: the raw text still survives
+// in the server log.
+//
+// Go's regexp prefers the first matching branch, not the longest, so the
+// IPv4-tailed branch goes first to match v4-mapped addresses whole.
+var ipv6Pattern = regexp.MustCompile(`(?i)\[?(?:` +
+	// IPv6 with an embedded IPv4 tail (v4-mapped/translated), e.g. ::ffff:1.2.3.4
+	`(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?::(?:[0-9a-f]{1,4}:)*(?:\d{1,3}\.){3}\d{1,3}` +
+	`|` +
+	// Compressed IPv6 (contains "::"), e.g. 2001:db8::1, ::1, fe80::
+	`(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?` +
+	`|` +
+	// Full eight-group IPv6, e.g. 2001:db8:0:0:0:0:2:1
+	`(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}` +
+	`)(?:%[0-9a-zA-Z._-]+)?\]?`)
 
 // buildErrorResult converts a tool execution error into an MCP-compliant
 // CallToolResult with IsError: true. Per the MCP spec, tool execution errors
@@ -254,9 +275,9 @@ func buildSEMPv2Message(err *sempv2.SEMPError) string {
 
 // isRetryable returns true for errors that represent transient conditions where
 // the same request might succeed later: exhausted internal retries (the
-// resilience layer only exhausts on genuinely transient statuses), an HTTP 503
-// or a transient comRc_t code (229 TIME_OUT) from the broker. All other SEMP/envelope
-// errors are deterministic and non-retryable.
+// resilience layer only exhausts on genuinely transient HTTP statuses, e.g.
+// 429/503), a live HTTP 503, or a transient comRc_t code (229 TIME_OUT).
+// All other SEMP/envelope errors are deterministic and non-retryable.
 func isRetryable(err error) bool {
 	var retriesErr *resilience.RetriesExhaustedError
 	if errors.As(err, &retriesErr) {

--- a/internal/tools/errors_test.go
+++ b/internal/tools/errors_test.go
@@ -37,9 +37,12 @@ func TestSanitizeBrokerText(t *testing.T) {
 		{"ipv6 full form replaced", "from 2001:db8:0:0:0:0:2:1 closed", "from [ip] closed"},
 		{"ipv6 with zone replaced", "bind fe80::1%eth0 failed", "bind [ip] failed"},
 		{"ipv6 v4-mapped replaced", "mapped ::ffff:1.2.3.4 seen", "mapped [ip] seen"},
-		// Must NOT trip on colon-hex that isn't an address: no "::", not eight groups.
+		// Must NOT trip on colon-hex that isn't an address: no "::", not eight groups,
+		// or a "::" separator with a non-hextet side (e.g. C++ scope resolution).
 		{"clock time preserved", "last seen at 12:34:56 UTC", "last seen at 12:34:56 UTC"},
 		{"mac address preserved", "device 12:34:56:78:9a:bc joined", "device 12:34:56:78:9a:bc joined"},
+		{"double-colon separator preserved", "namespace foo::bar referenced", "namespace foo::bar referenced"},
+		{"cpp scope resolution preserved", "use std::string here", "use std::string here"},
 		// A bracketed token with no colon is not an address and must be left alone.
 		{"bracketed non-address preserved", "queue [deadbeef] is full", "queue [deadbeef] is full"},
 		{"fs path replaced", "Error reading /opt/solace/config.json", "Error reading [path]"},
@@ -78,7 +81,8 @@ func TestIsRetryable(t *testing.T) {
 		{"retries exhausted, non-transient status still true", &resilience.RetriesExhaustedError{StatusCode: 500, Attempts: 3}, true},
 		{"wrapped retries exhausted (errors.As traversal)", fmt.Errorf("executing tool %q: %w", "list-queues", &resilience.RetriesExhaustedError{StatusCode: 503, Attempts: 3}), true},
 
-		// SEMPv2: retryable on 503 or a retryable comRc_t code (229).
+		// SEMPv2: retryable on 429/503 or a retryable comRc_t code (229).
+		{"sempv2 429 (live, e.g. fronting proxy)", &sempv2.SEMPError{StatusCode: 429}, true},
 		{"sempv2 503", &sempv2.SEMPError{StatusCode: 503}, true},
 		{"sempv2 503 with non-retryable code (status wins)", &sempv2.SEMPError{StatusCode: 503, SEMPCode: 6}, true},
 		{"sempv2 retryable code 229, non-503 status", &sempv2.SEMPError{StatusCode: 400, SEMPCode: 229}, true},
@@ -86,7 +90,8 @@ func TestIsRetryable(t *testing.T) {
 		{"sempv2 code not in table", &sempv2.SEMPError{StatusCode: 400, SEMPCode: 999}, false},
 		{"sempv2 zero code (lookup miss safe)", &sempv2.SEMPError{StatusCode: 400, SEMPCode: 0}, false},
 
-		// SEMPv1: retryable on 503 or a retryable reasonCode (229).
+		// SEMPv1: retryable on 429/503 or a retryable reasonCode (229).
+		{"sempv1 429 (HTTP kind)", &sempv1.Error{Kind: sempv1.ErrorKindHTTP, StatusCode: 429}, true},
 		{"sempv1 503 (HTTP kind)", &sempv1.Error{Kind: sempv1.ErrorKindHTTP, StatusCode: 503}, true},
 		{"sempv1 retryable reasonCode 229 (status 200 execute-fail)", &sempv1.Error{Kind: sempv1.ErrorKindExecuteFail, StatusCode: 200, ReasonCode: 229}, true},
 		{"sempv1 500", &sempv1.Error{Kind: sempv1.ErrorKindHTTP, StatusCode: 500}, false},

--- a/internal/tools/errors_test.go
+++ b/internal/tools/errors_test.go
@@ -33,12 +33,20 @@ func TestSanitizeBrokerText(t *testing.T) {
 	}{
 		{"plain text unchanged", "Queue 'myQueue' not found", "Queue 'myQueue' not found"},
 		{"ipv4 replaced", "Connected to 192.168.1.100 on port 8080", "Connected to [ip] on port 8080"},
-		// The broker formats IPv6 peer addresses bracket-wrapped.
-		{"ipv6 replaced", "SSL rejected from [2001:db8::1] port 55443", "SSL rejected from [ip] port 55443"},
-		{"ipv6 loopback replaced", "connect to [::1] failed", "connect to [ip] failed"},
+		{"ipv6 bracketed replaced", "SSL rejected from [2001:db8::1] port 55443", "SSL rejected from [ip] port 55443"},
+		{"ipv6 full form replaced", "from 2001:db8:0:0:0:0:2:1 closed", "from [ip] closed"},
+		{"ipv6 with zone replaced", "bind fe80::1%eth0 failed", "bind [ip] failed"},
+		{"ipv6 v4-mapped replaced", "mapped ::ffff:1.2.3.4 seen", "mapped [ip] seen"},
+		// Must NOT trip on colon-hex that isn't an address: no "::", not eight groups.
+		{"clock time preserved", "last seen at 12:34:56 UTC", "last seen at 12:34:56 UTC"},
+		{"mac address preserved", "device 12:34:56:78:9a:bc joined", "device 12:34:56:78:9a:bc joined"},
 		// A bracketed token with no colon is not an address and must be left alone.
 		{"bracketed non-address preserved", "queue [deadbeef] is full", "queue [deadbeef] is full"},
 		{"fs path replaced", "Error reading /opt/solace/config.json", "Error reading [path]"},
+		// Broadened FS prefixes: /home, /tmp, /root must redact too.
+		{"home path replaced", "dump written to /home/solace/core.123", "dump written to [path]"},
+		{"tmp path replaced", "spool at /tmp/sol/spool.db locked", "spool at [path] locked"},
+		{"root path replaced", "key at /root/.ssh/id_rsa missing", "key at [path] missing"},
 		// SEMP object paths (no FS prefix) must not be redacted.
 		{"semp path preserved", "Object /msgVpns/default/queues/myQueue not found", "Object /msgVpns/default/queues/myQueue not found"},
 		// The regex intentionally swallows the adjacent ':' — over-redaction is safe; the


### PR DESCRIPTION
## Summary

Addressing remaining review comments for https://github.com/SolaceDev/solace-broker-mcp/pull/85:  completes the agent-facing error contract docs, removes dead code, and closes two defense-in-depth gaps in the output sanitizer.
