### PR TITLE
SOL-150797: capture raw subject token on ctx after SDK validation

### DIFF
--- a/docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md
+++ b/docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md
@@ -77,6 +77,23 @@ The Hop 2 prototype carried a `BMS_DEMO_LOG_TOKENS` env-flag for demo logging. T
 - All per-request data lives on the stack of the request goroutine and on the request's ctx.
 - The unexported key type ensures no other package can collide with our slot.
 
+### 7. Rejection is the upstream component's responsibility, not ours
+
+When the Authorization header is missing or malformed, `InjectRawSubjectToken` does **not** reject the request. It calls `next.ServeHTTP(w, r)` unchanged — no error, no log, no 401, no `WWW-Authenticate` header.
+
+The principle is positional, not coupled to any specific upstream component:
+
+- **Capture is our responsibility.** If a valid Bearer header is present, copy the token onto ctx.
+- **Rejection is the responsibility of whatever component sits in front of us in the chain.** Today that is `sdkauth.RequireBearerToken`; tomorrow it could be a different validator (e.g. an opaque-token introspection middleware), a custom auth layer, or a hand-built chain in tests.
+
+Two consequences:
+
+1. **No duplication of upstream gating.** Reasonable upstream auth components already produce well-formed 401 responses with the right `WWW-Authenticate` headers, RFC 9728 metadata pointers, and so on. Reimplementing that here would risk subtle disagreement between layers.
+
+2. **Composable in any chain.** The middleware can be wired with or without an upstream validator without becoming an accidental auth gate. In production it sits behind a validator; in some tests it is exercised in isolation. Behaviour stays consistent.
+
+This design intentionally trades "fail fast at the HTTP boundary" for "single responsibility." In production, the upstream validator will reject missing/malformed headers before our middleware ever sees them, so the silent-pass branch is effectively unreachable in real traffic. It exists so the middleware composes safely in non-production paths (tests, future configurations) without quietly turning into an auth enforcer.
+
 ---
 
 ## Files touched
@@ -123,7 +140,7 @@ This section covers production-code work only. Test work is in the next section.
      - Field 1 must be `"Bearer"` matched case-insensitively (`strings.EqualFold`). This matches the SDK's `strings.ToLower(fields[0]) != "bearer"` check.
      - Field 2 must be non-empty.
      - When all three conditions hold: derive a new ctx with `context.WithValue(r.Context(), rawSubjectTokenKey{}, token)` and call `next.ServeHTTP(w, r.WithContext(ctx))`.
-     - When any condition fails: call `next.ServeHTTP(w, r)` unchanged. **No rejection, no error, no log.** The SDK middleware upstream already rejected this case if it was a security issue; we only run when the SDK approved.
+     - When any condition fails: call `next.ServeHTTP(w, r)` unchanged. **No rejection, no error, no log.** Rejection is the responsibility of whatever component sits in front of this middleware in the chain (in production today, that is `sdkauth.RequireBearerToken`). This middleware only captures — it does not duplicate the upstream component's gating role.
 
 4. **Accessor** `RawSubjectTokenFromContext(ctx context.Context) (string, bool)`:
    - `v := ctx.Value(rawSubjectTokenKey{})`.

--- a/docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md
+++ b/docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md
@@ -1,0 +1,317 @@
+# SOL-150797 (T3): Capture the raw subject token on ctx after SDK validation
+
+**Status**: planned
+**Date**: 2026-06-21
+**Branch**: `amorade/SOL-150797`
+**Parent epic**: SOL-150070 (OAuth token exchange / Hop 2)
+**Predecessors**: SOL-150794 (Authenticator interface), SOL-150795 (SEMP clients consume Authenticator), SOL-150796 (broker_oauth config schema + Hop 1/Hop 2 alignment guard)
+
+---
+
+## Why this ticket exists
+
+When `broker_oauth` is enabled, the MCP server performs RFC 8693 token exchange against the customer's IdP per request. The exchange request needs the user's original signed JWT as the `subject_token` parameter. That JWT arrives in the `Authorization: Bearer <jwt>` header of the incoming MCP request, but the MCP Go SDK's `sdkauth.RequireBearerToken` middleware validates the token and forwards only the parsed `*TokenInfo` on ctx — the raw signed string is dropped.
+
+A later ticket will add the OAuth `semp/auth.Authenticator` implementation that calls the IdP. That implementation needs the raw JWT but has only `ctx` to work with. T3 closes this gap: a small middleware stashes the raw bearer token on ctx under an unexported key, and a typed accessor returns it.
+
+---
+
+## Key design decisions (locked)
+
+### 1. Position in the middleware chain: **after** the SDK's `RequireBearerToken`
+
+Chain order at runtime:
+
+```
+sdkauth.RequireBearerToken  →  InjectRawSubjectToken  →  next handler
+       (validates)              (stashes raw JWT)         (MCP SDK)
+```
+
+**Rationale.** Placing `InjectRawSubjectToken` after SDK validation gives the value on ctx a stronger contract: *if a token is present on ctx, the SDK has already validated its signature, issuer, audience, and expiry*. Downstream code (the future OAuth Authenticator) can rely on this invariant without re-validating.
+
+This is encoded in the wiring by wrapping `next` with our middleware first, then letting the SDK middleware wrap that:
+
+```go
+middleware := sdkauth.RequireBearerToken(verifier, &opts)
+return middleware(InjectRawSubjectToken(next)), nil
+```
+
+At request time, the SDK's middleware runs first. If validation fails, it writes 4xx and returns — our middleware is unreachable. If validation succeeds, the SDK calls `handler.ServeHTTP`, which is our middleware. The ordering is guaranteed by Go's control flow in `RequireBearerToken`'s body, not by configuration.
+
+### 2. No `Authenticator` wrapper refactor
+
+We considered building an `auth.AuthResult` + `auth.Authenticator` wrapper around the SDK's auth surface so the raw token would be a field on `AuthResult` (collapsing T3 into validator output). We rejected this for now:
+
+- The MCP SDK is a **framework** the server lives inside, not a **library** it calls. Standard "abstract at the boundary" advice is written for libraries. SDK types appearing in our code where the SDK delivers them is the normal mode of being inside an SDK.
+- The actual leak is small: `*sdkauth.TokenInfo` appears in two non-auth files (`internal/tools/identity.go`, `internal/tools/register.go`), where it is immediately converted to our `Identity` type at the call to `NewIdentityFromTokenInfo`. That conversion *is* the boundary.
+- The wrapper would still have to "shadow-write" `*TokenInfo` on ctx so the SDK's `StreamableHTTPHandler` session-affinity check (`streamable.go:306`) keeps working. The wrapper does not free us from the SDK's auth contract; it only renames it.
+- Cost of the wrapper (≈900 lines touched across production and tests) is disproportionate to the benefit when there is no second consumer of `*sdkauth.TokenInfo` in sight.
+
+If a third consumer of `*sdkauth.TokenInfo` appears outside `internal/auth/` in the future, that is the trigger to reconsider (rule of three). Until then, T3's small middleware is the right tool.
+
+### 3. Naming: `rawSubjectToken`, not `rawToken`
+
+The value's role is RFC 8693's `subject_token`. Naming it after that role makes the contract self-documenting and reserves room for other raw tokens (none today) without name collision.
+
+- File: `internal/auth/raw_subject_token.go`
+- Type: `type rawSubjectTokenKey struct{}` (unexported)
+- Middleware: `func InjectRawSubjectToken(next http.Handler) http.Handler`
+- Accessor: `func RawSubjectTokenFromContext(ctx context.Context) (string, bool)`
+
+The ticket's title and prior commit history use `rawToken`; the PR description will note the rename and the reasoning.
+
+### 4. No per-request logging; one startup log
+
+- **No log of the token bytes at any level**, not even at DEBUG. Token never appears in any log line.
+- **No per-request "token stashed" log.** A per-request log would be noise on a busy server, would constitute a side-channel ("this request carried a valid bearer header"), and the real failure mode (token missing on ctx when downstream needs it) is already loudly observable via the future OAuth Authenticator's error.
+- **One DEBUG line per installation**: `"InjectRawSubjectToken middleware installed"`. Emitted from inside `InjectRawSubjectToken`'s constructor (not from `NewAuthMiddleware`), so the log is colocated with the thing it describes. Today this fires once at startup because there is exactly one call site; if a future configuration installs the middleware on a second endpoint, the log will correctly emit a second line. No `sync.Once`, no package-level state.
+
+### 5. No demo or instrumentation hooks
+
+The Hop 2 prototype carried a `BMS_DEMO_LOG_TOKENS` env-flag for demo logging. T3 does not port that flag or any equivalent. Per parent ticket SOL-150070 acceptance criteria.
+
+### 6. Stateless, ctx-only data flow
+
+- No package-level mutable state.
+- No caches, sync primitives, or maps.
+- All per-request data lives on the stack of the request goroutine and on the request's ctx.
+- The unexported key type ensures no other package can collide with our slot.
+
+---
+
+## Files touched
+
+### New
+
+- `internal/auth/raw_subject_token.go` — middleware, accessor, key type, doc comments.
+- `internal/auth/raw_subject_token_test.go` — full test suite (see test plan below).
+
+### Modified
+
+- `internal/auth/middleware.go` — one-line change at line 72 wrapping `next` with `InjectRawSubjectToken`, plus an explanatory comment and the one startup DEBUG log.
+
+### Not touched
+
+- `cmd/server/main.go` — wiring lives inside `NewAuthMiddleware`; main.go is unaffected.
+- `internal/tools/*` — tool handlers continue to receive `ctx`, no consumer of `RawSubjectTokenFromContext` exists yet.
+- `internal/semp/auth/*` — the future OAuth Authenticator (different ticket) will be the first consumer.
+- Configs, schemas, CHANGELOG.
+
+---
+
+## Implementation plan
+
+This section covers production-code work only. Test work is in the next section.
+
+### Step 1 — Create `internal/auth/raw_subject_token.go`
+
+**Contents, in order:**
+
+1. **Package doc comment** at the top of the file explaining the purpose: the SDK validates and discards the raw bearer token, RFC 8693 token exchange needs it back, this file plugs that hole. Reference the parent architecture plan and this ticket.
+
+2. **Unexported key type**:
+   ```go
+   type rawSubjectTokenKey struct{}
+   ```
+   Empty struct. Zero bytes. Matches the pattern used by `retryStateKey{}` and `retrySafeKey{}` in `internal/semp/resilience/retry.go`.
+
+3. **Middleware** `InjectRawSubjectToken(next http.Handler) http.Handler`:
+   - **At construction time** (before returning the handler): emit one `slog.Debug("InjectRawSubjectToken middleware installed")`. This fires when the constructor runs, which today is once at startup.
+   - **At request time** (inside the returned `http.HandlerFunc`):
+     - Read `r.Header.Get("Authorization")`.
+     - Split with `strings.Fields`. The result must have exactly two fields.
+     - Field 1 must be `"Bearer"` matched case-insensitively (`strings.EqualFold`). This matches the SDK's `strings.ToLower(fields[0]) != "bearer"` check.
+     - Field 2 must be non-empty.
+     - When all three conditions hold: derive a new ctx with `context.WithValue(r.Context(), rawSubjectTokenKey{}, token)` and call `next.ServeHTTP(w, r.WithContext(ctx))`.
+     - When any condition fails: call `next.ServeHTTP(w, r)` unchanged. **No rejection, no error, no log.** The SDK middleware upstream already rejected this case if it was a security issue; we only run when the SDK approved.
+
+4. **Accessor** `RawSubjectTokenFromContext(ctx context.Context) (string, bool)`:
+   - `v := ctx.Value(rawSubjectTokenKey{})`.
+   - If `v == nil` → return `("", false)`.
+   - Type-assert to `string` with `v, ok := v.(string)`. If `!ok` → return `("", false)` (defensive; only this package writes the key).
+   - If `s == ""` → return `("", false)`.
+   - Otherwise return `(s, true)`.
+
+5. **GoDoc comments** on each exported symbol explaining:
+   - `InjectRawSubjectToken`: position constraint (must run after `RequireBearerToken`), what the contract on ctx guarantees, no-op behaviour on malformed headers.
+   - `RawSubjectTokenFromContext`: when it returns true (token present and non-empty), when it returns false (key absent, non-string value, empty string), and the intended consumer (the future OAuth Authenticator).
+
+### Step 2 — Modify `internal/auth/middleware.go`
+
+Current code at lines 68–72:
+
+```go
+middleware := sdkauth.RequireBearerToken(verifier, &sdkauth.RequireBearerTokenOptions{
+    ResourceMetadataURL: metadataURL,
+})
+
+return middleware(next), nil
+```
+
+Replace with:
+
+```go
+middleware := sdkauth.RequireBearerToken(verifier, &sdkauth.RequireBearerTokenOptions{
+    ResourceMetadataURL: metadataURL,
+})
+
+// InjectRawSubjectToken runs AFTER the SDK validates, so any value
+// present on ctx under rawSubjectTokenKey{} has been validated by the
+// SDK (signature, issuer, audience, expiry). Downstream code can rely
+// on this invariant without re-validating. See SOL-150797.
+return middleware(InjectRawSubjectToken(next)), nil
+```
+
+The startup `slog.Debug` lives inside `InjectRawSubjectToken`'s constructor (see Step 1), not here. The wiring site stays a clean one-liner.
+
+### Step 3 — Local verification before commit
+
+- Run `make check` (build, vet, lint, race-enabled tests). Must pass cleanly.
+- Run `/check-logs` against `internal/auth/raw_subject_token.go`. The only log in the file is the startup `slog.Debug("InjectRawSubjectToken middleware installed")` with no fields and no token content. Any findings beyond zero are a regression to investigate.
+
+### Step 4 — Commit
+
+Single commit on `amorade/SOL-150797`. Message:
+
+```
+SOL-150797: capture raw subject token on ctx after SDK auth validates
+
+InjectRawSubjectToken runs after sdkauth.RequireBearerToken so the
+raw bearer token is stashed on ctx only when SDK validation has
+already succeeded. The future OAuth semp Authenticator reads it via
+RawSubjectTokenFromContext to use as subject_token in RFC 8693
+token exchange.
+
+Key type is unexported (rawSubjectTokenKey struct{}); accessor
+returns (string, bool) so callers branch once. No logging of token
+bytes at any level. Stateless — per-request data flows only via ctx.
+```
+
+No `Co-Authored-By` line.
+
+### Step 5 — Open PR
+
+PR description covers:
+
+- What and why in plain English.
+- The position decision (after-validation): SDK validates first, we stash after, so presence-on-ctx implies validation.
+- The naming decision (`rawSubjectToken`, not `rawToken`) and the reason.
+- Why no wrapper refactor (SDK-vs-library distinction).
+- Why no per-request logging (no signal, side-channel risk).
+- The one startup DEBUG log and where it lives.
+- Concurrency note (per-request ctx, stateless middleware).
+- Test coverage summary.
+- Link to this plan document.
+
+### Step 6 — Self-review
+
+Run `/review` on the PR before requesting human review. Address any findings.
+
+---
+
+## Testing plan
+
+This section is intentionally separated from the implementation plan above. Tests live in `internal/auth/raw_subject_token_test.go`. One test file, five named test functions, ≈150–200 lines total, race-clean, expected to run in under 100ms.
+
+### What we are pinning down
+
+Tests should make a future change that breaks any of the following fail loudly:
+
+- The middleware extracts the token correctly from every valid `Bearer` shape and ignores invalid shapes (parsing logic).
+- Concurrent requests do not see each other's tokens (security-critical isolation).
+- The middleware runs only after the SDK has validated the token (position contract).
+- The middleware does not mutate the original request's header or the parent ctx (isolation invariants).
+- The accessor returns the exact captured token, or `("", false)`, with no string-empty surprises (contract).
+
+### What we are NOT testing
+
+- **Log output.** No logs in the file under test; nothing to assert.
+- **Performance / benchmarks.** Two function calls; benchmarks are theater.
+- **The unexported key from outside the package.** Cannot be done; that is the point of the unexported type.
+- **The SDK's own behaviour.** The SDK is its own package's responsibility.
+- **End-to-end OAuth token exchange.** That is the future ticket's test scope.
+
+### Test functions
+
+#### `TestInjectRawSubjectToken_HeaderShapes`
+
+Table-driven. Each row sends one request through `InjectRawSubjectToken` (without the SDK in front, to isolate parsing), captures what the next handler sees via `RawSubjectTokenFromContext`, and asserts the expected outcome.
+
+| Case | Authorization header | Expected `(token, ok)` |
+|---|---|---|
+| Missing | (header absent) | `("", false)` |
+| Empty | `""` | `("", false)` |
+| Bearer + JWT | `Bearer eyJhbGc.payload.sig` | `("eyJhbGc.payload.sig", true)` |
+| lowercase bearer | `bearer eyJhbGc.payload.sig` | `("eyJhbGc.payload.sig", true)` |
+| UPPERCASE BEARER | `BEARER eyJhbGc.payload.sig` | `("eyJhbGc.payload.sig", true)` |
+| MixedCase | `BeArEr eyJhbGc.payload.sig` | `("eyJhbGc.payload.sig", true)` |
+| Bearer alone | `Bearer` | `("", false)` |
+| Bearer with empty token | `Bearer ` | `("", false)` |
+| Basic scheme | `Basic dXNlcjpw` | `("", false)` |
+| DPoP scheme | `DPoP eyJhbGc.payload.sig` | `("", false)` |
+| Token only, no scheme | `eyJhbGc.payload.sig` | `("", false)` |
+| Three fields | `Bearer foo bar` | `("", false)` |
+| Multiple spaces | `Bearer   eyJhbGc.payload.sig` | `("eyJhbGc.payload.sig", true)` (strings.Fields collapses) |
+| Tab separator | `Bearer\teyJhbGc.payload.sig` | `("eyJhbGc.payload.sig", true)` |
+
+#### `TestInjectRawSubjectToken_ConcurrentRequests`
+
+The most important test in the suite. Spins up N goroutines (N = 1000), each sending one request with `Bearer token-<i>`. Inside the next handler, each goroutine captures whatever `RawSubjectTokenFromContext` returns and asserts it matches its own `token-<i>`. Run under `-race`. Any cross-contamination or race detector hit fails the test.
+
+The test exists not because we expect a race — the design has no shared state, so a race is structurally impossible. It exists as a tripwire: if a future change introduces shared state (a package variable, a sync.Map cache, a wrapping of the key into a non-empty struct), this test fails. The absence of races is the exact property the security model depends on.
+
+#### `TestInjectRawSubjectToken_PositionAfterSDK`
+
+Wires `sdkauth.RequireBearerToken(verifier)(InjectRawSubjectToken(probe))` and exercises two scenarios:
+
+- **Valid token**: verifier accepts. Assert the probe handler is reached, that `auth.TokenInfoFromContext` returns non-nil with the expected claims (SDK contract), and that `RawSubjectTokenFromContext` returns the exact original token string. This pins that both the SDK and our middleware ran, in the expected order.
+- **Invalid token**: verifier returns `sdkauth.ErrInvalidToken`. The probe sets `invoked := true`; the test asserts `invoked` stays `false` after the request, proving our middleware was never reached because the SDK short-circuited. This is the load-bearing test for the position decision.
+
+#### `TestInjectRawSubjectToken_RequestIsolation`
+
+Three sub-cases:
+
+- **Header not mutated**: read `r.Header.Get("Authorization")` after the middleware has run. The original header value must be unchanged.
+- **Parent ctx not mutated**: capture the original `r.Context()` before passing to the middleware. After the middleware runs, calling `RawSubjectTokenFromContext` on the *original* parent ctx must return `("", false)`. Only the derived ctx (the one passed to `next`) should carry the token.
+- **No-op passes the request through**: send a request with no `Authorization` header. Use a probe handler that sets `invoked := true`. Assert `invoked` is `true` after the middleware runs. We are not the auth gate; we always call `next`.
+
+#### `TestRawSubjectTokenFromContext_AccessorContract`
+
+Edge cases for the accessor, bypassing the middleware to construct ctxs directly:
+
+- `context.Background()` → `("", false)`.
+- ctx with `rawSubjectTokenKey{}` explicitly set to `nil` → `("", false)`.
+- ctx with `rawSubjectTokenKey{}` set to a non-string value (e.g. an int) → `("", false)` (defensive type-assertion).
+- ctx with `rawSubjectTokenKey{}` set to `""` (empty string) → `("", false)`. This is the contract that lets callers branch once.
+- ctx with `rawSubjectTokenKey{}` set to `"eyJhbGc.payload.sig"` → `("eyJhbGc.payload.sig", true)`. Byte-for-byte round trip.
+
+### Outside-the-file consideration
+
+The wiring in `NewAuthMiddleware` is what makes T3 actually run in production. The existing `internal/auth/middleware_test.go` covers `NewAuthMiddleware` output. A small assertion added there — "the handler returned by `NewAuthMiddleware` for OAuth mode, when invoked with a valid token, produces a ctx where `RawSubjectTokenFromContext` returns the original token" — closes the gap that a future maintainer could otherwise create by accidentally removing the `InjectRawSubjectToken` wrap.
+
+This is a minor addition (~15 lines) to an existing test file. It is in scope for T3.
+
+### Local verification
+
+- `go test ./internal/auth/... -race -v` must pass with zero races.
+- `make check` must pass cleanly.
+- `/check-logs` must report zero findings on the new and modified files.
+
+---
+
+## Out-of-scope reminders
+
+To prevent scope drift during implementation:
+
+- **No demo logging or instrumentation hooks** (no `BMS_DEMO_LOG_TOKENS` or equivalent).
+- **No caching** of the raw token or any derived value. Deferred to a separate follow-up story.
+- **No changes to the future OAuth Authenticator.** That implementation lives in its own ticket and is the first consumer of `RawSubjectTokenFromContext`.
+- **No wrapper refactor.** Considered and rejected; reasons documented in the "Key design decisions" section.
+- **No `cmd/server/main.go` edits.** The wiring is contained in `NewAuthMiddleware`.
+- **No schema, config, or CHANGELOG changes.** T3 is plumbing internal to the auth layer.
+
+---
+
+## Open items at time of writing
+
+None. All design decisions locked. Ready to implement.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -69,7 +69,14 @@ func NewAuthMiddleware(cfg *config.ServerConfig, next http.Handler) (http.Handle
 		ResourceMetadataURL: metadataURL,
 	})
 
-	return middleware(next), nil
+	// InjectRawSubjectToken is wrapped INSIDE the SDK middleware so it runs
+	// only after sdkauth.RequireBearerToken has validated the bearer token
+	// (signature, issuer, audience, expiry). A value reaching ctx under
+	// rawSubjectTokenKey{} therefore carries the SDK-validated invariant,
+	// which the future OAuth Authenticator relies on as the subject_token
+	// for RFC 8693 exchange. See SOL-150797 and
+	// docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md.
+	return middleware(InjectRawSubjectToken(next)), nil
 }
 
 // NewTokenVerifier creates a TokenVerifier based on cfg.MCPClientAuth.Mode.

--- a/internal/auth/raw_subject_token.go
+++ b/internal/auth/raw_subject_token.go
@@ -49,14 +49,13 @@ type rawSubjectTokenKey struct{}
 // InjectRawSubjectToken returns middleware that copies the bearer token
 // from the Authorization header onto the request context.
 //
-// The middleware is intended to run AFTER the MCP SDK's RequireBearerToken
-// in the chain, so the token it captures has already been validated by
-// the SDK. The position is established at wiring time in NewAuthMiddleware.
-//
 // On any malformed or non-Bearer Authorization header the middleware is a
 // no-op — it does not reject the request and does not modify the context.
 // Rejection is the responsibility of whatever component sits in front of
 // this middleware in the chain; this middleware only captures.
+//
+// See the package doc for the position invariant and why this middleware
+// exists.
 func InjectRawSubjectToken(next http.Handler) http.Handler {
 	// One-shot startup log per installation. Today this fires exactly
 	// once at server startup (single call site in NewAuthMiddleware);
@@ -87,18 +86,14 @@ func InjectRawSubjectToken(next http.Handler) http.Handler {
 // RawSubjectTokenFromContext returns the raw bearer token captured by
 // InjectRawSubjectToken, or ("", false) if none is present.
 //
-// The ok return is false when:
-//   - no value is stored under the key (InjectRawSubjectToken was not in
-//     the chain, or the request had no valid Bearer header);
-//   - the stored value is the empty string (defensive; the middleware
-//     never stores an empty token, but the accessor folds the check in
-//     so callers branch once);
-//   - the stored value is not a string (impossible in production; only
-//     this package writes the key).
+// The ok return is false when no value is stored, when the stored value
+// is the empty string, or when it is not a string (the latter two are
+// defensive; the middleware never stores either in production). Folding
+// these into ok=false lets callers branch once.
 //
-// A successful return implies the token has been validated by the SDK
-// middleware upstream of InjectRawSubjectToken (signature, issuer,
-// audience, expiry). The caller does not re-validate.
+// See the package doc for the validation invariant: a true return means
+// the token has already been validated upstream and the caller does not
+// re-validate.
 func RawSubjectTokenFromContext(ctx context.Context) (string, bool) {
 	v := ctx.Value(rawSubjectTokenKey{})
 	if v == nil {

--- a/internal/auth/raw_subject_token.go
+++ b/internal/auth/raw_subject_token.go
@@ -1,0 +1,112 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package auth — raw subject token plumbing for RFC 8693 token exchange.
+//
+// The MCP SDK's RequireBearerToken validates the incoming bearer token and
+// places a *TokenInfo (parsed claims) on the request context, but discards
+// the raw signed JWT string. Hop 2 token exchange (SOL-150797) needs that
+// raw string as the subject_token in the RFC 8693 exchange request to the
+// IdP.
+//
+// InjectRawSubjectToken runs immediately downstream of the SDK middleware
+// and captures the raw token from the Authorization header onto the
+// request context under an unexported key. RawSubjectTokenFromContext is
+// the read-side accessor used by the outbound OAuth Authenticator.
+//
+// Position invariant: InjectRawSubjectToken is wired so it runs only AFTER
+// sdkauth.RequireBearerToken has validated the token. Therefore a value
+// present under rawSubjectTokenKey{} has already been validated by the
+// SDK (signature, issuer, audience, expiry). Downstream code reads it
+// without re-validating.
+package auth
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// rawSubjectTokenKey is the unexported context key under which the raw
+// bearer token is stored. The empty-struct, package-private type makes
+// the key impossible to construct from outside this package, so no other
+// package can collide with it or read the value except through
+// RawSubjectTokenFromContext.
+type rawSubjectTokenKey struct{}
+
+// InjectRawSubjectToken returns middleware that copies the bearer token
+// from the Authorization header onto the request context.
+//
+// The middleware is intended to run AFTER the MCP SDK's RequireBearerToken
+// in the chain, so the token it captures has already been validated by
+// the SDK. The position is established at wiring time in NewAuthMiddleware.
+//
+// On any malformed or non-Bearer Authorization header the middleware is a
+// no-op — it does not reject the request and does not modify the context.
+// The SDK middleware upstream is the authority on whether a request is
+// allowed through.
+func InjectRawSubjectToken(next http.Handler) http.Handler {
+	// One-shot startup log per installation. Today this fires exactly
+	// once at server startup (single call site in NewAuthMiddleware);
+	// future multi-endpoint installs would correctly emit one line each.
+	// No token content is logged here or anywhere else in this file.
+	slog.Debug("InjectRawSubjectToken middleware installed")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The parse here intentionally mirrors sdkauth.verify in
+		// go-sdk v1.5.0 (auth/auth.go: strings.Fields + case-insensitive
+		// "bearer" check). Because the SDK runs upstream of us, anything
+		// it rejected we never see; anything it accepted should match
+		// these conditions. If the SDK ever changes its parsing rules,
+		// this code may under-capture (we'd silently fail to stash a
+		// token the SDK approved) — the safe drift direction, but worth
+		// revisiting on SDK upgrades.
+		authHeader := r.Header.Get("Authorization")
+		fields := strings.Fields(authHeader)
+		if len(fields) == 2 && strings.EqualFold(fields[0], "Bearer") && fields[1] != "" {
+			ctx := context.WithValue(r.Context(), rawSubjectTokenKey{}, fields[1])
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// RawSubjectTokenFromContext returns the raw bearer token captured by
+// InjectRawSubjectToken, or ("", false) if none is present.
+//
+// The ok return is false when:
+//   - no value is stored under the key (InjectRawSubjectToken was not in
+//     the chain, or the request had no valid Bearer header);
+//   - the stored value is the empty string (defensive; the middleware
+//     never stores an empty token, but the accessor folds the check in
+//     so callers branch once);
+//   - the stored value is not a string (impossible in production; only
+//     this package writes the key).
+//
+// A successful return implies the token has been validated by the SDK
+// middleware upstream of InjectRawSubjectToken (signature, issuer,
+// audience, expiry). The caller does not re-validate.
+func RawSubjectTokenFromContext(ctx context.Context) (string, bool) {
+	v := ctx.Value(rawSubjectTokenKey{})
+	if v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}

--- a/internal/auth/raw_subject_token.go
+++ b/internal/auth/raw_subject_token.go
@@ -55,8 +55,8 @@ type rawSubjectTokenKey struct{}
 //
 // On any malformed or non-Bearer Authorization header the middleware is a
 // no-op — it does not reject the request and does not modify the context.
-// The SDK middleware upstream is the authority on whether a request is
-// allowed through.
+// Rejection is the responsibility of whatever component sits in front of
+// this middleware in the chain; this middleware only captures.
 func InjectRawSubjectToken(next http.Handler) http.Handler {
 	// One-shot startup log per installation. Today this fires exactly
 	// once at server startup (single call site in NewAuthMiddleware);

--- a/internal/auth/raw_subject_token_test.go
+++ b/internal/auth/raw_subject_token_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -124,7 +125,7 @@ func TestInjectRawSubjectToken_ConcurrentRequests(t *testing.T) {
 			for i := 0; i < iterationsPerGoroutine; i++ {
 				// Build a unique token per request so any cross-talk
 				// would be immediately observable.
-				tok := "token-w" + itoa(workerID) + "-i" + itoa(i)
+				tok := "token-w" + strconv.Itoa(workerID) + "-i" + strconv.Itoa(i)
 				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 				req.Header.Set("Authorization", "Bearer "+tok)
 				req.Header.Set("X-Expected-Token", tok)
@@ -235,25 +236,3 @@ func TestRawSubjectTokenFromContext_AccessorContract(t *testing.T) {
 	})
 }
 
-// itoa avoids importing strconv in the concurrency test. Small, single-purpose.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
-}

--- a/internal/auth/raw_subject_token_test.go
+++ b/internal/auth/raw_subject_token_test.go
@@ -37,7 +37,7 @@ func runMiddleware(t *testing.T, authHeader string) (gotToken string, ok bool, n
 		nextInvoked = true
 		gotToken, ok = RawSubjectTokenFromContext(r.Context())
 	}))
-	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 	if authHeader != "" {
 		req.Header.Set("Authorization", authHeader)
 	}
@@ -129,7 +129,7 @@ func TestInjectRawSubjectToken_ConcurrentRequests(t *testing.T) {
 				// Build a unique token per request so any cross-talk
 				// would be immediately observable.
 				tok := "token-w" + itoa(workerID) + "-i" + itoa(i)
-				req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 				req.Header.Set("Authorization", "Bearer "+tok)
 				req.Header.Set("X-Expected-Token", tok)
 				rec := httptest.NewRecorder()
@@ -157,7 +157,7 @@ func TestInjectRawSubjectToken_RequestIsolation(t *testing.T) {
 	t.Parallel()
 	const jwt = "eyJhbGciOiJSUzI1NiJ9.payload.sig"
 
-	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer "+jwt)
 	parentCtx := req.Context()
 
@@ -212,7 +212,7 @@ func TestInjectRawSubjectToken_PositionAfterSDK(t *testing.T) {
 		})
 		chain := sdkauth.RequireBearerToken(verifier, nil)(InjectRawSubjectToken(downstream))
 
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer "+goodToken)
 		chain.ServeHTTP(httptest.NewRecorder(), req)
 
@@ -241,7 +241,7 @@ func TestInjectRawSubjectToken_PositionAfterSDK(t *testing.T) {
 		// short-circuit before InjectRawSubjectToken's inner func runs.
 		chain := sdkauth.RequireBearerToken(verifier, nil)(InjectRawSubjectToken(ourMiddleware))
 
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer bogus")
 		rec := httptest.NewRecorder()
 		chain.ServeHTTP(rec, req)

--- a/internal/auth/raw_subject_token_test.go
+++ b/internal/auth/raw_subject_token_test.go
@@ -1,0 +1,331 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+)
+
+// runMiddleware sends a request with the given Authorization header through
+// InjectRawSubjectToken and returns whatever RawSubjectTokenFromContext
+// observes inside the downstream handler. ok is the second return of the
+// accessor; nextInvoked reports whether the wrapped handler actually ran.
+func runMiddleware(t *testing.T, authHeader string) (gotToken string, ok bool, nextInvoked bool) {
+	t.Helper()
+	handler := InjectRawSubjectToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextInvoked = true
+		gotToken, ok = RawSubjectTokenFromContext(r.Context())
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	return gotToken, ok, nextInvoked
+}
+
+// TestInjectRawSubjectToken_HeaderShapes pins the parse rules: which
+// Authorization header values cause the token to be stashed on ctx, and
+// which are silently passed through as no-ops. The middleware never
+// rejects on its own — the SDK upstream is the authority.
+func TestInjectRawSubjectToken_HeaderShapes(t *testing.T) {
+	t.Parallel()
+	const jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature"
+
+	cases := []struct {
+		name        string
+		header      string
+		wantToken   string
+		wantOK      bool
+		description string
+	}{
+		{"missing header", "", "", false, "no Authorization at all"},
+		{"valid Bearer", "Bearer " + jwt, jwt, true, "canonical shape"},
+		{"lowercase bearer", "bearer " + jwt, jwt, true, "scheme matched case-insensitively"},
+		{"uppercase BEARER", "BEARER " + jwt, jwt, true, "scheme matched case-insensitively"},
+		{"mixed case", "BeArEr " + jwt, jwt, true, "scheme matched case-insensitively"},
+		{"Bearer alone", "Bearer", "", false, "one field after split"},
+		{"Bearer trailing space", "Bearer ", "", false, "trailing whitespace collapses to one field"},
+		{"Basic scheme", "Basic dXNlcjpwYXNz", "", false, "wrong scheme"},
+		{"DPoP scheme", "DPoP " + jwt, "", false, "wrong scheme"},
+		{"token only no scheme", jwt, "", false, "one field"},
+		{"three fields", "Bearer " + jwt + " extra", "", false, "extra token"},
+		{"extra spaces", "Bearer   " + jwt, jwt, true, "strings.Fields collapses whitespace"},
+		{"tab separator", "Bearer\t" + jwt, jwt, true, "strings.Fields handles tabs"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotToken, ok, nextInvoked := runMiddleware(t, tc.header)
+			if !nextInvoked {
+				t.Fatalf("next handler was not invoked; middleware must always pass through (%s)", tc.description)
+			}
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v (%s)", ok, tc.wantOK, tc.description)
+			}
+			if gotToken != tc.wantToken {
+				t.Errorf("token = %q, want %q (%s)", gotToken, tc.wantToken, tc.description)
+			}
+		})
+	}
+}
+
+// TestInjectRawSubjectToken_ConcurrentRequests is the security-critical
+// test: prove that two concurrent requests with different tokens cannot
+// see each other's token. The design has no shared mutable state, so a
+// race is structurally impossible — this test pins that property so any
+// future change that introduces shared state fails CI.
+//
+// Run under -race for the full guarantee.
+func TestInjectRawSubjectToken_ConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 64
+	const iterationsPerGoroutine = 1000
+
+	handler := InjectRawSubjectToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expected := r.Header.Get("X-Expected-Token")
+		got, ok := RawSubjectTokenFromContext(r.Context())
+		if !ok || got != expected {
+			// Write a marker so the spawning goroutine can detect the
+			// cross-contamination. We do NOT log the actual token
+			// values — only the fact that they did not match.
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var mismatches atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < iterationsPerGoroutine; i++ {
+				// Build a unique token per request so any cross-talk
+				// would be immediately observable.
+				tok := "token-w" + itoa(workerID) + "-i" + itoa(i)
+				req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+				req.Header.Set("Authorization", "Bearer "+tok)
+				req.Header.Set("X-Expected-Token", tok)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				if rec.Code != http.StatusOK {
+					mismatches.Add(1)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	if n := mismatches.Load(); n > 0 {
+		t.Fatalf("cross-request token contamination detected: %d mismatches out of %d requests", n, goroutines*iterationsPerGoroutine)
+	}
+}
+
+// TestInjectRawSubjectToken_RequestIsolation pins two no-mutation
+// guarantees: the middleware must not alter the original request's
+// Authorization header, and the parent context (the one on the original
+// r before ServeHTTP was called) must not carry the stashed token —
+// only the derived context handed to the next handler does.
+func TestInjectRawSubjectToken_RequestIsolation(t *testing.T) {
+	t.Parallel()
+	const jwt = "eyJhbGciOiJSUzI1NiJ9.payload.sig"
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	parentCtx := req.Context()
+
+	var nextSawHeader string
+	handler := InjectRawSubjectToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextSawHeader = r.Header.Get("Authorization")
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Header on the original request must be untouched.
+	if got := req.Header.Get("Authorization"); got != "Bearer "+jwt {
+		t.Errorf("original Authorization header was mutated: got %q", got)
+	}
+	// Header must also be visible to the next handler (i.e. the SDK
+	// downstream session-affinity logic that may read it).
+	if nextSawHeader != "Bearer "+jwt {
+		t.Errorf("next handler did not see Authorization header: got %q", nextSawHeader)
+	}
+	// The parent context (the one the request had before InjectRawSubjectToken
+	// derived its own) must NOT carry the stashed token — only the
+	// derived ctx handed to next does.
+	if _, ok := RawSubjectTokenFromContext(parentCtx); ok {
+		t.Error("parent context was polluted with rawSubjectTokenKey; middleware must derive a new ctx instead")
+	}
+}
+
+// TestInjectRawSubjectToken_PositionAfterSDK pins the wiring contract:
+// when chained behind the SDK's RequireBearerToken (as NewAuthMiddleware
+// does), InjectRawSubjectToken runs only after the SDK has approved the
+// request. A rejected request must never reach our middleware, and the
+// raw token observed by downstream must equal the token the SDK passed
+// to the verifier.
+func TestInjectRawSubjectToken_PositionAfterSDK(t *testing.T) {
+	t.Parallel()
+	const goodToken = "eyJhbGciOiJSUzI1NiJ9.good.sig"
+
+	t.Run("valid token reaches our middleware and downstream sees the raw token", func(t *testing.T) {
+		t.Parallel()
+		var verifierSawToken string
+		verifier := func(_ context.Context, token string, _ *http.Request) (*sdkauth.TokenInfo, error) {
+			verifierSawToken = token
+			return &sdkauth.TokenInfo{
+				UserID:     "test-user",
+				Expiration: time.Now().Add(time.Hour),
+			}, nil
+		}
+
+		var downstreamSawToken string
+		var downstreamOK bool
+		downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamSawToken, downstreamOK = RawSubjectTokenFromContext(r.Context())
+		})
+		chain := sdkauth.RequireBearerToken(verifier, nil)(InjectRawSubjectToken(downstream))
+
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer "+goodToken)
+		chain.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !downstreamOK {
+			t.Fatal("downstream did not see a raw token; InjectRawSubjectToken did not stash it")
+		}
+		if downstreamSawToken != verifierSawToken {
+			t.Errorf("downstream token %q != verifier token %q (must be the same bytes)", downstreamSawToken, verifierSawToken)
+		}
+		if downstreamSawToken != goodToken {
+			t.Errorf("downstream token %q != expected %q", downstreamSawToken, goodToken)
+		}
+	})
+
+	t.Run("invalid token is rejected by SDK; our middleware is never invoked", func(t *testing.T) {
+		t.Parallel()
+		verifier := func(_ context.Context, _ string, _ *http.Request) (*sdkauth.TokenInfo, error) {
+			return nil, errors.New("token rejected for test: " + sdkauth.ErrInvalidToken.Error())
+		}
+
+		var ourMiddlewareInvoked bool
+		ourMiddleware := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ourMiddlewareInvoked = true
+		})
+		// Wrap our handler with InjectRawSubjectToken; the SDK should
+		// short-circuit before InjectRawSubjectToken's inner func runs.
+		chain := sdkauth.RequireBearerToken(verifier, nil)(InjectRawSubjectToken(ourMiddleware))
+
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer bogus")
+		rec := httptest.NewRecorder()
+		chain.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusInternalServerError {
+			// We tolerate either 401 (errors.Is(err, ErrInvalidToken)) or
+			// 500 (any other error), depending on how the SDK unwraps.
+			t.Errorf("expected SDK to reject the request; got status %d", rec.Code)
+		}
+		if ourMiddlewareInvoked {
+			t.Fatal("downstream handler was invoked despite SDK rejection; chain order is broken")
+		}
+	})
+}
+
+// TestRawSubjectTokenFromContext_AccessorContract covers the accessor's
+// edge cases: nil value, wrong type, empty string. The middleware never
+// writes any of these in production, but the accessor folds the checks
+// in so callers branch once.
+func TestRawSubjectTokenFromContext_AccessorContract(t *testing.T) {
+	t.Parallel()
+
+	t.Run("background context has no token", func(t *testing.T) {
+		t.Parallel()
+		s, ok := RawSubjectTokenFromContext(context.Background())
+		if ok || s != "" {
+			t.Errorf("got (%q, %v), want (\"\", false)", s, ok)
+		}
+	})
+
+	t.Run("context with non-string value returns not-ok", func(t *testing.T) {
+		t.Parallel()
+		// Only this package can construct rawSubjectTokenKey{}, so this
+		// test is defensive only — guards against a future bug inside
+		// this package that stores the wrong type.
+		ctx := context.WithValue(context.Background(), rawSubjectTokenKey{}, 42)
+		s, ok := RawSubjectTokenFromContext(ctx)
+		if ok || s != "" {
+			t.Errorf("got (%q, %v), want (\"\", false)", s, ok)
+		}
+	})
+
+	t.Run("context with empty string returns not-ok", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.WithValue(context.Background(), rawSubjectTokenKey{}, "")
+		s, ok := RawSubjectTokenFromContext(ctx)
+		if ok || s != "" {
+			t.Errorf("got (%q, %v), want (\"\", false)", s, ok)
+		}
+	})
+
+	t.Run("exact round-trip preserves token bytes", func(t *testing.T) {
+		t.Parallel()
+		const want = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature_with-special.chars"
+		ctx := context.WithValue(context.Background(), rawSubjectTokenKey{}, want)
+		got, ok := RawSubjectTokenFromContext(ctx)
+		if !ok {
+			t.Fatal("ok = false, want true")
+		}
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+// itoa avoids importing strconv in the concurrency test. Small, single-purpose.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/auth/raw_subject_token_test.go
+++ b/internal/auth/raw_subject_token_test.go
@@ -16,15 +16,11 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
-
-	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 )
 
 // runMiddleware sends a request with the given Authorization header through
@@ -184,78 +180,10 @@ func TestInjectRawSubjectToken_RequestIsolation(t *testing.T) {
 	}
 }
 
-// TestInjectRawSubjectToken_PositionAfterSDK pins the wiring contract:
-// when chained behind the SDK's RequireBearerToken (as NewAuthMiddleware
-// does), InjectRawSubjectToken runs only after the SDK has approved the
-// request. A rejected request must never reach our middleware, and the
-// raw token observed by downstream must equal the token the SDK passed
-// to the verifier.
-func TestInjectRawSubjectToken_PositionAfterSDK(t *testing.T) {
-	t.Parallel()
-	const goodToken = "eyJhbGciOiJSUzI1NiJ9.good.sig"
-
-	t.Run("valid token reaches our middleware and downstream sees the raw token", func(t *testing.T) {
-		t.Parallel()
-		var verifierSawToken string
-		verifier := func(_ context.Context, token string, _ *http.Request) (*sdkauth.TokenInfo, error) {
-			verifierSawToken = token
-			return &sdkauth.TokenInfo{
-				UserID:     "test-user",
-				Expiration: time.Now().Add(time.Hour),
-			}, nil
-		}
-
-		var downstreamSawToken string
-		var downstreamOK bool
-		downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			downstreamSawToken, downstreamOK = RawSubjectTokenFromContext(r.Context())
-		})
-		chain := sdkauth.RequireBearerToken(verifier, nil)(InjectRawSubjectToken(downstream))
-
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
-		req.Header.Set("Authorization", "Bearer "+goodToken)
-		chain.ServeHTTP(httptest.NewRecorder(), req)
-
-		if !downstreamOK {
-			t.Fatal("downstream did not see a raw token; InjectRawSubjectToken did not stash it")
-		}
-		if downstreamSawToken != verifierSawToken {
-			t.Errorf("downstream token %q != verifier token %q (must be the same bytes)", downstreamSawToken, verifierSawToken)
-		}
-		if downstreamSawToken != goodToken {
-			t.Errorf("downstream token %q != expected %q", downstreamSawToken, goodToken)
-		}
-	})
-
-	t.Run("invalid token is rejected by SDK; our middleware is never invoked", func(t *testing.T) {
-		t.Parallel()
-		verifier := func(_ context.Context, _ string, _ *http.Request) (*sdkauth.TokenInfo, error) {
-			return nil, errors.New("token rejected for test: " + sdkauth.ErrInvalidToken.Error())
-		}
-
-		var ourMiddlewareInvoked bool
-		ourMiddleware := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ourMiddlewareInvoked = true
-		})
-		// Wrap our handler with InjectRawSubjectToken; the SDK should
-		// short-circuit before InjectRawSubjectToken's inner func runs.
-		chain := sdkauth.RequireBearerToken(verifier, nil)(InjectRawSubjectToken(ourMiddleware))
-
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
-		req.Header.Set("Authorization", "Bearer bogus")
-		rec := httptest.NewRecorder()
-		chain.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusInternalServerError {
-			// We tolerate either 401 (errors.Is(err, ErrInvalidToken)) or
-			// 500 (any other error), depending on how the SDK unwraps.
-			t.Errorf("expected SDK to reject the request; got status %d", rec.Code)
-		}
-		if ourMiddlewareInvoked {
-			t.Fatal("downstream handler was invoked despite SDK rejection; chain order is broken")
-		}
-	})
-}
+// The chain-order integration test (SDK middleware + InjectRawSubjectToken
+// composed) lives at test/integration/raw_subject_token_capture_test.go.
+// It belongs there because the assertion only makes sense when both
+// middlewares are wired together; see test/integration/README.md.
 
 // TestRawSubjectTokenFromContext_AccessorContract covers the accessor's
 // edge cases: nil value, wrong type, empty string. The middleware never

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -56,6 +56,10 @@ marker; cheap-to-create new files are the structure.
 - `broker_credential_isolation_test.go` — credentials configured for one
   broker never reach another broker's wire, under concurrent load. Static
   modes only (basic, bearer).
+- `raw_subject_token_capture_test.go` — the SOL-150797 chain-order
+  invariant: `auth.InjectRawSubjectToken` wrapped inside the SDK's
+  `RequireBearerToken` makes the raw bearer token reachable on ctx
+  downstream of validation, and never reachable when validation failed.
 
 ### Anticipated future files (see SOL-150070 decomposition)
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -56,10 +56,13 @@ marker; cheap-to-create new files are the structure.
 - `broker_credential_isolation_test.go` — credentials configured for one
   broker never reach another broker's wire, under concurrent load. Static
   modes only (basic, bearer).
-- `raw_subject_token_capture_test.go` — the SOL-150797 chain-order
-  invariant: `auth.InjectRawSubjectToken` wrapped inside the SDK's
-  `RequireBearerToken` makes the raw bearer token reachable on ctx
-  downstream of validation, and never reachable when validation failed.
+- `raw_subject_token_capture_test.go` — two SOL-150797 invariants:
+  (a) the chain-order contract — `auth.InjectRawSubjectToken` wrapped
+  inside the SDK's `RequireBearerToken` makes the raw bearer token
+  reachable on ctx downstream of validation, and never reachable when
+  validation failed; (b) the production wiring — `auth.NewAuthMiddleware`
+  itself installs `InjectRawSubjectToken` into the chain (regression
+  guard for a future refactor that silently drops the wrap).
 
 ### Anticipated future files (see SOL-150070 decomposition)
 

--- a/test/integration/raw_subject_token_capture_test.go
+++ b/test/integration/raw_subject_token_capture_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/auth"
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 )
@@ -122,4 +123,52 @@ func TestRawSubjectTokenCapture_AfterSDKValidation(t *testing.T) {
 		}
 		t.Logf("rejection short-circuit ok: SDK returned %d and probe was never invoked", rec.Code)
 	})
+}
+
+// TestRawSubjectTokenCapture_WiredByNewAuthMiddleware pins the production
+// wiring: calling auth.NewAuthMiddleware on a real *config.ServerConfig
+// installs auth.InjectRawSubjectToken into the chain. Without this test,
+// a refactor that drops `InjectRawSubjectToken(next)` from
+// internal/auth/middleware.go would not fail any existing test — the
+// chain-order test above builds the chain by hand and so does not
+// exercise NewAuthMiddleware.
+//
+// Static mode is used because it is the smallest production-supported
+// MCPClientAuth.Mode that activates the auth chain (the disabled mode
+// returns next directly without wrapping). The dev token doubles as a
+// readable test fixture; production OIDC mode would require an IdP and
+// would not change what is asserted here.
+func TestRawSubjectTokenCapture_WiredByNewAuthMiddleware(t *testing.T) {
+	t.Parallel()
+	const devToken = "static-mode-dev-token-fixture"
+
+	cfg := &config.ServerConfig{
+		MCPClientAuth: config.MCPClientAuthConfig{
+			Mode:     config.AuthModeStatic,
+			DevToken: devToken,
+		},
+	}
+
+	var downstreamSawToken string
+	var downstreamOK bool
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamSawToken, downstreamOK = auth.RawSubjectTokenFromContext(r.Context())
+	})
+
+	handler, err := auth.NewAuthMiddleware(cfg, downstream)
+	if err != nil {
+		t.Fatalf("NewAuthMiddleware returned error: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+devToken)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !downstreamOK {
+		t.Fatal("downstream did not observe a raw token on ctx — NewAuthMiddleware is not wiring InjectRawSubjectToken into the chain")
+	}
+	if downstreamSawToken != devToken {
+		t.Errorf("downstream token %q != dev token %q", downstreamSawToken, devToken)
+	}
+	t.Logf("production wiring ok: NewAuthMiddleware in static mode passes the bearer token through to ctx")
 }

--- a/test/integration/raw_subject_token_capture_test.go
+++ b/test/integration/raw_subject_token_capture_test.go
@@ -16,7 +16,7 @@ package integration_test
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,6 +49,17 @@ import (
 // mode-agnostic, so the choice of verifier does not change what is
 // being tested. Validator correctness for static and OIDC modes is
 // covered by internal/auth/middleware_test.go.
+//
+// What the rejection subtest does and does NOT assert:
+// the load-bearing assertion is "our middleware was not invoked"
+// (probeInvoked == false). The HTTP status code is a sanity guard
+// only — we accept any 4xx/5xx and do not pin a specific value.
+// The SDK returns 401 when the verifier wraps ErrInvalidToken and
+// 500 otherwise; both are correct from the perspective of this
+// test, which is about chain-order behaviour, not about which SDK
+// branch the rejection took. Pinning a specific status code would
+// be false precision — it would couple the test to an SDK internal
+// while adding no signal about our middleware.
 func TestRawSubjectTokenCapture_AfterSDKValidation(t *testing.T) {
 	t.Parallel()
 	const goodToken = "eyJhbGciOiJSUzI1NiJ9.good.sig"
@@ -93,13 +104,19 @@ func TestRawSubjectTokenCapture_AfterSDKValidation(t *testing.T) {
 
 	t.Run("rejected token short-circuits at the SDK and never reaches our middleware", func(t *testing.T) {
 		t.Parallel()
-		// Wrap with %w so errors.Is(err, ErrInvalidToken) returns true
-		// inside the SDK. That makes the SDK take its 401 branch — the
-		// same code path production hits when go-oidc rejects a JWT.
-		// Returning a plain errors.New here would fall through to the
-		// SDK's 500 fallback, exercising the wrong production path.
+		// Any error from the verifier causes the SDK to reject the
+		// request. The specific status code depends on SDK internals
+		// (401 if errors.Is(err, ErrInvalidToken), 500 otherwise) and is
+		// not the property under test. The property is: when the upstream
+		// validator rejects, our middleware does not run.
+		//
+		// Earlier iterations of this test wrapped the sentinel with %w
+		// and asserted status 401 exactly. That was reverted: pinning a
+		// specific SDK branch is false precision when our assertion
+		// is about middleware behaviour, not SDK behaviour. See the
+		// function-level doc above for the full reasoning.
 		verifier := func(_ context.Context, _ string, _ *http.Request) (*sdkauth.TokenInfo, error) {
-			return nil, fmt.Errorf("token rejected for test: %w", sdkauth.ErrInvalidToken)
+			return nil, errors.New("token rejected for test")
 		}
 
 		// Probe handler under InjectRawSubjectToken. If control flow ever
@@ -117,12 +134,10 @@ func TestRawSubjectTokenCapture_AfterSDKValidation(t *testing.T) {
 		rec := httptest.NewRecorder()
 		chain.ServeHTTP(rec, req)
 
-		// Verifier wraps ErrInvalidToken, so the SDK must take its 401
-		// branch — matching production where go-oidc rejects with the
-		// same wrapped error. A 500 here would indicate the verifier's
-		// error stopped unwrapping correctly.
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("expected SDK to reject the request with 401, got status %d", rec.Code)
+		// Sanity guard: the SDK must respond with some 4xx/5xx. The
+		// load-bearing assertion is probeInvoked == false below.
+		if rec.Code < 400 {
+			t.Errorf("expected SDK to reject the request with a 4xx/5xx status, got %d", rec.Code)
 		}
 		if probeInvoked {
 			t.Fatal("downstream handler ran despite SDK rejection — chain-order invariant is broken; InjectRawSubjectToken is positioned outside the SDK")

--- a/test/integration/raw_subject_token_capture_test.go
+++ b/test/integration/raw_subject_token_capture_test.go
@@ -1,0 +1,125 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/auth"
+
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+)
+
+// TestRawSubjectTokenCapture_AfterSDKValidation pins the chain-order
+// invariant for SOL-150797: when auth.InjectRawSubjectToken is wrapped
+// inside the SDK's RequireBearerToken (the production wiring established
+// in internal/auth/middleware.go), the raw bearer token reaches the
+// request context downstream of validation, and only when validation
+// succeeded.
+//
+// Why this lives in test/integration (not internal/auth):
+// the assertion is a contract between two components — the MCP SDK's
+// RequireBearerToken middleware and our auth.InjectRawSubjectToken. It
+// cannot be expressed using only one component's public surface. Per
+// test/integration/README.md, that is precisely the criterion for the
+// integration tier.
+//
+// Why a hand-written verifier (not createOIDCTokenVerifier or
+// createStaticTokenVerifier): we want to control the SDK's accept /
+// reject decision deterministically without standing up an IdP or
+// hard-coding a static dev token. The middleware's behaviour is
+// mode-agnostic, so the choice of verifier does not change what is
+// being tested. Validator correctness for static and OIDC modes is
+// covered by internal/auth/middleware_test.go.
+func TestRawSubjectTokenCapture_AfterSDKValidation(t *testing.T) {
+	t.Parallel()
+	const goodToken = "eyJhbGciOiJSUzI1NiJ9.good.sig"
+
+	t.Run("valid token survives the chain and reaches downstream on ctx", func(t *testing.T) {
+		t.Parallel()
+		var verifierSawToken string
+		verifier := func(_ context.Context, token string, _ *http.Request) (*sdkauth.TokenInfo, error) {
+			verifierSawToken = token
+			return &sdkauth.TokenInfo{
+				UserID:     "test-user",
+				Expiration: time.Now().Add(time.Hour),
+			}, nil
+		}
+
+		var downstreamSawToken string
+		var downstreamOK bool
+		downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			downstreamSawToken, downstreamOK = auth.RawSubjectTokenFromContext(r.Context())
+		})
+
+		// Wiring mirrors internal/auth/middleware.go:
+		//   chain = RequireBearerToken( InjectRawSubjectToken(next) )
+		// Our middleware runs only after the SDK calls handler.ServeHTTP.
+		chain := sdkauth.RequireBearerToken(verifier, nil)(auth.InjectRawSubjectToken(downstream))
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer "+goodToken)
+		chain.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !downstreamOK {
+			t.Fatal("downstream did not observe a raw token on ctx — InjectRawSubjectToken did not run, or it failed to stash the token")
+		}
+		if downstreamSawToken != verifierSawToken {
+			t.Errorf("token bytes drifted between layers: SDK verifier saw %q, downstream saw %q (must be identical)", verifierSawToken, downstreamSawToken)
+		}
+		if downstreamSawToken != goodToken {
+			t.Errorf("downstream token %q != wire token %q", downstreamSawToken, goodToken)
+		}
+		t.Logf("end-to-end ok: wire→verifier→ctx, %d bytes preserved exactly", len(goodToken))
+	})
+
+	t.Run("rejected token short-circuits at the SDK and never reaches our middleware", func(t *testing.T) {
+		t.Parallel()
+		verifier := func(_ context.Context, _ string, _ *http.Request) (*sdkauth.TokenInfo, error) {
+			return nil, errors.New("token rejected for test: " + sdkauth.ErrInvalidToken.Error())
+		}
+
+		// Probe handler under InjectRawSubjectToken. If control flow ever
+		// reaches it, the chain-order invariant is broken: either the SDK
+		// is not short-circuiting on rejection, or InjectRawSubjectToken
+		// is wrapped on the outside (the rejected design).
+		var probeInvoked bool
+		probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			probeInvoked = true
+		})
+		chain := sdkauth.RequireBearerToken(verifier, nil)(auth.InjectRawSubjectToken(probe))
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer bogus")
+		rec := httptest.NewRecorder()
+		chain.ServeHTTP(rec, req)
+
+		// We tolerate either 401 (errors.Is(err, ErrInvalidToken)) or
+		// 500 (the SDK's default for unrecognized errors), depending on
+		// how the SDK unwraps the verifier's return.
+		if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected SDK to reject the request with 401 or 500, got status %d", rec.Code)
+		}
+		if probeInvoked {
+			t.Fatal("downstream handler ran despite SDK rejection — chain-order invariant is broken; InjectRawSubjectToken is positioned outside the SDK")
+		}
+		t.Logf("rejection short-circuit ok: SDK returned %d and probe was never invoked", rec.Code)
+	})
+}

--- a/test/integration/raw_subject_token_capture_test.go
+++ b/test/integration/raw_subject_token_capture_test.go
@@ -16,7 +16,7 @@ package integration_test
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -93,8 +93,13 @@ func TestRawSubjectTokenCapture_AfterSDKValidation(t *testing.T) {
 
 	t.Run("rejected token short-circuits at the SDK and never reaches our middleware", func(t *testing.T) {
 		t.Parallel()
+		// Wrap with %w so errors.Is(err, ErrInvalidToken) returns true
+		// inside the SDK. That makes the SDK take its 401 branch — the
+		// same code path production hits when go-oidc rejects a JWT.
+		// Returning a plain errors.New here would fall through to the
+		// SDK's 500 fallback, exercising the wrong production path.
 		verifier := func(_ context.Context, _ string, _ *http.Request) (*sdkauth.TokenInfo, error) {
-			return nil, errors.New("token rejected for test: " + sdkauth.ErrInvalidToken.Error())
+			return nil, fmt.Errorf("token rejected for test: %w", sdkauth.ErrInvalidToken)
 		}
 
 		// Probe handler under InjectRawSubjectToken. If control flow ever
@@ -112,11 +117,12 @@ func TestRawSubjectTokenCapture_AfterSDKValidation(t *testing.T) {
 		rec := httptest.NewRecorder()
 		chain.ServeHTTP(rec, req)
 
-		// We tolerate either 401 (errors.Is(err, ErrInvalidToken)) or
-		// 500 (the SDK's default for unrecognized errors), depending on
-		// how the SDK unwraps the verifier's return.
-		if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusInternalServerError {
-			t.Errorf("expected SDK to reject the request with 401 or 500, got status %d", rec.Code)
+		// Verifier wraps ErrInvalidToken, so the SDK must take its 401
+		// branch — matching production where go-oidc rejects with the
+		// same wrapped error. A 500 here would indicate the verifier's
+		// error stopped unwrapping correctly.
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected SDK to reject the request with 401, got status %d", rec.Code)
 		}
 		if probeInvoked {
 			t.Fatal("downstream handler ran despite SDK rejection — chain-order invariant is broken; InjectRawSubjectToken is positioned outside the SDK")


### PR DESCRIPTION
## Summary

Adds `InjectRawSubjectToken` middleware that captures the raw bearer token onto `ctx` after the MCP SDK has validated it, so the future OAuth `Authenticator` can use it as the `subject_token` in RFC 8693 token exchange (Hop 2).

Jira: [SOL-150797](https://sol-jira.atlassian.net/browse/SOL-150797).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

The MCP SDK's `RequireBearerToken` validates the incoming bearer token and places `*TokenInfo` (parsed claims) on the request context — but it discards the raw signed JWT string. Hop 2 token exchange needs that raw string as the `subject_token` in the exchange request to the IdP (RFC 8693 §2.1, Microsoft Entra OBO, Keycloak token-exchange all agree: the full signed token, verbatim, not a claim).

Without this middleware, the raw token is unreachable to any downstream code — the SDK passes only `ctx` (no `*http.Request`) into tool handlers and the outbound `Authenticator`.

## Changes Made

**Production code:**
- `internal/auth/raw_subject_token.go` (new):
  - `InjectRawSubjectToken(next http.Handler) http.Handler` — middleware that copies the bearer token onto `ctx` under an unexported key when the Authorization header is `Bearer <non-empty>`. No-op on any other shape (rejection is the responsibility of whatever component sits in front of us in the chain; we only capture).
  - `RawSubjectTokenFromContext(ctx) (string, bool)` — read-side accessor. Returns `("", false)` when no token is stashed, when the stored value is empty, or when the stored value is the wrong type (defensive).
  - Unexported `rawSubjectTokenKey struct{}` type prevents cross-package collision.
  - One-shot startup `slog.Debug("InjectRawSubjectToken middleware installed")` from inside the constructor.
- `internal/auth/middleware.go`: wrap `next` with `InjectRawSubjectToken` so the chain becomes `RequireBearerToken → InjectRawSubjectToken → next`.

**Tests:**
- `internal/auth/raw_subject_token_test.go` (new) — unit tests against the middleware in isolation.
- `test/integration/raw_subject_token_capture_test.go` (new) — integration tests against the composed chain and against the production wiring path.
- `test/integration/README.md` — index entry for the new integration test file.

**Documentation:**
- `docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md` (new): design, decisions, testing plan.

## Position decision

`InjectRawSubjectToken` runs **after** `sdkauth.RequireBearerToken`. That means a value reaching `ctx` under `rawSubjectTokenKey{}` has already been validated by whatever upstream validator is wired (today: the SDK, which checks signature, issuer, audience, expiry). Downstream code reads it without re-validating. This was a deliberate choice over the alternative of running before validation; the reasoning is in the plan doc under Decision 1.

## Responsibility boundary

The middleware does **not** reject missing or malformed Authorization headers. Capture is its responsibility; rejection is the responsibility of whatever component sits in front of it in the chain. This keeps the middleware composable with or without an upstream validator and avoids duplicating gating logic. See Decision 7 in the plan doc.

## Why no wrapper refactor

This was considered (wrapping the SDK's auth in our own `Authenticator` interface) and rejected. The MCP SDK is the substrate we live inside, not a library we call. Wrapping its types for replaceability defeats the point of using it. The leak is small (two files read four fields off `*sdkauth.TokenInfo`) and contained at a clean boundary (`NewIdentityFromTokenInfo`). The wrapper refactor was ~800 lines of churn for marginal benefit. Details in the plan doc under Decision 2.

## Why no per-request logging

The middleware is plumbing — it does not connect to anything, manage state, or fail in interesting ways. A per-request "stashed token" log line would:
- offer no operational signal beyond what the future OAuth Authenticator already provides on failure,
- create a side-channel leak (presence of the log line reveals a valid bearer header was seen on a given request).

The single startup line is enough to confirm the middleware is installed; runtime correctness surfaces via downstream token-exchange success or failure. See Decision 4.

## Testing

**Test Environment:**
- Go version: 1.26.0 (darwin/arm64)
- OS: macOS

**Tests Performed:**
- [x] Unit tests added (5 functions in `internal/auth/raw_subject_token_test.go`)
- [x] Integration tests added (2 functions in `test/integration/raw_subject_token_capture_test.go`)
- [x] Tested locally with `go test -race ./...` (all packages pass)
- [x] `/check-logs` scan: zero violations on the changed files

**Unit-level coverage (in `internal/auth/raw_subject_token_test.go`):**

- `TestInjectRawSubjectToken_HeaderShapes` — 13 subtests covering valid Bearer, case-insensitive scheme matching, missing header, empty token, wrong scheme (Basic/DPoP), token-only, extra-fields, whitespace/tab handling.
- `TestInjectRawSubjectToken_ConcurrentRequests` — 64 goroutines × 1000 iterations × `-race`. Pins the no-shared-state invariant so any future change introducing shared mutable state fails CI.
- `TestInjectRawSubjectToken_RequestIsolation` — original Authorization header is not mutated; parent ctx is not polluted; next handler still sees the header.
- `TestRawSubjectTokenFromContext_AccessorContract` — background ctx, non-string value, empty string, exact round-trip.

**Integration-level coverage (in `test/integration/raw_subject_token_capture_test.go`):**

- `TestRawSubjectTokenCapture_AfterSDKValidation` — chain-order invariant. Wires `sdkauth.RequireBearerToken(verifier)(auth.InjectRawSubjectToken(probe))` and exercises two scenarios:
  - **Valid token**: round-trips byte-for-byte from the wire through the SDK verifier to ctx readable by downstream.
  - **Invalid token**: SDK short-circuits with 4xx/5xx; our middleware is never invoked (proves the position decision).
- `TestRawSubjectTokenCapture_WiredByNewAuthMiddleware` — production-wiring regression guard ([added in response to Copilot review](https://github.com/SolaceDev/solace-broker-mcp/pull/111#discussion_r2659876870)). Builds a static-mode `*config.ServerConfig`, calls `auth.NewAuthMiddleware(cfg, downstream)`, sends a request with the configured dev token, and asserts the downstream handler observes the same token via `RawSubjectTokenFromContext`. Catches the failure mode where a future refactor silently drops `InjectRawSubjectToken(next)` from `internal/auth/middleware.go`.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Code is well-commented (explains why, not what)
- [x] Complex logic has explanatory comments (position decision, responsibility boundary, parse-mirrors-SDK note)
- [x] No commented-out code or debug statements

### Security
- [x] No credentials in code or logs
- [x] Followed secure logging rules — `/check-logs` clean
- [x] Token bytes never appear in any log call
- [x] Unexported ctx key type prevents cross-package read

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [x] Regression guard for production wiring path

### Documentation
- [x] godoc comments on all exported symbols
- [x] Plan doc tracked under `docs/superpowers/plans/oauth-token-exchange/`
- [x] README entry under `test/integration/`

### Git & CI
- [x] Commit messages clear and descriptive
- [x] Branch fresh from main (no merge conflicts expected)
- [x] CI lint passing (initial commit failed `noctx`; fixed in commit `7abdc26` by switching to `httptest.NewRequestWithContext`)

## For Reviewers

**Focus Areas:**

1. **Position decision** — is wrapping `InjectRawSubjectToken(next)` inside `sdkauth.RequireBearerToken(...)` the right chain order? Plan doc covers the rationale.
2. **Responsibility boundary** — agree that this middleware should silently pass through missing/malformed headers rather than duplicate the upstream validator's rejection logic?
3. **Per-request logging absence** — agree we should not log per-request token presence?
4. **Parse mirroring** — `raw_subject_token.go` mirrors `sdkauth.verify`'s parse logic (case-insensitive Bearer, `strings.Fields`). Comment in the file flags this dependency for future SDK upgrades.

**Questions:**

None blocking. Plan doc captures every decision and rejected alternative.

[SOL-150797]: https://sol-jira.atlassian.net/browse/SOL-150797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ