### PR TITLE
SOL-150660: Cap inbound /mcp request body at 4 MiB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.dylib
 bin/
 mcp-server
-server
+/server
 
 # Test binary
 *.test

--- a/cmd/server/body_limit_test.go
+++ b/cmd/server/body_limit_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+)
+
+// readAllHandler mimics the MCP SDK's StreamableHTTPHandler, which buffers
+// the entire request body with io.ReadAll before processing. It records the
+// read outcome so tests can assert what the SDK would observe.
+type readAllHandler struct {
+	readErr error
+	read    int
+}
+
+func (h *readAllHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	h.read = len(body)
+	h.readErr = err
+	if err != nil {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestLimitRequestBody_UnderLimitPassesThrough(t *testing.T) {
+	inner := &readAllHandler{}
+	handler := limitRequestBody(inner)
+
+	body := bytes.Repeat([]byte("a"), 1024) // typical KB-scale MCP payload
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/mcp", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if inner.readErr != nil {
+		t.Fatalf("downstream read failed for under-limit body: %v", inner.readErr)
+	}
+	if inner.read != len(body) {
+		t.Errorf("downstream read %d bytes, want %d", inner.read, len(body))
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestLimitRequestBody_OversizedBodyFailsDownstreamRead(t *testing.T) {
+	inner := &readAllHandler{}
+	handler := limitRequestBody(inner)
+
+	body := bytes.Repeat([]byte("a"), defaults.MaxMCPRequestBytes+1)
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/mcp", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	var maxBytesErr *http.MaxBytesError
+	if !errors.As(inner.readErr, &maxBytesErr) {
+		t.Fatalf("downstream read error = %v, want *http.MaxBytesError", inner.readErr)
+	}
+	if maxBytesErr.Limit != defaults.MaxMCPRequestBytes {
+		t.Errorf("MaxBytesError.Limit = %d, want %d", maxBytesErr.Limit, defaults.MaxMCPRequestBytes)
+	}
+	// The oversized body must never be fully buffered downstream.
+	if inner.read > defaults.MaxMCPRequestBytes {
+		t.Errorf("downstream buffered %d bytes, want <= %d", inner.read, defaults.MaxMCPRequestBytes)
+	}
+}

--- a/cmd/server/body_limit_test.go
+++ b/cmd/server/body_limit_test.go
@@ -21,37 +21,70 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
-	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// testBodyLimit keeps oversized test bodies small; the middleware behavior
+// is independent of the cap value (production wires
+// defaults.MaxMCPRequestBytes in main).
+const testBodyLimit = 1024
 
 // readAllHandler mimics the MCP SDK's StreamableHTTPHandler, which buffers
 // the entire request body with io.ReadAll before processing. It records the
-// read outcome so tests can assert what the SDK would observe.
+// read outcome so tests can assert what the SDK would observe. Client-visible
+// status and body are asserted against the real SDK handler in the
+// TestLimitRequestBody_RealSDK tests below, not against this mimic.
 type readAllHandler struct {
+	invoked bool
 	readErr error
 	read    int
 }
 
 func (h *readAllHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.invoked = true
 	body, err := io.ReadAll(r.Body)
 	h.read = len(body)
 	h.readErr = err
 	if err != nil {
-		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
 }
 
+// newRealSDKHandler builds a genuine StreamableHTTPHandler (no tools needed)
+// wrapped by limitRequestBody, so tests observe the exact status and body a
+// real MCP client gets when the cap trips inside the SDK's io.ReadAll.
+func newRealSDKHandler() http.Handler {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "body-limit-test",
+		Version: "0.0.1",
+	}, nil)
+	sdkHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return server
+	}, nil)
+	return limitRequestBody(sdkHandler, testBodyLimit)
+}
+
+// newMCPRequest builds a POST /mcp request with the Accept and Content-Type
+// headers the SDK validates before reading the body.
+func newMCPRequest(body io.Reader) *http.Request {
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/mcp", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	return req
+}
+
 func TestLimitRequestBody_UnderLimitPassesThrough(t *testing.T) {
 	inner := &readAllHandler{}
-	handler := limitRequestBody(inner)
+	handler := limitRequestBody(inner, testBodyLimit)
 
-	body := bytes.Repeat([]byte("a"), 1024) // typical KB-scale MCP payload
-	req := httptest.NewRequestWithContext(context.Background(),
-		http.MethodPost, "/mcp", bytes.NewReader(body))
+	body := bytes.Repeat([]byte("a"), testBodyLimit/2)
+	req := newMCPRequest(bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -69,11 +102,12 @@ func TestLimitRequestBody_UnderLimitPassesThrough(t *testing.T) {
 
 func TestLimitRequestBody_OversizedBodyFailsDownstreamRead(t *testing.T) {
 	inner := &readAllHandler{}
-	handler := limitRequestBody(inner)
+	handler := limitRequestBody(inner, testBodyLimit)
 
-	body := bytes.Repeat([]byte("a"), defaults.MaxMCPRequestBytes+1)
-	req := httptest.NewRequestWithContext(context.Background(),
-		http.MethodPost, "/mcp", bytes.NewReader(body))
+	// Wrap the reader so httptest does not set Content-Length; the request
+	// must reach the downstream read for MaxBytesReader to trip.
+	body := bytes.Repeat([]byte("a"), testBodyLimit+1)
+	req := newMCPRequest(struct{ io.Reader }{bytes.NewReader(body)})
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -82,11 +116,91 @@ func TestLimitRequestBody_OversizedBodyFailsDownstreamRead(t *testing.T) {
 	if !errors.As(inner.readErr, &maxBytesErr) {
 		t.Fatalf("downstream read error = %v, want *http.MaxBytesError", inner.readErr)
 	}
-	if maxBytesErr.Limit != defaults.MaxMCPRequestBytes {
-		t.Errorf("MaxBytesError.Limit = %d, want %d", maxBytesErr.Limit, defaults.MaxMCPRequestBytes)
+	if maxBytesErr.Limit != testBodyLimit {
+		t.Errorf("MaxBytesError.Limit = %d, want %d", maxBytesErr.Limit, testBodyLimit)
 	}
 	// The oversized body must never be fully buffered downstream.
-	if inner.read > defaults.MaxMCPRequestBytes {
-		t.Errorf("downstream buffered %d bytes, want <= %d", inner.read, defaults.MaxMCPRequestBytes)
+	if inner.read > testBodyLimit {
+		t.Errorf("downstream buffered %d bytes, want <= %d", inner.read, testBodyLimit)
+	}
+}
+
+func TestLimitRequestBody_DeclaredOversizeRejectedBeforeHandler(t *testing.T) {
+	inner := &readAllHandler{}
+	handler := limitRequestBody(inner, testBodyLimit)
+
+	// bytes.Reader gives httptest a known size, so Content-Length declares
+	// the overage and the middleware rejects without invoking the handler.
+	body := bytes.Repeat([]byte("a"), testBodyLimit+1)
+	req := newMCPRequest(bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+	if inner.invoked {
+		t.Error("downstream handler was invoked for a declared-oversize request")
+	}
+}
+
+// TestLimitRequestBody_RealSDK_UnderLimit proves the middleware does not
+// interfere with a normal MCP exchange through the real SDK handler.
+func TestLimitRequestBody_RealSDK_UnderLimit(t *testing.T) {
+	handler := newRealSDKHandler()
+
+	initialize := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{` +
+		`"protocolVersion":"2025-06-18","capabilities":{},` +
+		`"clientInfo":{"name":"body-limit-test","version":"0.0.1"}}}`
+	req := newMCPRequest(strings.NewReader(initialize))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+// TestLimitRequestBody_RealSDK_StreamedOversize pins the client-observable
+// contract when MaxBytesReader trips inside the SDK's io.ReadAll: the SDK
+// turns the read failure into 400 "failed to read body" (streamable.go,
+// go-sdk v1.5.0). If an SDK upgrade changes how it buffers or reports the
+// body, this test surfaces it so the mitigation can be re-verified.
+func TestLimitRequestBody_RealSDK_StreamedOversize(t *testing.T) {
+	handler := newRealSDKHandler()
+
+	body := bytes.Repeat([]byte("a"), testBodyLimit+1)
+	req := newMCPRequest(struct{ io.Reader }{bytes.NewReader(body)})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := rec.Body.String(); !strings.Contains(got, "failed to read body") {
+		t.Errorf("body = %q, want it to contain %q", got, "failed to read body")
+	}
+}
+
+// TestLimitRequestBody_RealSDK_DeclaredOversize proves a client that declares
+// its oversized Content-Length gets a 413 from the middleware; the SDK never
+// produces that status, so observing it confirms the short-circuit.
+func TestLimitRequestBody_RealSDK_DeclaredOversize(t *testing.T) {
+	handler := newRealSDKHandler()
+
+	body := bytes.Repeat([]byte("a"), testBodyLimit+1)
+	req := newMCPRequest(bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+	}
+	if got := rec.Body.String(); !strings.Contains(got, "request body too large") {
+		t.Errorf("body = %q, want it to contain %q", got, "request body too large")
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -216,13 +216,20 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 	}
 }
 
-// limitRequestBody bounds the inbound request body at
-// defaults.MaxMCPRequestBytes before the MCP SDK buffers it with io.ReadAll.
-// http.MaxBytesReader fails the downstream read once the limit is exceeded
-// and closes the connection, so an oversized body is never fully buffered.
-func limitRequestBody(next http.Handler) http.Handler {
+// limitRequestBody bounds the inbound request body at maxBytes before the
+// MCP SDK buffers it with io.ReadAll. A request that declares an oversized
+// Content-Length is rejected with 413 before the SDK runs. Bodies without a
+// declared length (or that lie) are caught by http.MaxBytesReader, which
+// fails the downstream read once the limit is exceeded and closes the
+// connection, so an oversized body is never fully buffered; the SDK surfaces
+// that read failure to the client as 400 "failed to read body".
+func limitRequestBody(next http.Handler, maxBytes int64) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Body = http.MaxBytesReader(w, r.Body, defaults.MaxMCPRequestBytes)
+		if r.ContentLength > maxBytes {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
 		next.ServeHTTP(w, r)
 	})
 }
@@ -451,7 +458,7 @@ func main() {
 
 	// Register authenticated MCP endpoint. The body limit wraps the outside
 	// so it bounds the request before any layer can buffer it.
-	mux.Handle("/mcp", limitRequestBody(authedHandler))
+	mux.Handle("/mcp", limitRequestBody(authedHandler, defaults.MaxMCPRequestBytes))
 
 	// Register OAuth Protected Resource Metadata endpoint (RFC 9728)
 	// This enables MCP clients to discover the authorization server for OAuth flows.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -216,6 +216,17 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 	}
 }
 
+// limitRequestBody bounds the inbound request body at
+// defaults.MaxMCPRequestBytes before the MCP SDK buffers it with io.ReadAll.
+// http.MaxBytesReader fails the downstream read once the limit is exceeded
+// and closes the connection, so an oversized body is never fully buffered.
+func limitRequestBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, defaults.MaxMCPRequestBytes)
+		next.ServeHTTP(w, r)
+	})
+}
+
 // startServer starts httpServer in a background goroutine and returns a channel
 // that receives any startup/runtime error (excluding http.ErrServerClosed, which
 // is the normal result of Shutdown). The channel is buffered so the goroutine
@@ -438,8 +449,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Register authenticated MCP endpoint
-	mux.Handle("/mcp", authedHandler)
+	// Register authenticated MCP endpoint. The body limit wraps the outside
+	// so it bounds the request before any layer can buffer it.
+	mux.Handle("/mcp", limitRequestBody(authedHandler))
 
 	// Register OAuth Protected Resource Metadata endpoint (RFC 9728)
 	// This enables MCP clients to discover the authorization server for OAuth flows.

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -72,8 +72,9 @@ const MaxSEMPResponseBytes = 16 * 1024 * 1024
 // Reasoning: MCP tool-call payloads are JSON-RPC messages, typically a few
 // KB. 4 MiB is ~1000x headroom above any realistic tool call while bounding
 // the worst-case per-request allocation.
-// Trade-off: a legitimately larger request fails with a read error surfaced
-// by the SDK as a request-level failure. No known MCP client produces one.
+// Trade-off: a legitimately larger request is rejected — 413 when its
+// Content-Length declares the overage, otherwise a read error the SDK
+// surfaces as 400. No known MCP client produces one.
 const MaxMCPRequestBytes = 4 * 1024 * 1024
 
 // DefaultMaxConcurrentPerBroker is the maximum number of concurrent SEMP

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -62,6 +62,20 @@ const DefaultOIDCHTTPTimeout = 10 * time.Second
 // SEMP pagination contract makes this implausible in practice.
 const MaxSEMPResponseBytes = 16 * 1024 * 1024
 
+// MaxMCPRequestBytes caps the size of an inbound /mcp request body. The MCP
+// SDK's StreamableHTTPHandler buffers the entire POST body in memory with
+// io.ReadAll; without a cap, a client can stream a multi-GB body within the
+// ReadTimeout window and OOM the server. This is the inbound counterpart of
+// MaxSEMPResponseBytes.
+//
+// Decided: 4 MiB.
+// Reasoning: MCP tool-call payloads are JSON-RPC messages, typically a few
+// KB. 4 MiB is ~1000x headroom above any realistic tool call while bounding
+// the worst-case per-request allocation.
+// Trade-off: a legitimately larger request fails with a read error surfaced
+// by the SDK as a request-level failure. No known MCP client produces one.
+const MaxMCPRequestBytes = 4 * 1024 * 1024
+
 // DefaultMaxConcurrentPerBroker is the maximum number of concurrent SEMP
 // requests allowed per broker, enforced via a per-broker semaphore.
 //


### PR DESCRIPTION
## Summary

Closes a memory-exhaustion vector on the `/mcp` endpoint ([SOL-150660](https://sol-jira.atlassian.net/browse/SOL-150660)).

The MCP go-sdk's `StreamableHTTPHandler` buffers the entire POST body in memory with `io.ReadAll` (streamable.go:427, :1098). The server never bounded the inbound body — `ReadTimeout` (30s) bounds duration, not bytes — so a client could stream a multi-GB JSON-RPC POST and OOM the server. The outbound direction was already hardened (`MaxSEMPResponseBytes` = 16 MiB); this adds the inbound counterpart.

## Changes

- `limitRequestBody(next, maxBytes)` middleware wraps the authed `/mcp` handler; production wires `defaults.MaxMCPRequestBytes` (4 MiB — MCP tool calls are KB-scale, so ~1000x headroom).
- A request that declares an oversized `Content-Length` is rejected with 413 before the SDK runs. Bodies without a declared length (or that lie) are bounded by `http.MaxBytesReader`; the SDK surfaces the failed read to the client as 400 "failed to read body".
- Root-anchors the `server` .gitignore pattern, which was matching the `cmd/server/` source directory instead of just the built binary (blocked adding the test file).

## Testing

- Mimic-handler tests prove the security property: oversized body fails the downstream read with `*http.MaxBytesError` and is never fully buffered; under-limit body passes through intact; declared-oversize never reaches the handler.
- Real-SDK tests (review feedback from @amitmorade) run an actual `StreamableHTTPHandler` behind the middleware at a 1 KiB cap and pin the client-observable contract: 200 for a normal initialize, 400 "failed to read body" for streamed oversize, 413 for declared oversize. An SDK upgrade that changes body buffering fails these tests loudly.
- Full `go test ./...` green; `/check-logs` clean (no log calls added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-150660]: https://sol-jira.atlassian.net/browse/SOL-150660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ