### PR TITLE
SOL-151052: Implement composite-tool postprocessor + first handler for list-queues

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/banner"
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite"
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite/definitions"
+	_ "github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess/handlers" // register handlers via init()
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
@@ -418,6 +419,16 @@ func main() {
 	}
 	slog.Info("loaded composite tool definitions",
 		slog.Int("tool_count", len(compositeTools)))
+
+	// Cross-check that every postProcess handler's RequiredFields are covered
+	// by its tool's step `select:` clauses. Catches SEMP field-name drift
+	// (e.g. bindSuccessCount vs bindCount) at boot rather than first call.
+	// The handlers package was registered via blank import above, so the
+	// postprocess registry is populated before this runs.
+	if err := composite.ValidatePostProcess(compositeTools); err != nil {
+		slog.Error("composite tool postProcess validation failed", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
 
 	// 5. Create composite executor
 	executor := composite.NewCompositeExecutor(operations)

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -144,6 +144,11 @@ sequenceDiagram
     SDK-->>User: Tool response
 ```
 
+The executor supports two `result.strategy` values:
+
+- **`collect`** — returns the raw step-result map keyed by step ID.
+- **`postProcess`** — runs a Go handler registered in [`internal/composite/postprocess/`](../../internal/composite/postprocess/) over the step results and merges its summary map under a top-level `"summary"` key alongside the raw results. Handlers register from `init()`; `cmd/server/main.go` blank-imports the handlers package so registration happens before startup validation. At boot the server cross-checks each handler's `RequiredFields` against the union of its tool's step `select:` arrays and refuses to start on a mismatch (template: `tool %q: handler %q reads %q but it is not in select`). This catches SEMP field-name drift before any tool call.
+
 ---
 
 ## Concurrency — Multiple Users, Same Broker

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -147,7 +147,7 @@ sequenceDiagram
 The executor supports two `result.strategy` values:
 
 - **`collect`** — returns the raw step-result map keyed by step ID.
-- **`postProcess`** — runs a Go handler registered in [`internal/composite/postprocess/`](../../internal/composite/postprocess/) over the step results and merges its summary map under a top-level `"summary"` key alongside the raw results. Handlers register from `init()`; `cmd/server/main.go` blank-imports the handlers package so registration happens before startup validation. At boot the server cross-checks each handler's `RequiredFields` against the union of its tool's step `select:` arrays and refuses to start on a mismatch (template: `tool %q: handler %q reads %q but it is not in select`). This catches SEMP field-name drift before any tool call.
+- **`postProcess`** — runs a Go handler registered in [`internal/composite/postprocess/`](../../internal/composite/postprocess/) over the step results and merges its summary map under a top-level `"summary"` key alongside the raw results. Handlers register from `init()`; `cmd/server/main.go` blank-imports the handlers package so registration happens before startup validation. At boot the server cross-checks each handler's `RequiredFields` against the union of its tool's step `select:` arrays and refuses to start on a mismatch (template: `tool %q: postprocessor %q reads %q but it is not in select`). This catches SEMP field-name drift before any tool call.
 
 ---
 

--- a/internal/composite/definition.go
+++ b/internal/composite/definition.go
@@ -16,7 +16,7 @@
 // Broker MCP Server. It loads multi-step tool definitions from embedded YAML,
 // executes steps against a broker via the sempv2.Client interface, resolves Go
 // template expressions in step arguments, and combines results using configurable
-// strategies (collect, merge, unwrap).
+// strategies (collect, postProcess).
 package composite
 
 // CompositeToolsFile is the top-level structure of the embedded YAML file.
@@ -54,17 +54,19 @@ type Step struct {
 	ID          string            `yaml:"id"`
 	Operation   string            `yaml:"operation"`   // prefixed operationId (e.g., "monitor/getMsgVpnQueue")
 	Args        map[string]string `yaml:"args"`        // values are Go text/template expressions
+	Select      []string          `yaml:"select"`      // SEMP select fields; joined with ", " into args["select"] at execute time
 	Parallel    bool              `yaml:"parallel"`    // group with adjacent parallel:true steps
 	FollowPages bool              `yaml:"followPages"` // follow SEMP nextPageUri links and aggregate all pages
 }
 
 // ResultStrategy defines how step results are combined into the tool's final
-// output. Currently only "collect" is supported, which returns all step results
-// keyed by step ID. Additional strategies (merge, unwrap) are deferred pending
-// design discussion around SEMP response envelope overlap and per-step data
-// transformation needs.
+// output. "collect" returns all step results keyed by step ID. "postProcess"
+// runs a registered Go postprocessor (see internal/composite/postprocess) on
+// the collected step results and merges its output under a top-level "summary"
+// key alongside the raw step results.
 type ResultStrategy struct {
-	Strategy string `yaml:"strategy"` // only "collect" is currently supported
+	Strategy    string `yaml:"strategy"`    // "collect" or "postProcess"
+	PostProcess string `yaml:"postProcess"` // registry name of the handler when strategy="postProcess"
 }
 
 // ToolAnnotations holds behavior hints for a composite tool, matching the MCP

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -225,9 +225,23 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
-          select: "accessType, bindCount, egressEnabled, ingressEnabled, lowPriorityMsgCongestionState, maxMsgSpoolUsage, msgSpoolUsage, msgVpnName, queueName, rxMsgRate, spooledMsgCount, txMsgRate, txUnackedMsgCount"
+        select:
+          - accessType
+          - bindCount
+          - egressEnabled
+          - ingressEnabled
+          - lowPriorityMsgCongestionState
+          - maxMsgSpoolUsage
+          - msgSpoolUsage
+          - msgVpnName
+          - queueName
+          - rxMsgRate
+          - spooledMsgCount
+          - txMsgRate
+          - txUnackedMsgCount
     result:
-      strategy: collect
+      strategy: postProcess
+      postProcess: listQueues
 
   - name: list-clients
     description: >

--- a/internal/composite/executor.go
+++ b/internal/composite/executor.go
@@ -388,6 +388,7 @@ func (ce *CompositeExecutor) executeBatch(ctx context.Context, batch ExecutionBa
 			if err != nil {
 				return fmt.Errorf("tool step %s: failed to resolve args: %w", step.ID, err)
 			}
+			applySelect(args, step.Select)
 
 			op, ok := ce.operations[step.Operation]
 			if !ok {

--- a/internal/composite/executor.go
+++ b/internal/composite/executor.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 	"text/template"
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 )
 
@@ -152,6 +154,7 @@ func (ce *CompositeExecutor) executeStep(ctx context.Context, step Step, client 
 	if err != nil {
 		return fmt.Errorf("tool step %s: failed to resolve args: %w", step.ID, err)
 	}
+	applySelect(args, step.Select)
 
 	op, ok := ce.operations[step.Operation]
 	if !ok {
@@ -165,6 +168,19 @@ func (ce *CompositeExecutor) executeStep(ctx context.Context, step Step, client 
 
 	execCtx.StepResults[step.ID] = result.Data
 	return nil
+}
+
+// applySelect joins step.Select (if non-empty) into the comma-separated
+// "select" arg the SEMP client sends as a query parameter. The ", " separator
+// is cosmetic — SEMPv2 accepts either "a,b" or "a, b". The structured form on
+// Step is what lets ValidatePostProcess cross-check handler RequiredFields
+// without re-parsing the joined string. validateTool in loader.go rejects the
+// case where args["select"] is also templated, so this overwrite is safe.
+func applySelect(args map[string]any, fields []string) {
+	if len(fields) == 0 {
+		return
+	}
+	args["select"] = strings.Join(fields, ", ")
 }
 
 // executePaginatedStep executes a step that returns paginated results. It
@@ -181,6 +197,7 @@ func (ce *CompositeExecutor) executePaginatedStep(ctx context.Context, step Step
 	if err != nil {
 		return fmt.Errorf("tool step %s: failed to resolve args: %w", step.ID, err)
 	}
+	applySelect(baseArgs, step.Select)
 
 	op, ok := ce.operations[step.Operation]
 	if !ok {
@@ -444,20 +461,32 @@ func safeTemplateExecute(tmpl *template.Template, data any) (result string, err 
 
 // ApplyResultStrategy combines step results according to the tool's result
 // strategy configuration. "collect" returns all step results keyed by step ID.
+// "postProcess" runs a registered Go postprocessor over the step results and
+// merges its summary map under a top-level "summary" key alongside the raw
+// results.
 func ApplyResultStrategy(strategy ResultStrategy, stepResults map[string]map[string]any) (map[string]any, error) {
 	switch strategy.Strategy {
 	case "collect":
-		return collectStrategy(stepResults)
+		return collectSteps(stepResults, 0), nil
+	case "postProcess":
+		summary, err := postprocess.Apply(strategy.PostProcess, stepResults)
+		if err != nil {
+			return nil, err
+		}
+		out := collectSteps(stepResults, 1)
+		out["summary"] = summary
+		return out, nil
 	default:
-		return nil, fmt.Errorf("result strategy %q is not supported; supported values: collect", strategy.Strategy)
+		return nil, fmt.Errorf("result strategy %q is not supported; supported values: collect, postProcess", strategy.Strategy)
 	}
 }
 
-// collectStrategy returns all step results keyed by step ID.
-func collectStrategy(stepResults map[string]map[string]any) (map[string]any, error) {
-	result := make(map[string]any, len(stepResults))
+// collectSteps returns a new map keyed by step ID. extraCap reserves space
+// for keys the caller will add (e.g. "summary").
+func collectSteps(stepResults map[string]map[string]any, extraCap int) map[string]any {
+	out := make(map[string]any, len(stepResults)+extraCap)
 	for stepID, res := range stepResults {
-		result[stepID] = res
+		out[stepID] = res
 	}
-	return result, nil
+	return out
 }

--- a/internal/composite/executor_test.go
+++ b/internal/composite/executor_test.go
@@ -534,6 +534,55 @@ func TestExecute_ParallelSteps(t *testing.T) {
 	}
 }
 
+// TestExecute_ParallelSteps_AppliesSelect pins applySelect inside executeBatch.
+// Regression test: an earlier revision of the parallel path skipped applySelect,
+// so structured Select fields on parallel steps never reached the SEMP wire as
+// args["select"] — silently dropping the field filter. Without this assertion
+// the next refactor of executeBatch can regress the same way.
+func TestExecute_ParallelSteps_AppliesSelect(t *testing.T) {
+	ops := map[string]*sempv2.Operation{
+		"monitor/getA": {ID: "getA", Method: "GET", Path: "/a"},
+		"monitor/getB": {ID: "getB", Method: "GET", Path: "/b"},
+	}
+
+	var recorded []callRecord
+	var mu sync.Mutex
+	capture := &argCapturingClient{inner: newMockClient(), recorded: &recorded, mu: &mu}
+
+	tool := CompositeTool{
+		Name:        "test",
+		Description: "test",
+		Steps: []Step{
+			{ID: "stepA", Operation: "monitor/getA", Args: map[string]string{}, Select: []string{"a1", "a2"}, Parallel: true},
+			{ID: "stepB", Operation: "monitor/getB", Args: map[string]string{}, Select: []string{"b1"}, Parallel: true},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+
+	_, err := NewCompositeExecutor(ops).Execute(context.Background(), tool, capture, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(recorded) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(recorded))
+	}
+	wantByOp := map[string]string{
+		"getA": "a1, a2",
+		"getB": "b1",
+	}
+	for _, call := range recorded {
+		got, ok := call.args["select"].(string)
+		if !ok {
+			t.Errorf("op %q: args[\"select\"] missing or not string: %v", call.opID, call.args["select"])
+			continue
+		}
+		if want := wantByOp[call.opID]; got != want {
+			t.Errorf("op %q: args[\"select\"] = %q, want %q", call.opID, got, want)
+		}
+	}
+}
+
 func TestExecute_ResultStrategy_Collect(t *testing.T) {
 	client := newMockClient()
 	client.responses["getMsgVpnQueue"] = &sempv2.Result{Data: map[string]any{"queue": "data"}, StatusCode: 200}

--- a/internal/composite/loader.go
+++ b/internal/composite/loader.go
@@ -20,6 +20,8 @@ import (
 	"io/fs"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
 )
 
 // LoadTools reads a YAML file from the given filesystem, parses it into
@@ -48,10 +50,12 @@ func LoadTools(fsys fs.FS, filename string) ([]CompositeTool, error) {
 	return file.Tools, nil
 }
 
-// validateTool checks the structural correctness of a composite tool definition.
-// It verifies required fields, unique step IDs, and valid result strategy
-// configuration. It validates that a result strategy is specified and is a
-// supported value.
+// validateTool checks the structural correctness of a composite tool definition:
+// required fields, unique step IDs, mutually exclusive `select` forms, reserved
+// step IDs, and a supported result strategy. This is the first of two
+// validation passes — the second, ValidatePostProcess, runs after the
+// postprocess registry is populated and cross-checks each handler's
+// RequiredFields against the step `select:` clauses.
 func validateTool(tool *CompositeTool) error {
 	if tool.Name == "" {
 		return fmt.Errorf("tool name is required")
@@ -79,15 +83,68 @@ func validateTool(tool *CompositeTool) error {
 		if step.Operation == "" {
 			return fmt.Errorf("step operation is required for step %s", step.ID)
 		}
+
+		// The structured `select:` and a templated `args.select` would race at
+		// execute time (applySelect in executor.go overwrites args["select"]).
+		// Reject the ambiguity at load time.
+		if len(step.Select) > 0 {
+			if _, dup := step.Args["select"]; dup {
+				return fmt.Errorf("step %s: cannot set both args.select and select", step.ID)
+			}
+		}
 	}
 
 	if tool.Result.Strategy == "" {
-		return fmt.Errorf("result strategy is required; supported values: collect")
+		return fmt.Errorf("result strategy is required; supported values: collect, postProcess")
 	}
 
-	if tool.Result.Strategy != "collect" {
-		return fmt.Errorf("result strategy %q is not supported; supported values: collect", tool.Result.Strategy)
+	switch tool.Result.Strategy {
+	case "collect":
+		if tool.Result.PostProcess != "" {
+			return fmt.Errorf("postProcess must be empty when strategy is %q", tool.Result.Strategy)
+		}
+	case "postProcess":
+		if tool.Result.PostProcess == "" {
+			return fmt.Errorf("postProcess is required when strategy is %q", tool.Result.Strategy)
+		}
+		// "summary" is reserved at the top level of a postProcess result for the
+		// handler's output (see ApplyResultStrategy). A step named "summary"
+		// would silently shadow it.
+		if stepIDs["summary"] {
+			return fmt.Errorf(`step ID "summary" is reserved when strategy is "postProcess"`)
+		}
+	default:
+		return fmt.Errorf("result strategy %q is not supported; supported values: collect, postProcess", tool.Result.Strategy)
 	}
 
+	return nil
+}
+
+// ValidatePostProcess cross-checks every postProcess tool's postprocessor
+// against the union of its steps' `select:` clauses. It runs as a second pass
+// after LoadTools because handlers register from init() and the postprocess
+// registry must be populated before this check is meaningful. Errors use the
+// uniform template defined by postprocess.ValidateTool so a missing field
+// surfaces the same message regardless of which tool tripped it.
+//
+// TODO multi-step: RequiredFields is checked against the union across all
+// steps, so a postprocessor reading field X from step A passes validation
+// when only step B selects X. Today every postProcess tool has one step
+// (list-queues), so the union is precise. When a multi-step postProcess
+// tool lands, change Handler.RequiredFields to map[stepID][]string and
+// validate per step.
+func ValidatePostProcess(tools []CompositeTool) error {
+	for _, t := range tools {
+		if t.Result.Strategy != "postProcess" {
+			continue
+		}
+		var selectFields []string
+		for _, s := range t.Steps {
+			selectFields = append(selectFields, s.Select...)
+		}
+		if err := postprocess.ValidateTool(t.Name, t.Result.PostProcess, selectFields); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/internal/composite/loader.go
+++ b/internal/composite/loader.go
@@ -121,11 +121,12 @@ func validateTool(tool *CompositeTool) error {
 }
 
 // ValidatePostProcess cross-checks every postProcess tool's postprocessor
-// against the union of its steps' `select:` clauses. It runs as a second pass
+// against the tool's step IDs (Handler.RequiredSteps) and the union of its
+// steps' `select:` clauses (Handler.RequiredFields). It runs as a second pass
 // after LoadTools because handlers register from init() and the postprocess
 // registry must be populated before this check is meaningful. Errors use the
-// uniform template defined by postprocess.ValidateTool so a missing field
-// surfaces the same message regardless of which tool tripped it.
+// uniform template defined by postprocess.ValidateTool so a missing step or
+// field surfaces the same message regardless of which tool tripped it.
 //
 // TODO multi-step: RequiredFields is checked against the union across all
 // steps, so a postprocessor reading field X from step A passes validation
@@ -138,11 +139,13 @@ func ValidatePostProcess(tools []CompositeTool) error {
 		if t.Result.Strategy != "postProcess" {
 			continue
 		}
+		stepIDs := make([]string, 0, len(t.Steps))
 		var selectFields []string
 		for _, s := range t.Steps {
+			stepIDs = append(stepIDs, s.ID)
 			selectFields = append(selectFields, s.Select...)
 		}
-		if err := postprocess.ValidateTool(t.Name, t.Result.PostProcess, selectFields); err != nil {
+		if err := postprocess.ValidateTool(t.Name, t.Result.PostProcess, stepIDs, selectFields); err != nil {
 			return err
 		}
 	}

--- a/internal/composite/loader.go
+++ b/internal/composite/loader.go
@@ -113,6 +113,17 @@ func validateTool(tool *CompositeTool) error {
 		if stepIDs["summary"] {
 			return fmt.Errorf(`step ID "summary" is reserved when strategy is "postProcess"`)
 		}
+		// ValidatePostProcess cross-checks a handler's RequiredFields against the
+		// structured `select:` only — it has no view into a templated args.select.
+		// Allowing args.select here would pass the loader, then trip the postprocess
+		// cross-check with a "reads X but it is not in select" message that points
+		// at the field instead of the real cause. Reject up front so the requirement
+		// is visible at the source.
+		for _, step := range tool.Steps {
+			if _, has := step.Args["select"]; has {
+				return fmt.Errorf(`step %s: args.select is not allowed when strategy is "postProcess"; declare fields under select:`, step.ID)
+			}
+		}
 	default:
 		return fmt.Errorf("result strategy %q is not supported; supported values: collect, postProcess", tool.Result.Strategy)
 	}

--- a/internal/composite/loader.go
+++ b/internal/composite/loader.go
@@ -121,7 +121,7 @@ func validateTool(tool *CompositeTool) error {
 		// is visible at the source.
 		for _, step := range tool.Steps {
 			if _, has := step.Args["select"]; has {
-				return fmt.Errorf(`step %s: args.select is not allowed when strategy is "postProcess"; declare fields under select:`, step.ID)
+				return fmt.Errorf(`step %s: args.select is not allowed when strategy is "postProcess"; declare fields under top-level select`, step.ID)
 			}
 		}
 	default:

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -2,8 +2,12 @@ package composite
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"testing/fstest"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess/postprocesstest"
 )
 
 func TestLoadTools_Valid(t *testing.T) {
@@ -1086,4 +1090,152 @@ tools:
 	if tool.Parameters[1].Name != "maxResults" || tool.Parameters[1].Required {
 		t.Error("expected optional maxResults parameter")
 	}
+}
+
+// TestLoadTools_StrategyConfig covers the cross-field rules between
+// result.strategy and result.postProcess plus the reserved "summary" step ID
+// and the args.select / select coexistence guard.
+func TestLoadTools_StrategyConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			name: "postProcess without name",
+			yaml: `
+tools:
+  - name: bad
+    description: missing handler name
+    steps:
+      - id: s1
+        operation: monitor/getVpn
+    result:
+      strategy: postProcess
+`,
+			wantSub: `postProcess is required when strategy is "postProcess"`,
+		},
+		{
+			name: "collect with postProcess set",
+			yaml: `
+tools:
+  - name: bad
+    description: postProcess on collect strategy
+    steps:
+      - id: s1
+        operation: monitor/getVpn
+    result:
+      strategy: collect
+      postProcess: someHandler
+`,
+			wantSub: `postProcess must be empty when strategy is "collect"`,
+		},
+		{
+			name: "summary step ID reserved under postProcess",
+			yaml: `
+tools:
+  - name: bad
+    description: reserved step ID
+    steps:
+      - id: summary
+        operation: monitor/getVpn
+    result:
+      strategy: postProcess
+      postProcess: someHandler
+`,
+			wantSub: `step ID "summary" is reserved`,
+		},
+		{
+			name: "both args.select and select set",
+			yaml: `
+tools:
+  - name: bad
+    description: select set twice
+    steps:
+      - id: s1
+        operation: monitor/getVpn
+        args:
+          select: "a, b"
+        select:
+          - a
+          - b
+    result:
+      strategy: collect
+`,
+			wantSub: "cannot set both args.select and select",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsys := fstest.MapFS{"tools.yaml": &fstest.MapFile{Data: []byte(tc.yaml)}}
+			_, err := LoadTools(fsys, "tools.yaml")
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestValidatePostProcess covers the boot-time cross-check between a
+// postProcess tool's handler RequiredFields and the union of its steps'
+// `select:` arrays. Builds CompositeTool values directly rather than going
+// through YAML so the test isolates the validation logic.
+func TestValidatePostProcess(t *testing.T) {
+	postprocesstest.Register(t, "__test_pp_handler", postprocess.Handler{
+		Fn:             func(map[string]map[string]any) (map[string]any, error) { return nil, nil },
+		RequiredFields: []string{"a", "b"},
+	})
+
+	t.Run("collect tool is ignored", func(t *testing.T) {
+		tools := []CompositeTool{{
+			Name:   "collect-tool",
+			Steps:  []Step{{ID: "s1", Operation: "x"}},
+			Result: ResultStrategy{Strategy: "collect"},
+		}}
+		if err := ValidatePostProcess(tools); err != nil {
+			t.Fatalf("collect tool should be skipped, got %v", err)
+		}
+	})
+
+	t.Run("happy path with required fields covered", func(t *testing.T) {
+		tools := []CompositeTool{{
+			Name: "ok-tool",
+			Steps: []Step{
+				{ID: "s1", Operation: "x", Select: []string{"a"}},
+				{ID: "s2", Operation: "y", Select: []string{"b", "c"}},
+			},
+			Result: ResultStrategy{Strategy: "postProcess", PostProcess: "__test_pp_handler"},
+		}}
+		if err := ValidatePostProcess(tools); err != nil {
+			t.Fatalf("expected ok, got %v", err)
+		}
+	})
+
+	t.Run("missing required field surfaces templated error", func(t *testing.T) {
+		tools := []CompositeTool{{
+			Name:   "bad-tool",
+			Steps:  []Step{{ID: "s1", Operation: "x", Select: []string{"a"}}}, // b missing
+			Result: ResultStrategy{Strategy: "postProcess", PostProcess: "__test_pp_handler"},
+		}}
+		err := ValidatePostProcess(tools)
+		want := `tool "bad-tool": postprocessor "__test_pp_handler" reads "b" but it is not in select`
+		if err == nil || err.Error() != want {
+			t.Fatalf("\nwant: %s\ngot:  %v", want, err)
+		}
+	})
+
+	t.Run("unregistered handler", func(t *testing.T) {
+		tools := []CompositeTool{{
+			Name:   "no-handler",
+			Steps:  []Step{{ID: "s1", Operation: "x"}},
+			Result: ResultStrategy{Strategy: "postProcess", PostProcess: "nope"},
+		}}
+		err := ValidatePostProcess(tools)
+		if err == nil || !strings.Contains(err.Error(), `postprocessor "nope" not registered`) {
+			t.Fatalf("got %v", err)
+		}
+	})
 }

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -1164,6 +1164,26 @@ tools:
 `,
 			wantSub: "cannot set both args.select and select",
 		},
+		{
+			// args.select under postProcess would silently bypass the
+			// RequiredFields cross-check (it only reads structured select),
+			// so the message must point at the real cause — not the field.
+			name: "args.select under postProcess is rejected",
+			yaml: `
+tools:
+  - name: bad
+    description: args.select under postProcess
+    steps:
+      - id: s1
+        operation: monitor/getVpn
+        args:
+          select: "a, b"
+    result:
+      strategy: postProcess
+      postProcess: someHandler
+`,
+			wantSub: `args.select is not allowed when strategy is "postProcess"`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/composite/postprocess/handlers/list_queues.go
+++ b/internal/composite/postprocess/handlers/list_queues.go
@@ -30,9 +30,16 @@ import (
 // risk of taking SPOOL_OVER_QUOTA discards if their consumers don't catch up.
 const nearFullThreshold = 0.8
 
+// listQueuesStepID is the step ID this handler keys into. Declared as a const
+// so the init-time RequiredSteps registration and the runtime lookup cannot
+// drift out of sync — and so the boot-time check in ValidatePostProcess
+// catches a YAML rename of the step.
+const listQueuesStepID = "queues"
+
 func init() {
 	postprocess.Register("listQueues", postprocess.Handler{
-		Fn: ListQueues,
+		Fn:            ListQueues,
+		RequiredSteps: []string{listQueuesStepID},
 		RequiredFields: []string{
 			"bindCount",
 			"spooledMsgCount",
@@ -49,10 +56,16 @@ func init() {
 //   - backloggedCount: queues with spooledMsgCount > 0 (any backlog at all)
 //   - nearFullCount:   queues with msgSpoolUsage/maxMsgSpoolUsage >= 0.8
 //     (skips queues with maxMsgSpoolUsage == 0 — unbounded or unset)
+//
+// The counts are over what the paginator actually returned. Under truncation
+// (followPages stopped at maxResults / capMax / maxPages), the summary also
+// includes scanned (the count of items observed) and truncated: true so the
+// LLM sees the partial-scan reality next to the counts rather than only on
+// the raw data block.
 func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
-	step, ok := stepResults["queues"]
+	step, ok := stepResults[listQueuesStepID]
 	if !ok {
-		return nil, fmt.Errorf("step %q not in results", "queues")
+		return nil, fmt.Errorf("step %q not in results", listQueuesStepID)
 	}
 	items, ok := step["data"].([]any)
 	if !ok {
@@ -97,12 +110,17 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 			nearFull++
 		}
 	}
-	return map[string]any{
+	out := map[string]any{
 		"noConsumerCount": noConsumer,
 		"congestedCount":  congested,
 		"backloggedCount": backlogged,
 		"nearFullCount":   nearFull,
-	}, nil
+		"scanned":         len(items),
+	}
+	if t, _ := step["truncated"].(bool); t {
+		out["truncated"] = true
+	}
+	return out, nil
 }
 
 // numField accepts any of the numeric shapes JSON decoders produce: float64

--- a/internal/composite/postprocess/handlers/list_queues.go
+++ b/internal/composite/postprocess/handlers/list_queues.go
@@ -52,7 +52,7 @@ func init() {
 
 // ListQueues aggregates the queue list into four counts:
 //   - noConsumerCount: queues with bindCount == 0 (nothing reading)
-//   - congestedCount:  queues whose lowPriorityMsgCongestionState == "active"
+//   - congestedCount:  queues whose lowPriorityMsgCongestionState == "congested"
 //   - backloggedCount: queues with spooledMsgCount > 0 (any backlog at all)
 //   - nearFullCount:   queues with msgSpoolUsage/maxMsgSpoolUsage >= 0.8
 //     (skips queues with maxMsgSpoolUsage == 0 — unbounded or unset)
@@ -95,7 +95,7 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 		if bindCount == 0 {
 			noConsumer++
 		}
-		if state == "active" {
+		if state == "congested" {
 			congested++
 		}
 		if spooled > 0 {

--- a/internal/composite/postprocess/handlers/list_queues.go
+++ b/internal/composite/postprocess/handlers/list_queues.go
@@ -88,7 +88,7 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 		spooled, ok3 := numField(q, "spooledMsgCount")
 		usage, ok4 := numField(q, "msgSpoolUsage")
 		maxUsage, ok5 := numField(q, "maxMsgSpoolUsage")
-		if !(ok1 && ok2 && ok3 && ok4 && ok5) {
+		if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 {
 			skipped++
 			continue
 		}

--- a/internal/composite/postprocess/handlers/list_queues.go
+++ b/internal/composite/postprocess/handlers/list_queues.go
@@ -62,6 +62,12 @@ func init() {
 // includes scanned (the count of items observed) and truncated: true so the
 // LLM sees the partial-scan reality next to the counts rather than only on
 // the raw data block.
+//
+// A queue whose required fields are missing or the wrong type is skipped from
+// every counter and tallied into skipped (surfaced when non-zero). One odd row
+// must not drop the raw list — that would be a robustness step down from the
+// collect strategy. Structural errors (step missing, data not a list, item not
+// an object) still hard-fail since the whole result is unusable.
 func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 	step, ok := stepResults[listQueuesStepID]
 	if !ok {
@@ -71,31 +77,20 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 	if !ok {
 		return nil, fmt.Errorf("queues.data: want []any, got %T", step["data"])
 	}
-	var noConsumer, congested, backlogged, nearFull int
+	var noConsumer, congested, backlogged, nearFull, skipped int
 	for i, raw := range items {
 		q, ok := raw.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("queues.data[%d]: want object, got %T", i, raw)
 		}
-		bindCount, err := numField(q, "bindCount", i)
-		if err != nil {
-			return nil, err
-		}
-		state, err := stringField(q, "lowPriorityMsgCongestionState", i)
-		if err != nil {
-			return nil, err
-		}
-		spooled, err := numField(q, "spooledMsgCount", i)
-		if err != nil {
-			return nil, err
-		}
-		usage, err := numField(q, "msgSpoolUsage", i)
-		if err != nil {
-			return nil, err
-		}
-		maxUsage, err := numField(q, "maxMsgSpoolUsage", i)
-		if err != nil {
-			return nil, err
+		bindCount, ok1 := numField(q, "bindCount")
+		state, ok2 := stringField(q, "lowPriorityMsgCongestionState")
+		spooled, ok3 := numField(q, "spooledMsgCount")
+		usage, ok4 := numField(q, "msgSpoolUsage")
+		maxUsage, ok5 := numField(q, "maxMsgSpoolUsage")
+		if !(ok1 && ok2 && ok3 && ok4 && ok5) {
+			skipped++
+			continue
 		}
 		if bindCount == 0 {
 			noConsumer++
@@ -117,6 +112,9 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 		"nearFullCount":   nearFull,
 		"scanned":         len(items),
 	}
+	if skipped > 0 {
+		out["skipped"] = skipped
+	}
 	if t, _ := step["truncated"].(bool); t {
 		out["truncated"] = true
 	}
@@ -126,30 +124,28 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 // numField accepts any of the numeric shapes JSON decoders produce: float64
 // (encoding/json default for map[string]any), json.Number (decoder with
 // UseNumber), int / int64 (custom unmarshalers). Keeps the handler insulated
-// from future SEMP-client decode-mode changes.
-func numField(item map[string]any, name string, i int) (float64, error) {
+// from future SEMP-client decode-mode changes. Returns ok=false for missing,
+// nil, or unexpected types so the caller can skip the row rather than abort.
+func numField(item map[string]any, name string) (float64, bool) {
 	switch v := item[name].(type) {
 	case float64:
-		return v, nil
+		return v, true
 	case int:
-		return float64(v), nil
+		return float64(v), true
 	case int64:
-		return float64(v), nil
+		return float64(v), true
 	case json.Number:
 		f, err := v.Float64()
 		if err != nil {
-			return 0, fmt.Errorf("queues.data[%d].%s: parse json.Number: %w", i, name, err)
+			return 0, false
 		}
-		return f, nil
+		return f, true
 	default:
-		return 0, fmt.Errorf("queues.data[%d].%s: want number, got %T", i, name, item[name])
+		return 0, false
 	}
 }
 
-func stringField(item map[string]any, name string, i int) (string, error) {
+func stringField(item map[string]any, name string) (string, bool) {
 	v, ok := item[name].(string)
-	if !ok {
-		return "", fmt.Errorf("queues.data[%d].%s: want string, got %T", i, name, item[name])
-	}
-	return v, nil
+	return v, ok
 }

--- a/internal/composite/postprocess/handlers/list_queues.go
+++ b/internal/composite/postprocess/handlers/list_queues.go
@@ -1,0 +1,137 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package handlers registers the production postprocess handlers. Each handler
+// lives in its own file and self-registers from init(). main.go pulls them in
+// via a blank import so the registry is populated before startup validation.
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
+)
+
+// nearFullThreshold is the msgSpoolUsage / maxMsgSpoolUsage ratio at or above
+// which a queue is counted as "near full". 0.8 is the conventional warning
+// threshold for guaranteed-message storage; queues at this fill level are at
+// risk of taking SPOOL_OVER_QUOTA discards if their consumers don't catch up.
+const nearFullThreshold = 0.8
+
+func init() {
+	postprocess.Register("listQueues", postprocess.Handler{
+		Fn: ListQueues,
+		RequiredFields: []string{
+			"bindCount",
+			"spooledMsgCount",
+			"lowPriorityMsgCongestionState",
+			"msgSpoolUsage",
+			"maxMsgSpoolUsage",
+		},
+	})
+}
+
+// ListQueues aggregates the queue list into four counts:
+//   - noConsumerCount: queues with bindCount == 0 (nothing reading)
+//   - congestedCount:  queues whose lowPriorityMsgCongestionState == "active"
+//   - backloggedCount: queues with spooledMsgCount > 0 (any backlog at all)
+//   - nearFullCount:   queues with msgSpoolUsage/maxMsgSpoolUsage >= 0.8
+//     (skips queues with maxMsgSpoolUsage == 0 — unbounded or unset)
+func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
+	step, ok := stepResults["queues"]
+	if !ok {
+		return nil, fmt.Errorf("step %q not in results", "queues")
+	}
+	items, ok := step["data"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("queues.data: want []any, got %T", step["data"])
+	}
+	var noConsumer, congested, backlogged, nearFull int
+	for i, raw := range items {
+		q, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("queues.data[%d]: want object, got %T", i, raw)
+		}
+		bindCount, err := numField(q, "bindCount", i)
+		if err != nil {
+			return nil, err
+		}
+		state, err := stringField(q, "lowPriorityMsgCongestionState", i)
+		if err != nil {
+			return nil, err
+		}
+		spooled, err := numField(q, "spooledMsgCount", i)
+		if err != nil {
+			return nil, err
+		}
+		usage, err := numField(q, "msgSpoolUsage", i)
+		if err != nil {
+			return nil, err
+		}
+		maxUsage, err := numField(q, "maxMsgSpoolUsage", i)
+		if err != nil {
+			return nil, err
+		}
+		if bindCount == 0 {
+			noConsumer++
+		}
+		if state == "active" {
+			congested++
+		}
+		if spooled > 0 {
+			backlogged++
+		}
+		if maxUsage > 0 && usage/maxUsage >= nearFullThreshold {
+			nearFull++
+		}
+	}
+	return map[string]any{
+		"noConsumerCount": noConsumer,
+		"congestedCount":  congested,
+		"backloggedCount": backlogged,
+		"nearFullCount":   nearFull,
+	}, nil
+}
+
+// numField accepts any of the numeric shapes JSON decoders produce: float64
+// (encoding/json default for map[string]any), json.Number (decoder with
+// UseNumber), int / int64 (custom unmarshalers). Keeps the handler insulated
+// from future SEMP-client decode-mode changes.
+func numField(item map[string]any, name string, i int) (float64, error) {
+	switch v := item[name].(type) {
+	case float64:
+		return v, nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("queues.data[%d].%s: parse json.Number: %w", i, name, err)
+		}
+		return f, nil
+	default:
+		return 0, fmt.Errorf("queues.data[%d].%s: want number, got %T", i, name, item[name])
+	}
+}
+
+func stringField(item map[string]any, name string, i int) (string, error) {
+	v, ok := item[name].(string)
+	if !ok {
+		return "", fmt.Errorf("queues.data[%d].%s: want string, got %T", i, name, item[name])
+	}
+	return v, nil
+}

--- a/internal/composite/postprocess/handlers/list_queues_test.go
+++ b/internal/composite/postprocess/handlers/list_queues_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// queue is a tiny helper to build a queue item with the five required fields.
+func queue(bindCount, spooled, usage, maxUsage float64, state string) map[string]any {
+	return map[string]any{
+		"bindCount":                     bindCount,
+		"spooledMsgCount":               spooled,
+		"msgSpoolUsage":                 usage,
+		"maxMsgSpoolUsage":              maxUsage,
+		"lowPriorityMsgCongestionState": state,
+	}
+}
+
+func TestListQueues_Counts(t *testing.T) {
+	items := []any{
+		queue(0, 0, 0, 100, "idle"),     // noConsumer
+		queue(0, 50, 80, 100, "active"), // noConsumer + congested + backlogged + nearFull (0.8)
+		queue(2, 10, 99, 100, "idle"),   // backlogged + nearFull (0.99)
+		queue(2, 0, 50, 100, "idle"),    // nothing
+		queue(1, 5, 0, 0, "idle"),       // backlogged only (unbounded — skip nearFull)
+	}
+	got, err := ListQueues(map[string]map[string]any{
+		"queues": {"data": items},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := map[string]int{
+		"noConsumerCount": 2,
+		"congestedCount":  1,
+		"backloggedCount": 3,
+		"nearFullCount":   2,
+	}
+	for k, want := range checks {
+		if got[k] != want {
+			t.Errorf("%s: got %v, want %d", k, got[k], want)
+		}
+	}
+}
+
+func TestListQueues_Empty(t *testing.T) {
+	got, err := ListQueues(map[string]map[string]any{
+		"queues": {"data": []any{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"noConsumerCount", "congestedCount", "backloggedCount", "nearFullCount"} {
+		if got[k] != 0 {
+			t.Errorf("%s: got %v, want 0", k, got[k])
+		}
+	}
+}
+
+func TestListQueues_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]map[string]any
+		wantSub string
+	}{
+		{
+			name:    "missing step",
+			input:   map[string]map[string]any{},
+			wantSub: `step "queues" not in results`,
+		},
+		{
+			name:    "data wrong type",
+			input:   map[string]map[string]any{"queues": {"data": "oops"}},
+			wantSub: "queues.data: want []any",
+		},
+		{
+			name:    "item wrong type",
+			input:   map[string]map[string]any{"queues": {"data": []any{"not-an-object"}}},
+			wantSub: "queues.data[0]: want object",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListQueues(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("got %v, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestListQueues_MissingField asserts that omitting any one required field
+// produces an error naming that specific field. Table-driven over each field
+// rather than relying on the handler's read-order, so reordering the loop
+// doesn't break the test for the wrong reason.
+func TestListQueues_MissingField(t *testing.T) {
+	full := queue(0, 0, 0, 100, "idle")
+	// Sanity: full input must succeed, otherwise the omission cases prove nothing.
+	if _, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{full}}}); err != nil {
+		t.Fatalf("baseline full input should pass, got %v", err)
+	}
+	for field := range full {
+		t.Run(field, func(t *testing.T) {
+			item := map[string]any{}
+			for k, v := range full {
+				if k != field {
+					item[k] = v
+				}
+			}
+			_, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{item}}})
+			if err == nil {
+				t.Fatalf("expected error when %q is missing, got nil", field)
+			}
+			if !strings.Contains(err.Error(), field) {
+				t.Fatalf("error %q does not name the omitted field %q", err, field)
+			}
+		})
+	}
+}

--- a/internal/composite/postprocess/handlers/list_queues_test.go
+++ b/internal/composite/postprocess/handlers/list_queues_test.go
@@ -144,9 +144,10 @@ func TestListQueues_Errors(t *testing.T) {
 }
 
 // TestListQueues_MissingField asserts that omitting any one required field
-// produces an error naming that specific field. Table-driven over each field
-// rather than relying on the handler's read-order, so reordering the loop
-// doesn't break the test for the wrong reason.
+// skips that queue rather than aborting the call. Table-driven over each
+// field so reordering the handler's reads doesn't break the test for the
+// wrong reason. Hard-failing on one bad row would drop the raw list too —
+// a step down from the collect strategy.
 func TestListQueues_MissingField(t *testing.T) {
 	full := queue(0, 0, 0, 100, "idle")
 	// Sanity: full input must succeed, otherwise the omission cases prove nothing.
@@ -161,13 +162,60 @@ func TestListQueues_MissingField(t *testing.T) {
 					item[k] = v
 				}
 			}
-			_, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{item}}})
-			if err == nil {
-				t.Fatalf("expected error when %q is missing, got nil", field)
+			// Pair the broken row with a healthy one so we can also assert the
+			// healthy row's signal still lands (the broken row in the baseline
+			// is a noConsumer, so use a row that ISN'T to disambiguate).
+			healthy := queue(2, 10, 99, 100, "active") // congested + backlogged + nearFull
+			got, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{item, healthy}}})
+			if err != nil {
+				t.Fatalf("expected skip on missing %q, got error %v", field, err)
 			}
-			if !strings.Contains(err.Error(), field) {
-				t.Fatalf("error %q does not name the omitted field %q", err, field)
+			if got["skipped"] != 1 {
+				t.Errorf("skipped: got %v, want 1", got["skipped"])
+			}
+			if got["scanned"] != 2 {
+				t.Errorf("scanned: got %v, want 2", got["scanned"])
+			}
+			// Healthy row should still contribute.
+			for _, k := range []string{"congestedCount", "backloggedCount", "nearFullCount"} {
+				if got[k] != 1 {
+					t.Errorf("%s: got %v, want 1 (healthy row should still count)", k, got[k])
+				}
 			}
 		})
+	}
+}
+
+// TestListQueues_NilField asserts that an explicit nil (what SEMP returns for
+// an unset numeric field) is treated as a skip, not a hard fail. This is the
+// motivating case for the skip-don't-abort behavior: one queue with a nil
+// msgSpoolUsage shouldn't lose the raw list of every other queue.
+func TestListQueues_NilField(t *testing.T) {
+	bad := queue(0, 0, 0, 100, "idle")
+	bad["msgSpoolUsage"] = nil
+	healthy := queue(2, 10, 99, 100, "idle")
+	got, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{bad, healthy}}})
+	if err != nil {
+		t.Fatalf("nil field should skip, got %v", err)
+	}
+	if got["skipped"] != 1 {
+		t.Errorf("skipped: got %v, want 1", got["skipped"])
+	}
+	if got["backloggedCount"] != 1 || got["nearFullCount"] != 1 {
+		t.Errorf("healthy row signals lost: %+v", got)
+	}
+}
+
+// TestListQueues_SkippedOmittedWhenZero keeps the summary key set minimal in
+// the common case — skipped is noise when nothing was skipped.
+func TestListQueues_SkippedOmittedWhenZero(t *testing.T) {
+	got, err := ListQueues(map[string]map[string]any{
+		"queues": {"data": []any{queue(0, 0, 0, 100, "idle")}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := got["skipped"]; present {
+		t.Errorf("skipped key should be omitted when 0, got %v", got["skipped"])
 	}
 }

--- a/internal/composite/postprocess/handlers/list_queues_test.go
+++ b/internal/composite/postprocess/handlers/list_queues_test.go
@@ -57,6 +57,46 @@ func TestListQueues_Counts(t *testing.T) {
 	}
 }
 
+// TestListQueues_TruncationSurfaced asserts that when the paginator marks the
+// step result truncated, the summary exposes scanned (item count) and
+// truncated: true alongside the counts. Without this the LLM sees authoritative
+// looking counts and a truncation flag buried in a sibling object, and tends to
+// treat the counts as global rather than over the visible page.
+func TestListQueues_TruncationSurfaced(t *testing.T) {
+	items := []any{
+		queue(0, 0, 0, 100, "idle"),
+		queue(2, 10, 50, 100, "idle"),
+	}
+	t.Run("truncated", func(t *testing.T) {
+		got, err := ListQueues(map[string]map[string]any{
+			"queues": {"data": items, "truncated": true},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got["scanned"] != 2 {
+			t.Errorf("scanned: got %v, want 2", got["scanned"])
+		}
+		if got["truncated"] != true {
+			t.Errorf("truncated: got %v, want true", got["truncated"])
+		}
+	})
+	t.Run("not truncated omits flag", func(t *testing.T) {
+		got, err := ListQueues(map[string]map[string]any{
+			"queues": {"data": items, "truncated": false},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got["scanned"] != 2 {
+			t.Errorf("scanned: got %v, want 2", got["scanned"])
+		}
+		if _, present := got["truncated"]; present {
+			t.Errorf("truncated key should be omitted when false, got %v", got["truncated"])
+		}
+	})
+}
+
 func TestListQueues_Empty(t *testing.T) {
 	got, err := ListQueues(map[string]map[string]any{
 		"queues": {"data": []any{}},

--- a/internal/composite/postprocess/handlers/list_queues_test.go
+++ b/internal/composite/postprocess/handlers/list_queues_test.go
@@ -32,11 +32,11 @@ func queue(bindCount, spooled, usage, maxUsage float64, state string) map[string
 
 func TestListQueues_Counts(t *testing.T) {
 	items := []any{
-		queue(0, 0, 0, 100, "idle"),     // noConsumer
-		queue(0, 50, 80, 100, "active"), // noConsumer + congested + backlogged + nearFull (0.8)
-		queue(2, 10, 99, 100, "idle"),   // backlogged + nearFull (0.99)
-		queue(2, 0, 50, 100, "idle"),    // nothing
-		queue(1, 5, 0, 0, "idle"),       // backlogged only (unbounded — skip nearFull)
+		queue(0, 0, 0, 100, "not-congested"),     // noConsumer
+		queue(0, 50, 80, 100, "congested"), // noConsumer + congested + backlogged + nearFull (0.8)
+		queue(2, 10, 99, 100, "not-congested"),   // backlogged + nearFull (0.99)
+		queue(2, 0, 50, 100, "not-congested"),    // nothing
+		queue(1, 5, 0, 0, "not-congested"),       // backlogged only (unbounded — skip nearFull)
 	}
 	got, err := ListQueues(map[string]map[string]any{
 		"queues": {"data": items},
@@ -64,8 +64,8 @@ func TestListQueues_Counts(t *testing.T) {
 // treat the counts as global rather than over the visible page.
 func TestListQueues_TruncationSurfaced(t *testing.T) {
 	items := []any{
-		queue(0, 0, 0, 100, "idle"),
-		queue(2, 10, 50, 100, "idle"),
+		queue(0, 0, 0, 100, "not-congested"),
+		queue(2, 10, 50, 100, "not-congested"),
 	}
 	t.Run("truncated", func(t *testing.T) {
 		got, err := ListQueues(map[string]map[string]any{
@@ -149,7 +149,7 @@ func TestListQueues_Errors(t *testing.T) {
 // wrong reason. Hard-failing on one bad row would drop the raw list too —
 // a step down from the collect strategy.
 func TestListQueues_MissingField(t *testing.T) {
-	full := queue(0, 0, 0, 100, "idle")
+	full := queue(0, 0, 0, 100, "not-congested")
 	// Sanity: full input must succeed, otherwise the omission cases prove nothing.
 	if _, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{full}}}); err != nil {
 		t.Fatalf("baseline full input should pass, got %v", err)
@@ -165,7 +165,7 @@ func TestListQueues_MissingField(t *testing.T) {
 			// Pair the broken row with a healthy one so we can also assert the
 			// healthy row's signal still lands (the broken row in the baseline
 			// is a noConsumer, so use a row that ISN'T to disambiguate).
-			healthy := queue(2, 10, 99, 100, "active") // congested + backlogged + nearFull
+			healthy := queue(2, 10, 99, 100, "congested") // congested + backlogged + nearFull
 			got, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{item, healthy}}})
 			if err != nil {
 				t.Fatalf("expected skip on missing %q, got error %v", field, err)
@@ -191,9 +191,9 @@ func TestListQueues_MissingField(t *testing.T) {
 // motivating case for the skip-don't-abort behavior: one queue with a nil
 // msgSpoolUsage shouldn't lose the raw list of every other queue.
 func TestListQueues_NilField(t *testing.T) {
-	bad := queue(0, 0, 0, 100, "idle")
+	bad := queue(0, 0, 0, 100, "not-congested")
 	bad["msgSpoolUsage"] = nil
-	healthy := queue(2, 10, 99, 100, "idle")
+	healthy := queue(2, 10, 99, 100, "not-congested")
 	got, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{bad, healthy}}})
 	if err != nil {
 		t.Fatalf("nil field should skip, got %v", err)
@@ -210,7 +210,7 @@ func TestListQueues_NilField(t *testing.T) {
 // the common case — skipped is noise when nothing was skipped.
 func TestListQueues_SkippedOmittedWhenZero(t *testing.T) {
 	got, err := ListQueues(map[string]map[string]any{
-		"queues": {"data": []any{queue(0, 0, 0, 100, "idle")}},
+		"queues": {"data": []any{queue(0, 0, 0, 100, "not-congested")}},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/composite/postprocess/postprocess.go
+++ b/internal/composite/postprocess/postprocess.go
@@ -1,0 +1,102 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package postprocess provides a registry of named Go postprocessors that the
+// composite-tool executor can apply to step results. A handler returns a
+// "summary" map (e.g., aggregate counts) which the executor merges with the
+// raw step results under a top-level "summary" key.
+//
+// Handlers register from their package's init() block; main.go pulls them in
+// via a blank import. Each handler declares the field names it reads off each
+// item in RequiredFields; ValidateTool cross-checks those at startup against
+// the SEMP step's `select:` clause so a missing-field bug is caught at boot,
+// not at first invocation.
+//
+// Test-only registration is provided by the sibling postprocesstest package
+// so production binaries importing postprocess do not pull in the testing
+// package or its flag side effects.
+package postprocess
+
+import "fmt"
+
+// Handler bundles a postprocessor function with the field names it expects
+// to read off each item. Fn receives the raw step results (keyed by step ID)
+// and returns the summary map the executor merges under "summary".
+type Handler struct {
+	Fn             func(stepResults map[string]map[string]any) (map[string]any, error)
+	RequiredFields []string
+}
+
+var registry = map[string]Handler{}
+
+// Register installs a handler under the given name. Panics on duplicate
+// registration since handlers register from init() and a duplicate would
+// indicate a programming error.
+func Register(name string, h Handler) {
+	if _, dup := registry[name]; dup {
+		panic("postprocess: postprocessor already registered: " + name)
+	}
+	registry[name] = h
+}
+
+// Apply runs the named postprocessor against the given step results.
+func Apply(name string, stepResults map[string]map[string]any) (map[string]any, error) {
+	h, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("postprocess: postprocessor %q not registered", name)
+	}
+	return h.Fn(stepResults)
+}
+
+// ValidateTool checks that postprocessorName is registered and that every
+// field in its RequiredFields appears in selectFields. Returns the
+// ticket-specified error template on a missing field so the message is
+// uniform across tools.
+func ValidateTool(toolName, postprocessorName string, selectFields []string) error {
+	h, ok := registry[postprocessorName]
+	if !ok {
+		return fmt.Errorf("tool %q: postprocessor %q not registered", toolName, postprocessorName)
+	}
+	selectSet := make(map[string]struct{}, len(selectFields))
+	for _, f := range selectFields {
+		selectSet[f] = struct{}{}
+	}
+	for _, f := range h.RequiredFields {
+		if _, ok := selectSet[f]; !ok {
+			return fmt.Errorf("tool %q: postprocessor %q reads %q but it is not in select", toolName, postprocessorName, f)
+		}
+	}
+	return nil
+}
+
+// IsRegistered reports whether a handler is registered under name.
+// Exported only to support the postprocesstest helper package; production
+// code has no reason to call this.
+func IsRegistered(name string) bool {
+	_, ok := registry[name]
+	return ok
+}
+
+// Unregister removes a handler from the registry. Exported only to support
+// the postprocesstest helper package's t.Cleanup hook; production code must
+// not call this — production handlers register once at init() and stay for
+// the process lifetime.
+func Unregister(name string) {
+	delete(registry, name)
+}
+
+// resetForTest clears the registry. Test-only helper used by tests in this
+// package; not exported because nothing outside should mutate the registry
+// after init().
+func resetForTest() { registry = map[string]Handler{} }

--- a/internal/composite/postprocess/postprocess.go
+++ b/internal/composite/postprocess/postprocess.go
@@ -28,22 +28,39 @@
 // package or its flag side effects.
 package postprocess
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // Handler bundles a postprocessor function with the field names it expects
 // to read off each item. Fn receives the raw step results (keyed by step ID)
 // and returns the summary map the executor merges under "summary".
+//
+// RequiredSteps lists the step IDs Fn keys into. ValidateTool cross-checks
+// these against the tool's declared step IDs at startup so a YAML rename of a
+// step (without updating the handler) is caught at boot rather than at first
+// invocation.
+//
+// RequiredFields lists the field names Fn reads off each item. ValidateTool
+// cross-checks these against the union of the tool's step `select:` clauses.
 type Handler struct {
 	Fn             func(stepResults map[string]map[string]any) (map[string]any, error)
+	RequiredSteps  []string
 	RequiredFields []string
 }
 
-var registry = map[string]Handler{}
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]Handler{}
+)
 
 // Register installs a handler under the given name. Panics on duplicate
 // registration since handlers register from init() and a duplicate would
 // indicate a programming error.
 func Register(name string, h Handler) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
 	if _, dup := registry[name]; dup {
 		panic("postprocess: postprocessor already registered: " + name)
 	}
@@ -52,21 +69,34 @@ func Register(name string, h Handler) {
 
 // Apply runs the named postprocessor against the given step results.
 func Apply(name string, stepResults map[string]map[string]any) (map[string]any, error) {
+	registryMu.RLock()
 	h, ok := registry[name]
+	registryMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("postprocess: postprocessor %q not registered", name)
 	}
 	return h.Fn(stepResults)
 }
 
-// ValidateTool checks that postprocessorName is registered and that every
-// field in its RequiredFields appears in selectFields. Returns the
-// ticket-specified error template on a missing field so the message is
-// uniform across tools.
-func ValidateTool(toolName, postprocessorName string, selectFields []string) error {
+// ValidateTool checks that postprocessorName is registered, that every step
+// in its RequiredSteps appears in stepIDs, and that every field in its
+// RequiredFields appears in selectFields. Returns the ticket-specified error
+// template on a missing field/step so the message is uniform across tools.
+func ValidateTool(toolName, postprocessorName string, stepIDs, selectFields []string) error {
+	registryMu.RLock()
 	h, ok := registry[postprocessorName]
+	registryMu.RUnlock()
 	if !ok {
 		return fmt.Errorf("tool %q: postprocessor %q not registered", toolName, postprocessorName)
+	}
+	stepSet := make(map[string]struct{}, len(stepIDs))
+	for _, s := range stepIDs {
+		stepSet[s] = struct{}{}
+	}
+	for _, s := range h.RequiredSteps {
+		if _, ok := stepSet[s]; !ok {
+			return fmt.Errorf("tool %q: postprocessor %q reads step %q but no such step is defined", toolName, postprocessorName, s)
+		}
 	}
 	selectSet := make(map[string]struct{}, len(selectFields))
 	for _, f := range selectFields {
@@ -84,6 +114,8 @@ func ValidateTool(toolName, postprocessorName string, selectFields []string) err
 // Exported only to support the postprocesstest helper package; production
 // code has no reason to call this.
 func IsRegistered(name string) bool {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
 	_, ok := registry[name]
 	return ok
 }
@@ -93,10 +125,16 @@ func IsRegistered(name string) bool {
 // not call this — production handlers register once at init() and stay for
 // the process lifetime.
 func Unregister(name string) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
 	delete(registry, name)
 }
 
 // resetForTest clears the registry. Test-only helper used by tests in this
 // package; not exported because nothing outside should mutate the registry
 // after init().
-func resetForTest() { registry = map[string]Handler{} }
+func resetForTest() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = map[string]Handler{}
+}

--- a/internal/composite/postprocess/postprocess_test.go
+++ b/internal/composite/postprocess/postprocess_test.go
@@ -1,0 +1,97 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postprocess
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegister_Duplicate_Panics(t *testing.T) {
+	resetForTest()
+	t.Cleanup(resetForTest)
+
+	Register("h", Handler{Fn: func(map[string]map[string]any) (map[string]any, error) { return nil, nil }})
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on duplicate Register")
+		}
+		if !strings.Contains(r.(string), "already registered") {
+			t.Fatalf("unexpected panic message: %v", r)
+		}
+	}()
+	Register("h", Handler{Fn: func(map[string]map[string]any) (map[string]any, error) { return nil, nil }})
+}
+
+func TestApply_UnknownHandler(t *testing.T) {
+	resetForTest()
+	t.Cleanup(resetForTest)
+
+	_, err := Apply("missing", nil)
+	if err == nil || !strings.Contains(err.Error(), `postprocessor "missing" not registered`) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestApply_DispatchesToHandler(t *testing.T) {
+	resetForTest()
+	t.Cleanup(resetForTest)
+
+	Register("ok", Handler{Fn: func(stepResults map[string]map[string]any) (map[string]any, error) {
+		return map[string]any{"count": len(stepResults)}, nil
+	}})
+	got, err := Apply("ok", map[string]map[string]any{"a": {}, "b": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["count"] != 2 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestValidateTool(t *testing.T) {
+	resetForTest()
+	t.Cleanup(resetForTest)
+
+	Register("h", Handler{
+		Fn:             func(map[string]map[string]any) (map[string]any, error) { return nil, nil },
+		RequiredFields: []string{"a", "b"},
+	})
+
+	t.Run("unknown handler", func(t *testing.T) {
+		err := ValidateTool("tool-x", "missing", []string{"a"})
+		if err == nil || !strings.Contains(err.Error(), `postprocessor "missing" not registered`) {
+			t.Fatalf("got %v", err)
+		}
+	})
+
+	t.Run("missing required field", func(t *testing.T) {
+		err := ValidateTool("tool-x", "h", []string{"a"}) // b is missing
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		want := `tool "tool-x": postprocessor "h" reads "b" but it is not in select`
+		if err.Error() != want {
+			t.Fatalf("\nwant: %s\ngot:  %s", want, err.Error())
+		}
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		if err := ValidateTool("tool-x", "h", []string{"a", "b", "c"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/internal/composite/postprocess/postprocess_test.go
+++ b/internal/composite/postprocess/postprocess_test.go
@@ -68,18 +68,30 @@ func TestValidateTool(t *testing.T) {
 
 	Register("h", Handler{
 		Fn:             func(map[string]map[string]any) (map[string]any, error) { return nil, nil },
+		RequiredSteps:  []string{"s1"},
 		RequiredFields: []string{"a", "b"},
 	})
 
 	t.Run("unknown handler", func(t *testing.T) {
-		err := ValidateTool("tool-x", "missing", []string{"a"})
+		err := ValidateTool("tool-x", "missing", []string{"s1"}, []string{"a"})
 		if err == nil || !strings.Contains(err.Error(), `postprocessor "missing" not registered`) {
 			t.Fatalf("got %v", err)
 		}
 	})
 
+	t.Run("missing required step", func(t *testing.T) {
+		err := ValidateTool("tool-x", "h", []string{"other"}, []string{"a", "b"})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		want := `tool "tool-x": postprocessor "h" reads step "s1" but no such step is defined`
+		if err.Error() != want {
+			t.Fatalf("\nwant: %s\ngot:  %s", want, err.Error())
+		}
+	})
+
 	t.Run("missing required field", func(t *testing.T) {
-		err := ValidateTool("tool-x", "h", []string{"a"}) // b is missing
+		err := ValidateTool("tool-x", "h", []string{"s1"}, []string{"a"}) // b is missing
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -90,7 +102,7 @@ func TestValidateTool(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		if err := ValidateTool("tool-x", "h", []string{"a", "b", "c"}); err != nil {
+		if err := ValidateTool("tool-x", "h", []string{"s1"}, []string{"a", "b", "c"}); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/internal/composite/postprocess/postprocesstest/register.go
+++ b/internal/composite/postprocess/postprocesstest/register.go
@@ -1,0 +1,38 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package postprocesstest provides test-only registration for the postprocess
+// registry. It lives in a sibling package so that production binaries
+// importing postprocess do not pull in the testing package and its flag
+// side effects.
+package postprocesstest
+
+import (
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
+)
+
+// Register installs a postprocessor for the duration of one test, removing
+// it via t.Cleanup so test runs don't leak entries into the package-global
+// registry across t.Parallel / go test -count=N. Use this instead of calling
+// postprocess.Register directly from tests outside the postprocess package.
+func Register(t *testing.T, name string, h postprocess.Handler) {
+	t.Helper()
+	if postprocess.IsRegistered(name) {
+		t.Fatalf("postprocess: postprocessor %q already registered", name)
+	}
+	postprocess.Register(name, h)
+	t.Cleanup(func() { postprocess.Unregister(name) })
+}

--- a/internal/composite/result_strategy_test.go
+++ b/internal/composite/result_strategy_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package composite_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite"
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess/postprocesstest"
+)
+
+func TestApplyResultStrategy_Collect(t *testing.T) {
+	stepResults := map[string]map[string]any{
+		"a": {"x": 1},
+		"b": {"y": 2},
+	}
+	got, err := composite.ApplyResultStrategy(composite.ResultStrategy{Strategy: "collect"}, stepResults)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"a": map[string]any{"x": 1},
+		"b": map[string]any{"y": 2},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyResultStrategy_PostProcess_MergesSummary(t *testing.T) {
+	postprocesstest.Register(t, "__test_summary", postprocess.Handler{
+		Fn: func(map[string]map[string]any) (map[string]any, error) {
+			return map[string]any{"count": 7}, nil
+		},
+	})
+	stepResults := map[string]map[string]any{
+		"queues": {"data": []any{}},
+	}
+	got, err := composite.ApplyResultStrategy(
+		composite.ResultStrategy{Strategy: "postProcess", PostProcess: "__test_summary"},
+		stepResults,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary, ok := got["summary"].(map[string]any)
+	if !ok || summary["count"] != 7 {
+		t.Fatalf("summary: got %+v", got["summary"])
+	}
+	queues, ok := got["queues"].(map[string]any)
+	if !ok || !reflect.DeepEqual(queues["data"], []any{}) {
+		t.Fatalf("queues: got %+v", got["queues"])
+	}
+}
+
+func TestApplyResultStrategy_Unsupported(t *testing.T) {
+	_, err := composite.ApplyResultStrategy(composite.ResultStrategy{Strategy: "bogus"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Productionizes Approach C from the SOL-149390 spike: composite tools can declare `postProcess: <handlerName>` in `tools.yaml`, and a Go handler computes a `summary` map (e.g. aggregate counts) that the executor merges alongside the raw step results. Adds the first handler for `list-queues` and a startup validator that fails boot if a handler's required SEMP fields aren't selected.

Fixes [SOL-151052](https://sol-jira.atlassian.net/browse/SOL-151052)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

SOL-149390 chose Approach C (Go postprocessor) over Approach A (YAML aggregation DSL) for count-style aggregations; SOL-150904 prototyped both and confirmed the call. This story lands C in the real codebase. The payoff: LLM clients get pre-computed counts (queues with no consumers, congested, backlogged, near-full) instead of having to scan the raw list themselves.

The `nearFullCount` ratio aggregation is included specifically to demonstrate expressivity Approach A could not match.

## Changes Made

**New `postProcess` strategy**
- New `postProcess` value for `result.strategy` in `tools.yaml`, with a `postProcess: <name>` field naming a registered handler.
- Executor merges the handler's output under a top-level `summary` key alongside the raw step results (`internal/composite/executor.go`).
- New `internal/composite/postprocess/` package: registry, `Handler` shape (`Fn` + `RequiredSteps` + `RequiredFields`), self-registration via `init()`. `cmd/server/main.go` blank-imports the handlers package so the registry is populated before startup validation runs.

**YAML schema: structured `select:`**
- Step schema gains a structured `select:` list, replacing the old comma-joined string under `args.select`. The executor joins it into the SEMP `select` query parameter at execute time (`applySelect`).
- The structured form is what makes the boot-time field cross-check possible without re-parsing strings.
- The loader rejects setting both `args.select` and `select:` on the same step (they would race, since `applySelect` overwrites `args["select"]`).

**Boot-time safety nets** (in `loader.go` / `ValidatePostProcess`)
- Every handler's `RequiredFields` must appear in the union of its tool's step `select:` clauses — catches SEMP field-name drift (`bindCount` vs `bindSuccessCount` class of bug from the spike report).
- Every handler's `RequiredSteps` must match an actual step ID in the tool — catches YAML step renames that would otherwise surface only at first call.
- The step ID `"summary"` is reserved under the `postProcess` strategy so a step can't silently shadow the handler output.
- All four checks fail the process at boot with a uniform error template.

**First handler: `list-queues`**
- `internal/composite/postprocess/handlers/list_queues.go` return `noConsumerCount`, `congestedCount`, `backloggedCount`, `nearFullCount`, plus `scanned` (items observed) and (when the paginator truncated) `truncated: true`. Surfacing truncation in the summary keeps the LLM from treating partial counts as global.
- `tools.yaml` `list-queues` switched to `strategy: postProcess` with the five required fields in `select:`.

**Tests**
- Handler counts, edge cases, missing-field errors, truncation surfacing.
- Loader cross-field rules (postProcess/collect mutual exclusion, reserved step ID, args.select/select coexistence guard).
- `ValidatePostProcess` boot-time cross-check (happy path, missing field, unregistered handler).
- Executor merge contract: `collect` results pass through, `summary` lands next to them.
- Regression test pinning `applySelect` on the parallel-batch path.
- New `postprocesstest` helper package for test-scoped register/unregister
  (lives in a sibling package so production binaries don't import `testing`).

Architecture docs updated in `docs/internal/architecture.md`.
## Testing

**Test Environment:**
- Go version: go1.25.11
- OS: Linux 7.0.10-101.fc43.x86_64
- Broker version (if applicable): N/A for unit tests; E2E uses Dockerized brokers via `make e2e-all`

**Tests Performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**
- `list-queues` handler: each of `noConsumerCount`, `congestedCount`, `backloggedCount`, `nearFullCount` over representative queue sets, including the near-full ratio edge cases.
- Loader cross-check: tool with `postProcess` whose `select:` is missing a required field fails to load with the documented error template.
- Executor merge: `collect` results pass through under their existing key while the handler output lands under `summary`.
- E2E: `list-queues` against a real broker returns the merged `{summary, queues}` shape.

## Breaking Changes

N/A — `postProcess` is additive; the existing `collect` strategy is unchanged.

**Impact:**

**Migration Guide:**

## Checklist

### Code Quality
- [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (checked all files, commits, and logs)
- [x] Followed [secure logging rules](../docs/secure-logging-rules.md)
- [x] Credential-carrying types implement `slog.LogValuer`
- [x] No security vulnerabilities introduced (checked with golangci-lint/gosec)

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (if user-facing changes)
- [x] docs/ updated (if architecture/design changes)
- [x] godoc comments added/updated for exported functions
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Examples updated (if applicable)

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

### Breaking Changes (if applicable)
- [ ] Breaking changes documented in commit message
- [ ] Breaking changes documented in PR description
- [ ] Migration guide provided
- [ ] Deprecated functionality marked with comments and deprecation notices

## Related Issues/PRs

- Related to [SOL-149390](https://sol-jira.atlassian.net/browse/SOL-149390) (Approach C decision)
- Related to [SOL-150904](https://sol-jira.atlassian.net/browse/SOL-150904) (prototype validation)

---

**For Reviewers:**

Output:
<img width="2558" height="1534" alt="image" src="https://github.com/user-attachments/assets/94187367-b350-4ef6-abd6-53431fc70656" />


**Focus Areas**: The executor merge contract in `ApplyResultStrategy` (top-level `summary` key alongside the existing `collect` result), and the startup validator's error path — that's the SEMP-version-drift safety net (`bindCount` vs `bindSuccessCount` class of bug from the spike report).

[SOL-151052]: https://sol-jira.atlassian.net/browse/SOL-151052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-149390]: https://sol-jira.atlassian.net/browse/SOL-149390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ