### PR TITLE
SOL-150724: Add get-broker-status in e2e-monitoring

### DIFF
--- a/test/e2e-monitoring/README.md
+++ b/test/e2e-monitoring/README.md
@@ -32,15 +32,19 @@ aborted runs.
 ## Fixtures
 
 All fixtures apply to both brokers in parallel (`solace-e2e-mon-a`,
-`solace-e2e-mon-b`). `list-brokers`, `list-rdps`, and the existing RDP/queue
-tools run against the base fixture copied from `e2e-basic-mcp` — no new
-fixture needed.
+`solace-e2e-mon-b`). `list-brokers`, `list-rdps`, `get-broker-status`, and the
+existing RDP/queue tools run against the base fixture copied from
+`e2e-basic-mcp` — no new fixture needed. `get-broker-status` is broker-wide
+(version, scaling tier, system resources, memory and message-spool
+utilization), so the default Dockerized broker state already populates every
+curated field.
 
 F1–F7 are implemented today, driven by the `broker-driver` binary for the
 client-bearing fixtures (F3–F7).
 
 | ID       | Fixture                  | Required broker state                                                                                                                                  | Lifecycle                          | MCP tools supported                                                                |
 | -------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------- |
+| Base     | None (default state)     | Default Dockerized broker state from `e2e-basic-mcp` — version, scaling tier, system resources, memory, and message-spool utilization are populated out of the box | none (built-in)                    | `list-brokers`, `list-rdps`, `get-broker-status`                                   |
 | F1       | Multi-VPN                | Additional non-default VPN `test-vpn` on each broker, created with `enabled=false`                                                                     | one-shot SEMP                      | `list-vpns`, `get-vpn-health` (enabled + disabled state coverage)                  |
 | F2       | Multi-queue              | `test-queue-2` (bound to a test RDP) and `test-queue-3` (unbound), both non-exclusive on default VPN                                                   | one-shot SEMP                      | `list-queues` (multi-entry + pagination), `get-queue-metrics` (named-object lookup) |
 | F3       | Connected client         | One long-lived persistent receiver per broker on default VPN with deterministic `clientName` and ≥1 named topic subscription. **Verification:** client appears in `list-clients` and reports the expected subscription. | background broker-driver           | `list-clients`, `get-client-details`, `list-client-subscriptions`                  |
@@ -214,7 +218,7 @@ fixture sizes change.
   contribution alone, so it holds even when F4 is the only active publisher.
 - Instantaneous `txMsgRate` (delivery to the F3 receiver) is inherently lower
   and noisier than the publish rate — single-read samples on CI runners have
-  been observed across **57–88 msg/s** (SOL-150715). Asserted against `≥ 40`
+  been observed across **57–88 msg/s** (SOL-150715). Asserted against `≥ 50`
   with **peak-of-5 polling** (~5 s window) to absorb that variance without
   lowering the bar further.
 - `averageRxMsgRate` requires **~3–5 min** to converge. **Do not assert against

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -606,6 +606,83 @@ test_get_discard_stats_broker_wide_b() { test_get_discard_stats_broker_wide "bro
 test_get_discard_stats_per_vpn_a()     { test_get_discard_stats_per_vpn "broker-a"; }
 test_get_discard_stats_per_vpn_b()     { test_get_discard_stats_per_vpn "broker-b"; }
 
+# ── Tool 13: get-broker-status (broker-wide; SOL-150724) ─────────────────────
+# Shape + value check on the curated point-in-time status snapshot. The tool
+# is broker-wide (no VPN/queue scope) and runs against the base Dockerized
+# broker — no dedicated fixture; the ambient F4 sustained traffic and the
+# default spool config are what make memory/spool readings non-trivial.
+# Envelope: {"version":{...},"system":{...},"memory":{...},"spool":{...}} —
+# four step keys, each carrying the curated camelCase fields documented in
+# docs/internal/semp/get-broker-status-curated-fields.md.
+
+test_get_broker_status() {
+    local broker="$1"
+    local response content
+    response=$(mcp_call_tool "get-broker-status" \
+        "$(jq -nc --arg b "$broker" '{broker:$b}')") || return 1
+    content=$(extract_content "$response")
+
+    # Envelope shape: all four step keys present.
+    assert_json_field "$content" '.version | type' "object" \
+        "get-broker-status [$broker]: .version must be an object" || return 1
+    assert_json_field "$content" '.system | type' "object" \
+        "get-broker-status [$broker]: .system must be an object" || return 1
+    assert_json_field "$content" '.memory | type' "object" \
+        "get-broker-status [$broker]: .memory must be an object" || return 1
+    assert_json_field "$content" '.spool | type' "object" \
+        "get-broker-status [$broker]: .spool must be an object" || return 1
+
+    # version: description identifies a Solace broker; uptime is positive.
+    assert_json_field "$content" '(.version.description | type) == "string" and (.version.description | contains("Solace"))' "true" \
+        "get-broker-status [$broker]: .version.description must be a Solace string" || return 1
+    assert_json_field "$content" '.version.uptime.totalSecs > 0' "true" \
+        "get-broker-status [$broker]: .version.uptime.totalSecs must be > 0" || return 1
+
+    # system: uptime + restart context, scaling-tier limits, resource pair.
+    assert_json_field "$content" '.system.systemUptimeSeconds > 0' "true" \
+        "get-broker-status [$broker]: .system.systemUptimeSeconds must be > 0" || return 1
+    # lastRestartReason is an empty string on brokers that haven't been
+    # intentionally restarted (typical for the Dockerized fixtures), so only
+    # assert the shape — the field is present as a string.
+    assert_json_field "$content" '(.system.lastRestartReason | type) == "string"' "true" \
+        "get-broker-status [$broker]: .system.lastRestartReason must be a string" || return 1
+    assert_json_field "$content" '(.system.maxConnections | type) == "number"' "true" \
+        "get-broker-status [$broker]: .system.maxConnections must be numeric" || return 1
+    assert_json_field "$content" '(.system.maxQueueMessages | type) == "number"' "true" \
+        "get-broker-status [$broker]: .system.maxQueueMessages must be numeric" || return 1
+    assert_json_field "$content" '(.system.maxSubscriptions | type) == "number"' "true" \
+        "get-broker-status [$broker]: .system.maxSubscriptions must be numeric" || return 1
+    # cpuCores is the "available" half of the under-scaling pair. The
+    # "required" counterpart (cpuCoresRequired) is only emitted by appliance /
+    # cloud brokers — Dockerized PubSub+ Standard omits it — so we don't assert
+    # it here.
+    assert_json_field "$content" '(.system.cpuCores | type) == "number"' "true" \
+        "get-broker-status [$broker]: .system.cpuCores must be numeric" || return 1
+
+    # memory: utilization percentages bounded to [0, 100].
+    assert_json_field "$content" '.memory.physicalMemoryUsagePercent >= 0 and .memory.physicalMemoryUsagePercent <= 100' "true" \
+        "get-broker-status [$broker]: .memory.physicalMemoryUsagePercent must be in [0,100]" || return 1
+    assert_json_field "$content" '.memory.subscriptionMemoryUsagePercent >= 0 and .memory.subscriptionMemoryUsagePercent <= 100' "true" \
+        "get-broker-status [$broker]: .memory.subscriptionMemoryUsagePercent must be in [0,100]" || return 1
+
+    # spool: HA / datapath state plus disk-usage indicator. The envelope nests
+    # the curated fields under .spool.messageSpoolInfo (see spool_response.go).
+    # Dockerized brokers in this suite run with the spool enabled (see F5/F7
+    # fixtures), so configStatus and operationalStatus must be non-empty here.
+    # datapathUp and activeDiskPartitionUsage are strings as emitted by SEMPv1.
+    assert_json_field "$content" '(.spool.messageSpoolInfo.configStatus | type) == "string" and (.spool.messageSpoolInfo.configStatus | length) > 0' "true" \
+        "get-broker-status [$broker]: .spool.messageSpoolInfo.configStatus must be a non-empty string" || return 1
+    assert_json_field "$content" '(.spool.messageSpoolInfo.operationalStatus | type) == "string" and (.spool.messageSpoolInfo.operationalStatus | length) > 0' "true" \
+        "get-broker-status [$broker]: .spool.messageSpoolInfo.operationalStatus must be a non-empty string" || return 1
+    assert_json_field "$content" '(.spool.messageSpoolInfo.datapathUp | type) == "string"' "true" \
+        "get-broker-status [$broker]: .spool.messageSpoolInfo.datapathUp must be a string" || return 1
+    assert_json_field "$content" '(.spool.messageSpoolInfo.activeDiskPartitionUsage | type) == "string"' "true" \
+        "get-broker-status [$broker]: .spool.messageSpoolInfo.activeDiskPartitionUsage must be a string" || return 1
+}
+
+test_get_broker_status_a() { test_get_broker_status "broker-a"; }
+test_get_broker_status_b() { test_get_broker_status "broker-b"; }
+
 # ── Run ──────────────────────────────────────────────────────────────────────
 
 run_test "Tool 1 — list-vpns (broker-a)"               test_list_vpns_a
@@ -663,5 +740,8 @@ run_test "Tool 12 — get-discard-stats broker-wide (broker-a)"   test_get_disca
 run_test "Tool 12 — get-discard-stats broker-wide (broker-b)"   test_get_discard_stats_broker_wide_b
 run_test "Tool 12 — get-discard-stats per-VPN (broker-a)"       test_get_discard_stats_per_vpn_a
 run_test "Tool 12 — get-discard-stats per-VPN (broker-b)"       test_get_discard_stats_per_vpn_b
+
+run_test "Tool 13 — get-broker-status (broker-a)"               test_get_broker_status_a
+run_test "Tool 13 — get-broker-status (broker-b)"               test_get_broker_status_b
 
 print_summary "MCP tool tests"


### PR DESCRIPTION
## Summary

Adds `get-broker-status` tool coverage to the e2e-monitoring suite as Tool 13. Validates the curated four-step envelope (`version`, `system`, `memory`, `spool`) against the running Dockerized brokers.

Fixes [SOL-150724](https://sol-jira.atlassian.net/browse/SOL-150724)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

`get-broker-status` is the broker-wide health snapshot tool (introduced under SOL-150724). The other 12 MCP monitoring tools already have e2e coverage in `test/e2e-monitoring/tool-tests.sh`; this PR closes the gap so all supported tools are exercised end-to-end through the MCP server against real Dockerized brokers.

## Changes Made

- `test/e2e-monitoring/tool-tests.sh`: add `test_get_broker_status` plus broker-a / broker-b wrappers and `run_test` registrations as Tool 13.
- Assertions are scoped to what the Dockerized PubSub+ Standard broker actually emits:
  - `lastRestartReason` asserted as a string (legitimately `""` on a freshly-started broker — confirmed by the curated-fields doc example).
  - `cpuCoresRequired` is **not** asserted; the `*-required` half of the under-scaling pair is only emitted by appliance/cloud brokers.
  - Spool fields are read at their real nested path `.spool.messageSpoolInfo.*` (per `internal/tools/sempv1/brokerstatus/spool_response.go`); `datapathUp` and `activeDiskPartitionUsage` are strings as emitted by SEMPv1, not boolean/number.
- `test/e2e-monitoring/README.md`: add a `Base` row at the top of the fixtures table covering tools that need no fixture activation (`list-brokers`, `list-rdps`, `get-broker-status`), plus a short prose note that the default Dockerized broker state already populates every curated field for `get-broker-status`.
- `test/e2e-monitoring/README.md`: Updated assertion to be >= 50 as per follow up from https://github.com/SolaceDev/solace-broker-mcp/pull/100
## Testing

**Test Environment:**
- Go version: per repo `go.mod`
- OS: Linux (Fedora 43)
- Broker version: PubSub+ Standard (Dockerized fixtures `solace-e2e-mon-a` / `solace-e2e-mon-b`)

**Tests Performed:**
- [x] E2E tests added/updated
- [x] Tested locally with `go test -race ./...` (via `make check`)
- [x] Tested with real Solace broker (Dockerized e2e-monitoring fixtures)

**Test Coverage:**
- Tool 13 added against both `broker-a` and `broker-b`.
- Flake-tested 10× back-to-back against an already-running MCP server + brokers: **20/20 passing**, no flakes.
- Envelope shape: all four top-level keys (`version`, `system`, `memory`, `spool`) present and typed.
- Field-level assertions: `version.description` contains "Solace"; `version.uptime.totalSecs > 0`; `system.systemUptimeSeconds > 0`; `system.lastRestartReason` is a string; scaling-tier limits (`maxConnections`, `maxQueueMessages`, `maxSubscriptions`) and `cpuCores` are numeric; `memory.*UsagePercent` bounded to `[0,100]`; `spool.messageSpoolInfo.configStatus` / `operationalStatus` are non-empty strings; `datapathUp` and `activeDiskPartitionUsage` are strings.

## Breaking Changes

None.

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed
- [x] Code is well-commented (explains *why* — e.g. why `cpuCoresRequired` is omitted, why `lastRestartReason` may be empty)
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code
- [x] Followed secure logging rules (no new logging code in this PR)
- [x] Credential-carrying types implement `slog.LogValuer` (N/A — no new types)
- [x] No security vulnerabilities introduced

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered (empty `lastRestartReason`, broker variants that omit `*-required` fields, nested spool envelope)
- [x] Error paths tested (each assertion short-circuits the test on first failure)
- [x] Test names clearly describe what is being tested

### Documentation
- [x] README.md updated (`test/e2e-monitoring/README.md` — Base row + prose note)
- [ ] docs/ updated (N/A — no architecture/design changes)
- [ ] godoc comments added/updated (N/A — shell-only changes)
- [ ] CHANGELOG.md updated (N/A)
- [ ] Examples updated (N/A)

### Git & CI
- [x] All commits are signed off (DCO)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

## Additional Notes

The originally-drafted assertions were over-specified for a freshly-started Dockerized PubSub+ Standard broker. Three fields were relaxed to match what the broker actually emits, verified against the unit-test fixture at `internal/tools/sempv1/brokerstatus/testdata/show_system.xml` and the curated-fields example in `docs/internal/semp/get-broker-status-curated-fields.md`. Flake-tested 10× to confirm the assertions are stable.




[SOL-150724]: https://sol-jira.atlassian.net/browse/SOL-150724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ