### PR TITLE
SOL-151279: Correlation-ID HTTP middleware

### DIFF
--- a/cmd/server/correlation_wiring_test.go
+++ b/cmd/server/correlation_wiring_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+)
+
+// correlationRecorder stands in for authedHandler (auth → SDK): it captures the
+// correlation ID present on the request context by the time the inner handler
+// runs. Driving a request through the real buildMCPEndpoint chain (NOT a
+// hand-rebuilt copy) lets us assert the ADR-001 wiring order: correlation runs
+// inside the body limit and before this inner handler.
+type correlationRecorder struct {
+	gotID   string
+	invoked bool
+}
+
+func (c *correlationRecorder) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	c.invoked = true
+	c.gotID = correlation.From(r.Context())
+}
+
+// TestBuildMCPEndpoint_CorrelationWiringOrder pins the real assembled chain.
+//
+// KNOWN LIMITATION: on this branch the correlation ID is set on the context but
+// not yet emitted in logs (Story 3, SOL-151280) or response headers (Story 6),
+// so we cannot yet assert "a 401 response carries the ID" from outside the
+// chain. This test pins the wiring ORDER (correlation present, inside the body
+// limit, before the inner auth/SDK handler); the log-visibility guarantee is
+// realized by Story 3. It deliberately asserts nothing about log output or
+// response headers that does not exist yet.
+func TestBuildMCPEndpoint_CorrelationWiringOrder(t *testing.T) {
+	t.Run("enabled: inner handler sees a non-empty correlation ID", func(t *testing.T) {
+		rec := &correlationRecorder{}
+		endpoint := buildMCPEndpoint(rec, true)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+		endpoint.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !rec.invoked {
+			t.Fatal("inner handler was not invoked")
+		}
+		// A non-empty ID proves the correlation middleware ran inside the body
+		// limit and before the inner (auth/SDK) handler. A future refactor that
+		// moves correlation out of the chain breaks this.
+		if rec.gotID == "" {
+			t.Error("inner handler saw an empty correlation ID, want a non-empty ID (correlation must run before it)")
+		}
+	})
+
+	t.Run("disabled: inner handler sees an empty correlation ID", func(t *testing.T) {
+		rec := &correlationRecorder{}
+		endpoint := buildMCPEndpoint(rec, false)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+		endpoint.ServeHTTP(httptest.NewRecorder(), req)
+
+		if !rec.invoked {
+			t.Fatal("inner handler was not invoked")
+		}
+		// Middleware not wired, so From returns "".
+		if rec.gotID != "" {
+			t.Errorf("inner handler saw correlation ID %q, want \"\" (middleware not wired)", rec.gotID)
+		}
+	})
+}

--- a/cmd/server/correlation_wiring_test.go
+++ b/cmd/server/correlation_wiring_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 )
 
@@ -79,6 +80,41 @@ func TestBuildMCPEndpoint_CorrelationWiringOrder(t *testing.T) {
 		// Middleware not wired, so From returns "".
 		if rec.gotID != "" {
 			t.Errorf("inner handler saw correlation ID %q, want \"\" (middleware not wired)", rec.gotID)
+		}
+	})
+
+	// An oversized request is rejected with 413 and the inner handler never
+	// runs — a regression guard that limitRequestBody is wired into
+	// buildMCPEndpoint and short-circuits oversized requests.
+	//
+	// NOTE on what this does NOT prove: it does not establish that
+	// limitRequestBody sits OUTSIDE correlation. On the ContentLength-413
+	// short-circuit, correlation has no externally observable effect — it only
+	// stamps a context value that the inner handler reads, and the inner
+	// handler never runs — so both "body-limit → correlation" and
+	// "correlation → body-limit" produce the identical result here (413, inner
+	// not invoked). The body-limit-outermost guarantee (a 413 deliberately
+	// carries NO correlation ID) only becomes observable once correlation emits
+	// a response header (Story 6); the ordering is asserted there. This subtest
+	// guards the body limit's presence and short-circuit, not its position
+	// relative to correlation.
+	t.Run("oversized request is rejected with 413 and never reaches the inner handler", func(t *testing.T) {
+		rec := &correlationRecorder{}
+		endpoint := buildMCPEndpoint(rec, true)
+
+		// limitRequestBody rejects on declared ContentLength alone, so a real
+		// oversized body is unnecessary; declaring one past the cap is enough.
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+		req.ContentLength = defaults.MaxMCPRequestBytes + 1
+
+		resp := httptest.NewRecorder()
+		endpoint.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusRequestEntityTooLarge {
+			t.Errorf("response code = %d, want %d (body limit must reject the oversized request)", resp.Code, http.StatusRequestEntityTooLarge)
+		}
+		if rec.invoked {
+			t.Error("inner handler was invoked on an oversized request; the body limit must short-circuit it first")
 		}
 	})
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -238,6 +238,26 @@ func limitRequestBody(next http.Handler, maxBytes int64) http.Handler {
 	})
 }
 
+// buildMCPEndpoint assembles the /mcp handler chain around authedHandler.
+//
+// The layer order, outermost first, is: limitRequestBody → correlation →
+// authedHandler. limitRequestBody is the OUTERMOST layer so an oversized
+// request is rejected with 413 before any work is done. A deliberate
+// consequence: a 413 is returned BEFORE the correlation middleware runs, so
+// 413 responses carry no correlation ID. This is intentional. Correlation sits
+// OUTSIDE auth (ADR-001) so a 401 still gets an ID, but the body limit sits
+// outside correlation by design.
+//
+// When correlationEnabled is false the correlation layer is omitted entirely
+// (correlation.From then returns "").
+func buildMCPEndpoint(authedHandler http.Handler, correlationEnabled bool) http.Handler {
+	endpoint := authedHandler
+	if correlationEnabled {
+		endpoint = correlation.Middleware(authedHandler)
+	}
+	return limitRequestBody(endpoint, defaults.MaxMCPRequestBytes)
+}
+
 // startServer starts httpServer in a background goroutine and returns a channel
 // that receives any startup/runtime error (excluding http.ErrServerClosed, which
 // is the normal result of Shutdown). The channel is buffered so the goroutine
@@ -503,16 +523,14 @@ func main() {
 	// unauthenticated request rejected with 401 still gets a correlation ID
 	// attached (ADR-001 ordering). Gated on OBS_CORRELATION_ID_ENABLED: when
 	// off, the middleware is not wired and correlation.From returns "".
-	mcpEndpoint := authedHandler
-	if correlation.Enabled(cfg.Observability) {
-		mcpEndpoint = correlation.Middleware(authedHandler)
-	}
+	correlationEnabled := correlation.Enabled(cfg.Observability)
 	slog.Info("correlation-ID middleware wiring",
-		slog.Bool("enabled", correlation.Enabled(cfg.Observability)))
+		slog.Bool("enabled", correlationEnabled))
 
-	// Register authenticated MCP endpoint. The body limit wraps the outside
-	// so it bounds the request before any layer can buffer it.
-	mux.Handle("/mcp", limitRequestBody(mcpEndpoint, defaults.MaxMCPRequestBytes))
+	// Register authenticated MCP endpoint. buildMCPEndpoint wraps the body
+	// limit on the outside so it bounds the request before any layer buffers
+	// it; see buildMCPEndpoint for the full layer order and 413 rationale.
+	mux.Handle("/mcp", buildMCPEndpoint(authedHandler, correlationEnabled))
 
 	// Register OAuth Protected Resource Metadata endpoint (RFC 9728)
 	// This enables MCP clients to discover the authorization server for OAuth flows.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess/handlers" // register handlers via init()
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
@@ -498,9 +499,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Stamp a correlation ID immediately OUTSIDE the auth middleware so that an
+	// unauthenticated request rejected with 401 still gets a correlation ID
+	// attached (ADR-001 ordering). Gated on OBS_CORRELATION_ID_ENABLED: when
+	// off, the middleware is not wired and correlation.From returns "".
+	mcpEndpoint := authedHandler
+	if correlation.Enabled(cfg.Observability) {
+		mcpEndpoint = correlation.Middleware(authedHandler)
+	}
+	slog.Info("correlation-ID middleware wiring",
+		slog.Bool("enabled", correlation.Enabled(cfg.Observability)))
+
 	// Register authenticated MCP endpoint. The body limit wraps the outside
 	// so it bounds the request before any layer can buffer it.
-	mux.Handle("/mcp", limitRequestBody(authedHandler, defaults.MaxMCPRequestBytes))
+	mux.Handle("/mcp", limitRequestBody(mcpEndpoint, defaults.MaxMCPRequestBytes))
 
 	// Register OAuth Protected Resource Metadata endpoint (RFC 9728)
 	// This enables MCP clients to discover the authorization server for OAuth flows.

--- a/internal/observability/correlation/middleware.go
+++ b/internal/observability/correlation/middleware.go
@@ -1,0 +1,237 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package correlation
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Header names for inbound correlation. traceparent is the W3C Trace Context
+// header (https://www.w3.org/TR/trace-context/); X-Correlation-ID is the
+// fallback when no W3C trace is present.
+const (
+	headerTraceparent   = "traceparent"
+	headerCorrelationID = "X-Correlation-ID"
+)
+
+// maxIDLen caps the length of an accepted correlation ID. The value flows into
+// every log line for the request and (in a later story) onto outbound HTTP
+// headers, so an unbounded inbound value would be a log-flooding and
+// header-bloat vector. 128 chars comfortably holds a W3C 32-hex trace-id, a
+// UUID, or any sane client-supplied ID while rejecting abuse. A traceparent
+// trace-id is always exactly 32 chars and a generated UUIDv7 is 36, so this cap
+// only ever bites an oversized X-Correlation-ID.
+const maxIDLen = 128
+
+// Key is the context-key type under which the correlation ID is stored. The
+// empty-struct, package-private *type* is exported but has no exported fields
+// or constructor parameters beyond the zero value Key{}, mirroring the
+// unexported-key idiom in internal/auth (rawSubjectTokenKey{}, principalKey{}):
+// only code holding this type can address the value, so no other package can
+// collide with it or read it except through From. It is exported here because
+// the v1 default is for correlation to be ON and dependent observability code
+// reads the ID via From, not by constructing the key.
+type Key struct{}
+
+// With returns a copy of ctx carrying id as the correlation ID. It does not
+// validate id; the middleware is the sole production writer and only stores
+// values that already passed sanitize. Exported for tests and for any future
+// non-HTTP entry point that needs to seed a correlation ID.
+func With(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, Key{}, id)
+}
+
+// From returns the correlation ID stored on ctx, or "" when none is present
+// (including when the middleware is not wired because the capability is off).
+// Callers branch on the empty string rather than a separate ok bool: an empty
+// correlation ID is indistinguishable from "absent" for logging purposes, so a
+// single return keeps call sites simple.
+func From(ctx context.Context) string {
+	if v, ok := ctx.Value(Key{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// Middleware returns an http.Handler that derives a correlation ID for the
+// request and attaches it to the request context before calling next. The
+// resolution order is:
+//
+//  1. traceparent: if present and well-formed, use its 32-hex trace-id segment.
+//  2. X-Correlation-ID: if traceparent is absent or malformed, use this header
+//     when it holds a usable (sanitized, non-empty, bounded) value.
+//  3. Otherwise generate a fresh UUIDv7.
+//
+// The middleware always attaches a non-empty ID, so downstream code can rely on
+// From returning a value once Middleware is in the chain.
+//
+// Callers gate installation on Enabled (OBS_CORRELATION_ID_ENABLED). When the
+// capability is off the middleware is not wired and From returns "".
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := resolveID(r)
+		ctx := With(r.Context(), id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// resolveID applies the traceparent → X-Correlation-ID → generate precedence.
+func resolveID(r *http.Request) string {
+	if id, ok := traceIDFromTraceparent(r.Header.Get(headerTraceparent)); ok {
+		return id
+	}
+	if id, ok := sanitize(r.Header.Get(headerCorrelationID)); ok {
+		return id
+	}
+	return Generate()
+}
+
+// traceIDFromTraceparent extracts the trace-id from a W3C traceparent header.
+//
+// Format: "version-traceid-spanid-flags" — four hyphen-separated fields where
+// version is 2 hex chars, traceid is 32 hex chars, spanid is 16 hex chars, and
+// flags is 2 hex chars. We return only the trace-id (the correlation identity).
+//
+// ok is false for any header that does not yield a usable trace-id: wrong field
+// count, wrong trace-id length, non-hex characters, or the all-zero trace-id
+// (which the spec defines as invalid). On a false return the caller falls back
+// to X-Correlation-ID. For the known version 00 we require exactly four fields
+// and reject trailing data (per W3C Trace Context); for an unrecognized future
+// version we tolerate extra trailing fields. We do not require the version or
+// flags fields to be meaningful beyond being valid hex of the right length.
+func traceIDFromTraceparent(h string) (string, bool) {
+	if h == "" {
+		return "", false
+	}
+	parts := strings.Split(h, "-")
+	// The trace-id sits in field index 1, so at least the four core fields are
+	// required; fewer is always malformed.
+	if len(parts) < 4 {
+		return "", false
+	}
+	version, traceID, spanID, flags := parts[0], parts[1], parts[2], parts[3]
+	if len(version) != 2 || len(traceID) != 32 || len(spanID) != 16 || len(flags) != 2 {
+		return "", false
+	}
+	// Version ff is reserved/invalid per the spec.
+	if version == "ff" {
+		return "", false
+	}
+	// The known version 00 is defined as exactly four fields; trailing data is
+	// malformed and must be rejected. Only an unrecognized (future) version may
+	// carry extra trailing fields, which we tolerate for forward compatibility.
+	if version == "00" && len(parts) != 4 {
+		return "", false
+	}
+	if !isLowerHex(version) || !isLowerHex(traceID) || !isLowerHex(spanID) || !isLowerHex(flags) {
+		return "", false
+	}
+	// All-zero trace-id is invalid per the spec.
+	if traceID == "00000000000000000000000000000000" {
+		return "", false
+	}
+	return traceID, true
+}
+
+// isLowerHex reports whether s is non-empty and contains only lowercase hex
+// digits. The W3C spec mandates lowercase, so we do not accept uppercase here;
+// an uppercase traceparent is malformed and falls through to the
+// X-Correlation-ID path.
+func isLowerHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// sanitize trims surrounding whitespace from a client-supplied correlation ID
+// and validates it for safe use in logs and outbound headers. ok is false when
+// the trimmed value is empty, exceeds maxIDLen, or contains any byte that is
+// not a printable ASCII character (0x21–0x7E). The printable-only rule rejects
+// CR, LF, tabs, NUL, and other control characters, closing header-injection and
+// log-forging vectors: the value can be dropped verbatim into a slog field or
+// an HTTP header without escaping. We reject (fall back to generate) rather
+// than strip-and-keep so a hostile value never silently mutates into a
+// different-but-accepted ID.
+func sanitize(v string) (string, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" || len(v) > maxIDLen {
+		return "", false
+	}
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c < 0x21 || c > 0x7E {
+			return "", false
+		}
+	}
+	return v, true
+}
+
+// Generate returns a new UUIDv7 (RFC 9562) as a canonical lowercase string.
+// UUIDv7 embeds a Unix-millisecond timestamp in its high bits, so generated
+// IDs sort roughly by creation time — useful when correlation IDs land in
+// time-series logs. The remaining bits are filled from crypto/rand.
+//
+// We use the stdlib (crypto/rand) rather than adding a UUID dependency: the
+// layout is small and self-contained, and the project has no existing UUID
+// library to reuse.
+func Generate() string {
+	var b [16]byte
+	// crypto/rand.Read never returns an error in the stdlib implementation
+	// (it panics internally on a failing entropy source), so the error is
+	// safe to ignore here; a non-nil error is unreachable.
+	_, _ = rand.Read(b[:])
+
+	// Timestamp: 48-bit big-endian Unix milliseconds in the first 6 bytes.
+	ms := uint64(time.Now().UnixMilli())
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], ms)
+	copy(b[0:6], ts[2:8])
+
+	// Version 7 in the high nibble of byte 6; variant 10xx in the high bits of
+	// byte 8. The low nibble of byte 6 and the low 6 bits of byte 8 keep their
+	// random fill.
+	b[6] = (b[6] & 0x0F) | 0x70
+	b[8] = (b[8] & 0x3F) | 0x80
+
+	return formatUUID(b)
+}
+
+// formatUUID renders the 16-byte UUID in canonical 8-4-4-4-12 lowercase form.
+func formatUUID(b [16]byte) string {
+	var buf [36]byte
+	hex.Encode(buf[0:8], b[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], b[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], b[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], b[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:36], b[10:16])
+	return string(buf[:])
+}

--- a/internal/observability/correlation/middleware.go
+++ b/internal/observability/correlation/middleware.go
@@ -41,22 +41,19 @@ const (
 // only ever bites an oversized X-Correlation-ID.
 const maxIDLen = 128
 
-// Key is the context-key type under which the correlation ID is stored. The
-// empty-struct, package-private *type* is exported but has no exported fields
-// or constructor parameters beyond the zero value Key{}, mirroring the
-// unexported-key idiom in internal/auth (rawSubjectTokenKey{}, principalKey{}):
-// only code holding this type can address the value, so no other package can
-// collide with it or read it except through From. It is exported here because
-// the v1 default is for correlation to be ON and dependent observability code
-// reads the ID via From, not by constructing the key.
-type Key struct{}
+// key is the unexported context-key type under which the correlation ID is
+// stored. Only this package can construct key{}, mirroring the unexported-key
+// idiom in internal/auth (rawSubjectTokenKey{}, principalKey{}): no other
+// package can collide with it or read the value directly. External code seeds
+// the ID via With and reads it via From, never by addressing the key.
+type key struct{}
 
 // With returns a copy of ctx carrying id as the correlation ID. It does not
 // validate id; the middleware is the sole production writer and only stores
 // values that already passed sanitize. Exported for tests and for any future
 // non-HTTP entry point that needs to seed a correlation ID.
 func With(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, Key{}, id)
+	return context.WithValue(ctx, key{}, id)
 }
 
 // From returns the correlation ID stored on ctx, or "" when none is present
@@ -65,7 +62,7 @@ func With(ctx context.Context, id string) context.Context {
 // correlation ID is indistinguishable from "absent" for logging purposes, so a
 // single return keeps call sites simple.
 func From(ctx context.Context) string {
-	if v, ok := ctx.Value(Key{}).(string); ok {
+	if v, ok := ctx.Value(key{}).(string); ok {
 		return v
 	}
 	return ""
@@ -201,10 +198,16 @@ func sanitize(v string) (string, bool) {
 // library to reuse.
 func Generate() string {
 	var b [16]byte
-	// crypto/rand.Read never returns an error in the stdlib implementation
-	// (it panics internally on a failing entropy source), so the error is
-	// safe to ignore here; a non-nil error is unreachable.
-	_, _ = rand.Read(b[:])
+	// Fail loudly rather than silently emit zeroed/predictable bytes, which
+	// would defeat the ID's purpose. On modern Go crypto/rand.Read does not
+	// return an error (a failing entropy source crashes internally), so this
+	// panic is defensive and unreachable in practice. A panic on the request
+	// goroutine is caught by net/http's per-connection recovery (and, once the
+	// HTTP panic-recovery middleware is stacked, by that), so it does not crash
+	// the process.
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("correlation: crypto/rand.Read failed: " + err.Error())
+	}
 
 	// Timestamp: 48-bit big-endian Unix milliseconds in the first 6 bytes.
 	ms := uint64(time.Now().UnixMilli())

--- a/internal/observability/correlation/middleware_test.go
+++ b/internal/observability/correlation/middleware_test.go
@@ -268,7 +268,10 @@ func TestMiddleware_EndToEndPropagation(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if string(body) != validTraceID {
 			t.Errorf("downstream saw correlation ID %q, want %q", string(body), validTraceID)
 		}
@@ -284,7 +287,10 @@ func TestMiddleware_EndToEndPropagation(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if !isUUIDv7(string(body)) {
 			t.Errorf("downstream saw %q, want a generated UUIDv7", string(body))
 		}

--- a/internal/observability/correlation/middleware_test.go
+++ b/internal/observability/correlation/middleware_test.go
@@ -1,0 +1,321 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package correlation
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// runMiddleware sends a request carrying the given headers through Middleware
+// and returns the correlation ID observed by the downstream handler.
+// nextInvoked reports whether the wrapped handler actually ran (it always must:
+// the middleware never rejects).
+func runMiddleware(t *testing.T, headers map[string]string) (gotID string, nextInvoked bool) {
+	t.Helper()
+	handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextInvoked = true
+		gotID = From(r.Context())
+	}))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	return gotID, nextInvoked
+}
+
+const validTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+const validTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+// TestMiddleware_TraceparentExtraction pins that a well-formed traceparent
+// yields its 32-hex trace-id segment as the correlation ID.
+func TestMiddleware_TraceparentExtraction(t *testing.T) {
+	t.Parallel()
+	gotID, nextInvoked := runMiddleware(t, map[string]string{headerTraceparent: validTraceparent})
+	if !nextInvoked {
+		t.Fatal("next handler was not invoked")
+	}
+	if gotID != validTraceID {
+		t.Errorf("correlation ID = %q, want trace-id %q", gotID, validTraceID)
+	}
+}
+
+// TestMiddleware_FutureVersionTraceparentToleratesTrailingFields pins forward
+// compatibility: an unrecognized (future) version may carry extra trailing
+// fields and still yields its trace-id. Only the known version 00 is held to
+// exactly four fields (see TestMiddleware_MalformedTraceparentFallsBack).
+func TestMiddleware_FutureVersionTraceparentToleratesTrailingFields(t *testing.T) {
+	t.Parallel()
+	tp := "01-" + validTraceID + "-00f067aa0ba902b7-01-extrafield"
+	gotID, _ := runMiddleware(t, map[string]string{headerTraceparent: tp})
+	if gotID != validTraceID {
+		t.Errorf("correlation ID = %q, want trace-id %q from future-version traceparent", gotID, validTraceID)
+	}
+}
+
+// TestMiddleware_TraceparentPrecedence pins that a valid traceparent wins over
+// a present X-Correlation-ID.
+func TestMiddleware_TraceparentPrecedence(t *testing.T) {
+	t.Parallel()
+	gotID, _ := runMiddleware(t, map[string]string{
+		headerTraceparent:   validTraceparent,
+		headerCorrelationID: "client-supplied-id",
+	})
+	if gotID != validTraceID {
+		t.Errorf("correlation ID = %q, want traceparent trace-id %q to win", gotID, validTraceID)
+	}
+}
+
+// TestMiddleware_MalformedTraceparentFallsBack pins that every malformed
+// traceparent shape falls back to a present, valid X-Correlation-ID.
+func TestMiddleware_MalformedTraceparentFallsBack(t *testing.T) {
+	t.Parallel()
+	const fallback = "fallback-correlation-id"
+	cases := []struct {
+		name        string
+		traceparent string
+	}{
+		{"too few fields", "00-" + validTraceID + "-00f067aa0ba902b7"},
+		{"empty", ""},
+		{"trace-id too short", "00-4bf92f3577b34da6-00f067aa0ba902b7-01"},
+		{"trace-id too long", "00-" + validTraceID + "ab-00f067aa0ba902b7-01"},
+		{"non-hex trace-id", "00-zzf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+		{"uppercase trace-id", "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01"},
+		{"all-zero trace-id", "00-00000000000000000000000000000000-00f067aa0ba902b7-01"},
+		{"reserved version ff", "ff-" + validTraceID + "-00f067aa0ba902b7-01"},
+		{"bad version length", "0-" + validTraceID + "-00f067aa0ba902b7-01"},
+		{"bad span length", "00-" + validTraceID + "-00f067aa-01"},
+		{"bad flags length", "00-" + validTraceID + "-00f067aa0ba902b7-1"},
+		{"trailing fields on version 00", validTraceparent + "-extra"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotID, _ := runMiddleware(t, map[string]string{
+				headerTraceparent:   tc.traceparent,
+				headerCorrelationID: fallback,
+			})
+			if gotID != fallback {
+				t.Errorf("correlation ID = %q, want fallback %q", gotID, fallback)
+			}
+		})
+	}
+}
+
+// TestMiddleware_CorrelationIDEchoed pins that a valid X-Correlation-ID is
+// echoed verbatim when no traceparent is present.
+func TestMiddleware_CorrelationIDEchoed(t *testing.T) {
+	t.Parallel()
+	const id = "abc-123_XYZ.456"
+	gotID, _ := runMiddleware(t, map[string]string{headerCorrelationID: id})
+	if gotID != id {
+		t.Errorf("correlation ID = %q, want %q echoed", gotID, id)
+	}
+}
+
+// TestMiddleware_CorrelationIDTrimmed pins that surrounding whitespace is
+// trimmed from an otherwise-valid X-Correlation-ID.
+func TestMiddleware_CorrelationIDTrimmed(t *testing.T) {
+	t.Parallel()
+	gotID, _ := runMiddleware(t, map[string]string{headerCorrelationID: "  padded-id  "})
+	if gotID != "padded-id" {
+		t.Errorf("correlation ID = %q, want trimmed %q", gotID, "padded-id")
+	}
+}
+
+// TestMiddleware_GeneratesWhenNeitherPresent pins that, with no usable inbound
+// header, the middleware generates a valid UUIDv7.
+func TestMiddleware_GeneratesWhenNeitherPresent(t *testing.T) {
+	t.Parallel()
+	gotID, _ := runMiddleware(t, nil)
+	if !isUUIDv7(gotID) {
+		t.Errorf("correlation ID = %q, want a valid UUIDv7", gotID)
+	}
+}
+
+// TestMiddleware_InvalidInputsGenerate pins that the full invalid-input domain
+// for X-Correlation-ID (with no traceparent) causes a generated UUIDv7 rather
+// than echoing or sanitizing the bad value.
+func TestMiddleware_InvalidInputsGenerate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   \t  "},
+		{"oversized", strings.Repeat("a", maxIDLen+1)},
+		{"CR injection", "id\rinjected"},
+		{"LF injection", "id\ninjected"},
+		{"CRLF header split", "id\r\nX-Evil: 1"},
+		{"NUL byte", "id\x00bad"},
+		{"tab", "id\tbad"},
+		{"DEL char", "id\x7fbad"},
+		{"non-ascii", "idÃ© bad"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotID, _ := runMiddleware(t, map[string]string{headerCorrelationID: tc.value})
+			if !isUUIDv7(gotID) {
+				t.Errorf("for input %q: correlation ID = %q, want a generated UUIDv7 (bad input must not be echoed)", tc.value, gotID)
+			}
+		})
+	}
+}
+
+// TestMiddleware_BoundaryLength pins the maxIDLen boundary: exactly maxIDLen is
+// accepted, maxIDLen+1 is rejected (and thus generated).
+func TestMiddleware_BoundaryLength(t *testing.T) {
+	t.Parallel()
+	atLimit := strings.Repeat("a", maxIDLen)
+	gotID, _ := runMiddleware(t, map[string]string{headerCorrelationID: atLimit})
+	if gotID != atLimit {
+		t.Errorf("at-limit (%d chars) correlation ID = %q, want it echoed", maxIDLen, gotID)
+	}
+}
+
+// TestGenerate_ValidUUIDv7 pins Generate's output shape and uniqueness.
+func TestGenerate_ValidUUIDv7(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{})
+	for i := 0; i < 1000; i++ {
+		id := Generate()
+		if !isUUIDv7(id) {
+			t.Fatalf("Generate() = %q, not a valid UUIDv7", id)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("Generate() produced a duplicate: %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestFrom_Absent pins that From returns "" when no ID is on the context —
+// the contract dependent code relies on when the capability is off (middleware
+// not wired).
+func TestFrom_Absent(t *testing.T) {
+	t.Parallel()
+	if got := From(context.Background()); got != "" {
+		t.Errorf("From(background) = %q, want \"\"", got)
+	}
+}
+
+// TestWithFrom_RoundTrip pins the With/From round-trip.
+func TestWithFrom_RoundTrip(t *testing.T) {
+	t.Parallel()
+	const id = "round-trip-id"
+	ctx := With(context.Background(), id)
+	if got := From(ctx); got != id {
+		t.Errorf("From(With(ctx, %q)) = %q, want %q", id, got, id)
+	}
+}
+
+// TestMiddleware_DoesNotMutateParentContext pins that the stamped ID lands only
+// on the derived context handed to next, not on the original request context.
+func TestMiddleware_DoesNotMutateParentContext(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+	req.Header.Set(headerCorrelationID, "some-id")
+	parentCtx := req.Context()
+
+	handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got := From(parentCtx); got != "" {
+		t.Errorf("parent context was polluted: From = %q, want \"\"", got)
+	}
+}
+
+// TestMiddleware_EndToEndPropagation is the httptest.Server integration test:
+// it proves the correlation ID survives the full HTTP round-trip and reaches a
+// real downstream handler's context.
+func TestMiddleware_EndToEndPropagation(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, From(r.Context()))
+	})))
+	defer srv.Close()
+
+	// Subtests are intentionally NOT parallel: a parallel subtest defers its
+	// body until the parent returns, by which point defer srv.Close() has
+	// already shut the server down.
+	t.Run("traceparent propagates end to end", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set(headerTraceparent, validTraceparent)
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != validTraceID {
+			t.Errorf("downstream saw correlation ID %q, want %q", string(body), validTraceID)
+		}
+	})
+
+	t.Run("generated when no header", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if !isUUIDv7(string(body)) {
+			t.Errorf("downstream saw %q, want a generated UUIDv7", string(body))
+		}
+	})
+}
+
+// isUUIDv7 reports whether s is a canonical lowercase UUID with version nibble
+// 7 and RFC 4122/9562 variant bits (10xx). It is a test-only structural check.
+func isUUIDv7(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
+		return false
+	}
+	for i, c := range s {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			continue
+		}
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	// Version nibble sits at index 14; variant high bits at index 19.
+	if s[14] != '7' {
+		return false
+	}
+	switch s[19] {
+	case '8', '9', 'a', 'b':
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Part of the **Broker MCP Observability & Telemetry** epic ([SOL-150251](https://sol-jira.atlassian.net/browse/SOL-150251)) → MUST child epic [SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791). Story: [SOL-151279](https://sol-jira.atlassian.net/browse/SOL-151279). Builds on the merged Story 1 skeleton.

## What this does
Adds the HTTP middleware that gives every inbound MCP request a correlation ID on its context, so all downstream logs and calls for that request can be linked.

- **Resolution precedence:** `traceparent` (W3C trace-id) → `X-Correlation-ID` → generated **UUIDv7**.
- **Flag-gated** by `OBS_CORRELATION_ID_ENABLED`; when off, the middleware isn't wired and `correlation.From(ctx)` returns `""`.
- **Wired outside auth**, so an unauthenticated 401 still carries a correlation ID (ADR-001); the body limit stays outermost.

## Input handling (the careful part)
- **`traceparent`:** exact segment lengths, lowercase-hex enforced, reserved version `ff` and all-zero trace-id rejected, known version `00` held to exactly four fields (future versions tolerate trailing fields). Malformed input *falls back* — it never errors the request.
- **`X-Correlation-ID`:** printable-ASCII only (rejects CR/LF, control chars, NUL) and capped at 128 bytes, so the value is injection-safe for slog and a future outbound header. Hostile values are rejected (fall back to generate), never silently mutated.
- **UUIDv7** via stdlib `crypto/rand` — **no new dependency**.

Out of scope (Story 6): the response header and `CallToolResult.Meta`.

## Testing
traceparent extraction/precedence; a full malformed-input table (incl. trailing-fields-on-v00 and injection/control-char cases); UUIDv7 fallback; flag-off no-op; and an `httptest` end-to-end propagation test. `go build`, `go vet`, `go test ./...`, `-race`, and `golangci-lint` all pass. Reviewed by a principal-architect Opus pass (one W3C conformance nit found and fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOL-150251]: https://sol-jira.atlassian.net/browse/SOL-150251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151279]: https://sol-jira.atlassian.net/browse/SOL-151279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ