### PR TITLE
SOL-150662: Contain tool handler panics to the failing call

### DIFF
--- a/internal/tools/recover.go
+++ b/internal/tools/recover.go
@@ -1,0 +1,49 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// withPanicRecovery wraps an MCP tool handler so a panic in any tool
+// implementation is contained to that call instead of killing the process.
+// The MCP SDK dispatches each request on a bare goroutine with no recover,
+// so without this wrapper a single latent panic in one tool takes down every
+// active session and all broker monitoring.
+//
+// The panic value and stack stay server-side in the log; the agent-facing
+// error is generic so internal details (which may embed request state) never
+// reach the client.
+func withPanicRecovery(toolName string, next mcp.ToolHandler) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("tool handler panicked",
+					slog.String("tool", toolName),
+					slog.String("panic", fmt.Sprintf("%v", r)),
+					slog.String("stack", string(debug.Stack())))
+				result = nil
+				err = fmt.Errorf("internal error in tool %q", toolName)
+			}
+		}()
+		return next(ctx, req)
+	}
+}

--- a/internal/tools/recover_test.go
+++ b/internal/tools/recover_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestWithPanicRecovery_PanicBecomesError(t *testing.T) {
+	handler := withPanicRecovery("get-broker-health", func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var m map[string]int
+		m["boom"] = 1 // nil map write — representative latent handler bug
+		return nil, nil
+	})
+
+	result, err := handler(context.Background(), &mcp.CallToolRequest{})
+
+	if err == nil {
+		t.Fatal("expected error from recovered panic, got nil")
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil", result)
+	}
+	if !strings.Contains(err.Error(), "get-broker-health") {
+		t.Errorf("error %q should name the tool", err.Error())
+	}
+	// The panic detail stays server-side (logs); the agent-facing error
+	// must not echo internal panic values.
+	if strings.Contains(err.Error(), "assignment to entry in nil map") {
+		t.Errorf("error %q leaks internal panic detail", err.Error())
+	}
+}
+
+func TestWithPanicRecovery_NormalCallPassesThrough(t *testing.T) {
+	want := &mcp.CallToolResult{}
+	wantErr := errors.New("broker unreachable")
+	handler := withPanicRecovery("list-queues", func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return want, wantErr
+	})
+
+	result, err := handler(context.Background(), &mcp.CallToolRequest{})
+
+	if result != want {
+		t.Errorf("result not passed through unchanged")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/tools/recover_test.go
+++ b/internal/tools/recover_test.go
@@ -26,7 +26,7 @@ import (
 func TestWithPanicRecovery_PanicBecomesError(t *testing.T) {
 	handler := withPanicRecovery("get-broker-health", func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		var m map[string]int
-		m["boom"] = 1 // nil map write — representative latent handler bug
+		m["boom"] = 1 //nolint:staticcheck // SA5000: deliberate nil-map write — representative latent handler bug; the test needs the real runtime panic message
 		return nil, nil
 	})
 

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -53,7 +53,7 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 	for _, reg := range regs {
 		mcpTool := toMCPTool(reg.meta, pool)
 
-		server.AddTool(mcpTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		server.AddTool(mcpTool, withPanicRecovery(reg.name, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var params map[string]any
 			if err := json.Unmarshal(req.Params.Arguments, &params); err != nil {
 				return nil, fmt.Errorf("parsing tool arguments: %w", err)
@@ -68,7 +68,7 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 				info = req.Extra.TokenInfo
 			}
 			return mgr.CallTool(ctx, reg.name, params, NewIdentityFromTokenInfo(info))
-		})
+		}))
 	}
 }
 
@@ -121,7 +121,7 @@ func RegisterListBrokers(server *mcp.Server, pool *semp.BrokerPool) {
 				ReadOnlyHint: true,
 			},
 		},
-		func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		withPanicRecovery("list-brokers", func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			aliases := pool.Aliases()
 			result := map[string]any{"brokers": aliases}
 			resultJSON, err := json.MarshalIndent(result, "", "  ")
@@ -132,7 +132,7 @@ func RegisterListBrokers(server *mcp.Server, pool *semp.BrokerPool) {
 				StructuredContent: result,
 				Content:           []mcp.Content{&mcp.TextContent{Text: string(resultJSON)}},
 			}, nil
-		},
+		}),
 	)
 }
 


### PR DESCRIPTION
## Summary

Adds the missing panic containment layer on the tool-call path ([SOL-150662](https://sol-jira.atlassian.net/browse/SOL-150662)).

The MCP go-sdk v1.5.0 dispatches each JSON-RPC request on a bare goroutine (internal/jsonrpc2/conn.go:715-719) with no recover, and there was no `recover()` anywhere on our request path. A single latent nil-deref or map-write regression in any tool would crash the entire long-lived multi-session server instead of failing one tool call. The risk is not hypothetical: `identity.go`'s doc comment records that an earlier shipped version panicked on a verifier contract violation.

## Changes

- New `withPanicRecovery(toolName, handler)` middleware: logs the panic value and stack server-side, returns a generic `internal error in tool "<name>"` to the agent (no internal detail leaks to the client).
- Applied at both `AddTool` sites in `register.go` (`RegisterWithServer` and `RegisterListBrokers`) — the single translation boundary, so every tool is covered.

## Testing

- New tests: a nil-map-write panic is recovered into an error naming the tool without echoing panic internals; normal results and errors pass through unchanged. Panic test fails (crashes) without the wrapper.
- Full `go test ./...` green; `/check-logs` reviewed (panic/stack in structured server-side fields, generic agent-facing error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150662]: https://sol-jira.atlassian.net/browse/SOL-150662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ