### PR TITLE
SOL-150661: Close response body when SEMP retries are exhausted

### DIFF
--- a/internal/semp/resilience/body_close_test.go
+++ b/internal/semp/resilience/body_close_test.go
@@ -86,9 +86,9 @@ func newExhaustedResponse(t *testing.T, body *trackingBody) *http.Response {
 func TestSender_ErrorHandler_ClosesBody_OnHTTPExhaustion(t *testing.T) {
 	sender := newErrorHandlerTestSender(t)
 	body := &trackingBody{reader: strings.NewReader("rate limited")}
-	resp := newExhaustedResponse(t, body)
+	resp := newExhaustedResponse(t, body) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
 
-	_, err := sender.errorHandler(resp, nil, 3)
+	_, err := sender.errorHandler(resp, nil, 3) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
 	if err == nil {
 		t.Fatal("expected RetriesExhaustedError")
 	}
@@ -105,9 +105,9 @@ func TestSender_ErrorHandler_ClosesBody_OnErrorWithResponse(t *testing.T) {
 	// response (and its body) is still open.
 	sender := newErrorHandlerTestSender(t)
 	body := &trackingBody{reader: strings.NewReader("broker down")}
-	resp := newExhaustedResponse(t, body)
+	resp := newExhaustedResponse(t, body) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
 
-	_, err := sender.errorHandler(resp, context.Canceled, 1)
+	_, err := sender.errorHandler(resp, context.Canceled, 1) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/semp/resilience/body_close_test.go
+++ b/internal/semp/resilience/body_close_test.go
@@ -89,8 +89,15 @@ func TestSender_ErrorHandler_ClosesBody_OnHTTPExhaustion(t *testing.T) {
 	resp := newExhaustedResponse(t, body) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
 
 	_, err := sender.errorHandler(resp, nil, 3) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
-	if err == nil {
-		t.Fatal("expected RetriesExhaustedError")
+	var exhausted *RetriesExhaustedError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("expected *RetriesExhaustedError, got %T: %v", err, err)
+	}
+	if exhausted.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want %d", exhausted.StatusCode, http.StatusTooManyRequests)
+	}
+	if exhausted.Attempts != 3 {
+		t.Errorf("Attempts = %d, want 3", exhausted.Attempts)
 	}
 	if !body.closed {
 		t.Error("response body not closed — connection leaked until client timeout")
@@ -108,10 +115,17 @@ func TestSender_ErrorHandler_ClosesBody_OnErrorWithResponse(t *testing.T) {
 	resp := newExhaustedResponse(t, body) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
 
 	_, err := sender.errorHandler(resp, context.Canceled, 1) //nolint:bodyclose // errorHandler closes the body; this test asserts exactly that
-	if err == nil {
-		t.Fatal("expected error")
+	var exhausted *RetriesExhaustedError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("expected *RetriesExhaustedError, got %T: %v", err, err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error does not wrap context.Canceled: %v", err)
 	}
 	if !body.closed {
 		t.Error("response body not closed on error branch")
+	}
+	if !body.drained {
+		t.Error("response body not drained on error branch — connection cannot be reused")
 	}
 }

--- a/internal/semp/resilience/body_close_test.go
+++ b/internal/semp/resilience/body_close_test.go
@@ -1,0 +1,117 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resilience
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+)
+
+// trackingBody records whether the response body was fully read (drained)
+// and closed. Both must happen for the underlying connection to be returned
+// to the transport's idle pool instead of being torn down.
+type trackingBody struct {
+	reader  io.Reader
+	drained bool
+	closed  bool
+}
+
+func (b *trackingBody) Read(p []byte) (int, error) {
+	n, err := b.reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		b.drained = true
+	}
+	return n, err
+}
+
+func (b *trackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func newErrorHandlerTestSender(t *testing.T) *Sender {
+	t.Helper()
+	retries := 2
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		Retries:            &retries,
+		RequestMinInterval: &minInterval,
+		RetryMinInterval:   1 * time.Millisecond,
+		RetryMaxInterval:   10 * time.Millisecond,
+	}
+	authCfg := config.AuthConfig{Mode: "basic", Username: "admin", Password: "secret"}
+	jar := mustNewSafeCookieJar(t)
+	return New(&http.Client{Jar: jar}, jar, sempCfg, authCfg, "http://broker.example:8080")
+}
+
+func newExhaustedResponse(t *testing.T, body *trackingBody) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, "http://broker.example:8080/SEMP/v2/monitor/about", nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Request:    req,
+		Body:       body,
+	}
+}
+
+// retryablehttp does NOT drain or close the final response body when a custom
+// ErrorHandler is set (go-retryablehttp client.go:395-399: the handler owns
+// the body). These tests pin the errorHandler side of that contract; without
+// the drain+close the connection's persistConn is leaked until the client
+// timeout fires.
+
+func TestSender_ErrorHandler_ClosesBody_OnHTTPExhaustion(t *testing.T) {
+	sender := newErrorHandlerTestSender(t)
+	body := &trackingBody{reader: strings.NewReader("rate limited")}
+	resp := newExhaustedResponse(t, body)
+
+	_, err := sender.errorHandler(resp, nil, 3)
+	if err == nil {
+		t.Fatal("expected RetriesExhaustedError")
+	}
+	if !body.closed {
+		t.Error("response body not closed — connection leaked until client timeout")
+	}
+	if !body.drained {
+		t.Error("response body not drained — connection cannot be reused")
+	}
+}
+
+func TestSender_ErrorHandler_ClosesBody_OnErrorWithResponse(t *testing.T) {
+	// The checkRetry ctx-cancellation path returns a non-nil error while the
+	// response (and its body) is still open.
+	sender := newErrorHandlerTestSender(t)
+	body := &trackingBody{reader: strings.NewReader("broker down")}
+	resp := newExhaustedResponse(t, body)
+
+	_, err := sender.errorHandler(resp, context.Canceled, 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !body.closed {
+		t.Error("response body not closed on error branch")
+	}
+}

--- a/internal/semp/resilience/sender.go
+++ b/internal/semp/resilience/sender.go
@@ -3,6 +3,7 @@ package resilience
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -135,11 +136,26 @@ func (d *Sender) Close() {
 	}
 }
 
+// errorHandlerDrainLimit bounds how much of the final response body the
+// errorHandler reads before closing it. Matches retryablehttp's own
+// respReadLimit for the between-attempts drain. A fully drained body lets
+// the transport return the connection to the idle pool; past the limit,
+// closing (and tearing down the connection) is cheaper than the read.
+const errorHandlerDrainLimit = 4096
+
 // errorHandler is called by retryablehttp when retries are exhausted (RetryMax
-// reached while CheckRetry kept returning true). At this point the response
-// body has been drained/closed by retryablehttp's retry loop, so we construct
-// a RetriesExhaustedError from the status code and attempt count.
+// reached while CheckRetry kept returning true). retryablehttp drains the
+// response body only between attempts — on the final attempt it returns
+// through the custom ErrorHandler without touching the body, and the handler
+// owns closing it (go-retryablehttp client.go ErrorHandler contract). Drain
+// and close here, then construct a RetriesExhaustedError from the status code
+// and attempt count.
 func (d *Sender) errorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	if resp != nil && resp.Body != nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, errorHandlerDrainLimit))
+		_ = resp.Body.Close()
+	}
+
 	if err != nil {
 		return nil, &RetriesExhaustedError{Attempts: numTries, Err: err}
 	}


### PR DESCRIPTION
## Summary

Fixes a connection leak on the retries-exhausted path ([SOL-150661](https://sol-jira.atlassian.net/browse/SOL-150661)).

`Sender.errorHandler`'s comment claimed retryablehttp's retry loop had already drained/closed the final response body. That's only true when no custom `ErrorHandler` is set: go-retryablehttp v0.7.8 drains between attempts, but on the final attempt it returns through the custom handler (client.go:824-825), which must close the body per the documented contract (client.go:395-399). Ours never did, and the protocol clients only close the body on the nil-error path.

**Effect:** every GET that exhausts retries on sustained 429/503 leaked an open `http.Response.Body` — socket and transport goroutines held until the 60s client timeout, destroying keep-alive reuse precisely when the broker is already overloaded.

## Changes

- Drain (bounded at 4 KiB, matching retryablehttp's own `respReadLimit`) and close `resp.Body` in both `errorHandler` branches.
- Replace the factually wrong comment with the actual ErrorHandler contract.

## Testing

- New tests pin both branches (HTTP exhaustion and error-with-response) with a close/drain-tracking body; failed before the fix.
- Full `go test ./...` green, `-race` clean on the resilience package; `/check-logs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150661]: https://sol-jira.atlassian.net/browse/SOL-150661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ