### PR TITLE
SOL-150717: Add unit test for auth mode: disabled (no-auth-required p…

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -165,6 +165,60 @@ brokers:
 	}
 }
 
+func TestLoadConfig_DisabledAuth(t *testing.T) {
+	// client_auth.mode: disabled is a valid, dev-only profile: no client auth
+	// is enforced and no further client_auth fields are required. The broker's
+	// own auth block is still validated as usual.
+	yaml := `
+client_auth:
+  mode: disabled
+brokers:
+  dev:
+    url: "https://broker.example.com:1943"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	cfg, err := LoadConfig(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("unexpected error for disabled auth mode: %v", err)
+	}
+	if cfg.ClientAuth.Mode != AuthModeDisabled {
+		t.Errorf("expected client_auth.mode %q, got %q", AuthModeDisabled, cfg.ClientAuth.Mode)
+	}
+	// disabled is a dev profile, not production.
+	if cfg.IsProductionMode() {
+		t.Errorf("disabled mode should not be production mode")
+	}
+	// Broker auth block is still parsed and validated normally.
+	broker := cfg.brokers["dev"]
+	if broker == nil {
+		t.Fatal("expected broker 'dev' to be loaded")
+	}
+	if broker.Auth.Username != "admin" || broker.Auth.Password != "secret" {
+		t.Errorf("unexpected broker credentials: %q/%q", broker.Auth.Username, broker.Auth.Password)
+	}
+}
+
+func TestLoadConfig_DisabledAuth_AllowsHTTPBroker(t *testing.T) {
+	// disabled is a dev-only mode, so http:// broker URLs are permitted
+	yaml := `
+client_auth:
+  mode: disabled
+brokers:
+  dev:
+    url: "http://localhost:8080"
+    auth:
+      mode: basic
+      username: admin
+      password: secret
+`
+	if _, err := LoadConfig(writeTemp(t, yaml)); err != nil {
+		t.Fatalf("http:// broker URL should be allowed under mode: disabled, got: %v", err)
+	}
+}
+
 func TestLoadConfig_MalformedYAML(t *testing.T) {
 	_, err := LoadConfig(writeTemp(t, `{{{ not yaml`))
 	if err == nil {


### PR DESCRIPTION
…ath)

## Summary

Adds unit test coverage for the client_auth.mode: disabled config path, verifying that the no-auth-required (dev-only) profile loads and validates correctly. Test-only change - no production code is touched.

Fixes #[SOL-150717](https://sol-jira.atlassian.net/browse/SOL-150717)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Dependency update

## Motivation and Context

The disabled client-auth mode (AuthModeDisabled) is a valid, dev-only profile in internal/config that enforces no client authentication and requires no further client_auth fields. While the static and oauth modes had dedicated unit tests, the disabled mode's load/validation path had no direct coverage. This PR closes that gap so the behavior is pinned against future refactors of the config validator.

## Changes Made

- Added TestLoadConfig_DisabledAuth: loads a config with client_auth.mode: disabled and asserts the mode normalizes to AuthModeDisabled, that IsProductionMode() returns false, and that the broker's own auth block is still parsed and validated as usual.
- Added TestLoadConfig_DisabledAuth_AllowsHTTPBroker: asserts that http:// broker URLs are permitted under disabled mode, unlike OAuth which requires https://.

## Testing

**Test Environment:**
- Go version: go1.25.0 (linux/amd64)
- OS: Fedora Linux 41
- Broker version (if applicable): N/A - pure config unit test, no broker required

**Tests Performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Tested locally with `go test -race ./...`
- [ ] Tested with real Solace broker

## Breaking Changes

None. No production behaviour was modified.


[SOL-150717]: https://sol-jira.atlassian.net/browse/SOL-150717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ