### PR TITLE
SOL-151114: F7-ttl fixture flaky in e2e-monitoring: maxTtlExpiredDiscardedMsgCount stays 0

### DIFF
--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -390,6 +390,6 @@ tools:
         args:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
-          select: "clientProfileDeniedDiscardedMsgCount, destinationGroupErrorDiscardedMsgCount, disabledDiscardedMsgCount, lowPriorityMsgCongestionDiscardedMsgCount, maxMsgSizeExceededDiscardedMsgCount, maxMsgSpoolUsageExceededDiscardedMsgCount, maxRedeliveryExceededDiscardedMsgCount, maxRedeliveryExceededToDmqMsgCount, maxTtlExceededDiscardedMsgCount, maxTtlExpiredDiscardedMsgCount, maxTtlExpiredToDmqMsgCount, msgVpnName, noLocalDeliveryDiscardedMsgCount, queueName, xaTransactionNotSupportedDiscardedMsgCount"
+          select: "clientProfileDeniedDiscardedMsgCount, destinationGroupErrorDiscardedMsgCount, disabledDiscardedMsgCount, lowPriorityMsgCongestionDiscardedMsgCount, maxMsgSizeExceededDiscardedMsgCount, maxMsgSpoolUsageExceededDiscardedMsgCount, maxRedeliveryExceededDiscardedMsgCount, maxRedeliveryExceededToDmqMsgCount, maxTtlExceededDiscardedMsgCount, maxTtlExpiredDiscardedMsgCount, maxTtlExpiredToDmqMsgCount, maxTtlExpiredToDmqFailedMsgCount, msgVpnName, noLocalDeliveryDiscardedMsgCount, queueName, xaTransactionNotSupportedDiscardedMsgCount"
     result:
       strategy: collect

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -523,15 +523,18 @@ test_list_queue_discards() {
     content=$(extract_content "$response")
     spool=$(echo "$content" | jq -r \
         "(.queueDiscards.data[] | select(.queueName==\"$F7_SPOOL_QUEUE\") | .maxMsgSpoolUsageExceededDiscardedMsgCount) // 0")
+    # Sum all three TTL-expired paths (Discarded + ToDmq + ToDmqFailed): a
+    # queue that inherits a default DMQ routes expired messages via ToDmq
+    # (or ToDmqFailed if the DMQ can't be resolved) instead of pure Discarded.
     ttl=$(echo "$content" | jq -r \
-        "(.queueDiscards.data[] | select(.queueName==\"$F7_TTL_QUEUE\") | .maxTtlExpiredDiscardedMsgCount) // 0")
-    log_info "list-queue-discards [$broker]: $F7_SPOOL_QUEUE spool-exceeded=$spool $F7_TTL_QUEUE ttl-expired=$ttl"
+        "(.queueDiscards.data[] | select(.queueName==\"$F7_TTL_QUEUE\") | (.maxTtlExpiredDiscardedMsgCount + .maxTtlExpiredToDmqMsgCount + .maxTtlExpiredToDmqFailedMsgCount)) // 0")
+    log_info "list-queue-discards [$broker]: $F7_SPOOL_QUEUE spool-exceeded=$spool $F7_TTL_QUEUE ttl-expired-total=$ttl"
     assert_json_field "$content" \
         "(.queueDiscards.data[] | select(.queueName==\"$F7_SPOOL_QUEUE\") | .maxMsgSpoolUsageExceededDiscardedMsgCount) > 0" "true" \
         "list-queue-discards [$broker]: $F7_SPOOL_QUEUE maxMsgSpoolUsageExceededDiscardedMsgCount must be > 0 (got $spool)" || return 1
     assert_json_field "$content" \
-        "(.queueDiscards.data[] | select(.queueName==\"$F7_TTL_QUEUE\") | .maxTtlExpiredDiscardedMsgCount) > 0" "true" \
-        "list-queue-discards [$broker]: $F7_TTL_QUEUE maxTtlExpiredDiscardedMsgCount must be > 0 (got $ttl)" || return 1
+        "(.queueDiscards.data[] | select(.queueName==\"$F7_TTL_QUEUE\") | (.maxTtlExpiredDiscardedMsgCount + .maxTtlExpiredToDmqMsgCount + .maxTtlExpiredToDmqFailedMsgCount)) > 0" "true" \
+        "list-queue-discards [$broker]: $F7_TTL_QUEUE total TTL-expired count must be > 0 (got $ttl)" || return 1
     # VPN scoping: every returned queue belongs to the default VPN.
     assert_json_field "$content" '.queueDiscards.data | all(.msgVpnName == "default")' "true" \
         "list-queue-discards [$broker]: every queue must be scoped to the default VPN" || return 1
@@ -578,9 +581,12 @@ test_get_discard_stats_broker_wide() {
     response=$(mcp_call_tool "get-discard-stats" \
         "$(jq -nc --arg b "$broker" '{broker:$b}')") || return 1
     content=$(extract_content "$response")
-    ttl=$(echo "$content" | jq -r '.spoolDiscards.totalTtlExpiredDiscardMessages // 0')
+    # Sum all three TTL-expired paths (Discarded + ToDmq + ToDmqFailures): a
+    # queue that inherits a default DMQ routes expired messages via ToDmq
+    # (or ToDmqFailures if the DMQ can't be resolved) instead of pure Discarded.
+    ttl=$(echo "$content" | jq -r '((.spoolDiscards.totalTtlExpiredDiscardMessages // 0) + (.spoolDiscards.totalTtlExpiredToDmqMessages // 0) + (.spoolDiscards.totalTtlExpiredToDmqFailures // 0))')
     total=$(echo "$content" | jq -r '.spoolDiscards.totalDiscardedMessages // 0')
-    log_info "get-discard-stats [$broker] broker-wide: spool totalTtlExpiredDiscardMessages=$ttl totalDiscardedMessages=$total"
+    log_info "get-discard-stats [$broker] broker-wide: spool totalTtlExpired(all-paths)=$ttl totalDiscardedMessages=$total"
     # Broker-wide envelope carries both client- and spool-level aggregates.
     assert_json_field "$content" '.clientDiscards | type' "object" \
         "get-discard-stats [$broker]: broker-wide must include clientDiscards object" || return 1
@@ -588,8 +594,8 @@ test_get_discard_stats_broker_wide() {
         "get-discard-stats [$broker]: broker-wide must include spoolDiscards object" || return 1
     # F7 discards surface in the spool aggregate: TTL-expired (F7-ttl, directly
     # mapped) and the total roll-up (fed by both F7-ttl and F7-spool).
-    assert_json_field "$content" '.spoolDiscards.totalTtlExpiredDiscardMessages > 0' "true" \
-        "get-discard-stats [$broker]: spoolDiscards.totalTtlExpiredDiscardMessages must be > 0 (got $ttl)" || return 1
+    assert_json_field "$content" '((.spoolDiscards.totalTtlExpiredDiscardMessages // 0) + (.spoolDiscards.totalTtlExpiredToDmqMessages // 0) + (.spoolDiscards.totalTtlExpiredToDmqFailures // 0)) > 0' "true" \
+        "get-discard-stats [$broker]: total TTL-expired count must be > 0 (got $ttl)" || return 1
     assert_json_field "$content" '.spoolDiscards.totalDiscardedMessages > 0' "true" \
         "get-discard-stats [$broker]: spoolDiscards.totalDiscardedMessages must be > 0 (got $total)" || return 1
 }

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -523,9 +523,8 @@ test_list_queue_discards() {
     content=$(extract_content "$response")
     spool=$(echo "$content" | jq -r \
         "(.queueDiscards.data[] | select(.queueName==\"$F7_SPOOL_QUEUE\") | .maxMsgSpoolUsageExceededDiscardedMsgCount) // 0")
-    # Sum all three TTL-expired paths (Discarded + ToDmq + ToDmqFailed): a
-    # queue that inherits a default DMQ routes expired messages via ToDmq
-    # (or ToDmqFailed if the DMQ can't be resolved) instead of pure Discarded.
+    # Sum all three TTL-expired counter paths the broker may use:
+    # Discarded, ToDmq, or ToDmqFailed (DMQ resolution failed).
     ttl=$(echo "$content" | jq -r \
         "(.queueDiscards.data[] | select(.queueName==\"$F7_TTL_QUEUE\") | (.maxTtlExpiredDiscardedMsgCount + .maxTtlExpiredToDmqMsgCount + .maxTtlExpiredToDmqFailedMsgCount)) // 0")
     log_info "list-queue-discards [$broker]: $F7_SPOOL_QUEUE spool-exceeded=$spool $F7_TTL_QUEUE ttl-expired-total=$ttl"
@@ -581,9 +580,8 @@ test_get_discard_stats_broker_wide() {
     response=$(mcp_call_tool "get-discard-stats" \
         "$(jq -nc --arg b "$broker" '{broker:$b}')") || return 1
     content=$(extract_content "$response")
-    # Sum all three TTL-expired paths (Discarded + ToDmq + ToDmqFailures): a
-    # queue that inherits a default DMQ routes expired messages via ToDmq
-    # (or ToDmqFailures if the DMQ can't be resolved) instead of pure Discarded.
+    # Sum all three TTL-expired counter paths the broker may use:
+    # Discarded, ToDmq, or ToDmqFailures (DMQ resolution failed).
     ttl=$(echo "$content" | jq -r '((.spoolDiscards.totalTtlExpiredDiscardMessages // 0) + (.spoolDiscards.totalTtlExpiredToDmqMessages // 0) + (.spoolDiscards.totalTtlExpiredToDmqFailures // 0))')
     total=$(echo "$content" | jq -r '.spoolDiscards.totalDiscardedMessages // 0')
     log_info "get-discard-stats [$broker] broker-wide: spool totalTtlExpired(all-paths)=$ttl totalDiscardedMessages=$total"

--- a/test/e2e-monitoring/verify-fixtures.sh
+++ b/test/e2e-monitoring/verify-fixtures.sh
@@ -289,10 +289,9 @@ verify_discard_ttl_state() {
         log_fail "F7-ttl [$label]: GET queues/$F7_TTL_QUEUE failed"
         return 1
     }
-    # Sum all three TTL-expired paths: a queue that inherits a default DMQ
-    # routes expired messages via ToDmq (or ToDmqFailed if the DMQ can't be
-    # resolved) instead of pure Discarded. We only care that expiry happened,
-    # not which path the broker took.
+    # Sum all three TTL-expired counter paths the broker may use: pure
+    # Discarded, ToDmq, or ToDmqFailed (DMQ resolution failed). We only care
+    # that expiry happened, not which path the broker took.
     local discarded to_dmq to_dmq_failed
     discarded=$(echo "$body" | jq -r '.data.maxTtlExpiredDiscardedMsgCount')
     to_dmq=$(echo "$body" | jq -r '.data.maxTtlExpiredToDmqMsgCount')

--- a/test/e2e-monitoring/verify-fixtures.sh
+++ b/test/e2e-monitoring/verify-fixtures.sh
@@ -289,11 +289,17 @@ verify_discard_ttl_state() {
         log_fail "F7-ttl [$label]: GET queues/$F7_TTL_QUEUE failed"
         return 1
     }
-    local count
-    count=$(echo "$body" | jq -r '.data.maxTtlExpiredDiscardedMsgCount')
+    # Sum all three TTL-expired paths: a queue that inherits a default DMQ
+    # routes expired messages via ToDmq (or ToDmqFailed if the DMQ can't be
+    # resolved) instead of pure Discarded. We only care that expiry happened,
+    # not which path the broker took.
+    local discarded to_dmq to_dmq_failed
+    discarded=$(echo "$body" | jq -r '.data.maxTtlExpiredDiscardedMsgCount')
+    to_dmq=$(echo "$body" | jq -r '.data.maxTtlExpiredToDmqMsgCount')
+    to_dmq_failed=$(echo "$body" | jq -r '.data.maxTtlExpiredToDmqFailedMsgCount')
     assert_json_field "$body" \
-        ".data.maxTtlExpiredDiscardedMsgCount > 0" "true" \
-        "F7-ttl [$label]: maxTtlExpiredDiscardedMsgCount must be > 0 (got $count)" || return 1
+        "(.data.maxTtlExpiredDiscardedMsgCount + .data.maxTtlExpiredToDmqMsgCount + .data.maxTtlExpiredToDmqFailedMsgCount) > 0" "true" \
+        "F7-ttl [$label]: total TTL-expired count must be > 0 (discarded=$discarded toDmq=$to_dmq toDmqFailed=$to_dmq_failed)" || return 1
 }
 
 test_ac9_discard_ttl_a() { verify_discard_ttl_state "broker-a" "$BROKER_A_URL"; }


### PR DESCRIPTION
## Summary

Fix flaky F7-ttl assertions in `test/e2e-monitoring` by broadening them to sum all three TTL-expired counter paths (Discarded + ToDmq + ToDmqFailed) instead of asserting on the pure-discard counter alone. Adds the missing `maxTtlExpiredToDmqFailedMsgCount` field to `list-queue-discards`'s YAML projection so the broadened tool-layer assertion can see it.

Fixes [SOL-151114](https://sol-jira.atlassian.net/browse/SOL-151114)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`AC 9 — F7-ttl discard count` (in `verify-fixtures.sh`) and the parallel TTL assertions in `tool-tests.sh` (Tool 11 `list-queue-discards`, Tool 12 `get-discard-stats`) were failing with `maxTtlExpiredDiscardedMsgCount must be > 0 (got 0)` on `solace/solace-pubsub-standard:10.26.0`. Reproduces deterministically on both CI and local.

Root cause: when a TTL-expired message hits the queue, the broker increments **exactly one** of three counters depending on DMQ resolution:

| Counter | When it fires |
|---|---|
| `maxTtlExpiredDiscardedMsgCount` | No DMQ → message dropped |
| `maxTtlExpiredToDmqMsgCount` | DMQ resolved → message moved |
| `maxTtlExpiredToDmqFailedMsgCount` | DMQ configured but failed to resolve |

The F7-ttl queue inherits the broker default DMQ (`#DEAD_MSG_QUEUE`), which doesn't exist on our test brokers, so every expiry increments `maxTtlExpiredToDmqFailedMsgCount` — the one path our assertions never checked. The fixture itself works correctly; the assertions are just looking at the wrong field.

Secondary issue found during diagnosis: `list-queue-discards`'s composite YAML didn't project `maxTtlExpiredToDmqFailedMsgCount`, so even a broadened tool-layer assertion would have come up empty.

## Changes Made

- `test/e2e-monitoring/verify-fixtures.sh`: AC 9 now sums all three TTL-expired counters (`Discarded + ToDmq + ToDmqFailed`) rather than asserting `Discarded > 0` alone. Failure message reports each component for diagnosability.
- `test/e2e-monitoring/tool-tests.sh`: same broadening applied to Tool 11 (queue-level via `list-queue-discards`) and Tool 12 (broker-wide via SEMPv1 `get-discard-stats`, using the equivalent `totalTtlExpired{Discard,ToDmq,ToDmqFailures}` fields).
- `internal/composite/definitions/tools.yaml`: added `maxTtlExpiredToDmqFailedMsgCount` to `list-queue-discards`'s `select` clause so the field is exposed to callers.

No fixture or queue-config changes — the queue still inherits whatever DMQ default the broker provides; we just stopped over-constraining which expiry path counts.

## Testing

**Test Environment:**
- Go version: as per `go.mod`
- OS: Linux
- Broker version: `solace/solace-pubsub-standard:10.26.0` (CI `:latest` + local repro)

**Tests Performed:**
- [x] E2E tests updated (verify-fixtures.sh AC 9, tool-tests.sh Tool 11 + Tool 12)
- [x] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker (e2e-monitoring suite)

**Test Coverage:**
- AC 9 passes against the actual broker behavior (DMQ-failed path).
- Tool 11 and Tool 12 assertions pass under the same fixture without requiring any DMQ to be provisioned.
- Diagnostic log line now reports `ttl-expired-total=N`, the sum across all three paths.

## Breaking Changes

None. The YAML change adds one extra field to `list-queue-discards`'s response — callers ignoring unknown fields are unaffected.

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what")
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code
- [x] Followed secure logging rules (no logging changes)

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] Edge cases covered (jq's `// 0` guards missing fields per term)

### Documentation
- [x] Inline comments updated to explain the three-path model and why summation is the correct assertion shape

### Git & CI
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main

## Additional Notes

This supersedes the earlier approach on this branch (commits `116c57e` / `ccf5c73`), which attempted to toggle `deadMsgQueue:""` on the fixture queue. That was a red herring — main has no `deadMsgQueue` field either, and the underlying cause (counter selection, not queue config) is what this PR fixes. Local branch has been reset to `origin/main` and rewritten with the smaller, assertion-only fix.

## Related Issues/PRs

- Fixes SOL-151114
- Replaces earlier attempt on this branch
- Follow-up to PR #112 (where the flake first surfaced)


[SOL-151114]: https://sol-jira.atlassian.net/browse/SOL-151114