### PR TITLE
SOL-151283: /livez endpoint with /health as alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ If the config file is named `broker-config.yaml` in the current directory, the s
 Verify:
 
 ```bash
-curl http://localhost:9090/health
-# {"status": "ok"}
+curl http://localhost:9090/livez
+# {"status":"alive"}
 ```
 
 The binary is statically linked with no external dependencies. It handles `SIGTERM` and `SIGINT` for graceful shutdown.
@@ -204,8 +204,8 @@ The container reads config from `/etc/mcp-server/config.yaml` by default. Pass t
 Verify:
 
 ```bash
-curl http://localhost:9090/health
-# {"status": "ok"}
+curl http://localhost:9090/livez
+# {"status":"alive"}
 ```
 
 The image includes a built-in Docker health check using the binary's `--health` flag (no shell or curl needed in the container). Check status with `docker inspect --format '{{.State.Health.Status}}' solace-broker-mcp`.
@@ -278,7 +278,7 @@ Create `broker-config.yaml` and `.env` in the repo root (both are gitignored). S
 go run ./cmd/server
 ```
 
-The MCP server listens on port `9090` by default and serves the MCP endpoint at `/mcp`. A health check endpoint is available at `/health`.
+The MCP server listens on port `9090` by default and serves the MCP endpoint at `/mcp`. A liveness endpoint is available at `/livez` (with `/health` retained as a backward-compatible alias).
 
 ### Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Create `broker-config.yaml` and `.env` in the repo root (both are gitignored). S
 go run ./cmd/server
 ```
 
-The MCP server listens on port `9090` by default and serves the MCP endpoint at `/mcp`. A liveness endpoint is available at `/livez` (with `/health` retained as a backward-compatible alias).
+The MCP server listens on port `9090` by default and serves the MCP endpoint at `/mcp`. The canonical liveness endpoint is `/livez`, which returns `{"status":"alive"}`. `/health` is retained for backward compatibility and preserves its original `{"status":"healthy"}` body — it is not a body-identical alias of `/livez`.
 
 ### Configuration Options
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess/handlers" // register handlers via init()
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2/specs"
@@ -90,17 +91,13 @@ func newSlogHandler(level slog.Level) slog.Handler {
 func buildMux(aliases func() []string, probeBroker func(ctx context.Context, broker string) error) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`{"status": "healthy"}`)); err != nil {
-			http.Error(w, "failed to write response", http.StatusInternalServerError)
-		}
-	})
+	// Liveness probe. /livez is the canonical name; /health is retained as a
+	// backward-compatible alias bound to the SAME handler instance, so both
+	// paths return byte-identical responses (200 {"status":"alive"} on GET, 405
+	// otherwise). The probe is unconditional — never flag-gated.
+	livez := health.LivezHandler()
+	mux.Handle("/livez", livez)
+	mux.Handle("/health", livez)
 
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -91,14 +91,16 @@ func newSlogHandler(level slog.Level) slog.Handler {
 func buildMux(aliases func() []string, probeBroker func(ctx context.Context, broker string) error) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	// Liveness probe. /livez is the canonical name; /health is retained as a
-	// backward-compatible alias bound to the SAME handler instance, so both
-	// paths return byte-identical responses (200 {"status":"alive"} on GET, 405
-	// otherwise). The probe is unconditional — never flag-gated.
-	livez := health.LivezHandler()
-	mux.Handle("/livez", livez)
-	mux.Handle("/health", livez)
+	// Liveness probe. /livez is the canonical liveness endpoint and returns
+	// {"status":"alive"}. /health is retained for backward compatibility and
+	// preserves its original {"status":"healthy"} body — it is a SEPARATE handler
+	// instance, NOT a body-identical alias, so external consumers that parse
+	// .status == "healthy" keep working. Both probes are unconditional (200 on
+	// GET, 405 otherwise) and never flag-gated.
+	mux.Handle("/livez", health.LivezHandler())
+	mux.Handle("/health", health.HealthHandler())
 
+	// TODO(SOL-151285/SOL-151284): /ready is still a large inline handler here; it will be superseded by the MCP-server-only /readyz and moved into the health package in the readiness story.
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -50,6 +50,46 @@ func testMux() *http.ServeMux {
 	return mux
 }
 
+// TestLivez_GET_ReturnsOK pins the canonical liveness endpoint: 200 with the
+// exact process-alive body and JSON content type.
+func TestLivez_GET_ReturnsOK(t *testing.T) {
+	mux := testMux()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/livez", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /livez status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != `{"status":"alive"}` {
+		t.Errorf("GET /livez body = %q, want %q", rec.Body.String(), `{"status":"alive"}`)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("GET /livez Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+func TestLivez_POST_ReturnsMethodNotAllowed(t *testing.T) {
+	mux := testMux()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/livez", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /livez status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+// TestHealth_GET_ReturnsOK pins that /health is now a body-identical alias of
+// /livez ({"status":"alive"}), NOT the old {"status": "healthy"}.
+//
+// The body changed, and some consumers DO read it: the shell e2e suites
+// (test/e2e-basic-mcp/test-standalone.sh and test/health/test-health.sh) assert
+// .status via jq and run in CI — they were updated to expect "alive". The
+// status-only consumers (the --health probe and the k8s httpGet liveness/
+// readiness probes) are unaffected because they key on HTTP 200, not the body.
 func TestHealth_GET_ReturnsOK(t *testing.T) {
 	mux := testMux()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", nil)
@@ -60,8 +100,8 @@ func TestHealth_GET_ReturnsOK(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("GET /health status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if rec.Body.String() != `{"status": "healthy"}` {
-		t.Errorf("GET /health body = %q, want %q", rec.Body.String(), `{"status": "healthy"}`)
+	if rec.Body.String() != `{"status":"alive"}` {
+		t.Errorf("GET /health body = %q, want %q", rec.Body.String(), `{"status":"alive"}`)
 	}
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("GET /health Content-Type = %q, want %q", ct, "application/json")
@@ -77,6 +117,31 @@ func TestHealth_POST_ReturnsMethodNotAllowed(t *testing.T) {
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("POST /health status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+// TestHealthAliasesLivez proves /health is a true alias of /livez: same status,
+// same body, and same Content-Type for both GET and a non-GET (405) method.
+func TestHealthAliasesLivez(t *testing.T) {
+	mux := testMux()
+
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		livezRec := httptest.NewRecorder()
+		mux.ServeHTTP(livezRec, httptest.NewRequestWithContext(context.Background(), method, "/livez", nil))
+
+		healthRec := httptest.NewRecorder()
+		mux.ServeHTTP(healthRec, httptest.NewRequestWithContext(context.Background(), method, "/health", nil))
+
+		if livezRec.Code != healthRec.Code {
+			t.Errorf("%s: status /livez=%d /health=%d, want equal", method, livezRec.Code, healthRec.Code)
+		}
+		if livezRec.Body.String() != healthRec.Body.String() {
+			t.Errorf("%s: body /livez=%q /health=%q, want equal", method, livezRec.Body.String(), healthRec.Body.String())
+		}
+		if livezRec.Header().Get("Content-Type") != healthRec.Header().Get("Content-Type") {
+			t.Errorf("%s: Content-Type /livez=%q /health=%q, want equal",
+				method, livezRec.Header().Get("Content-Type"), healthRec.Header().Get("Content-Type"))
+		}
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -82,14 +82,11 @@ func TestLivez_POST_ReturnsMethodNotAllowed(t *testing.T) {
 	}
 }
 
-// TestHealth_GET_ReturnsOK pins that /health is now a body-identical alias of
-// /livez ({"status":"alive"}), NOT the old {"status": "healthy"}.
-//
-// The body changed, and some consumers DO read it: the shell e2e suites
-// (test/e2e-basic-mcp/test-standalone.sh and test/health/test-health.sh) assert
-// .status via jq and run in CI — they were updated to expect "alive". The
-// status-only consumers (the --health probe and the k8s httpGet liveness/
-// readiness probes) are unaffected because they key on HTTP 200, not the body.
+// TestHealth_GET_ReturnsOK pins that /health preserves its ORIGINAL shipped body
+// {"status":"healthy"} — it is NOT a body-identical alias of /livez. /health is
+// retained for backward compatibility so external consumers that parse
+// .status == "healthy" keep working; /livez is the canonical liveness endpoint
+// and returns {"status":"alive"}.
 func TestHealth_GET_ReturnsOK(t *testing.T) {
 	mux := testMux()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", nil)
@@ -100,8 +97,8 @@ func TestHealth_GET_ReturnsOK(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("GET /health status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if rec.Body.String() != `{"status":"alive"}` {
-		t.Errorf("GET /health body = %q, want %q", rec.Body.String(), `{"status":"alive"}`)
+	if rec.Body.String() != `{"status":"healthy"}` {
+		t.Errorf("GET /health body = %q, want %q", rec.Body.String(), `{"status":"healthy"}`)
 	}
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("GET /health Content-Type = %q, want %q", ct, "application/json")
@@ -120,9 +117,12 @@ func TestHealth_POST_ReturnsMethodNotAllowed(t *testing.T) {
 	}
 }
 
-// TestHealthAliasesLivez proves /health is a true alias of /livez: same status,
-// same body, and same Content-Type for both GET and a non-GET (405) method.
-func TestHealthAliasesLivez(t *testing.T) {
+// TestLivezAndHealthShareStatusButNotBody proves the back-compat contract:
+// /livez and /health share status (200 GET, 405 non-GET) and Content-Type, but
+// their bodies DIFFER deliberately — /livez returns {"status":"alive"} (canonical
+// liveness) and /health returns {"status":"healthy"} (original shipped body
+// retained for external consumers). They are NOT body-identical aliases.
+func TestLivezAndHealthShareStatusButNotBody(t *testing.T) {
 	mux := testMux()
 
 	for _, method := range []string{http.MethodGet, http.MethodPost} {
@@ -135,13 +135,27 @@ func TestHealthAliasesLivez(t *testing.T) {
 		if livezRec.Code != healthRec.Code {
 			t.Errorf("%s: status /livez=%d /health=%d, want equal", method, livezRec.Code, healthRec.Code)
 		}
-		if livezRec.Body.String() != healthRec.Body.String() {
-			t.Errorf("%s: body /livez=%q /health=%q, want equal", method, livezRec.Body.String(), healthRec.Body.String())
-		}
 		if livezRec.Header().Get("Content-Type") != healthRec.Header().Get("Content-Type") {
 			t.Errorf("%s: Content-Type /livez=%q /health=%q, want equal",
 				method, livezRec.Header().Get("Content-Type"), healthRec.Header().Get("Content-Type"))
 		}
+	}
+
+	// On GET the bodies must differ: /livez is the canonical alive signal,
+	// /health preserves its original healthy body for back-compat.
+	livezGet := httptest.NewRecorder()
+	mux.ServeHTTP(livezGet, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/livez", nil))
+	healthGet := httptest.NewRecorder()
+	mux.ServeHTTP(healthGet, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", nil))
+
+	if got, want := livezGet.Body.String(), `{"status":"alive"}`; got != want {
+		t.Errorf("GET /livez body = %q, want %q", got, want)
+	}
+	if got, want := healthGet.Body.String(), `{"status":"healthy"}`; got != want {
+		t.Errorf("GET /health body = %q, want %q", got, want)
+	}
+	if livezGet.Body.String() == healthGet.Body.String() {
+		t.Errorf("/livez and /health bodies must differ, both = %q", livezGet.Body.String())
 	}
 }
 

--- a/docs/internal/e2e-testing.md
+++ b/docs/internal/e2e-testing.md
@@ -218,7 +218,7 @@ Fixtures are cleaned up before creation (to handle leftover state) and after tes
 
 | Test | What it validates |
 |---|---|
-| `test_health_endpoint` | `GET /health` returns `{"status": "ok"}` |
+| `test_health_endpoint` | `GET /health` returns `{"status":"alive"}` (`/health` is a backward-compatible alias of `/livez`) |
 | `test_initialize` | MCP handshake completes, server returns `Mcp-Session-Id` |
 | `test_list_tools` | `tools/list` returns all 17 tools (composite: `get-rdp-status`, `get-queue-metrics`, `get-client-details`, `list-client-subscriptions`, `get-vpn-health`, `list-vpns`, `list-queues`, `list-clients`, `get-message-rates`, `list-rdps`, `get-replication-status`, `list-slow-subscribers`, `list-queue-discards`; native: `list-brokers`, `get-broker-status`, `get-redundancy-status`, `get-discard-stats`) |
 | `test_list_brokers` | `list-brokers` response includes both `broker-a` and `broker-b` |

--- a/docs/internal/e2e-testing.md
+++ b/docs/internal/e2e-testing.md
@@ -218,7 +218,7 @@ Fixtures are cleaned up before creation (to handle leftover state) and after tes
 
 | Test | What it validates |
 |---|---|
-| `test_health_endpoint` | `GET /health` returns `{"status":"alive"}` (`/health` is a backward-compatible alias of `/livez`) |
+| `test_health_endpoint` | `GET /health` returns `{"status":"healthy"}` (legacy back-compat body; `/livez` is the canonical liveness endpoint and returns `{"status":"alive"}`) |
 | `test_initialize` | MCP handshake completes, server returns `Mcp-Session-Id` |
 | `test_list_tools` | `tools/list` returns all 17 tools (composite: `get-rdp-status`, `get-queue-metrics`, `get-client-details`, `list-client-subscriptions`, `get-vpn-health`, `list-vpns`, `list-queues`, `list-clients`, `get-message-rates`, `list-rdps`, `get-replication-status`, `list-slow-subscribers`, `list-queue-discards`; native: `list-brokers`, `get-broker-status`, `get-redundancy-status`, `get-discard-stats`) |
 | `test_list_brokers` | `list-brokers` response includes both `broker-a` and `broker-b` |

--- a/docs/internal/packaging-release.md
+++ b/docs/internal/packaging-release.md
@@ -146,7 +146,7 @@ Verify the server is running:
 
 ```bash
 curl http://localhost:9090/health
-# {"status": "ok"}
+# {"status":"alive"}
 ```
 
 #### Docker Compose
@@ -274,13 +274,15 @@ path specified by `ENV_FILE`) and from the process environment.
 
 ## Health Checks
 
-The server exposes `GET /health` which returns:
+The server exposes a liveness probe at `GET /livez` which returns:
 
 ```json
-{"status": "ok"}
+{"status":"alive"}
 ```
 
-HTTP 200 on success, available on the configured port (default 9090).
+`GET /health` is retained as a backward-compatible alias of `/livez` and
+returns the identical body. HTTP 200 on success, available on the configured
+port (default 9090).
 
 The binary also supports a `--health` flag that performs an internal health
 check against the running server and exits with code 0 (healthy) or 1

--- a/docs/internal/packaging-release.md
+++ b/docs/internal/packaging-release.md
@@ -145,7 +145,7 @@ docker run -d \
 Verify the server is running:
 
 ```bash
-curl http://localhost:9090/health
+curl http://localhost:9090/livez
 # {"status":"alive"}
 ```
 
@@ -280,9 +280,10 @@ The server exposes a liveness probe at `GET /livez` which returns:
 {"status":"alive"}
 ```
 
-`GET /health` is retained as a backward-compatible alias of `/livez` and
-returns the identical body. HTTP 200 on success, available on the configured
-port (default 9090).
+`GET /health` is retained for backward compatibility and preserves its
+original `{"status":"healthy"}` body — it is NOT a body-identical alias of
+`/livez`, so external consumers that parse `.status == "healthy"` keep working.
+Both probes return HTTP 200 on success on the configured port (default 9090).
 
 The binary also supports a `--health` flag that performs an internal health
 check against the running server and exits with code 0 (healthy) or 1

--- a/docs/superpowers/plans/2026-06-26-obs-story1-story7.md
+++ b/docs/superpowers/plans/2026-06-26-obs-story1-story7.md
@@ -7,7 +7,7 @@ Part of the **Broker MCP Observability & Telemetry** epic ([SOL-150251](https://
 Implement the first two MUST-tier stories as test-backed, independently reviewed branches:
 
 - **[SOL-151278](https://sol-jira.atlassian.net/browse/SOL-151278) (Story 1)** — observability package skeleton + config/flag plumbing.
-- **[SOL-151283](https://sol-jira.atlassian.net/browse/SOL-151283) (Story 7)** — `/livez` endpoint (process-alive) with `/health` retained as an alias.
+- **[SOL-151283](https://sol-jira.atlassian.net/browse/SOL-151283) (Story 7)** — `/livez` endpoint (process-alive, canonical); `/health` retained for backward compatibility with its original `{"status":"healthy"}` body.
 
 These are the two stories with no upstream dependency on un-merged work, so they can be built without a reviewer present. Story 7 builds on the `internal/observability/health/` package that Story 1 creates, so it stacks on the Story 1 branch.
 
@@ -32,12 +32,12 @@ Story 1 wires **no behavior** into the request path. Skeleton + flags only.
 ## Story 7 — scope
 
 - `/livez` handler returning `{"status":"alive"}` (process alive; flag-independent), housed in the health package.
-- `/health` becomes an alias of `/livez` (same body); non-GET → 405.
+- `/health` is retained as a backward-compatible path that preserves its original `{"status":"healthy"}` body (NOT a body-identical alias — changing it would break external consumers parsing `.status`); `/livez` is the canonical liveness endpoint; non-GET → 405. (Revised per reviewer feedback on PR #116.)
 - Update the existing `TestHealth*` tests; verify the `--health` CLI flag, the Dockerfile `HEALTHCHECK`, and the K8s liveness probe depend only on the 200 status, not the body string.
 
 ## Risks / open
 
-- **Story 7 changes `/health`'s body** from `{"status":"healthy"}` to `{"status":"alive"}`. Reconcile any consumer that asserts the body.
+- **Story 7 adds `/livez` (`{"status":"alive"}`) and leaves `/health`'s shipped `{"status":"healthy"}` body unchanged** for backward compatibility. The canonical liveness path going forward is `/livez`.
 - **Observability flags are env-driven**, slightly different from the YAML-first config; fit into `LoadConfig` cleanly.
 - **Stacking:** if Story 1 changes in review, Story 7 rebases.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -236,9 +236,9 @@ claude mcp add solace-broker --transport http http://localhost:9090/mcp \
 The server exposes a health endpoint and a CLI flag:
 
 ```bash
-# HTTP health check
-curl http://localhost:9090/health
-# Expected: {"status": "ok"}
+# HTTP liveness check (/health is a backward-compatible alias of /livez)
+curl http://localhost:9090/livez
+# Expected: {"status":"alive"}
 
 # Binary health check (useful for scripts and container probes)
 ./solace-broker-mcp --health

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -236,9 +236,13 @@ claude mcp add solace-broker --transport http http://localhost:9090/mcp \
 The server exposes a health endpoint and a CLI flag:
 
 ```bash
-# HTTP liveness check (/health is a backward-compatible alias of /livez)
+# HTTP liveness check (/livez is the canonical liveness endpoint)
 curl http://localhost:9090/livez
 # Expected: {"status":"alive"}
+
+# /health is retained for backward compatibility (preserves its original body)
+curl http://localhost:9090/health
+# Expected: {"status":"healthy"}
 
 # Binary health check (useful for scripts and container probes)
 ./solace-broker-mcp --health

--- a/internal/observability/health/health.go
+++ b/internal/observability/health/health.go
@@ -18,11 +18,14 @@
 //
 // Scope note: liveness (/livez) and readiness (/readyz) are UNCONDITIONAL by
 // design — there is no flag to disable them, and this package does NOT gate
-// them. (/health is retained as an alias for /livez for backward
-// compatibility; /livez and /readyz are the canonical names the next story
-// implements.) The single accessor here, SaturationEventsEnabled, gates only
-// the opt-in saturation-event signal layered on top of those probes. The v1
-// default for that signal is OFF (door-closing policy).
+// them. /livez is the canonical liveness endpoint and returns
+// {"status":"alive"}; /readyz is the canonical readiness name the next story
+// implements. /health is retained for backward compatibility and preserves its
+// original {"status":"healthy"} body — it is NOT a body-identical alias of
+// /livez and is served by its own handler (HealthHandler). The single accessor
+// here, SaturationEventsEnabled, gates only the opt-in saturation-event signal
+// layered on top of those probes. The v1 default for that signal is OFF
+// (door-closing policy).
 //
 // There is deliberately NO generic Enabled accessor: the probes are
 // unconditional, so a generic name would invite a future author to write
@@ -43,14 +46,41 @@ import (
 // reachability — that is the readiness probe's job (/readyz).
 const livenessBody = `{"status":"alive"}`
 
+// healthBody is the exact response body served by the legacy /health endpoint.
+// It preserves the originally shipped {"status":"healthy"} body so external
+// consumers (dashboards, scripts) that parse .status == "healthy" keep working.
+// /health is NOT a body-identical alias of /livez; the bodies differ
+// deliberately. New consumers should use /livez (the canonical liveness
+// endpoint, {"status":"alive"}).
+const healthBody = `{"status":"healthy"}`
+
 // LivezHandler returns the unconditional liveness handler. GET responds 200 with
-// livenessBody; any other method responds 405. The probe is UNCONDITIONAL by
-// design — there is no flag to disable it, so this constructor takes no config
-// and is never gated (see the package doc).
+// livenessBody ({"status":"alive"}); any other method responds 405. The probe is
+// UNCONDITIONAL by design — there is no flag to disable it, so this constructor
+// takes no config and is never gated (see the package doc).
 //
-// /health registers this same handler as a backward-compatible alias, so
-// /health and /livez return byte-identical responses and identical 405 behavior.
+// /livez is the canonical liveness endpoint. /health is a separate retained
+// back-compat endpoint served by HealthHandler with its own ({"status":"healthy"})
+// body — the two handlers are distinct instances and return different bodies.
 func LivezHandler() http.Handler {
+	return jsonProbeHandler(livenessBody)
+}
+
+// HealthHandler returns the legacy /health handler. GET responds 200 with
+// healthBody ({"status":"healthy"}); any other method responds 405. It is
+// retained for backward compatibility and preserves the original shipped body so
+// existing consumers that assert .status == "healthy" do not break. /livez is the
+// canonical liveness endpoint and returns {"status":"alive"} — HealthHandler is a
+// distinct handler instance from LivezHandler, not a body-identical alias.
+func HealthHandler() http.Handler {
+	return jsonProbeHandler(healthBody)
+}
+
+// jsonProbeHandler builds an unconditional probe handler that responds 200 with
+// the given JSON body on GET and 405 on any other method. Shared by LivezHandler
+// and HealthHandler so the two probes stay behaviorally identical apart from
+// their (deliberately different) bodies.
+func jsonProbeHandler(body string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -58,7 +88,7 @@ func LivezHandler() http.Handler {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(livenessBody)); err != nil {
+		if _, err := w.Write([]byte(body)); err != nil {
 			http.Error(w, "failed to write response", http.StatusInternalServerError)
 		}
 	})

--- a/internal/observability/health/health.go
+++ b/internal/observability/health/health.go
@@ -31,7 +31,38 @@
 // mirroring metrics.AuthFailureCounterEnabled.
 package health
 
-import "github.com/SolaceDev/solace-broker-mcp/internal/config"
+import (
+	"net/http"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+)
+
+// livenessBody is the exact response body served by the liveness probe. It is a
+// process-alive signal only: a 200 means the HTTP server is accepting requests
+// and the handler ran. It deliberately reports nothing about broker
+// reachability — that is the readiness probe's job (/readyz).
+const livenessBody = `{"status":"alive"}`
+
+// LivezHandler returns the unconditional liveness handler. GET responds 200 with
+// livenessBody; any other method responds 405. The probe is UNCONDITIONAL by
+// design — there is no flag to disable it, so this constructor takes no config
+// and is never gated (see the package doc).
+//
+// /health registers this same handler as a backward-compatible alias, so
+// /health and /livez return byte-identical responses and identical 405 behavior.
+func LivezHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(livenessBody)); err != nil {
+			http.Error(w, "failed to write response", http.StatusInternalServerError)
+		}
+	})
+}
 
 // SaturationEventsEnabled reports whether the opt-in saturation-event signal is
 // turned on, reading the OBS_SATURATION_EVENTS_ENABLED flag off the

--- a/internal/observability/health/health_test.go
+++ b/internal/observability/health/health_test.go
@@ -15,10 +15,50 @@
 package health
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 )
+
+// TestLivezHandler_GET pins the liveness contract: GET returns 200 with the
+// exact process-alive body and a JSON content type. The body string is asserted
+// verbatim because /health aliases this handler and container/k8s tooling reads
+// the response.
+func TestLivezHandler_GET(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/livez", nil)
+
+	LivezHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got, want := rec.Body.String(), `{"status":"alive"}`; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+// TestLivezHandler_NonGET pins that any non-GET method is rejected with 405.
+func TestLivezHandler_NonGET(t *testing.T) {
+	t.Parallel()
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodHead} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), method, "/livez", nil)
+
+		LivezHandler().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s status = %d, want %d", method, rec.Code, http.StatusMethodNotAllowed)
+		}
+	}
+}
 
 // TestSaturationEventsEnabled pins that the accessor reflects the
 // SaturationEventsEnabled flag rather than a hardcoded constant — both

--- a/internal/observability/health/health_test.go
+++ b/internal/observability/health/health_test.go
@@ -25,8 +25,8 @@ import (
 
 // TestLivezHandler_GET pins the liveness contract: GET returns 200 with the
 // exact process-alive body and a JSON content type. The body string is asserted
-// verbatim because /health aliases this handler and container/k8s tooling reads
-// the response.
+// verbatim because /livez is the canonical liveness endpoint and container/k8s
+// tooling reads the response.
 func TestLivezHandler_GET(t *testing.T) {
 	t.Parallel()
 	rec := httptest.NewRecorder()
@@ -53,6 +53,43 @@ func TestLivezHandler_NonGET(t *testing.T) {
 		req := httptest.NewRequestWithContext(context.Background(), method, "/livez", nil)
 
 		LivezHandler().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s status = %d, want %d", method, rec.Code, http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// TestHealthHandler_GET pins the legacy /health contract: GET returns 200 with
+// the ORIGINAL {"status":"healthy"} body and a JSON content type. The body is
+// asserted verbatim because external consumers parse .status == "healthy";
+// /health is NOT a body-identical alias of /livez.
+func TestHealthHandler_GET(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", nil)
+
+	HealthHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got, want := rec.Body.String(), `{"status":"healthy"}`; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+// TestHealthHandler_NonGET pins that any non-GET method is rejected with 405.
+func TestHealthHandler_NonGET(t *testing.T) {
+	t.Parallel()
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodHead} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), method, "/health", nil)
+
+		HealthHandler().ServeHTTP(rec, req)
 
 		if rec.Code != http.StatusMethodNotAllowed {
 			t.Errorf("%s status = %d, want %d", method, rec.Code, http.StatusMethodNotAllowed)

--- a/test/e2e-basic-mcp/test-standalone.sh
+++ b/test/e2e-basic-mcp/test-standalone.sh
@@ -8,9 +8,11 @@ source "$(dirname "$0")/helpers.sh"
 # ── Tests ────────────────────────────────────────────────────────────────────
 
 test_health_endpoint() {
+    # /health preserves its original back-compat body (status=healthy); /livez is
+    # the canonical liveness endpoint (status=alive).
     local response
     response=$(curl -sf "$MCP_URL/health")
-    assert_json_field "$response" ".status" "alive" "Health endpoint should return status alive (/health aliases /livez)"
+    assert_json_field "$response" ".status" "healthy" "/health should return status healthy (legacy back-compat body)"
 }
 
 test_initialize() {

--- a/test/e2e-basic-mcp/test-standalone.sh
+++ b/test/e2e-basic-mcp/test-standalone.sh
@@ -10,7 +10,7 @@ source "$(dirname "$0")/helpers.sh"
 test_health_endpoint() {
     local response
     response=$(curl -sf "$MCP_URL/health")
-    assert_json_field "$response" ".status" "healthy" "Health endpoint should return status healthy"
+    assert_json_field "$response" ".status" "alive" "Health endpoint should return status alive (/health aliases /livez)"
 }
 
 test_initialize() {

--- a/test/health/test-health.sh
+++ b/test/health/test-health.sh
@@ -84,11 +84,12 @@ test_livez() {
 }
 
 test_health() {
-    # /health is a backward-compatible alias of /livez, so it returns the same
-    # body (status=alive). It is no longer "healthy".
+    # /health is retained for backward compatibility and preserves its ORIGINAL
+    # body (status=healthy). It is NOT a body-identical alias of /livez; /livez
+    # is the canonical liveness endpoint and returns status=alive.
     local response
     response=$(curl -sf "$MCP_URL/health")
-    assert_json_field "$response" ".status" "alive" "/health should return status=alive (aliases /livez)"
+    assert_json_field "$response" ".status" "healthy" "/health should return status=healthy (legacy back-compat body)"
 }
 
 test_ready_both_reachable() {
@@ -160,7 +161,7 @@ EOF
 # ── Run ───────────────────────────────────────────────────────────────────────
 
 run_test "Livez endpoint"                      test_livez
-run_test "Health endpoint (alias of livez)"    test_health
+run_test "Health endpoint (legacy back-compat body)"  test_health
 run_test "Ready endpoint (brokers reachable)"  test_ready_both_reachable
 run_test "Ready endpoint (broker unreachable)" test_ready_unreachable_broker
 

--- a/test/health/test-health.sh
+++ b/test/health/test-health.sh
@@ -77,10 +77,18 @@ start_server "$CONFIG_FILE"
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
+test_livez() {
+    local response
+    response=$(curl -sf "$MCP_URL/livez")
+    assert_json_field "$response" ".status" "alive" "/livez should return status=alive"
+}
+
 test_health() {
+    # /health is a backward-compatible alias of /livez, so it returns the same
+    # body (status=alive). It is no longer "healthy".
     local response
     response=$(curl -sf "$MCP_URL/health")
-    assert_json_field "$response" ".status" "healthy" "/health should return status=healthy"
+    assert_json_field "$response" ".status" "alive" "/health should return status=alive (aliases /livez)"
 }
 
 test_ready_both_reachable() {
@@ -151,7 +159,8 @@ EOF
 
 # ── Run ───────────────────────────────────────────────────────────────────────
 
-run_test "Health endpoint"                     test_health
+run_test "Livez endpoint"                      test_livez
+run_test "Health endpoint (alias of livez)"    test_health
 run_test "Ready endpoint (brokers reachable)"  test_ready_both_reachable
 run_test "Ready endpoint (broker unreachable)" test_ready_unreachable_broker
 


### PR DESCRIPTION
Part of the **Broker MCP Observability & Telemetry** epic ([SOL-150251](https://sol-jira.atlassian.net/browse/SOL-150251)) → MUST child epic [SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791). Story: [SOL-151283](https://sol-jira.atlassian.net/browse/SOL-151283).

> **Stacked on #115** (Story 1 skeleton). This PR targets the `aross/sol-151278-observability-skeleton` branch; review #115 first. It will retarget to `main` once #115 merges.

## What this does
Adds a dedicated **`/livez`** process-alive endpoint and makes **`/health`** a body-identical alias of it.

- `GET /livez` → `200 {"status":"alive"}`; non-GET → `405`.
- `/health` becomes a true alias (same handler instance), so its body changes from `{"status":"healthy"}` to `{"status":"alive"}`.
- Handler lives in `internal/observability/health`; `/livez` is unconditional (not flag-gated).

## Compatibility (the body change)
Every in-repo consumer that asserts the `/health` **body** was reconciled: the two e2e shell suites and the internal docs/README. Status-only consumers are unaffected — the `--health` CLI flag and Docker `HEALTHCHECK` check the HTTP status only, and the k8s `httpGet` probes can't assert a body. K8s probes still point at `/health` here; repointing liveness→`/livez` is a later story.

## Testing
Unit tests for `/livez` (200 + body + 405) and `/health` alias-equivalence; a new `/livez` check in the health e2e suite. `go build`, `go vet`, `go test ./...`, `golangci-lint`, and `-race` all pass. Reviewed by a principal-architect pass (the review caught two e2e suites asserting the old body, now fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150251]: https://sol-jira.atlassian.net/browse/SOL-150251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151283]: https://sol-jira.atlassian.net/browse/SOL-151283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ