### PR TITLE
SOL-150749: Re-arm F6 slowSubscriber flag before Tool 10 assertions (fix flaky e2e-monitoring)

### DIFF
--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -447,10 +447,18 @@ test_get_queue_metrics_slow_consumer_b() { test_get_queue_metrics_slow_consumer 
 # entry — it confirms the cap is honored but, like list-rdps, cannot demonstrate
 # multi-page truncation (no second slow subscriber exists to drop).
 # Envelope: {"slowSubscribers":{"data":[...],"truncated":bool}}.
+#
+# Precondition re-arm: slowSubscriber is computed over a rolling ~1 min window
+# (see wait_for_slow_subscriber) and can drop back to false between the
+# verify-fixtures F6 check and this test — observed verified-true then gone
+# 63 s later on a slow runner (2026-06-12, runs 27424785855 / 27425041949).
+# Each test re-polls the flag via the broker before asserting on the tool;
+# the poll returns immediately when the flag is already set.
 
 test_list_slow_subscribers() {
-    local broker="$1" own="$2" other="$3"
+    local broker="$1" broker_url="$2" own="$3" other="$4"
     local response content
+    wait_for_slow_subscriber "$broker_url" "$broker" "$own" || return 1
     response=$(mcp_call_tool "list-slow-subscribers" \
         "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default"}')") || return 1
     content=$(extract_content "$response")
@@ -472,8 +480,10 @@ test_list_slow_subscribers() {
 }
 
 test_list_slow_subscribers_pagination() {
-    local broker="$1"
+    local broker="$1" broker_url="$2" client_name="$3"
     local response content
+    # Same rolling-window hazard as the presence test above — re-arm first.
+    wait_for_slow_subscriber "$broker_url" "$broker" "$client_name" || return 1
     response=$(mcp_call_tool "list-slow-subscribers" \
         "$(jq -nc --arg b "$broker" '{broker:$b,msgVpnName:"default",maxResults:1}')") || return 1
     content=$(extract_content "$response")
@@ -481,10 +491,10 @@ test_list_slow_subscribers_pagination() {
         "list-slow-subscribers [$broker]: maxResults=1 must return exactly 1 slow subscriber" || return 1
 }
 
-test_list_slow_subscribers_a() { test_list_slow_subscribers "broker-a" "$F6_SUB_CLIENT_NAME_A" "$F6_SUB_CLIENT_NAME_B"; }
-test_list_slow_subscribers_b() { test_list_slow_subscribers "broker-b" "$F6_SUB_CLIENT_NAME_B" "$F6_SUB_CLIENT_NAME_A"; }
-test_list_slow_subscribers_pagination_a() { test_list_slow_subscribers_pagination "broker-a"; }
-test_list_slow_subscribers_pagination_b() { test_list_slow_subscribers_pagination "broker-b"; }
+test_list_slow_subscribers_a() { test_list_slow_subscribers "broker-a" "$BROKER_A_URL" "$F6_SUB_CLIENT_NAME_A" "$F6_SUB_CLIENT_NAME_B"; }
+test_list_slow_subscribers_b() { test_list_slow_subscribers "broker-b" "$BROKER_B_URL" "$F6_SUB_CLIENT_NAME_B" "$F6_SUB_CLIENT_NAME_A"; }
+test_list_slow_subscribers_pagination_a() { test_list_slow_subscribers_pagination "broker-a" "$BROKER_A_URL" "$F6_SUB_CLIENT_NAME_A"; }
+test_list_slow_subscribers_pagination_b() { test_list_slow_subscribers_pagination "broker-b" "$BROKER_B_URL" "$F6_SUB_CLIENT_NAME_B"; }
 
 # ── Tool 11: list-queue-discards (F7 spool + TTL discards; per-queue) ─────────
 # Value check (AC 13): list-queue-discards returns each queue's per-category


### PR DESCRIPTION
## Summary
Fixes the flaky `e2e-monitoring` Tool 10 (`list-slow-subscribers`) assertions by re-polling the F6 `slowSubscriber` flag immediately before each assertion, using the existing `wait_for_slow_subscriber` helper.

Fixes [SOL-150749](https://sol-jira.atlassian.net/browse/SOL-150749)

## Root cause
The F6 fixture SIGSTOPs a direct subscriber under a 3000 msg/s flood; the broker flips the per-client `slowSubscriber` flag on TCP egress back-pressure, computed over a rolling ~1 min window (the fixture comment and README both note this, and it is why `wait_for_slow_subscriber` polls instead of reading once). Tool 10, however, read the flag once.

On a healthy runner the gap between the verify-fixtures F6 check and Tool 10 is ~26 s. On 2026-06-12 two slow runners stretched it to ~63 s and the flag decayed on one broker in each run:

| Run | Branch | Failure |
| --- | --- | --- |
| [27424785855](https://github.com/SolaceDev/solace-broker-mcp/actions/runs/27424785855) | main | broker-a F6 client absent |
| [27425041949](https://github.com/SolaceDev/solace-broker-mcp/actions/runs/27425041949) | PR #97 | broker-b F6 client absent, pagination got 0 |

In the PR #97 run the flag was confirmed `true` at 15:24:22 and gone at 15:25:25, 63 s later, while the flood was still publishing (F4 rx ≈ 1500/s on both brokers seconds earlier). The ~15 s of `get-message-rates` sampling added by #100 sits in exactly this gap, which is why the flake surfaced today. Same class of bug as SOL-150715: a single read of a noisy, windowed broker metric.

## Changes Made
- `test_list_slow_subscribers` and `test_list_slow_subscribers_pagination` call `wait_for_slow_subscriber` (broker-direct SEMP poll, up to `F6_FLAG_TIMEOUT`) before invoking the MCP tool. The poll returns in 0 s when the flag is already set, so green-path runtime is unchanged.
- Wrappers pass the broker URL and F6 client name through.

If a future run shows the poll timing out (flag never returns once decayed), the escalation is to SIGCONT/SIGSTOP-cycle the subscriber to regenerate back-pressure events; the poll's per-attempt logging will make that failure mode unambiguous.

## Testing
- `bash -n` passes; change is confined to the e2e test scripts (no Go code).
- The full e2e-monitoring job runs in CI on this PR; that is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150749]: https://sol-jira.atlassian.net/browse/SOL-150749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ