### PR TITLE
SOL-150666: Keep secrets out of YAML config parse errors in startup logs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -261,6 +261,21 @@ func Load() (*ServerConfig, error) {
 	)
 }
 
+// yamlNodeValuePattern matches the backtick-quoted node values yaml.v3 embeds
+// in type-error messages, e.g. "cannot unmarshal !!int `123456` into string".
+var yamlNodeValuePattern = regexp.MustCompile("`[^`]*`")
+
+// sanitizeYAMLError strips raw node values from a YAML decode error before it
+// is wrapped and logged. yaml.v3 echoes the offending value when it lands in
+// a mismatched target type — most plausibly a credential pulled into a
+// non-string field by a wrong ${VAR} reference, since env substitution runs
+// before decode. The secret would ride inside the error string where the
+// slog ReplaceAttr redaction net cannot reach it. Line numbers and type
+// diagnostics are preserved.
+func sanitizeYAMLError(err error) error {
+	return errors.New(yamlNodeValuePattern.ReplaceAllString(err.Error(), "`[redacted]`"))
+}
+
 // LoadConfig reads a YAML configuration file from path, substitutes ${VAR_NAME}
 // env var references, parses YAML, applies defaults, validates, and returns a
 // ServerConfig ready for use.
@@ -290,7 +305,7 @@ func LoadConfig(path string) (*ServerConfig, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(&raw); err != nil {
-		return nil, fmt.Errorf("parsing config YAML: %w", err)
+		return nil, fmt.Errorf("parsing config YAML: %w", sanitizeYAMLError(err))
 	}
 
 	if raw.DevelopmentMode != nil {

--- a/internal/config/yaml_error_test.go
+++ b/internal/config/yaml_error_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// yaml.v3 type errors embed the offending node value in the message
+// (e.g. "cannot unmarshal !!str `hunter2...` into int"). The decode error is
+// wrapped and logged at startup, so a credential that lands in a non-string
+// field — most plausibly via a wrong ${VAR} reference, since env substitution
+// runs before decode — would flow into the error log field, a Never-Log List
+// item that the slog ReplaceAttr net cannot catch because the secret rides
+// inside the error string value. (Note: a plain numeric scalar into a string
+// field is silently coerced by yaml.v3, not echoed — the type error needs a
+// genuinely mismatched target type.) Decode errors must be scrubbed before
+// wrapping.
+
+func TestLoadConfig_YAMLTypeError_DoesNotEchoCredentialValue(t *testing.T) {
+	// A secret value in a non-string field: what an operator gets by
+	// referencing the wrong env var (e.g. port: ${BROKER_PASSWORD}), which
+	// substituteEnvVars expands before the YAML decode runs.
+	cfg := `port: hunter2secret
+client_auth:
+  mode: disabled
+brokers:
+  prod:
+    url: https://broker.example.com:1943
+    auth:
+      mode: basic
+      username: admin
+      password: ok
+`
+	path := filepath.Join(t.TempDir(), "broker-config.yaml")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected YAML type error for string value in int field")
+	}
+	if strings.Contains(err.Error(), "hunter2") {
+		t.Errorf("decode error echoes the credential value: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "parsing config YAML") {
+		t.Errorf("error %q lost its parse-failure context", err.Error())
+	}
+	// Operators still need to find the broken line.
+	if !strings.Contains(err.Error(), "line") {
+		t.Errorf("error %q lost line-number diagnostics", err.Error())
+	}
+}
+
+func TestSanitizeYAMLError_StripsBacktickedValues(t *testing.T) {
+	in := errors.New("yaml: unmarshal errors:\n  line 9: cannot unmarshal !!int `1234567` into string\n  line 12: cannot unmarshal !!bool `true` into string")
+	got := sanitizeYAMLError(in).Error()
+
+	if strings.Contains(got, "1234567") || strings.Contains(got, "`true`") {
+		t.Errorf("sanitized error still contains node values: %q", got)
+	}
+	for _, keep := range []string{"line 9", "line 12", "!!int", "into string"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("sanitized error %q lost diagnostic detail %q", got, keep)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a way a secret could leak into startup logs ([SOL-150666](https://sol-jira.atlassian.net/browse/SOL-150666)).

**The problem.** If a config file has a text value where a number belongs, YAML parsing fails and the error message quotes the bad value back. We log that error at startup. So if the bad value happens to be a password, the password lands in the log. Our existing log redaction can't catch this case because the secret is buried inside the error message text, not in a named log field.

**How would a password end up in a number field?** Most likely a typo in an env var reference. We substitute `${VAR}` references before parsing, so a config line like `port: ${BROKER_PASSWORD}` puts the password into `port`, parsing fails, and the error quotes it.

**The fix.** Before wrapping and logging the parse error, replace any quoted value in it with `[redacted]`. Line numbers and type info are kept, so operators can still find the broken line.

**Scope note.** The ticket's example (`password: 123456`) doesn't actually trigger this. YAML quietly converts a number to a string there, with no error and no echo. The leak needs the reverse case: text in a non-string field, as above. Narrower than the ticket says, but the scrub is still worth its five lines. I'll correct the ticket description.

## Changes

- `internal/config/config.go`: new `sanitizeYAMLError` strips quoted values from YAML decode errors before they're wrapped and logged.
- `internal/config/yaml_error_test.go`: new tests covering both the end-to-end case (a secret in the wrong field never appears in the `LoadConfig` error) and the sanitizer itself (all quoted values stripped, line and type diagnostics kept).

## Testing

- Full `go test ./...` green; `/check-logs` clean (no new log calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-150666]: https://sol-jira.atlassian.net/browse/SOL-150666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ