### PR TITLE
SOL-150860: complete remaining user documentation

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,13 @@
+# Examples
+
+Usage examples live in **[docs/examples.md](docs/examples.md)**:
+
+- [Connect Claude Desktop](docs/examples.md#connect-claude-desktop) (Streamable HTTP — Custom Connector or `mcp-remote`)
+- [Connect Claude Code](docs/examples.md#connect-claude-code)
+- [Natural-language queries](docs/examples.md#natural-language-queries)
+- [Tool invocations by category](docs/examples.md#tool-invocations-by-category)
+- [Multi-broker configuration](docs/examples.md#multi-broker-configuration)
+- [Static token (local development)](docs/examples.md#static-token-local-development)
+- [OAuth (production)](docs/examples.md#oauth-production)
+
+Related: [Tools Reference](docs/tools-reference.md) · [Configuration](docs/configuration.md) · [Authentication](docs/authentication.md)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ An MCP (Model Context Protocol) server for Solace event brokers, built with Go u
 - [Quickstart](#quickstart)
   - [Configuration](#configuration)
   - [Binary Deployment](#binary-deployment)
+  - [Install with go install](#install-with-go-install)
   - [Docker Deployment](#docker-deployment)
   - [Connect from Claude Code](#connect-from-claude-code)
   - [Connect from Solace Agent Mesh (SAM)](#connect-from-solace-agent-mesh-sam)
@@ -39,6 +40,7 @@ MCP-compatible clients, for example Claude Code, invoke these tools using natura
 ## Features
 
 - **17 read-only monitoring tools** — Event broker status, message VPNs, queues, clients, and REST delivery points
+- **Optional action tools** — Disconnect clients, delete queued messages, and reset statistics; gated behind `enable_write_tools` (off by default)
 - **Client authentication** — Development mode (no auth), static bearer tokens, or OAuth 2.1/OIDC with JWT validation
 - **Multi-broker configuration** — Connect to multiple brokers and address them by configured alias
 - **Retry and rate limiting** — Configurable backoff intervals and concurrent request limits per broker
@@ -64,7 +66,7 @@ The server implements the MCP HTTP transport specification and exposes event bro
 │                  │                    │   Broker MCP Server      │                      │                  │
 │   AI Agent       │ ────────────────▶ │                          │  ──────────────────▶ │  Solace          │
 │  (Claude Code,   │   JSON-RPC         │  • Auth (OAuth / token)  │   HTTP(S) /SEMP      │  Event           │
-│  Claude Desktop) │   + Bearer JWT     │  • 13 read-only tools    │                      │  Broker(s)       │
+│  Claude Desktop) │   + Bearer JWT     │  • 17 read-only tools    │                      │  Broker(s)       │
 │                  │                    │  • Rate-limit + retry    │                      │                  │
 │                  │ ◀──────────────── │  • SEMP client pool      │ ◀──────────────────  │                  │
 └──────────────────┘                    └──────────────────────────┘   basic / bearer     └──────────────────┘
@@ -72,7 +74,7 @@ The server implements the MCP HTTP transport specification and exposes event bro
 
 ## Tools
 
-The server exposes read-only tools grouped by what they inspect, plus a small set of action tools for operational workflows. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See the [user guide](docs/user-guide.md#tools) for per-tool descriptions, parameters, and pagination defaults.
+The server exposes read-only tools grouped by what they inspect, plus a small set of action tools for operational workflows. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See the [Tools Reference](docs/tools-reference.md) for full per-tool parameters, output shape, and example invocations; the [user guide](docs/user-guide.md#tools-reference) has the narrative overview.
 
 | Category | Tools | Description |
 |---|---|---|
@@ -89,6 +91,8 @@ The server exposes read-only tools grouped by what they inspect, plus a small se
 ## Guides
 
 - [User Guide](docs/user-guide.md) — overview, tools reference, deployment, and troubleshooting
+- [Tools Reference](docs/tools-reference.md) — per-tool parameters, output schema, and example invocations for all 21 tools
+- [Examples](docs/examples.md) — Claude Desktop config, natural-language queries, and multi-broker setup
 - [Configuration](docs/configuration.md) — server settings, event broker config, client auth, and rate-limit/retry settings
 - [Authentication](docs/authentication.md) — OAuth/OIDC and static token setup for MCP clients
 - [SAM Integration](docs/sam-integration.md) — wire this MCP server into a Solace Agent Mesh project as an agent
@@ -146,6 +150,7 @@ The `.env` file is loaded automatically. Environment variables set directly (for
 
 Select a deployment method:
 - **[Binary](#binary-deployment)** - Single executable with no dependencies; suitable for local development and VM deployment
+- **[go install](#install-with-go-install)** - Build and install from source with the Go toolchain; suitable when you already have Go and want the latest tagged release on your `PATH`
 - **[Docker](#docker-deployment)** - Containerized deployment; suitable for production and Kubernetes environments
 
 For contributors running from source, see [Development Setup](#development-setup).
@@ -182,6 +187,31 @@ curl http://localhost:9090/livez
 ```
 
 The binary is statically linked with no external dependencies. It handles `SIGTERM` and `SIGINT` for graceful shutdown.
+
+### Install with go install
+
+If you have the Go toolchain installed ([Go 1.25+](https://go.dev/dl/)), install the server directly from source:
+
+```bash
+go install github.com/SolaceDev/solace-broker-mcp/cmd/server@latest
+```
+
+This builds the latest tagged release and places a `server` binary in `$(go env GOBIN)` (or `$(go env GOPATH)/bin`). Ensure that directory is on your `PATH`. Pin a specific version by replacing `@latest` with a tag, for example `@v1.2.0`.
+
+Run it the same way as the downloaded binary, pointing `CONFIG_FILE` at your config:
+
+```bash
+CONFIG_FILE=./broker-config.yaml server
+```
+
+> **Note:** The installed binary is named `server` (the command's package directory), not `solace-broker-mcp`. Rename it or create a symlink if you prefer the longer name. Unlike release archives, `go install` does not include the example config or license — copy `broker-config.example.yaml` from the repository.
+
+Verify:
+
+```bash
+curl http://localhost:9090/health
+# {"status": "ok"}
+```
 
 ### Docker Deployment
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ CONFIG_FILE=./broker-config.yaml server
 Verify:
 
 ```bash
-curl http://localhost:9090/health
-# {"status": "ok"}
+curl http://localhost:9090/livez
+# {"status":"alive"}
 ```
 
 ### Docker Deployment

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,14 @@
+# Tools
+
+The complete tools reference lives in **[docs/tools-reference.md](docs/tools-reference.md)** —
+per-tool parameters, output schema, and example invocations for all 21 tools
+(17 read-only + 4 action tools).
+
+Quick links:
+
+- [Conventions](docs/tools-reference.md#conventions) — the `broker` parameter, pagination, rate limiting, output envelope, errors
+- [Tool index](docs/tools-reference.md#tool-index)
+- [Action tools and `enable_write_tools`](docs/tools-reference.md#action-tools-and-enable_write_tools)
+
+For a narrative overview see the [User Guide](docs/user-guide.md#tools-reference);
+for usage examples see [Examples](docs/examples.md).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -315,34 +315,21 @@ A browser window opens on first use for user login. The IdP must support anonymo
 **Authentication flow (`mode: oauth`):**
 
 ```
- AI Agent              MCP Server                 OAuth IdP            Solace Broker
-(Claude Code)                                  (Keycloak etc.)
-    │                       │                         │                      │
-    │ 1. MCP request (no token)                       │                      │
-    │──────────────────────▶│                         │                      │
-    │ 2. 401 + resource metadata pointer              │                      │
-    │◀──────────────────────│                         │                      │
-    │ 3. GET /.well-known/oauth-protected-resource    │                      │
-    │──────────────────────▶│  (discovers issuer)     │                      │
-    │◀──────────────────────│                         │                      │
-    │ 4. Register client (DCR) or use pre-registered client                  │
-    │────────────────────────────────────────────────▶│                      │
-    │ 5. Browser login — Authorization Code + PKCE     │                      │
-    │◀───────────────────────────────────────────────▶│                      │
-    │ 6. Access token (JWT, aud = configured audience) │                      │
-    │◀─────────────────────────────────────────────────                      │
-    │ 7. MCP request + Bearer JWT                      │                      │
-    │──────────────────────▶│                         │                      │
-    │                       │ 8. Validate JWT:        │                      │
-    │                       │    signature (JWKS), iss, aud, exp              │
-    │                       │────────fetch JWKS──────▶│                      │
-    │                       │◀────────keys────────────│                      │
-    │                       │ 9. Tool call → SEMP request                    │
-    │                       │    (broker auth: basic or bearer, separate)     │
-    │                       │────────────────────────────────────────────────▶
-    │                       │◀───────────10. SEMP response───────────────────│
-    │ 11. Tool result       │                         │                      │
-    │◀──────────────────────│                         │                      │
+ Agent          MCP Server     IdP            Broker
+   │              │              │              │
+   │───── 1 ──────▶              │              │       1. MCP request (no token)
+   ◀───── 2 ──────│              │              │       2. 401 + resource-metadata pointer
+   │───── 3 ──────▶              │              │       3. GET /.well-known/oauth-protected-resource
+   │              │              │              │          (discovers authorization server)
+   │───────────── 4 ─────────────▶              │       4. Register (DCR) or use pre-registered client
+   ◀───────────── 5 ─────────────▶              │       5. Browser login: Authorization Code + PKCE
+   ◀───────────── 6 ─────────────│              │       6. Access token (JWT, aud = configured audience)
+   │───── 7 ──────▶              │              │       7. MCP request + Bearer JWT
+   │              │───── 8 ──────▶              │       8. Validate JWT — fetch JWKS (sig, iss, aud, exp)
+   │              │───────────── 9 ─────────────▶       9. Tool call → SEMP (broker auth: basic/bearer)
+   │              ◀──────────── 10 ─────────────│       10. SEMP response
+   ◀──── 11 ──────│              │              │       11. Tool result
+   │              │              │              │
 ```
 
 > **Two independent auth legs.** Client→server auth (steps 1–8, the JWT above) is

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -312,6 +312,47 @@ A browser window opens on first use for user login. The IdP must support anonymo
 
 ### How It Works
 
+**Authentication flow (`mode: oauth`):**
+
+```
+ AI Agent              MCP Server                 OAuth IdP            Solace Broker
+(Claude Code)                                  (Keycloak etc.)
+    │                       │                         │                      │
+    │ 1. MCP request (no token)                       │                      │
+    │──────────────────────▶│                         │                      │
+    │ 2. 401 + resource metadata pointer              │                      │
+    │◀──────────────────────│                         │                      │
+    │ 3. GET /.well-known/oauth-protected-resource    │                      │
+    │──────────────────────▶│  (discovers issuer)     │                      │
+    │◀──────────────────────│                         │                      │
+    │ 4. Register client (DCR) or use pre-registered client                  │
+    │────────────────────────────────────────────────▶│                      │
+    │ 5. Browser login — Authorization Code + PKCE     │                      │
+    │◀───────────────────────────────────────────────▶│                      │
+    │ 6. Access token (JWT, aud = configured audience) │                      │
+    │◀─────────────────────────────────────────────────                      │
+    │ 7. MCP request + Bearer JWT                      │                      │
+    │──────────────────────▶│                         │                      │
+    │                       │ 8. Validate JWT:        │                      │
+    │                       │    signature (JWKS), iss, aud, exp              │
+    │                       │────────fetch JWKS──────▶│                      │
+    │                       │◀────────keys────────────│                      │
+    │                       │ 9. Tool call → SEMP request                    │
+    │                       │    (broker auth: basic or bearer, separate)     │
+    │                       │────────────────────────────────────────────────▶
+    │                       │◀───────────10. SEMP response───────────────────│
+    │ 11. Tool result       │                         │                      │
+    │◀──────────────────────│                         │                      │
+```
+
+> **Two independent auth legs.** Client→server auth (steps 1–8, the JWT above) is
+> distinct from server→broker auth (step 9), which uses each broker's configured
+> `auth.mode` (`basic` or `bearer`). Broker-bound OAuth via RFC 8693 token exchange
+> (the `broker_oauth:` config block) is **schema-only** in the current release and
+> not yet wired — see the [CHANGELOG](../CHANGELOG.md).
+
+The numbered steps in detail:
+
 1. Claude Code connects to the MCP server and receives a `401 Unauthorized` response
 2. Claude Code fetches the OAuth Protected Resource Metadata from `/.well-known/oauth-protected-resource` to discover the authorization server
 3. **Option A:** Claude Code uses the pre-registered client credentials and skips DCR

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -112,8 +112,9 @@ Read-only tools return their broker data in a step-keyed envelope — see
 
 ## Tool invocations by category
 
-Each block shows the `arguments` object of an MCP `tools/call` request. Replace
-`prod-broker` with one of your configured aliases (from `list-brokers`).
+Each block shows the `name` and `arguments` (the `params` of an MCP `tools/call`
+request). Replace `prod-broker` with one of your configured aliases (from
+`list-brokers`).
 
 **Discovery**
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,269 @@
+# Examples
+
+Task-oriented examples for connecting clients and using the tools. For the full
+per-tool schema reference see [Tools Reference](tools-reference.md); for setup and
+deployment see the [README](../README.md) and [User Guide](user-guide.md).
+
+> The server runs as a standalone HTTP service — it has **no stdio transport** and
+> cannot be auto-launched as a subprocess. Every client connects over Streamable
+> HTTP to an already-running server (default `http://localhost:9090/mcp`). Start
+> the server first.
+
+## Table of Contents
+
+- [Connect Claude Desktop](#connect-claude-desktop)
+- [Connect Claude Code](#connect-claude-code)
+- [Natural-language queries](#natural-language-queries)
+- [Tool invocations by category](#tool-invocations-by-category)
+- [Multi-broker configuration](#multi-broker-configuration)
+- [Static token (local development)](#static-token-local-development)
+- [OAuth (production)](#oauth-production)
+
+## Connect Claude Desktop
+
+Claude Desktop connects to this server as a **remote (HTTP) MCP server**, not a
+stdio subprocess. Two methods:
+
+### Method A — Custom Connector (recommended)
+
+1. Start the MCP server (binary, Docker, or `go run`).
+2. In Claude Desktop: **Settings → Connectors → Add custom connector**.
+3. Set the URL to the `/mcp` endpoint, for example `http://localhost:9090/mcp`.
+4. If the server runs in `mode: oauth`, Claude Desktop runs the browser login on
+   first use (the server advertises its authorization server via
+   `/.well-known/oauth-protected-resource`). In `mode: disabled` or `static`, no
+   browser flow runs.
+
+No config file editing required.
+
+### Method B — `mcp-remote` bridge
+
+Use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm bridge when
+you prefer file-based config. Edit `claude_desktop_config.json`:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+(Linux is not an officially supported Claude Desktop platform; on Linux use
+[Claude Code](#connect-claude-code) instead.)
+
+```json
+{
+  "mcpServers": {
+    "solace-broker": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:9090/mcp"]
+    }
+  }
+}
+```
+
+For `mode: static`, pass the dev token as a header via `mcp-remote`:
+
+```json
+{
+  "mcpServers": {
+    "solace-broker": {
+      "command": "npx",
+      "args": [
+        "-y", "mcp-remote", "http://localhost:9090/mcp",
+        "--header", "Authorization: Bearer my-secret-dev-token-123"
+      ]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing the file. Requires Node.js (`npx`).
+
+## Connect Claude Code
+
+```bash
+# No auth (mode: disabled)
+claude mcp add solace-broker --transport http http://localhost:9090/mcp
+
+# Static dev token (mode: static)
+claude mcp add solace-broker --transport http http://localhost:9090/mcp \
+  -H "Authorization: Bearer my-secret-dev-token-123"
+
+# OAuth (mode: oauth) — browser login on first use
+claude mcp add solace-broker --transport http http://localhost:9090/mcp \
+  --client-id mcp-client --callback-port 8081
+```
+
+See [Authentication](authentication.md) for full OAuth setup.
+
+## Natural-language queries
+
+Once connected, ask in plain language. The agent selects the tool and fills
+parameters. Representative queries and the shape they return:
+
+| You ask | Tool invoked | Returns (shape) |
+|---|---|---|
+| "What brokers are configured?" | `list-brokers` | `{ "brokers": ["prod-broker", "dev-broker"] }` |
+| "Is prod-broker healthy?" | `get-broker-status` | envelope with version, uptime, resource and spool utilization |
+| "List queues with a backlog on the default VPN" | `list-queues` | envelope `{ "queues": [ { "queueName": ..., "spooledMsgCount": ... }, ... ] }` |
+| "Why is orders.q backing up?" | `get-queue-metrics` | envelope `{ "queueMetrics": { "spooledMsgCount": ..., "txUnackedMsgCount": ..., "bindCount": ... } }` |
+| "Are there slow subscribers on the default VPN?" | `list-slow-subscribers` | envelope `{ "slowSubscribers": [ ... ] }` (empty array if none) |
+| "Are we dropping messages anywhere?" | `get-discard-stats` | `{ "clientDiscards": {...}, "spoolDiscards": {...} }` |
+
+Read-only tools return their broker data in a step-keyed envelope — see
+[Tools Reference → Output](tools-reference.md#output-the-step-keyed-envelope).
+
+## Tool invocations by category
+
+Each block shows the `arguments` object of an MCP `tools/call` request. Replace
+`prod-broker` with one of your configured aliases (from `list-brokers`).
+
+**Discovery**
+
+```json
+{ "name": "list-brokers", "arguments": {} }
+```
+
+**Broker status / replication**
+
+```json
+{ "name": "get-broker-status", "arguments": { "broker": "prod-broker" } }
+{ "name": "get-redundancy-status", "arguments": { "broker": "prod-broker" } }
+{ "name": "get-replication-status", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+```
+
+**Message VPN**
+
+```json
+{ "name": "list-vpns", "arguments": { "broker": "prod-broker", "maxResults": 50 } }
+{ "name": "get-vpn-health", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+{ "name": "get-message-rates", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+```
+
+**Queues**
+
+```json
+{ "name": "list-queues", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+{ "name": "get-queue-metrics", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q" } }
+```
+
+**Clients**
+
+```json
+{ "name": "list-clients", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+{ "name": "get-client-details", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" } }
+{ "name": "list-client-subscriptions", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" } }
+{ "name": "list-slow-subscribers", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+```
+
+**REST Delivery Points**
+
+```json
+{ "name": "list-rdps", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+{ "name": "get-rdp-status", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp" } }
+```
+
+**Discards**
+
+```json
+{ "name": "get-discard-stats", "arguments": { "broker": "prod-broker" } }
+{ "name": "list-queue-discards", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+```
+
+**Action tools** (only available when `enable_write_tools: true`; destructive tools
+prompt for confirmation through the agent):
+
+```json
+{ "name": "clear-queue-stats", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q" } }
+{ "name": "delete-queue-messages", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "queueName": "dead-letter.q" } }
+{ "name": "clear-client-stats", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" } }
+{ "name": "disconnect-client", "arguments": { "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" } }
+```
+
+## Multi-broker configuration
+
+Configure multiple brokers under `brokers:`; the map key is the alias used as the
+`broker` parameter and in `list-brokers` output. Aliases must be 1–63 characters,
+letters/digits/hyphens only, starting and ending alphanumeric, and are compared
+case-insensitively.
+
+```yaml
+mcp_client_auth:
+  mode: disabled        # local development only
+
+brokers:
+  prod-broker:
+    url: "https://prod.example.com:1943"
+    auth:
+      mode: basic
+      username: "${PROD_BROKER_USERNAME}"
+      password: "${PROD_BROKER_PASSWORD}"
+  dev-broker:
+    url: "http://dev.example.com:8080"
+    auth:
+      mode: basic
+      username: "${DEV_BROKER_USERNAME}"
+      password: "${DEV_BROKER_PASSWORD}"
+```
+
+Then query each by alias:
+
+```
+List the queues on prod-broker's default VPN.
+Compare message rates between prod-broker and dev-broker.
+```
+
+```json
+{ "name": "list-queues", "arguments": { "broker": "prod-broker", "msgVpnName": "default" } }
+{ "name": "get-message-rates", "arguments": { "broker": "dev-broker", "msgVpnName": "default" } }
+```
+
+## Static token (local development)
+
+Server config:
+
+```yaml
+mcp_client_auth:
+  mode: static
+  dev_token: "${DEV_TOKEN}"   # or a literal string for quick tests
+
+brokers:
+  dev-broker:
+    url: "http://dev.example.com:8080"
+    auth:
+      mode: basic
+      username: "${BROKER_USERNAME}"
+      password: "${BROKER_PASSWORD}"
+```
+
+`.env`:
+
+```env
+DEV_TOKEN=my-secret-dev-token-123
+BROKER_USERNAME=admin
+BROKER_PASSWORD=admin
+```
+
+Connect with the matching bearer token (see [Claude Code](#connect-claude-code) or
+[Claude Desktop Method B](#method-b--mcp-remote-bridge)).
+
+## OAuth (production)
+
+Server config (HTTPS broker URLs and issuer enforced in `oauth` mode):
+
+```yaml
+mcp_client_auth:
+  mode: oauth
+  issuer: "https://your-idp.example.com/realms/your-realm"
+  audience: "solace-mcp-server"
+  resource_url: "https://your-mcp-server.example.com/mcp"
+
+brokers:
+  prod-broker:
+    url: "https://prod.example.com:1943"
+    auth:
+      mode: basic
+      username: "${BROKER_USERNAME}"
+      password: "${BROKER_PASSWORD}"
+```
+
+Clients authenticate via the OAuth 2.1 Authorization Code + PKCE flow. Full IdP
+setup (Keycloak audience mapper, client registration, DCR) is in
+[Authentication](authentication.md).

--- a/docs/superpowers/plans/2026-06-29-sol-150860-docs-gaps.md
+++ b/docs/superpowers/plans/2026-06-29-sol-150860-docs-gaps.md
@@ -1,0 +1,83 @@
+# SOL-150860 — Complete Remaining User Documentation (hybrid model)
+
+**Status:** Approved 2026-06-29. Execution in progress.
+**Ticket:** https://sol-jira.atlassian.net/browse/SOL-150860 (Story under epic SOL-148546)
+
+## Context: ticket is partly stale
+
+The ticket was written against a 2026-06-16 snapshot. README.md and CHANGELOG.md
+were modified 2026-06-29 and the codebase has moved on. Most "missing" items have
+since landed in existing docs. Verified findings:
+
+- **Tool count drift.** Ticket says 17. Reality: **21** — 17 read-only (13 composite
+  + 3 native SEMPv1 + `list-brokers`) **plus 4 action/write tools**
+  (`disconnect-client`, `clear-client-stats`, `delete-queue-messages`,
+  `clear-queue-stats`) gated behind `enable_write_tools` (default off).
+- **README internal inconsistency.** Prose says "17 read-only tools" (lines 35, 41);
+  ASCII diagram says "13 read-only tools" (line 67).
+- `manage-queue`/`manage-vpn` are **not implemented** — referenced only as a naming
+  contrast in user-guide.md and a Go comment.
+
+### Overlap matrix (ticket item → reality)
+
+| Ticket item | Already exists | Genuine gap |
+|---|---|---|
+| INSTALL.md (binary, checksum, Docker, Compose, sysreqs, /health) | README Quickstart 153–225 + user-guide prereqs | only `go install` |
+| TOOLS.md (names + descriptions) | user-guide §Tools (all 21) + README table | per-tool JSON input + output schema |
+| TROUBLESHOOTING.md | user-guide (startup/conn/errors/session/health) + auth.md (10+ auth cases) | consolidation only |
+| EXAMPLES.md | scattered: NL queries, multi-broker, static/OAuth | Claude Desktop (HTTP) config |
+| Auth flow diagram | text "How It Works" only (auth.md 310–320) | the diagram itself |
+| `go install` | absent | real (small) |
+
+### Accuracy corrections needed in ticket
+1. Claude Desktop has **no stdio**; connects over Streamable HTTP to a running server
+   (user-guide line 40). DoD "verified end-to-end" must be scoped to HTTP-remote.
+2. Standalone INSTALL.md/TROUBLESHOOTING.md would duplicate README/user-guide/auth —
+   DRY risk, multiple sources of truth.
+
+### Schema derivability (drives step 3)
+- **Input schemas:** fully code-derivable (composite `tools.yaml` params; native `InputSchema`).
+- **Output schemas:** native 3 declare real `OutputSchema()`; the 13 composite tools share
+  one generic `StepKeyedEnvelopeSchema()`. Honest composite output docs = envelope + a
+  captured live `structuredContent` sample.
+
+## Goal
+
+Deliver the real, non-duplicated documentation the epic intends — complete per-tool
+reference (21 tools, with schemas), auth flow diagram, `go install`, consolidated
+examples — by extending existing docs. Fix the count drift. Revise the ticket.
+
+## Approach (hybrid)
+
+Canonical content stays where it lives (README, `docs/`). New files only for net-new
+value or OSS discoverability, and those are thin pointers, not copies. Generate schemas
+from code where possible to prevent drift.
+
+## Steps
+
+1. **Fix tool-count drift** — README diagram "13 read-only" → consistent with "17 read-only
+   + 4 action"; reconcile prose 35/41. Single source of truth.
+2. **`go install`** — add `go install github.com/SolaceDev/solace-broker-mcp/cmd/server@latest`
+   to README.
+3. **`docs/tools-reference.md`** (canonical) — all 21 tools: input schema (generated),
+   output schema (native from `OutputSchema()`; composite via envelope + live sample),
+   example invocation, example NL request, shared conventions (broker param, pagination,
+   rate limiting, error fields), `enable_write_tools` gating.
+4. **Auth flow diagram** — add to `docs/authentication.md` near "How It Works"
+   (agent → MCP server → IdP → broker token-exchange). ASCII to match README style.
+5. **`docs/examples.md`** — Claude Desktop config over Streamable HTTP (not stdio),
+   NL queries with expected shapes, per-category invocations, multi-broker, static vs OAuth.
+6. **Optional thin root pointers** — `TOOLS.md` + `EXAMPLES.md` linking to canonical docs.
+   No standalone INSTALL.md/TROUBLESHOOTING.md; add a troubleshooting cross-link index instead.
+7. **Ticket revision** — draft comment + rescoped DoD for review before any Jira write.
+8. **Verify + link-check** — run examples against a live server; fix broken links/typos.
+
+## Risks / open questions
+- Composite output samples need a live broker (or `make e2e-all` fixtures).
+- Diagram format: ASCII (chosen) vs Mermaid.
+- Step 6 optional — drop if zero new root files preferred.
+
+## Out of scope
+- `manage-queue`/`manage-vpn` (not implemented).
+- Any tool code changes.
+- CHANGELOG narrative beyond a docs entry.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -57,7 +57,7 @@ step. The broker may omit any optional field, so the envelope schema does not
 enumerate inner fields — the authoritative field list per tool is the `select`
 set documented under each tool's **Returns**.
 
-Three tools depart from the generic envelope with a strict, field-level output
+Five tools depart from the generic envelope with a strict, field-level output
 schema: `get-discard-stats` and the four action tools (documented inline below).
 
 ### Errors

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,0 +1,675 @@
+# Tools Reference
+
+Complete reference for every tool the Solace Event Broker MCP Server exposes:
+parameters, output shape, an example invocation, and an example natural-language
+request. For task-oriented walkthroughs see [Examples](examples.md); for a
+narrative overview see the [User Guide](user-guide.md).
+
+The server exposes **17 read-only tools** plus **4 action (write) tools**. The
+action tools are gated behind `enable_write_tools` (off by default) and are not
+registered with the MCP server when disabled — see
+[Action tools and `enable_write_tools`](#action-tools-and-enable_write_tools).
+
+## Conventions
+
+These apply to every tool unless noted otherwise.
+
+### The `broker` parameter
+
+Every tool **except `list-brokers`** takes a required `broker` parameter
+identifying which configured broker to query. It is injected automatically into
+each tool's input schema at registration (`injectBrokerParam` in
+`internal/tools/register.go`), so it is not declared in any tool definition:
+
+```json
+{ "type": "string", "description": "Target broker alias (required). Available brokers: <alias>, <alias>, ..." }
+```
+
+The accepted values are the broker aliases from your config. Call `list-brokers`
+to discover them. Alias matching is case-insensitive; original casing is
+preserved in output.
+
+### Pagination
+
+List tools accept an optional `maxResults` integer: **default 100, maximum 500**
+(`defaultMax`/`capMax` in the composite executor). The server pages through the
+broker's SEMP responses internally and returns up to `maxResults` items. Brokers
+with more than 500 matching objects require a narrower query. Applies to:
+`list-vpns`, `list-queues`, `list-clients`, `list-client-subscriptions`,
+`list-slow-subscribers`, `list-rdps`, `list-queue-discards`.
+
+### Rate limiting and retries
+
+Requests to each broker are subject to per-broker concurrency limits and an
+automatic retry policy with backoff. Transient upstream failures (HTTP 429 from a
+proxy/gateway, 503 from an overloaded broker) are retried automatically and
+reported as `retryable: true` if retries are exhausted. Tune these in
+[Configuration](configuration.md).
+
+### Output: the step-keyed envelope
+
+Most read-only tools return their broker data in a **step-keyed envelope** — a
+top-level JSON object whose keys are the tool's internal step IDs and whose values
+are the SEMP response objects for that step (schema:
+`{"type":"object","additionalProperties":{"type":"object"}}`). Single-step tools
+return one key; multi-step tools (for example `get-rdp-status`) return one key per
+step. The broker may omit any optional field, so the envelope schema does not
+enumerate inner fields — the authoritative field list per tool is the `select`
+set documented under each tool's **Returns**.
+
+Three tools depart from the generic envelope with a strict, field-level output
+schema: `get-discard-stats` and the four action tools (documented inline below).
+
+### Errors
+
+On failure a tool returns a structured error object. Full field reference and
+common HTTP-status causes (401/403/404/429/503) are in the
+[User Guide → Tool Returns an Error](user-guide.md#tool-returns-an-error). Key
+fields: `error` (message), `retryable` (bool), `status` (HTTP code), plus
+source-specific fields (`operation`, `sempStatus`, `sempCode` for SEMPv2; `kind`,
+`reasonCode` for SEMPv1) and `suggestions`.
+
+### Action tools and `enable_write_tools`
+
+The four action tools (`disconnect-client`, `clear-client-stats`,
+`delete-queue-messages`, `clear-queue-stats`) change broker state. They are gated
+behind the server-level `enable_write_tools` flag:
+
+- **Default (`false`):** not registered; absent from `tools/list`; an
+  authenticated client still cannot invoke them.
+- **`enable_write_tools: true`:** registered and callable.
+
+This is independent of `mcp_client_auth.mode`. The two **destructive** tools
+(`delete-queue-messages`, `disconnect-client`) carry the MCP `destructiveHint`
+annotation, instruct the calling LLM to obtain explicit user confirmation before
+invocation, and cause the server to log a WARNING audit line on every call. The
+two `clear-*-stats` tools are writes but non-destructive (counters only).
+
+## Tool index
+
+| Category | Tool | Write? |
+|---|---|---|
+| Discovery | [`list-brokers`](#list-brokers) | — |
+| Broker Status | [`get-broker-status`](#get-broker-status), [`get-redundancy-status`](#get-redundancy-status) | — |
+| Replication | [`get-replication-status`](#get-replication-status) | — |
+| Message VPN | [`list-vpns`](#list-vpns), [`get-vpn-health`](#get-vpn-health), [`get-message-rates`](#get-message-rates) | — |
+| Queues | [`list-queues`](#list-queues), [`get-queue-metrics`](#get-queue-metrics) | — |
+| Clients | [`list-clients`](#list-clients), [`get-client-details`](#get-client-details), [`list-client-subscriptions`](#list-client-subscriptions), [`list-slow-subscribers`](#list-slow-subscribers) | — |
+| REST Delivery Points | [`list-rdps`](#list-rdps), [`get-rdp-status`](#get-rdp-status) | — |
+| Discards | [`get-discard-stats`](#get-discard-stats), [`list-queue-discards`](#list-queue-discards) | — |
+| Actions | [`disconnect-client`](#disconnect-client), [`clear-client-stats`](#clear-client-stats), [`delete-queue-messages`](#delete-queue-messages), [`clear-queue-stats`](#clear-queue-stats) | write |
+
+Example invocations below show the `arguments` object of an MCP `tools/call`
+request. A full request wraps it: `{"method":"tools/call","params":{"name":"<tool>","arguments":{...}}}`.
+
+---
+
+## Discovery
+
+### list-brokers
+
+List all configured broker aliases. Use one of the returned names as the
+`broker` parameter on any other tool. This is the only tool with **no `broker`
+parameter**.
+
+**Parameters:** none.
+
+**Returns:** a strict object `{ "brokers": ["alias1", "alias2", ...] }`
+(`brokers` is a required array of strings).
+
+```json
+{}
+```
+
+```json
+{ "brokers": ["prod-broker", "dev-broker"] }
+```
+
+**Example request:** "What brokers are configured?"
+
+---
+
+## Broker Status
+
+### get-broker-status
+
+Curated point-in-time status snapshot of a broker: edition and version, uptime
+and restart reason, scaling limits and resource headroom, memory and
+message-spool utilization, and — on hardware appliances — chassis identity and
+physical-component inventory (CPU, memory, power, disks, blades). Reports raw
+state, not a health verdict.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+
+**Returns:** step-keyed envelope (native SEMPv1). Inner fields cover version,
+uptime/restart, scaling and resource utilization, spool state, and HA roles;
+appliances add a `hardwareDetails` section. Field shape is documented in
+`docs/internal/semp/get-broker-status-curated-fields.md`.
+
+```json
+{ "broker": "prod-broker" }
+```
+
+**Example request:** "Is prod-broker healthy? When did it last restart?"
+
+### get-redundancy-status
+
+Broker redundancy and high-availability status: config/operational status,
+active-standby role, mate router name, mate link state, and per-virtual-router
+activity. Single SEMPv1 call.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+
+**Returns:** step-keyed envelope (native SEMPv1) with redundancy/HA fields.
+
+```json
+{ "broker": "prod-broker" }
+```
+
+**Example request:** "What's the HA status on prod-broker — which node is active?"
+
+---
+
+## Replication
+
+### get-replication-status
+
+Replication state for a Message VPN: role, sync eligibility, bridge status,
+transaction mode, and queued-message counts. SEMP does not expose current
+`lagSeconds`; `replicationActiveTransitionToSyncIneligibleCount` is the most
+useful "has replication been flaky recently?" signal.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+
+**Returns:** step-keyed envelope, step `replication`. Selected fields:
+`replicationRole`, `replicationEnabled`, `replicationSyncEligible`,
+`replicationBridgeUp`, `replicationRemoteBridgeUp`, `replicationQueueBound`,
+`replicationTransactionMode`, `replicationActiveAsyncQueuedMsgCount`,
+`replicationActiveSyncQueuedMsgCount`,
+`replicationActiveTransitionToSyncIneligibleCount`, and related counters.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default" }
+```
+
+**Example request:** "Is replication in sync for the default VPN on prod-broker?"
+
+---
+
+## Message VPN
+
+### list-vpns
+
+List Message VPNs with enabled state, connection count, and basic health.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `maxResults` | integer | no | Max VPNs to return (default 100, max 500). |
+
+**Returns:** step-keyed envelope, step `vpns` (array). Selected fields per VPN:
+`msgVpnName`, `enabled`, `state`, `msgVpnConnections`,
+`msgVpnTotalUniqueSubscriptions`, `msgSpoolUsage`, `msgSpoolMsgCount`,
+`replicationEnabled`, `dmrEnabled`, per-service up/failure fields (SMF, MQTT,
+REST, Web), and discard counts.
+
+```json
+{ "broker": "prod-broker", "maxResults": 50 }
+```
+
+**Example request:** "List the VPNs on prod-broker and flag any that are down."
+
+### get-vpn-health
+
+Health and connection statistics for one VPN: enabled state, active connection
+count, total subscription count, and service states for SMF, REST, and MQTT.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+
+**Returns:** step-keyed envelope, step `vpnHealth`. Selected fields: `msgVpnName`,
+`enabled`, `state`, `msgVpnConnections`, `maxConnectionCount`,
+`msgVpnTotalUniqueSubscriptions`, per-service up/failure fields, spool usage, and
+discard counts.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default" }
+```
+
+**Example request:** "Is the default VPN on prod-broker operational?"
+
+### get-message-rates
+
+Current and average message and byte throughput rates for a VPN.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+
+**Returns:** step-keyed envelope, step `rates`. Selected fields: `msgVpnName`,
+`rxMsgRate`, `txMsgRate`, `rxByteRate`, `txByteRate`, and the `average*`
+equivalents.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default" }
+```
+
+**Example request:** "What are the current message rates on the default VPN?"
+
+---
+
+## Queues
+
+### list-queues
+
+List queues in a VPN with depth, unacked count, bind count, congestion state, and
+rates. Primary VPN-wide scan for slow guaranteed-message consumers (growing
+`spooledMsgCount`, high `txUnackedMsgCount`, `rxMsgRate > txMsgRate`,
+`bindCount > 0`).
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+| `maxResults` | integer | no | Max queues to return (default 100, max 500). |
+
+**Returns:** step-keyed envelope, step `queues` (array). Selected fields per queue:
+`queueName`, `accessType`, `spooledMsgCount`, `txUnackedMsgCount`, `bindCount`,
+`rxMsgRate`, `txMsgRate`, `msgSpoolUsage`, `maxMsgSpoolUsage`,
+`lowPriorityMsgCongestionState`, `ingressEnabled`, `egressEnabled`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "maxResults": 100 }
+```
+
+**Example request:** "Show queues with a backlog on the default VPN."
+
+### get-queue-metrics
+
+Detailed metrics for one queue: spool, unacked, bind count, rates, redelivery
+counts, congestion state, and spool usage. The right starting point for diagnosing
+a slow guaranteed-message consumer (the per-client `slowSubscriber` field does not
+flip for slow ACKs).
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+| `queueName` | string | yes | The queue name. |
+
+**Returns:** step-keyed envelope, step `queueMetrics`. Selected fields include
+`queueName`, `spooledMsgCount`, `txUnackedMsgCount`, `bindCount`, `maxBindCount`,
+`rxMsgRate`, `txMsgRate`, `rxByteRate`, `txByteRate`, `redeliveredMsgCount`,
+`maxDeliveredUnackedMsgsPerFlow`, `msgSpoolUsage`, `maxMsgSpoolUsage`,
+`lowPriorityMsgCongestionState`, plus per-category discard counters and config
+(`accessType`, `durable`, `owner`, `maxTtl`, `maxRedeliveryCount`, `maxMsgSize`).
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q" }
+```
+
+**Example request:** "Why is orders.q backing up on prod-broker?"
+
+---
+
+## Clients
+
+### list-clients
+
+List active clients in a VPN with rates, uptime, and the `slowSubscriber` field.
+Note: `slowSubscriber` flags TCP-egress stalls (mainly direct messaging); it does
+not flip for slow guaranteed consumers — use `list-queues` for those.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+| `maxResults` | integer | no | Max clients to return (default 100, max 500). |
+
+**Returns:** step-keyed envelope, step `clients` (array). Selected fields per
+client: `clientName`, `clientUsername`, `clientAddress`, `platform`, `rxMsgRate`,
+`txMsgRate`, `slowSubscriber`, `uptime`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "maxResults": 100 }
+```
+
+**Example request:** "List the connected clients on the default VPN."
+
+### get-client-details
+
+Per-client performance metrics including `slowSubscriber`. `slowSubscriber=false`
+does not rule out a slow consumer — for slow guaranteed-message consumers use
+`get-queue-metrics`.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN the client is connected to. |
+| `clientName` | string | yes | The client connection name. |
+
+**Returns:** step-keyed envelope, step `clientDetails`. Selected fields include
+`clientName`, `clientUsername`, `clientAddress`, `platform`, `softwareVersion`,
+`rxMsgRate`/`txMsgRate`, `rxByteRate`/`txByteRate`, `averageRxMsgRate`/
+`averageTxMsgRate`, `rxMsgCount`/`txMsgCount`, `rxDiscardedMsgCount`/
+`txDiscardedMsgCount`, `slowSubscriber`, `subscriptionCount`, `rxFlowCount`/
+`txFlowCount`, `elidingTopicCount`, `keepalive`, `uptime`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" }
+```
+
+**Example request:** "Get details for client consumer-7 on the default VPN."
+
+### list-client-subscriptions
+
+List topic subscriptions for a specific client.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN the client is connected to. |
+| `clientName` | string | yes | The client connection name. |
+| `maxResults` | integer | no | Max subscriptions to return (default 100, max 500). |
+
+**Returns:** step-keyed envelope, step `subscriptions` (array of subscription
+records as returned by the broker).
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" }
+```
+
+**Example request:** "What topics is consumer-7 subscribed to?"
+
+### list-slow-subscribers
+
+Clients in a VPN flagged with the broker's `slowSubscriber` field
+(server-side `where: slowSubscriber==true`). Narrow signal — catches direct-
+messaging/replication-bridge backpressure; does **not** flip for slow guaranteed
+consumers. For those, use `list-queues` / `get-queue-metrics`.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN to search. |
+| `maxResults` | integer | no | Max results to return (default 100, max 500). |
+
+**Returns:** step-keyed envelope, step `slowSubscribers` (array). Selected fields
+per client: `clientName`, `clientUsername`, `clientAddress`, `platform`,
+`rxMsgRate`, `txMsgRate`, `txDiscardedMsgCount`, `slowSubscriber`, `uptime`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default" }
+```
+
+**Example request:** "Are there any slow subscribers on the default VPN?"
+
+---
+
+## REST Delivery Points
+
+### list-rdps
+
+List all REST Delivery Points in a VPN with enabled state, up/down status, and
+last failure reason. For full detail use `get-rdp-status`.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+| `maxResults` | integer | no | Max RDPs to return (default 100, max 500). |
+
+**Returns:** step-keyed envelope, step `rdps` (array). Selected fields per RDP:
+`restDeliveryPointName`, `enabled`, `up`, `clientName`, `lastFailureReason`,
+`lastFailureTime`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default" }
+```
+
+**Example request:** "List the RDPs on the default VPN and flag any that are down."
+
+### get-rdp-status
+
+Detailed RDP status across three parallel SEMP calls: the RDP itself, its queue
+bindings, and its REST consumers.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN containing the RDP. |
+| `restDeliveryPointName` | string | yes | The RDP name. |
+
+**Returns:** step-keyed envelope with three keys:
+- `rdpStatus` — `enabled`, `up`, `clientName`, `clientProfileName`,
+  `lastFailureReason`, `lastFailureTime`, `timeConnectionsBlocked`.
+- `queueBindings` — per binding: `queueBindingName`, `postRequestTarget`, `up`,
+  `uptime`, `lastFailureReason`, `lastFailureTime`.
+- `restConsumers` — per consumer: `restConsumerName`, `enabled`, `up`,
+  `remoteHost`, `remotePort`, `authenticationScheme`, HTTP request/response
+  counters, and last-failure fields.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp" }
+```
+
+**Example request:** "Why is the webhook-rdp on the default VPN failing?"
+
+---
+
+## Discards
+
+### get-discard-stats
+
+Pre-aggregated message discard counters. **Without `vpnName`:** broker-wide totals
+(client-level ingress/egress discards plus broker-wide spool-level discards).
+**With `vpnName`:** client-level discards scoped to that VPN only — SEMPv1 exposes
+no per-VPN spool breakdown (use `list-queue-discards` for per-queue spool
+discards). Note the parameter is `vpnName`, not `msgVpnName`.
+
+**Parameters:**
+
+| Name | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| `broker` | string | yes | — | Target broker alias. |
+| `vpnName` | string | no | `minLength: 1` | Scope to a single VPN (client-level only). Omit for broker-wide totals. Empty string is rejected. |
+
+**Returns:** strict object (field-level schema):
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "vpnName":        { "type": "string" },
+    "clientDiscards": { "type": "object" },
+    "spoolDiscards":  { "type": "object" }
+  },
+  "required": ["clientDiscards"],
+  "additionalProperties": false
+}
+```
+
+`clientDiscards` is always present; `spoolDiscards` appears only for broker-wide
+scope; `vpnName` echoes the requested VPN when scoped.
+
+```json
+{ "broker": "prod-broker" }
+```
+
+```json
+{ "broker": "prod-broker", "vpnName": "default" }
+```
+
+**Example request:** "Are we dropping messages anywhere on prod-broker?"
+
+### list-queue-discards
+
+Per-queue message discard counts for a VPN: TTL-expired, max-redelivery-exceeded,
+spool-quota-exceeded, and other categories. For broker/VPN aggregates use
+`get-discard-stats`.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `broker` | string | yes | Target broker alias. |
+| `msgVpnName` | string | yes | The Message VPN. |
+| `maxResults` | integer | no | Max queues to return (default 100, max 500). |
+
+**Returns:** step-keyed envelope, step `queueDiscards` (array). Selected fields per
+queue: `queueName`, `maxTtlExpiredDiscardedMsgCount`,
+`maxRedeliveryExceededDiscardedMsgCount`,
+`maxMsgSpoolUsageExceededDiscardedMsgCount`, `maxMsgSizeExceededDiscardedMsgCount`,
+`lowPriorityMsgCongestionDiscardedMsgCount`, `disabledDiscardedMsgCount`,
+`noLocalDeliveryDiscardedMsgCount`, `clientProfileDeniedDiscardedMsgCount`,
+`destinationGroupErrorDiscardedMsgCount`, DMQ counters, and
+`xaTransactionNotSupportedDiscardedMsgCount`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default" }
+```
+
+**Example request:** "Which queues on the default VPN are discarding messages, and why?"
+
+---
+
+## Action Tools
+
+Write tools, gated behind `enable_write_tools` (off by default). See
+[Action tools and `enable_write_tools`](#action-tools-and-enable_write_tools).
+All four return the same strict success envelope on completion.
+
+### disconnect-client
+
+**Destructive.** Forcibly disconnect a connected client — service-impacting; the
+client must reconnect. The description instructs the LLM to obtain explicit user
+confirmation (restating broker, VPN, and client) as a separate reply before
+invoking. The server logs a WARNING audit line on every call.
+
+Annotations: `readOnly: false`, `destructiveHint: true`, `idempotentHint: false`.
+
+**Parameters:**
+
+| Name | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| `broker` | string | yes | — | Target broker alias. |
+| `msgVpnName` | string | yes | `minLength: 1` | The Message VPN the client is connected to. |
+| `clientName` | string | yes | `minLength: 1` | The client connection to disconnect. |
+
+**Returns:** strict object `{ status, msgVpnName, clientName }`, `status` is the
+enum `"ok"`, `additionalProperties: false`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" }
+```
+
+```json
+{ "status": "ok", "msgVpnName": "default", "clientName": "consumer-7" }
+```
+
+**Example request:** "Disconnect consumer-7 on the default VPN." (The agent will
+ask you to confirm before acting.)
+
+### clear-client-stats
+
+Write, non-destructive. Reset a client's per-connection statistics counters. Does
+not disconnect the client or affect delivery.
+
+Annotations: `readOnly: false`, `destructiveHint: false`, `idempotentHint: true`.
+
+**Parameters:** same as `disconnect-client` (`broker`, `msgVpnName`, `clientName`).
+
+**Returns:** `{ status: "ok", msgVpnName, clientName }`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" }
+```
+
+**Example request:** "Reset the stats counters for consumer-7 on the default VPN."
+
+### delete-queue-messages
+
+**Destructive.** Permanently delete ALL spooled messages from a queue —
+irreversible. The description instructs the LLM to obtain explicit user
+confirmation (restating broker, VPN, and queue) as a separate reply before
+invoking. The server logs a WARNING audit line on every call.
+
+Annotations: `readOnly: false`, `destructiveHint: true`, `idempotentHint: false`.
+
+**Parameters:**
+
+| Name | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| `broker` | string | yes | — | Target broker alias. |
+| `msgVpnName` | string | yes | `minLength: 1` | The Message VPN containing the queue. |
+| `queueName` | string | yes | `minLength: 1` | The queue to drain. |
+
+**Returns:** strict object `{ status, msgVpnName, queueName }`, `status` is the
+enum `"ok"`, `additionalProperties: false`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "queueName": "dead-letter.q" }
+```
+
+```json
+{ "status": "ok", "msgVpnName": "default", "queueName": "dead-letter.q" }
+```
+
+**Example request:** "Drain dead-letter.q on the default VPN." (The agent will ask
+you to confirm before acting.)
+
+### clear-queue-stats
+
+Write, non-destructive. Reset a queue's statistics counters. Does not affect
+spooled messages or delivery.
+
+Annotations: `readOnly: false`, `destructiveHint: false`, `idempotentHint: true`.
+
+**Parameters:** same as `delete-queue-messages` (`broker`, `msgVpnName`,
+`queueName`).
+
+**Returns:** `{ status: "ok", msgVpnName, queueName }`.
+
+```json
+{ "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q" }
+```
+
+**Example request:** "Reset the stats counters for orders.q on the default VPN."

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -91,7 +91,7 @@ What are the current message rates for default VPN on my-broker?
 
 ## Tools Reference
 
-The server exposes 17 read-only tools plus 4 action tools (21 total when action tools are enabled). All broker-querying tools require a `broker` parameter to identify which configured event broker to query; `list-brokers` is the exception and returns the available event broker aliases. The action tools are write operations gated behind `enable_write_tools` (default off); the destructive ones (`delete-queue-messages`, `disconnect-client`) are marked via the MCP `destructiveHint` annotation and their descriptions instruct the calling LLM to obtain explicit user confirmation before invocation.
+The server exposes 17 read-only tools plus 4 action tools (21 total when action tools are enabled). For full per-tool parameters, output shape, and example invocations, see the [Tools Reference](tools-reference.md); this section is the narrative overview. All broker-querying tools require a `broker` parameter to identify which configured event broker to query; `list-brokers` is the exception and returns the available event broker aliases. The action tools are write operations gated behind `enable_write_tools` (default off); the destructive ones (`delete-queue-messages`, `disconnect-client`) are marked via the MCP `destructiveHint` annotation and their descriptions instruct the calling LLM to obtain explicit user confirmation before invocation.
 
 ### Discovery
 


### PR DESCRIPTION
## Summary

Closes the genuine documentation gaps for the Broker MCP server (SOL-150860). The ticket was written against an earlier snapshot; most of its original scope had since landed in README/user-guide/authentication. This PR fills what was actually missing and corrects a tool-count inconsistency.

## What changed

| File | Change |
|---|---|
| `docs/tools-reference.md` | **New.** Parameters, output shape, example invocation, and example NL request for all **21 tools** (17 read-only + 4 action), plus shared conventions: `broker` param, pagination, rate limiting, step-keyed output envelope, error fields, `enable_write_tools` gating. |
| `docs/examples.md` | **New.** Claude Desktop over Streamable HTTP (Custom Connector + `mcp-remote` — the server has no stdio transport), NL queries, per-category tool invocations, multi-broker config, static + OAuth. |
| `docs/authentication.md` | OAuth auth-flow sequence diagram; notes the two independent auth legs and that broker-bound OAuth is schema-only. |
| `README.md` | `go install` method; tool-count drift fixed (diagram 13 → 17 read-only); action tools surfaced as a feature; links to the new docs. |
| `docs/user-guide.md` | Tools section now points to the reference. |
| `TOOLS.md`, `EXAMPLES.md` | **New.** Thin root-level pointers for OSS discoverability. |
| `docs/superpowers/plans/2026-06-29-...md` | Plan + overlap audit. |

## Why this shape

**Hybrid doc architecture.** Canonical content stays in `docs/`; thin root pointers give OSS discoverability. Deliberately **no standalone INSTALL.md/TROUBLESHOOTING.md** — that content already lives in README Quickstart + user-guide + authentication, and duplicating it would create multiple sources of truth.

**Two corrections to the original ticket**, captured on SOL-150860:
- Tool count is **21, not 17** (17 read-only + 4 action gated behind `enable_write_tools`, off by default).
- Claude Desktop has **no stdio transport**; it connects over Streamable HTTP.

All tool names, parameters, and output shapes were transcribed from the handlers and `tools.yaml`, not assumed.

## Testing

Docs-only change — no code touched. Internal links/anchors verified by hand. Live-server verification of examples and Claude Desktop end-to-end is **deferred to SOL-151302** (parented to SOL-148417).

## Definition of Done

Six of eight DoD items on SOL-150860 are met by this PR; the two remaining (live-server + Claude Desktop verification) are tracked in SOL-151302. Peer review by 2 reviewers is the last open item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)