### PR TITLE
SOL-150663: Truncate broker-controlled error text at capture

### DIFF
--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
@@ -57,7 +58,7 @@ func (e *SEMPError) Error() string {
 //
 // Rate limiting and retry logic are delegated to the shared resilience.Sender.
 type HTTPClient struct {
-	sender    *resilience.Sender
+	sender  *resilience.Sender
 	baseURL string
 	authCfg config.AuthConfig
 }
@@ -103,7 +104,7 @@ func NewHTTPClient(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) (
 	baseURL := strings.TrimSuffix(brokerCfg.URL, "/")
 
 	return &HTTPClient{
-		sender:    resilience.New(httpClient, jar, sempCfg, brokerCfg.Auth, baseURL),
+		sender:  resilience.New(httpClient, jar, sempCfg, brokerCfg.Auth, baseURL),
 		baseURL: baseURL,
 		authCfg: brokerCfg.Auth,
 	}, nil
@@ -317,15 +318,41 @@ func encodeCSVQueryParam(name string, val any) string {
 	return url.QueryEscape(name) + "=" + strings.Join(encoded, ",")
 }
 
+// maxErrorTextLen bounds broker-controlled error text (Description and the
+// raw Body fallback) captured into a SEMPError. The body read is capped at
+// 16 MiB (defaults.MaxSEMPResponseBytes), so without this bound a misbehaving
+// broker or intermediary can push a multi-MiB string into every downstream
+// sink: SEMPError.Error(), the tool-result log's detail field, and the
+// agent-facing MCP error message. Truncating at capture bounds all of them
+// at once. 4 KiB comfortably holds any real SEMP error description.
+const maxErrorTextLen = 4096
+
+// truncationMarker is appended to error text cut at maxErrorTextLen.
+const truncationMarker = "... [truncated]"
+
+// truncateErrorText caps s at maxErrorTextLen bytes, backing up to a rune
+// boundary so the result stays valid UTF-8, and appends truncationMarker.
+func truncateErrorText(s string) string {
+	if len(s) <= maxErrorTextLen {
+		return s
+	}
+	cut := maxErrorTextLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + truncationMarker
+}
+
 // parseSEMPError creates a SEMPError with best-effort extraction of the
 // broker's meta.error fields (code, status, description). If the body is not
 // valid JSON or the meta.error structure is absent, the structured fields stay
-// zero-valued and Body carries the raw response.
+// zero-valued and Body carries the raw response. Description and Body are
+// broker-controlled and truncated at maxErrorTextLen.
 func parseSEMPError(op string, statusCode int, body []byte) *SEMPError {
 	e := &SEMPError{
 		Operation:  op,
 		StatusCode: statusCode,
-		Body:       string(body),
+		Body:       truncateErrorText(string(body)),
 	}
 
 	var envelope struct {
@@ -340,7 +367,7 @@ func parseSEMPError(op string, statusCode int, body []byte) *SEMPError {
 	if json.Unmarshal(body, &envelope) == nil {
 		e.SEMPCode = envelope.Meta.Error.Code
 		e.SEMPStatus = envelope.Meta.Error.Status
-		e.Description = envelope.Meta.Error.Description
+		e.Description = truncateErrorText(envelope.Meta.Error.Description)
 	}
 
 	return e

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -332,6 +332,8 @@ const truncationMarker = "... [truncated]"
 
 // truncateErrorText caps s at maxErrorTextLen bytes, backing up to a rune
 // boundary so the result stays valid UTF-8, and appends truncationMarker.
+// The cut path concatenates, which allocates a fresh string, so an oversized
+// input's backing array is never retained.
 func truncateErrorText(s string) string {
 	if len(s) <= maxErrorTextLen {
 		return s
@@ -343,6 +345,20 @@ func truncateErrorText(s string) string {
 	return s[:cut] + truncationMarker
 }
 
+// truncateErrorBytes is truncateErrorText for a []byte source. Truncating
+// before the string conversion avoids transiently copying an oversized body
+// (up to defaults.MaxSEMPResponseBytes) just to throw most of it away.
+func truncateErrorBytes(b []byte) string {
+	if len(b) <= maxErrorTextLen {
+		return string(b)
+	}
+	cut := maxErrorTextLen
+	for cut > 0 && !utf8.RuneStart(b[cut]) {
+		cut--
+	}
+	return string(b[:cut]) + truncationMarker
+}
+
 // parseSEMPError creates a SEMPError with best-effort extraction of the
 // broker's meta.error fields (code, status, description). If the body is not
 // valid JSON or the meta.error structure is absent, the structured fields stay
@@ -352,7 +368,7 @@ func parseSEMPError(op string, statusCode int, body []byte) *SEMPError {
 	e := &SEMPError{
 		Operation:  op,
 		StatusCode: statusCode,
-		Body:       truncateErrorText(string(body)),
+		Body:       truncateErrorBytes(body),
 	}
 
 	var envelope struct {

--- a/internal/semp/sempv2/error_truncate_test.go
+++ b/internal/semp/sempv2/error_truncate_test.go
@@ -84,3 +84,19 @@ func TestTruncateErrorText_DoesNotSplitRune(t *testing.T) {
 		t.Errorf("expected truncation marker suffix")
 	}
 }
+
+func TestTruncateErrorBytes_DoesNotSplitRune(t *testing.T) {
+	// Fill so a 3-byte rune straddles the cut point.
+	b := []byte(strings.Repeat("a", maxErrorTextLen-1) + "世界")
+	got := truncateErrorBytes(b)
+
+	if !utf8.ValidString(got) {
+		t.Errorf("truncated text is not valid UTF-8")
+	}
+	if !strings.HasSuffix(got, truncationMarker) {
+		t.Errorf("expected truncation marker suffix")
+	}
+	if len(got) > maxErrorTextLen+len(truncationMarker) {
+		t.Errorf("length = %d, want <= %d", len(got), maxErrorTextLen+len(truncationMarker))
+	}
+}

--- a/internal/semp/sempv2/error_truncate_test.go
+++ b/internal/semp/sempv2/error_truncate_test.go
@@ -1,0 +1,86 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sempv2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// Broker-controlled error text is bounded at capture time so a misbehaving
+// broker or intermediary returning a multi-MiB error body cannot blow up
+// log records, MCP error results, or the agent's context. Capture-time
+// truncation bounds every downstream sink at once (Error(), logToolResult,
+// buildSEMPv2Message).
+
+func TestParseSEMPError_TruncatesOversizedBody(t *testing.T) {
+	// Unparseable body (HTML error page from a proxy) far over the cap.
+	body := []byte("<html>" + strings.Repeat("x", 1024*1024) + "</html>")
+	e := parseSEMPError("listQueues", 502, body)
+
+	if len(e.Body) > maxErrorTextLen+len(truncationMarker) {
+		t.Errorf("Body length = %d, want <= %d", len(e.Body), maxErrorTextLen+len(truncationMarker))
+	}
+	if !strings.HasSuffix(e.Body, truncationMarker) {
+		t.Errorf("truncated Body should end with %q", truncationMarker)
+	}
+	if msg := e.Error(); len(msg) > maxErrorTextLen+256 {
+		t.Errorf("Error() length = %d — raw-Body fallback not bounded", len(msg))
+	}
+}
+
+func TestParseSEMPError_TruncatesOversizedDescription(t *testing.T) {
+	desc := strings.Repeat("d", 1024*1024)
+	body := fmt.Sprintf(`{"meta":{"error":{"code":11,"status":"FAIL","description":%q}}}`, desc)
+	e := parseSEMPError("getMsgVpn", 400, []byte(body))
+
+	if len(e.Description) > maxErrorTextLen+len(truncationMarker) {
+		t.Errorf("Description length = %d, want <= %d", len(e.Description), maxErrorTextLen+len(truncationMarker))
+	}
+	if !strings.HasSuffix(e.Description, truncationMarker) {
+		t.Errorf("truncated Description should end with %q", truncationMarker)
+	}
+	// Structured fields must still be extracted from a parseable envelope.
+	if e.SEMPCode != 11 || e.SEMPStatus != "FAIL" {
+		t.Errorf("structured fields lost: code=%d status=%q", e.SEMPCode, e.SEMPStatus)
+	}
+}
+
+func TestParseSEMPError_SmallTextUnchanged(t *testing.T) {
+	body := []byte(`{"meta":{"error":{"code":6,"status":"NOT_FOUND","description":"queue not found"}}}`)
+	e := parseSEMPError("getQueue", 400, body)
+
+	if e.Description != "queue not found" {
+		t.Errorf("Description = %q, want unchanged", e.Description)
+	}
+	if e.Body != string(body) {
+		t.Error("Body should be unchanged when under the cap")
+	}
+}
+
+func TestTruncateErrorText_DoesNotSplitRune(t *testing.T) {
+	// Fill so a 3-byte rune straddles the cut point.
+	s := strings.Repeat("a", maxErrorTextLen-1) + "世界"
+	got := truncateErrorText(s)
+
+	if !utf8.ValidString(got) {
+		t.Errorf("truncated text is not valid UTF-8")
+	}
+	if !strings.HasSuffix(got, truncationMarker) {
+		t.Errorf("expected truncation marker suffix")
+	}
+}


### PR DESCRIPTION
## Summary

Bounds broker-controlled error text ([SOL-150663](https://sol-jira.atlassian.net/browse/SOL-150663)).

`parseSEMPError` stored the whole non-2xx response body (`Body`) and `meta.error.description` with no length cap — only the 16 MiB `ReadCappedBody` ceiling. Two unbounded sinks: `SEMPError.Error()` falls back to embedding the raw `Body` whenever the response isn't parseable JSON (proxy HTML error pages), and that string reaches the server log via `logToolResult`'s `detail` field; for 4xx, `buildSEMPv2Message` passes `Description` to the agent-facing error, sanitized but never truncated. Every other agent-facing path is bounded; this one wasn't.

## Changes

- `truncateErrorText`: caps at 4 KiB, backs up to a rune boundary (output stays valid UTF-8), appends a `... [truncated]` marker.
- Applied to both `Description` and the raw `Body` fallback inside `parseSEMPError` — capture-time truncation bounds the log record, the MCP error message, and `Error()` in one place.

## Testing

- New tests: 1 MiB unparseable body and 1 MiB description both truncated with marker (structured code/status still extracted); small text unchanged; multi-byte rune at the cut point not split. Failed before the fix.
- Full `go test ./...` green; `/check-logs` clean (no new log calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150663]: https://sol-jira.atlassian.net/browse/SOL-150663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ