### PR TITLE
SOL-150665: Enforce per-broker connection bound via MaxConnsPerHost

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,7 +195,7 @@ func (c ClientAuthConfig) LogValue() slog.Value {
 // applyDefaults runs, these fields are guaranteed non-nil so downstream code
 // can dereference safely.
 type SEMPConfig struct {
-	MaxConcurrentPerBroker int            `yaml:"max_concurrent_per_broker"` // semaphore size per broker
+	MaxConcurrentPerBroker int            `yaml:"max_concurrent_per_broker"` // transport MaxConnsPerHost per protocol client
 	RequestTimeoutDuration time.Duration  `yaml:"request_timeout_duration"`  // HTTP request timeout for SEMP calls (e.g., "30s")
 	RequestMinInterval     *time.Duration `yaml:"request_min_interval"`      // minimum spacing between SEMP requests; 0 = no throttle
 	Retries                *int           `yaml:"retries"`                   // max retry attempts for a failed SEMP call; 0 = no retries

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -63,7 +63,10 @@ const DefaultOIDCHTTPTimeout = 10 * time.Second
 const MaxSEMPResponseBytes = 16 * 1024 * 1024
 
 // DefaultMaxConcurrentPerBroker is the maximum number of concurrent SEMP
-// requests allowed per broker, enforced via a per-broker semaphore.
+// requests allowed per protocol client (SEMPv1, SEMPv2) to a broker,
+// enforced via the HTTP transport's MaxConnsPerHost (see
+// resilience.NewTunedTransport). Each broker has one transport per protocol
+// client, so the worst-case in-flight bound per broker is 2× this value.
 //
 // Assumption: 10 concurrent requests is a safe default per broker.
 // Reasoning: The KA document indicates 1-10 concurrent agent sessions as
@@ -73,8 +76,8 @@ const MaxSEMPResponseBytes = 16 * 1024 * 1024
 const DefaultMaxConcurrentPerBroker = 10
 
 // MaxConcurrentPerBrokerCeiling caps the operator-configurable
-// semp.max_concurrent_per_broker. The value backs a per-broker semaphore plus
-// the HTTP transport's MaxIdleConnsPerHost / MaxIdleConns (×2), so it
+// semp.max_concurrent_per_broker. The value backs the HTTP transport's
+// MaxConnsPerHost / MaxIdleConnsPerHost / MaxIdleConns (×2), so it
 // allocates fixed-size structures proportional to itself × the broker count.
 // 1024 leaves ~100× headroom above the documented typical 1-10 range while
 // rejecting pathological configurations (e.g. a million) that would OOM the

--- a/internal/semp/resilience/transport.go
+++ b/internal/semp/resilience/transport.go
@@ -16,8 +16,8 @@ import (
 const idleConnTimeout = 90 * time.Second
 
 // tlsHandshakeTimeout bounds how long the transport waits for a TLS
-// handshake. Without it, a broker stuck in handshake holds a
-// MaxConcurrentPerBroker semaphore slot for the full request timeout
+// handshake. Without it, a broker stuck in handshake holds one of the
+// MaxConnsPerHost connection slots for the full request timeout
 // window. 10s tolerates network outliers while bounding the failure
 // window to a small fraction of the request timeout.
 const tlsHandshakeTimeout = 10 * time.Second
@@ -31,6 +31,15 @@ const expectContinueTimeout = 1 * time.Second
 // NewTunedTransport builds an *http.Transport sized for the per-broker
 // concurrency cap. Both SEMPv1 and SEMPv2 clients use it so the connection
 // pool behaviour stays consistent across protocol versions.
+//
+// MaxConnsPerHost = MaxConcurrentPerBroker is the enforcement point for the
+// per-broker in-flight bound: supplying a custom TLSClientConfig disables
+// Go's automatic HTTP/2, so SEMP traffic is HTTP/1.1, one connection carries
+// one in-flight request, and the Nth+1 concurrent request queues (context-
+// aware) until a connection frees up. Each protocol client (SEMPv1, SEMPv2)
+// has its own transport, so the worst-case bound per broker is 2× the
+// configured value. This is what protects the broker management plane from
+// request bursts — there is no separate semaphore.
 //
 // Go's http.Transport defaults MaxIdleConnsPerHost to 2. With
 // MaxConcurrentPerBroker at 10+, every request beyond the 2nd opens a new
@@ -49,12 +58,13 @@ const expectContinueTimeout = 1 * time.Second
 // rather than a hardcoded constant. The granular timeout must stay strictly
 // less than the outer client-level request timeout, otherwise the outer
 // timeout wins and the regression this transport tuning fixes (a stuck
-// broker holding a MaxConcurrentPerBroker semaphore slot for the full
+// broker holding a MaxConnsPerHost connection slot for the full
 // request window) silently returns when operators set an aggressive
 // request_timeout_duration in broker-config.yaml.
 func NewTunedTransport(brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig) *http.Transport {
 	return &http.Transport{
 		TLSClientConfig:       &tls.Config{InsecureSkipVerify: brokerCfg.InsecureSkipVerify}, //nolint:gosec // G402 — user-configurable TLS skip for dev environments; defaults to false
+		MaxConnsPerHost:       sempCfg.MaxConcurrentPerBroker,
 		MaxIdleConnsPerHost:   sempCfg.MaxConcurrentPerBroker,
 		MaxIdleConns:          sempCfg.MaxConcurrentPerBroker * 2,
 		IdleConnTimeout:       idleConnTimeout,

--- a/internal/semp/resilience/transport_test.go
+++ b/internal/semp/resilience/transport_test.go
@@ -104,4 +104,11 @@ func TestNewTunedTransport_MaxConnsPerHostEnforcesConcurrencyCap(t *testing.T) {
 	if tr.ForceAttemptHTTP2 {
 		t.Error("ForceAttemptHTTP2 = true would multiplex streams over one connection, breaking the MaxConnsPerHost concurrency bound")
 	}
+	// Go's http.Transport only auto-enables HTTP/2 when TLSClientConfig is
+	// nil; the HTTP/1.1 guarantee above therefore depends on the transport
+	// continuing to supply a custom TLSClientConfig, not just on
+	// ForceAttemptHTTP2 staying false.
+	if tr.TLSClientConfig == nil {
+		t.Error("TLSClientConfig = nil re-enables Go's automatic HTTP/2, breaking the MaxConnsPerHost concurrency bound")
+	}
 }

--- a/internal/semp/resilience/transport_test.go
+++ b/internal/semp/resilience/transport_test.go
@@ -80,3 +80,28 @@ func TestResponseHeaderTimeout_TracksOperatorConfiguredRequestTimeout(t *testing
 		t.Errorf("ResponseHeaderTimeout = %s, want %s (half of operator-configured request timeout)", tr.ResponseHeaderTimeout, want)
 	}
 }
+
+// TestNewTunedTransport_MaxConnsPerHostEnforcesConcurrencyCap verifies the
+// per-broker in-flight bound is actually enforced at the transport. The
+// transport supplies a custom TLSClientConfig, which disables Go's automatic
+// HTTP/2, so SEMP traffic is HTTP/1.1 and one connection carries exactly one
+// in-flight request — MaxConnsPerHost is therefore a true concurrency cap.
+// Without it, a burst of tool calls against a slow broker opens unbounded
+// TCP+TLS connections to the management plane.
+func TestNewTunedTransport_MaxConnsPerHostEnforcesConcurrencyCap(t *testing.T) {
+	brokerCfg := &config.BrokerConfig{URL: "https://broker.example.com:1943"}
+	sempCfg := &config.SEMPConfig{
+		MaxConcurrentPerBroker: 7,
+		RequestTimeoutDuration: defaults.DefaultSEMPRequestTimeoutDuration,
+	}
+
+	tr := NewTunedTransport(brokerCfg, sempCfg)
+
+	if tr.MaxConnsPerHost != sempCfg.MaxConcurrentPerBroker {
+		t.Errorf("MaxConnsPerHost = %d, want %d (per-broker concurrency cap unenforced)",
+			tr.MaxConnsPerHost, sempCfg.MaxConcurrentPerBroker)
+	}
+	if tr.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 = true would multiplex streams over one connection, breaking the MaxConnsPerHost concurrency bound")
+	}
+}


### PR DESCRIPTION
## Summary

Makes the documented per-broker concurrency cap real ([SOL-150665](https://sol-jira.atlassian.net/browse/SOL-150665)).

`DefaultMaxConcurrentPerBroker` claims it is "enforced via a per-broker semaphore" that "protects the broker management plane from overload", and the transport tuning justifies its timeouts by reference to semaphore slots. No semaphore exists anywhere in the code; the value only sized idle pools (`MaxIdleConnsPerHost`/`MaxIdleConns`) and `MaxConnsPerHost` was unset — in-flight requests per broker were unbounded. With defaults (60s request timeout, two Senders per broker), a burst against one slow broker can accumulate hundreds of concurrent TCP+TLS connections to the management plane, and `request_min_interval: 0` (valid config) removes the only remaining throttle.

## Changes

- `MaxConnsPerHost = MaxConcurrentPerBroker` in `NewTunedTransport`. The transport supplies a custom `TLSClientConfig`, which disables Go's automatic HTTP/2, so SEMP is HTTP/1.1: one connection = one in-flight request, making this a true concurrency bound. Excess requests queue context-aware.
- Corrected every comment referencing the nonexistent semaphore (defaults.go ×2, transport.go ×3, config.go field comment), including the honest caveat that each protocol client (SEMPv1/SEMPv2) has its own transport, so the worst-case per-broker bound is 2× the configured value.

## Testing

- New test asserts `MaxConnsPerHost` equals the configured cap and `ForceAttemptHTTP2` stays off (HTTP/2 multiplexing would break the bound). Failed before the fix (`MaxConnsPerHost = 0`).
- Full `go test ./...` green; `/check-logs` clean (no new log calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150665]: https://sol-jira.atlassian.net/browse/SOL-150665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ