### PR TITLE
SOL-151287: gate tool-path panic recovery behind OBS_PANIC_RECOVERY_ENABLED

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/recovery"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2/specs"
@@ -160,6 +161,27 @@ func buildMux(aliases func() []string, probeBroker func(ctx context.Context, bro
 		_, _ = w.Write(resp)
 	})
 
+	return mux
+}
+
+// buildRootHandler returns the outermost HTTP handler for the server: the mux
+// wrapped with panic-recovery as the OUTERMOST layer (ADR-001 chain ordering),
+// gated on OBS_PANIC_RECOVERY_ENABLED. When the flag is off the mux is returned
+// unwrapped and panics propagate (today's behaviour).
+//
+// Recovery wraps the WHOLE mux, so it covers every route — the standalone
+// /livez, /health, /ready probes (and future /readyz, /metrics), the catch-all
+// 404, and the authenticated /mcp chain — sitting OUTSIDE the per-route
+// correlation.Middleware that main() installs only on /mcp. The two are
+// different layers and never conflict: recovery wraps the mux; correlation
+// wraps a handler inside it.
+//
+// Extracted from main() so the composition test can assert the assembled chain
+// order against the real wiring rather than a hand-rebuilt copy.
+func buildRootHandler(mux *http.ServeMux, obs config.ObservabilityConfig) http.Handler {
+	if recovery.Enabled(obs) {
+		return recovery.HTTPMiddleware(mux)
+	}
 	return mux
 }
 
@@ -551,9 +573,18 @@ func main() {
 		slog.Debug("catch-all 404: no route matched", slog.String("method", r.Method), slog.String("path", r.URL.Path))
 	}))
 
-	// 9. Start server with graceful shutdown
+	// 9. Wrap the whole mux with panic-recovery as the OUTERMOST handler
+	// (ADR-001), gated on OBS_PANIC_RECOVERY_ENABLED. A panic in ANY handler is
+	// caught, logged with a structured stack, and returned as a clean 500; the
+	// process keeps running. Recovery sits OUTSIDE the per-route correlation
+	// middleware wired on /mcp above — different layers, no conflict.
+	rootHandler := buildRootHandler(mux, cfg.Observability)
+	slog.Info("panic-recovery middleware wiring",
+		slog.Bool("enabled", recovery.Enabled(cfg.Observability)))
+
+	// 10. Start server with graceful shutdown
 	addr := fmt.Sprintf(":%d", cfg.Port)
-	httpServer := newHTTPServer(addr, mux)
+	httpServer := newHTTPServer(addr, rootHandler)
 
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -516,13 +516,19 @@ func main() {
 	mgr := tools.NewToolManagerFromComposite(pool, compositeTools, executor)
 	registerSEMPv1Tools(mgr)
 	registerSEMPv2Tools(mgr)
-	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools)
+	// Compute the panic-recovery gate once and thread it into tool
+	// registration. The single OBS_PANIC_RECOVERY_ENABLED flag governs both the
+	// tool path (SOL-151287) and the HTTP middleware (Story 12); computing the
+	// bool here keeps internal/tools free of any dependency on the recovery
+	// package.
+	panicRecoveryEnabled := recovery.Enabled(cfg.Observability)
+	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools, panicRecoveryEnabled)
 	slog.Info("tool registration complete",
 		slog.Bool("enable_write_tools", cfg.EnableWriteTools))
 
 	// list-brokers is a discovery tool registered directly on the MCP
 	// server (it doesn't need broker resolution or the ToolManager pipeline).
-	tools.RegisterListBrokers(server, pool)
+	tools.RegisterListBrokers(server, pool, panicRecoveryEnabled)
 
 	slog.Info("all tools registered")
 

--- a/cmd/server/panic_recovery_test.go
+++ b/cmd/server/panic_recovery_test.go
@@ -91,37 +91,41 @@ func TestBuildRootHandler_FlagOffPanicPropagates(t *testing.T) {
 	t.Error("ServeHTTP returned without panicking; recovery flag OFF must let panics propagate")
 }
 
-// TestChainOrder_CorrelationInsideRecovery pins AC #5: it assembles the SAME
-// layering main() builds — recovery wrapping the whole mux, and the /mcp route
-// gated on correlation.Middleware INSIDE the mux — then proves both halves of
-// the order at once:
+// TestChainOrder_CorrelationInsideRecovery pins AC #5 against the REAL wiring:
+// it assembles the /mcp route through the production buildMCPEndpoint and wraps
+// the mux through the production buildRootHandler — the same two functions
+// main() calls — then proves both halves of the chain order at once:
 //
-//   - correlation ran INSIDE recovery: the inner /mcp handler observes a
-//     non-empty correlation ID (correlation.From != "").
+//   - correlation ran INSIDE recovery: the inner /mcp handler (standing in for
+//     auth→SDK) observes a non-empty correlation ID (correlation.From != "").
 //   - recovery is OUTSIDE correlation: a panic in a sibling mux route is still
 //     caught and turned into a 500.
 //
-// This test fails if a future PR reorders the chain (e.g. wraps recovery inside
-// correlation) or leaves the mux unwrapped. It mirrors how main() wires the
-// /mcp endpoint (see cmd/server/main.go) and will need updating if that wiring
-// changes.
+// Because the /mcp layering comes from buildMCPEndpoint (not a hand-rebuilt
+// copy), this test FAILS if a future PR drops correlation from /mcp, or if
+// buildRootHandler stops wrapping the mux. It pins correlation's PRESENCE
+// inside recovery (the AC #5 essential); it does NOT pin the body-limit-vs-
+// correlation relative order — both wrap the same handler and neither is
+// observable to a normal GET, so asserting 413-before-correlation would need a
+// separate oversized-body test. The stand-in inner handler substitutes for the
+// auth+SDK handler that main() passes as authedHandler; auth's position
+// relative to the SDK is fixed where authedHandler is constructed, not here.
 func TestChainOrder_CorrelationInsideRecovery(t *testing.T) {
 	t.Parallel()
 	cfg := obsConfig(true, true)
 
 	var seenID string
-	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil })
-
-	// Inner /mcp handler records the correlation ID it observes.
-	var mcpEndpoint http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Stand-in for authedHandler (auth middleware → MCP SDK handler): records
+	// the correlation ID it observes so we can prove correlation ran upstream.
+	authedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seenID = correlation.From(r.Context())
 		w.WriteHeader(http.StatusOK)
 	})
-	// Gate correlation onto /mcp exactly as main() does.
-	if correlation.Enabled(cfg) {
-		mcpEndpoint = correlation.Middleware(mcpEndpoint)
-	}
-	mux.Handle("/mcp", mcpEndpoint)
+
+	// Assemble /mcp through the SAME function main() uses, so a production
+	// reorder of the route-local chain breaks this test.
+	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil })
+	mux.Handle("/mcp", buildMCPEndpoint(authedHandler, cfg.CorrelationIDEnabled))
 	mux.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
 		panic("boom")
 	})

--- a/cmd/server/panic_recovery_test.go
+++ b/cmd/server/panic_recovery_test.go
@@ -1,0 +1,143 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+)
+
+// obsConfig builds an ObservabilityConfig with the two flags this story cares
+// about; all other observability flags default to their zero value.
+func obsConfig(panicRecovery, correlationID bool) config.ObservabilityConfig {
+	return config.ObservabilityConfig{
+		PanicRecoveryEnabled: panicRecovery,
+		CorrelationIDEnabled: correlationID,
+	}
+}
+
+// get drives a GET request for path through handler and returns the recorder.
+func get(handler http.Handler, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// muxWithPanicRoute builds on the shared buildMux routes (/livez, /health,
+// /ready) and adds a /panic route whose handler always panics. Reusing the
+// shared buildMux keeps the probe routes identical to production, so the test
+// proves they still resolve through the recovery wrapper.
+func muxWithPanicRoute() *http.ServeMux {
+	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil })
+	mux.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
+		panic("boom from a route inside the mux")
+	})
+	return mux
+}
+
+// TestBuildRootHandler_PanicRecoveryWrapsWholeMux pins AC #1/#2: with the flag
+// ON, the assembled root handler catches a panic from a route INSIDE the mux
+// and returns 500 — proving recovery is the outermost wrapper around the whole
+// mux — while the standalone probe routes still pass through to 200, and the
+// process keeps running.
+func TestBuildRootHandler_PanicRecoveryWrapsWholeMux(t *testing.T) {
+	t.Parallel()
+	root := buildRootHandler(muxWithPanicRoute(), obsConfig(true, false))
+
+	// A panic in a mux route is caught -> 500.
+	if rec := get(root, "/panic"); rec.Code != http.StatusInternalServerError {
+		t.Errorf("/panic status = %d, want %d (recovery must wrap the whole mux)", rec.Code, http.StatusInternalServerError)
+	}
+	// The standalone probe routes still reach their handlers through the wrapper.
+	for _, path := range []string{"/livez", "/health"} {
+		if rec := get(root, path); rec.Code != http.StatusOK {
+			t.Errorf("%s status = %d, want %d through the recovery wrapper", path, rec.Code, http.StatusOK)
+		}
+	}
+}
+
+// TestBuildRootHandler_FlagOffPanicPropagates pins AC #4: with the flag OFF the
+// recovery middleware is NOT wired, so a panic propagates out of the root
+// handler (today's behaviour) instead of becoming a 500. We catch the re-panic
+// here to assert it WAS re-raised.
+func TestBuildRootHandler_FlagOffPanicPropagates(t *testing.T) {
+	t.Parallel()
+	root := buildRootHandler(muxWithPanicRoute(), obsConfig(false, false))
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("panic did not propagate with recovery flag OFF; want it to escape the root handler")
+		}
+	}()
+	_ = get(root, "/panic") // must panic; the deferred recover() asserts it did.
+	t.Error("ServeHTTP returned without panicking; recovery flag OFF must let panics propagate")
+}
+
+// TestChainOrder_CorrelationInsideRecovery pins AC #5: it assembles the SAME
+// layering main() builds — recovery wrapping the whole mux, and the /mcp route
+// gated on correlation.Middleware INSIDE the mux — then proves both halves of
+// the order at once:
+//
+//   - correlation ran INSIDE recovery: the inner /mcp handler observes a
+//     non-empty correlation ID (correlation.From != "").
+//   - recovery is OUTSIDE correlation: a panic in a sibling mux route is still
+//     caught and turned into a 500.
+//
+// This test fails if a future PR reorders the chain (e.g. wraps recovery inside
+// correlation) or leaves the mux unwrapped. It mirrors how main() wires the
+// /mcp endpoint (see cmd/server/main.go) and will need updating if that wiring
+// changes.
+func TestChainOrder_CorrelationInsideRecovery(t *testing.T) {
+	t.Parallel()
+	cfg := obsConfig(true, true)
+
+	var seenID string
+	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil })
+
+	// Inner /mcp handler records the correlation ID it observes.
+	var mcpEndpoint http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenID = correlation.From(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	// Gate correlation onto /mcp exactly as main() does.
+	if correlation.Enabled(cfg) {
+		mcpEndpoint = correlation.Middleware(mcpEndpoint)
+	}
+	mux.Handle("/mcp", mcpEndpoint)
+	mux.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	})
+
+	root := buildRootHandler(mux, cfg)
+
+	// correlation ran INSIDE recovery: a non-empty ID reached the inner handler.
+	if rec := get(root, "/mcp"); rec.Code != http.StatusOK {
+		t.Fatalf("/mcp status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if seenID == "" {
+		t.Error("inner /mcp handler saw no correlation ID; correlation.Middleware must run INSIDE recovery")
+	}
+
+	// recovery is OUTSIDE: a panic in a sibling route is still caught.
+	if rec := get(root, "/panic"); rec.Code != http.StatusInternalServerError {
+		t.Errorf("/panic status = %d, want %d; recovery must remain the outermost wrapper", rec.Code, http.StatusInternalServerError)
+	}
+}

--- a/internal/observability/recovery/middleware.go
+++ b/internal/observability/recovery/middleware.go
@@ -30,7 +30,7 @@ import (
 // correlation.Middleware attaches the ID to a CHILD context via
 // next.ServeHTTP(w, r.WithContext(ctx)), so the ID lives only on the downstream
 // request's context — it is never visible at this outer frame. Emitting a
-// correlation_id here would mean inventing one or reading "" , so we omit the
+// correlation_id here would mean inventing one or reading "", so we omit the
 // field entirely (the filed acceptance criteria do not require it in the body).
 const internalErrorBody = `{"error":"internal_error","error_description":"the server encountered an unexpected condition"}`
 
@@ -56,10 +56,30 @@ const internalErrorBody = `{"error":"internal_error","error_description":"the se
 // the /ready handler) is NOT caught here — that class must be recovered at the
 // point of goroutine creation. The SDK tool-handler goroutine is covered
 // separately by withRecovery in internal/tools/register.go.
+//
+// http.ErrAbortHandler is exempt: net/http documents it as a sentinel meaning
+// "abort this request, do not log, do not send a response". We re-raise it
+// unchanged so net/http's serving goroutine applies that built-in suppression.
+// The MCP streamable/SSE path on /mcp may panic with it on client-disconnect or
+// shutdown.
 func HTTPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// rw tracks whether the downstream handler committed the response (wrote
+		// a header or body bytes). It implements Unwrap() so http.ResponseController
+		// — which the MCP SDK's SSE path uses to flush (go-sdk mcp/streamable.go
+		// and mcp/event.go call http.NewResponseController(w).Flush()) — still
+		// reaches the underlying Flusher/Hijacker. Streaming on /mcp is preserved.
+		rw := &recoveryWriter{ResponseWriter: w}
 		defer func() {
 			if rec := recover(); rec != nil {
+				// http.ErrAbortHandler is net/http's sentinel: re-raise it before
+				// any logging or writing so net/http's serving goroutine handles
+				// it (abort the request, no log, no response). Logging or writing
+				// a 500 here would defeat the sentinel's contract.
+				if rec == http.ErrAbortHandler {
+					panic(rec)
+				}
+
 				// Log the type and stack, never the value's text (secure-logging
 				// rule). The stack pinpoints the panic site without echoing the
 				// value.
@@ -73,26 +93,48 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 				// infrastructure yet (internal/observability/metrics is a
 				// flag-only skeleton), so this story implements the LOG only.
 
-				// Best-effort 500. If the downstream handler already committed a
-				// status and wrote body bytes before panicking, the response is
-				// already on the wire and CANNOT be un-sent: WriteHeader becomes a
-				// no-op (net/http logs "superfluous WriteHeader") AND the Write
-				// below APPENDS internalErrorBody onto the partial bytes the
-				// handler already sent, producing a concatenated (malformed) body.
-				// We accept this best-effort behaviour for v1: (a) the in-tree
-				// handlers — the probes and the SDK /mcp handler — write their
-				// response atomically, so a panic after a partial write is not
-				// reached in practice; and (b) the alternative, wrapping w in a
-				// ResponseWriter that tracks commitment to suppress the append,
-				// would defeat the http.Flusher type-assertion the MCP streamable
-				// HTTP (SSE) path on /mcp depends on, breaking streaming. Keeping
-				// the process alive is the contract that matters; on the common
-				// path (panic before any write) the clean 500 below is correct.
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte(internalErrorBody))
+				// Best-effort 500, but only when the response is NOT yet committed.
+				// Once a handler has committed a status and written body bytes the
+				// response is on the wire and CANNOT be un-sent: WriteHeader would
+				// be a no-op and writing internalErrorBody would APPEND it onto the
+				// partial bytes, corrupting the body into malformed JSON. So when
+				// rw.wroteHeader is set we deliberately write NOTHING and leave the
+				// partial response as-is — the process still survives. On the common
+				// path (panic before any write) we send the clean 500 below.
+				if !rw.wroteHeader {
+					rw.Header().Set("Content-Type", "application/json")
+					rw.WriteHeader(http.StatusInternalServerError)
+					_, _ = rw.Write([]byte(internalErrorBody))
+				}
 			}
 		}()
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(rw, r)
 	})
 }
+
+// recoveryWriter wraps an http.ResponseWriter to track whether the downstream
+// handler committed the response (wrote a status header or body bytes). The
+// recovery middleware uses wroteHeader to decide whether it can safely write a
+// 500 (uncommitted) or must leave a partial response untouched (committed).
+//
+// Unwrap() exposes the underlying writer so http.ResponseController can walk to
+// the real Flusher/Hijacker. The MCP SDK's SSE path flushes via
+// http.NewResponseController(w).Flush(), so wrapping does NOT break streaming on
+// /mcp. We intentionally do not implement Flush/Hijack explicitly — Unwrap is
+// the idiomatic, sufficient mechanism for ResponseController-based consumers.
+type recoveryWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *recoveryWriter) WriteHeader(code int) {
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *recoveryWriter) Write(b []byte) (int, error) {
+	w.wroteHeader = true
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *recoveryWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }

--- a/internal/observability/recovery/middleware.go
+++ b/internal/observability/recovery/middleware.go
@@ -50,6 +50,12 @@ const internalErrorBody = `{"error":"internal_error","error_description":"the se
 // Callers gate installation on Enabled (OBS_PANIC_RECOVERY_ENABLED). When the
 // capability is off the middleware is not wired and a panic propagates to
 // net/http's per-connection recovery (today's behaviour).
+//
+// Scope: recover() catches only panics on the request's own goroutine. A panic
+// on a goroutine that a handler SPAWNS (e.g. the per-broker probe goroutines in
+// the /ready handler) is NOT caught here — that class must be recovered at the
+// point of goroutine creation. The SDK tool-handler goroutine is covered
+// separately by withRecovery in internal/tools/register.go.
 func HTTPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
@@ -68,13 +74,20 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 				// flag-only skeleton), so this story implements the LOG only.
 
 				// Best-effort 500. If the downstream handler already committed a
-				// status and wrote body bytes before panicking, the response
-				// headers are already on the wire and CANNOT be un-sent: this
-				// WriteHeader is a no-op (net/http logs "superfluous WriteHeader")
-				// and the client receives the partial body the handler started.
-				// This is an unavoidable limitation of HTTP, not something the
-				// middleware can paper over; we do best-effort and keep the
-				// process alive, which is the contract that matters.
+				// status and wrote body bytes before panicking, the response is
+				// already on the wire and CANNOT be un-sent: WriteHeader becomes a
+				// no-op (net/http logs "superfluous WriteHeader") AND the Write
+				// below APPENDS internalErrorBody onto the partial bytes the
+				// handler already sent, producing a concatenated (malformed) body.
+				// We accept this best-effort behaviour for v1: (a) the in-tree
+				// handlers — the probes and the SDK /mcp handler — write their
+				// response atomically, so a panic after a partial write is not
+				// reached in practice; and (b) the alternative, wrapping w in a
+				// ResponseWriter that tracks commitment to suppress the append,
+				// would defeat the http.Flusher type-assertion the MCP streamable
+				// HTTP (SSE) path on /mcp depends on, breaking streaming. Keeping
+				// the process alive is the contract that matters; on the common
+				// path (panic before any write) the clean 500 below is correct.
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte(internalErrorBody))

--- a/internal/observability/recovery/middleware.go
+++ b/internal/observability/recovery/middleware.go
@@ -1,0 +1,85 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+)
+
+// internalErrorBody is the JSON 500 response written when a panic is recovered.
+// It mirrors the repo's error-body convention used by the catch-all 404 handler
+// in cmd/server/main.go ({"error":"...","error_description":"..."}).
+//
+// It deliberately carries NO correlation_id field. The recovery middleware wraps
+// the ENTIRE mux as the outermost layer, OUTSIDE correlation.Middleware.
+// correlation.Middleware attaches the ID to a CHILD context via
+// next.ServeHTTP(w, r.WithContext(ctx)), so the ID lives only on the downstream
+// request's context — it is never visible at this outer frame. Emitting a
+// correlation_id here would mean inventing one or reading "" , so we omit the
+// field entirely (the filed acceptance criteria do not require it in the body).
+const internalErrorBody = `{"error":"internal_error","error_description":"the server encountered an unexpected condition"}`
+
+// HTTPMiddleware wraps next with a recover() that traps a panic in ANY
+// downstream handler and converts it to a clean HTTP 500, keeping the process
+// running. It is installed as the OUTERMOST wrapper around the whole HTTP mux
+// (outside correlation.Middleware), so it covers the standalone probe routes
+// (/livez, /health, /ready and future /readyz, /metrics), the catch-all 404,
+// and the authenticated /mcp chain alike (ADR-001 chain ordering).
+//
+// On a recovered panic it logs at ERROR with event="panic_recovered", the panic
+// value's Go TYPE (panic_type) and a structured stack trace. It logs only the
+// type, never the panic value's text: panic values are unaudited and can carry
+// arbitrary strings, the same secure-logging rule withRecovery applies in
+// internal/tools (see docs/internal/secure-logging-rules.md).
+//
+// Callers gate installation on Enabled (OBS_PANIC_RECOVERY_ENABLED). When the
+// capability is off the middleware is not wired and a panic propagates to
+// net/http's per-connection recovery (today's behaviour).
+func HTTPMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				// Log the type and stack, never the value's text (secure-logging
+				// rule). The stack pinpoints the panic site without echoing the
+				// value.
+				slog.Error("recovered panic in HTTP handler",
+					slog.String("event", "panic_recovered"),
+					slog.String("panic_type", fmt.Sprintf("%T", rec)),
+					slog.String("stack", string(debug.Stack())))
+
+				// TODO(SOL-151...metrics, Story 15): increment a recovered-panic
+				// counter once the metrics registry lands. There is no counter
+				// infrastructure yet (internal/observability/metrics is a
+				// flag-only skeleton), so this story implements the LOG only.
+
+				// Best-effort 500. If the downstream handler already committed a
+				// status and wrote body bytes before panicking, the response
+				// headers are already on the wire and CANNOT be un-sent: this
+				// WriteHeader is a no-op (net/http logs "superfluous WriteHeader")
+				// and the client receives the partial body the handler started.
+				// This is an unavoidable limitation of HTTP, not something the
+				// middleware can paper over; we do best-effort and keep the
+				// process alive, which is the contract that matters.
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(internalErrorBody))
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/observability/recovery/middleware_test.go
+++ b/internal/observability/recovery/middleware_test.go
@@ -197,16 +197,14 @@ func TestHTTPMiddleware_PanicNil(t *testing.T) {
 	}
 }
 
-// TestHTTPMiddleware_PartialWriteThenPanic PINS the partial-write behaviour,
-// including its known imperfection. Once a handler has committed a status (e.g.
-// 200) and written body bytes, the recovery layer cannot un-send them: the
-// status stays at what the handler committed, and the middleware's own
-// Write(internalErrorBody) APPENDS onto the partial bytes, yielding a
-// concatenated (malformed) body. We assert that EXACT body rather than just a
-// prefix so the imperfection is visible and pinned, not hidden — see the
-// middleware comment for why this best-effort behaviour is accepted for v1
-// (atomic in-tree handlers; wrapping w would break SSE on /mcp). The middleware
-// must NOT crash trying to rewrite the committed response.
+// TestHTTPMiddleware_PartialWriteThenPanic PINS the committed-response
+// behaviour. Once a handler has committed a status (e.g. 200) and written body
+// bytes, the recovery layer cannot un-send them. The middleware detects the
+// commitment (via the recoveryWriter wrapper) and deliberately writes NOTHING:
+// the status stays at what the handler committed and the body is EXACTLY the
+// partial bytes, never the error JSON appended onto them. Appending would
+// corrupt the response into malformed JSON, so we leave the partial response
+// untouched. The panic is still recovered and logged, so the process survives.
 func TestHTTPMiddleware_PartialWriteThenPanic(t *testing.T) {
 	// Not parallel: mutates the process-global slog default.
 	buf := captureLogs(t)
@@ -222,13 +220,89 @@ func TestHTTPMiddleware_PartialWriteThenPanic(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d (committed status cannot be rewritten)", rec.Code, http.StatusOK)
 	}
-	// Exact body: the handler's partial bytes followed by the appended error
-	// JSON. This documents the real (imperfect) wire output on this rare path.
-	if want := partial + internalErrorBody; rec.Body.String() != want {
-		t.Errorf("body = %q, want %q (partial bytes with the error body appended)", rec.Body.String(), want)
+	// Exact body: ONLY the handler's partial bytes. The middleware must NOT
+	// append internalErrorBody onto a committed response (that would corrupt it).
+	if rec.Body.String() != partial {
+		t.Errorf("body = %q, want %q (partial bytes only; error body must NOT be appended)", rec.Body.String(), partial)
 	}
 	// The panic is still recovered (process keeps running) and logged.
 	if buf.Len() == 0 {
 		t.Error("expected a panic_recovered log even after a partial write, got none")
+	}
+}
+
+// TestHTTPMiddleware_ErrAbortHandler PINS the http.ErrAbortHandler exemption: a
+// handler panicking with the sentinel is NOT logged and produces NO 500 body.
+// The middleware re-raises it so net/http's serving goroutine applies the
+// documented suppression (abort the request, no log, no response). We catch the
+// re-raise here with a deferred recover() and assert it is the same sentinel,
+// that nothing was logged, and that nothing was written.
+func TestHTTPMiddleware_ErrAbortHandler(t *testing.T) {
+	// Not parallel: mutates the process-global slog default.
+	buf := captureLogs(t)
+	handler := HTTPMiddleware(panicHandler(http.ErrAbortHandler))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected ErrAbortHandler to propagate (re-raise) past the middleware, but no panic escaped")
+			}
+			if r != http.ErrAbortHandler {
+				t.Fatalf("re-raised panic = %v, want http.ErrAbortHandler", r)
+			}
+		}()
+		handler.ServeHTTP(rec, req)
+	}()
+
+	// The sentinel must NOT be logged as a recovered panic.
+	if strings.Contains(buf.String(), "panic_recovered") {
+		t.Errorf("ErrAbortHandler was logged as a recovered panic; net/http's sentinel must be suppressed. log=%s", buf.String())
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output for ErrAbortHandler, got: %s", buf.String())
+	}
+	// The middleware must NOT write a 500 body for the sentinel.
+	if rec.Body.Len() != 0 {
+		t.Errorf("expected no response body for ErrAbortHandler, got %q", rec.Body.String())
+	}
+}
+
+// TestHTTPMiddleware_PreservesResponseControllerFlush pins the SSE-preservation
+// guarantee: the recoveryWriter the middleware injects must expose Unwrap() so
+// http.NewResponseController(rw).Flush() reaches the underlying Flusher. The MCP
+// SDK's streamable/SSE path on /mcp flushes exactly this way
+// (http.NewResponseController(w).Flush()), so without Unwrap() streaming would
+// break. httptest.ResponseRecorder implements Flush, so a nil error proves the
+// controller walked the Unwrap chain to it.
+func TestHTTPMiddleware_PreservesResponseControllerFlush(t *testing.T) {
+	t.Parallel()
+	var flushErr error
+	handler := HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flushErr = http.NewResponseController(w).Flush()
+	}))
+	_ = drive(handler)
+
+	if flushErr != nil {
+		t.Errorf("ResponseController.Flush() through recoveryWriter = %v, want nil (Unwrap must expose the underlying Flusher for SSE on /mcp)", flushErr)
+	}
+}
+
+// TestHTTPMiddleware_CleanPathWrites500 pins that when the handler panics
+// WITHOUT committing the response first, the middleware still writes the clean
+// 500 JSON body. This is the complement of the committed-response case and the
+// common path in practice.
+func TestHTTPMiddleware_CleanPathWrites500(t *testing.T) {
+	t.Parallel()
+	handler := HTTPMiddleware(panicHandler("boom-before-any-write"))
+	rec := drive(handler)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Body.String() != internalErrorBody {
+		t.Errorf("body = %q, want %q (clean 500 on the uncommitted path)", rec.Body.String(), internalErrorBody)
 	}
 }

--- a/internal/observability/recovery/middleware_test.go
+++ b/internal/observability/recovery/middleware_test.go
@@ -1,0 +1,226 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// panicHandler returns a handler that always panics with the given value.
+func panicHandler(v any) http.Handler {
+	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(v)
+	})
+}
+
+// captureLogs swaps slog's default to a JSON handler writing into buf for the
+// duration of the test, then restores the prior default. It returns buf so the
+// caller can decode the emitted records.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// drive sends a GET / request through handler and returns the recorder.
+func drive(handler http.Handler) *httptest.ResponseRecorder {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHTTPMiddleware_RecoversAndReturns500 pins the core contract: a panicking
+// downstream handler is caught and converted to a clean HTTP 500 with the
+// documented JSON error body, and the process keeps running (ServeHTTP returns
+// normally rather than re-panicking).
+func TestHTTPMiddleware_RecoversAndReturns500(t *testing.T) {
+	t.Parallel()
+	handler := HTTPMiddleware(panicHandler("boom"))
+	rec := drive(handler)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v; body=%q", err, rec.Body.String())
+	}
+	if body["error"] != "internal_error" {
+		t.Errorf(`body["error"] = %v, want "internal_error"`, body["error"])
+	}
+	if body["error_description"] != "the server encountered an unexpected condition" {
+		t.Errorf(`body["error_description"] = %v, want the documented description`, body["error_description"])
+	}
+	// The recovery layer sits OUTSIDE correlation, so it must NOT invent a
+	// correlation_id field it cannot see.
+	if _, present := body["correlation_id"]; present {
+		t.Errorf("body unexpectedly contains correlation_id: %v", body)
+	}
+}
+
+// TestHTTPMiddleware_PassesThroughWhenNoPanic pins that a well-behaved handler
+// is untouched: the middleware is transparent for normal traffic. This is what
+// keeps the standalone probe routes (/livez, /health, /ready) working through
+// the wrapper.
+func TestHTTPMiddleware_PassesThroughWhenNoPanic(t *testing.T) {
+	t.Parallel()
+	const want = `{"status":"alive"}`
+	handler := HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, want)
+	}))
+	rec := drive(handler)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body = %q, want %q (middleware must be transparent for normal traffic)", got, want)
+	}
+}
+
+// TestHTTPMiddleware_LogShape pins the structured ERROR log: event marker,
+// panic_type carrying only the Go TYPE (never the panic value's text), and a
+// non-empty stack trace. The secure-logging rule (mirrors withRecovery in
+// internal/tools) forbids logging the panic value's text.
+func TestHTTPMiddleware_LogShape(t *testing.T) {
+	// Not parallel: mutates the process-global slog default.
+	buf := captureLogs(t)
+	const secret = "super-secret-panic-text-do-not-log"
+	handler := HTTPMiddleware(panicHandler(secret))
+	_ = drive(handler)
+
+	if strings.Contains(buf.String(), secret) {
+		t.Fatalf("log leaked the panic value's text; secure-logging rule forbids it. log=%s", buf.String())
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("log line is not valid JSON: %v; line=%q", err, buf.String())
+	}
+	if rec["level"] != "ERROR" {
+		t.Errorf("log level = %v, want ERROR", rec["level"])
+	}
+	if rec["event"] != "panic_recovered" {
+		t.Errorf(`log event = %v, want "panic_recovered"`, rec["event"])
+	}
+	// panic("string") => panic_type "string", proving we log the type not the value.
+	if rec["panic_type"] != "string" {
+		t.Errorf(`log panic_type = %v, want "string"`, rec["panic_type"])
+	}
+	if s, ok := rec["stack"].(string); !ok || s == "" {
+		t.Errorf("log stack = %v, want a non-empty stack trace string", rec["stack"])
+	}
+}
+
+// TestHTTPMiddleware_NonStringPanicValues pins the full invalid-input domain:
+// the middleware recovers regardless of the panic value's type, and panic_type
+// reflects the concrete Go type each time.
+func TestHTTPMiddleware_NonStringPanicValues(t *testing.T) {
+	// Not parallel: mutates the process-global slog default.
+	type custom struct{ Field int }
+	cases := []struct {
+		name      string
+		value     any
+		wantType  string
+		wantPanic bool // whether next actually panics (nil panic does not)
+	}{
+		{"int", 42, "int", true},
+		{"struct", custom{Field: 7}, "recovery.custom", true},
+		{"pointer", &custom{Field: 7}, "*recovery.custom", true},
+		{"error", io.EOF, "*errors.errorString", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := captureLogs(t)
+			handler := HTTPMiddleware(panicHandler(tc.value))
+			rec := drive(handler)
+
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+			}
+			var logRec map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &logRec); err != nil {
+				t.Fatalf("log line is not valid JSON: %v; line=%q", err, buf.String())
+			}
+			if logRec["panic_type"] != tc.wantType {
+				t.Errorf("panic_type = %v, want %q", logRec["panic_type"], tc.wantType)
+			}
+		})
+	}
+}
+
+// TestHTTPMiddleware_PanicNil pins behaviour for panic(nil). Under Go 1.21+ a
+// panic(nil) is promoted to a *runtime.PanicNilError, so recover() returns a
+// non-nil value and the middleware still produces a 500.
+func TestHTTPMiddleware_PanicNil(t *testing.T) {
+	// Not parallel: mutates the process-global slog default.
+	buf := captureLogs(t)
+	handler := HTTPMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(nil) //nolint:govet // intentionally testing the panic(nil) edge
+	}))
+	rec := drive(handler)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d for panic(nil)", rec.Code, http.StatusInternalServerError)
+	}
+	if buf.Len() == 0 {
+		t.Error("expected a panic_recovered log for panic(nil), got none")
+	}
+}
+
+// TestHTTPMiddleware_PartialWriteThenPanic documents the partial-write
+// limitation: once a handler has committed a status (e.g. 200) and written
+// body bytes, the recovery layer cannot un-send them. The status stays at what
+// the handler committed; the middleware must NOT crash trying to rewrite it.
+func TestHTTPMiddleware_PartialWriteThenPanic(t *testing.T) {
+	// Not parallel: mutates the process-global slog default.
+	buf := captureLogs(t)
+	const partial = "partial-body-"
+	handler := HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, partial)
+		panic("after partial write")
+	}))
+	rec := drive(handler)
+
+	// The committed status wins; we cannot rewrite an already-sent header.
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (committed status cannot be rewritten)", rec.Code, http.StatusOK)
+	}
+	if !strings.HasPrefix(rec.Body.String(), partial) {
+		t.Errorf("body = %q, want it to start with the partial write %q", rec.Body.String(), partial)
+	}
+	// The panic is still recovered (process keeps running) and logged.
+	if buf.Len() == 0 {
+		t.Error("expected a panic_recovered log even after a partial write, got none")
+	}
+}

--- a/internal/observability/recovery/middleware_test.go
+++ b/internal/observability/recovery/middleware_test.go
@@ -197,10 +197,16 @@ func TestHTTPMiddleware_PanicNil(t *testing.T) {
 	}
 }
 
-// TestHTTPMiddleware_PartialWriteThenPanic documents the partial-write
-// limitation: once a handler has committed a status (e.g. 200) and written
-// body bytes, the recovery layer cannot un-send them. The status stays at what
-// the handler committed; the middleware must NOT crash trying to rewrite it.
+// TestHTTPMiddleware_PartialWriteThenPanic PINS the partial-write behaviour,
+// including its known imperfection. Once a handler has committed a status (e.g.
+// 200) and written body bytes, the recovery layer cannot un-send them: the
+// status stays at what the handler committed, and the middleware's own
+// Write(internalErrorBody) APPENDS onto the partial bytes, yielding a
+// concatenated (malformed) body. We assert that EXACT body rather than just a
+// prefix so the imperfection is visible and pinned, not hidden — see the
+// middleware comment for why this best-effort behaviour is accepted for v1
+// (atomic in-tree handlers; wrapping w would break SSE on /mcp). The middleware
+// must NOT crash trying to rewrite the committed response.
 func TestHTTPMiddleware_PartialWriteThenPanic(t *testing.T) {
 	// Not parallel: mutates the process-global slog default.
 	buf := captureLogs(t)
@@ -216,8 +222,10 @@ func TestHTTPMiddleware_PartialWriteThenPanic(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d (committed status cannot be rewritten)", rec.Code, http.StatusOK)
 	}
-	if !strings.HasPrefix(rec.Body.String(), partial) {
-		t.Errorf("body = %q, want it to start with the partial write %q", rec.Body.String(), partial)
+	// Exact body: the handler's partial bytes followed by the appended error
+	// JSON. This documents the real (imperfect) wire output on this rare path.
+	if want := partial + internalErrorBody; rec.Body.String() != want {
+		t.Errorf("body = %q, want %q (partial bytes with the error body appended)", rec.Body.String(), want)
 	}
 	// The panic is still recovered (process keeps running) and logged.
 	if buf.Len() == 0 {

--- a/internal/observability/recovery/recovery.go
+++ b/internal/observability/recovery/recovery.go
@@ -12,20 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package recovery is the home for panic-recovery in the request path.
-// Skeleton (SOL-151278): only the capability gate exists today; the recovery
-// middleware that traps a panicking handler and converts it to a clean error
-// lands in a later story. The v1 default is ON (door-closing policy).
+// Package recovery provides panic recovery for the request path. It exposes
+// the Enabled capability gate (OBS_PANIC_RECOVERY_ENABLED) and HTTPMiddleware,
+// the whole-mux recover() wrapper that traps a panicking HTTP handler and
+// converts it to a clean 500 (SOL-151286). The v1 default is ON (door-closing
+// policy). The tool-handler goroutine is recovered separately by withRecovery
+// in internal/tools, gated by the same flag (SOL-151287).
 //
 // The package is named recovery (not recover) so it does not shadow the Go
-// builtin recover(), which the panic-recovery middleware will need.
+// builtin recover(), which HTTPMiddleware uses.
 package recovery
 
 import "github.com/SolaceDev/solace-broker-mcp/internal/config"
 
 // Enabled reports whether panic recovery is turned on, reading the
-// OBS_PANIC_RECOVERY_ENABLED flag off the observability config. Later wiring
-// consults this before installing the recovery middleware.
+// OBS_PANIC_RECOVERY_ENABLED flag off the observability config. main() consults
+// it before installing HTTPMiddleware and before gating the tool-path wrapper.
 func Enabled(cfg config.ObservabilityConfig) bool {
 	return cfg.PanicRecoveryEnabled
 }

--- a/internal/tools/manager.go
+++ b/internal/tools/manager.go
@@ -112,12 +112,17 @@ func (m *ToolManager) CallTool(ctx context.Context, name string, params map[stri
 	var toolErr error
 
 	defer func() {
-		// Panic detection: this defer runs during unwinding, before the
-		// recover in withRecovery fires. Every error return below sets
-		// toolErr and the success return sets result, so both still being
-		// nil means the handler panicked — audit it as an error, never as a
-		// success (SOL-150685). Invariant for new return paths: set toolErr,
-		// or return a non-nil result.
+		// Panic detection: this defer runs during unwinding, before any
+		// recover further up the stack. When panic recovery is enabled
+		// (OBS_PANIC_RECOVERY_ENABLED, the default) withRecovery's recover
+		// fires AFTER this defer and turns the panic into a sanitized result;
+		// when it is disabled withRecovery installs no recover and the panic
+		// keeps propagating past this point. Either way this defer runs first,
+		// during unwinding. Every error return below sets toolErr and the
+		// success return sets result, so both still being nil means the
+		// handler panicked — audit it as an error, never as a success
+		// (SOL-150685). Invariant for new return paths: set toolErr, or return
+		// a non-nil result.
 		if toolErr == nil && result == nil {
 			errorType = "panic"
 			toolErr = panicError{}
@@ -228,7 +233,9 @@ func (m *ToolManager) CallTool(ctx context.Context, name string, params map[stri
 // panicError is the sentinel toolErr recorded when an invocation ends in a
 // recovered panic. logToolResult logs unaudited errors type-only, so the
 // audit line shows this type plus error_type=panic; the panic value itself
-// is never logged (withRecovery logs its Go type and the stack separately).
+// is never logged (when panic recovery is enabled, withRecovery logs its Go
+// type and the stack separately; when disabled, withRecovery installs no
+// recover and the panic propagates uncaught after this audit line is emitted).
 type panicError struct{}
 
 func (panicError) Error() string { return "tool handler panicked" }

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -40,10 +40,35 @@ const serverInternalErrorMessage = "The server encountered an internal error exe
 // with no recover() — net/http's per-connection recovery cannot catch a
 // panic on another goroutine — so without this wrapper a single panicking
 // handler takes down the whole server (SOL-150685).
-func withRecovery(toolName string, h mcp.ToolHandler) mcp.ToolHandler {
+//
+// The panicRecoveryEnabled gate is the OBS_PANIC_RECOVERY_ENABLED capability
+// (SOL-151287, Decision A). One flag governs BOTH this tool path and the HTTP
+// path's recovery.HTTPMiddleware (Story 12) — there are no per-tool
+// sub-switches.
+//   - Enabled (the v1 default): the wrapper installs recover() and a panic
+//     becomes the sanitized IsError result below. This preserves the
+//     SOL-150685 safety fix.
+//   - Disabled: the handler is returned unchanged — no recover() is installed,
+//     so a panic propagates and crashes the process, reintroducing the
+//     pre-SOL-150685 behaviour. This is the deliberate, documented dev/debug
+//     affordance for capturing the real crash stack; it is not how a
+//     production deployment should run.
+//
+// Scope: recover() catches only panics on its OWN goroutine. Any background
+// goroutine added later (e.g. the OTel batch-exporter wrapper or periodic
+// self-stats emitter in the future tracing stories) must install its own
+// goroutine-local recover — this wrapper does not and cannot cover them.
+func withRecovery(toolName string, panicRecoveryEnabled bool, h mcp.ToolHandler) mcp.ToolHandler {
+	if !panicRecoveryEnabled {
+		// Gate OFF: return the handler verbatim. A panic propagates uncaught
+		// (dev/debug only — see the doc comment above).
+		return h
+	}
 	return func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
 		defer func() {
 			if r := recover(); r != nil {
+				// TODO(Story 15 metrics): count recovered tool-path panics once
+				// the metrics registry lands. No counter infra exists today.
 				// Log only the panic value's Go type, never its text: panic
 				// values are unaudited and can carry arbitrary strings (the
 				// same rule logToolResult applies to non-broker errors). The
@@ -77,7 +102,11 @@ func withRecovery(toolName string, h mcp.ToolHandler) mcp.ToolHandler {
 // This function is the only translation boundary between our internal Metadata
 // type and the SDK's mcp.Tool. Handlers and the manager work in our own
 // vocabulary; this is where it crosses over to the SDK.
-func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerPool, enableWriteTools bool) {
+// panicRecoveryEnabled threads the OBS_PANIC_RECOVERY_ENABLED capability from
+// main() (computed there via recovery.Enabled, so this package takes no
+// dependency on internal/observability/recovery). It is passed to withRecovery
+// for every tool handler; see withRecovery for the ON/OFF semantics.
+func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerPool, enableWriteTools bool, panicRecoveryEnabled bool) {
 	type registration struct {
 		name    string
 		handler ToolHandler
@@ -110,7 +139,7 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 
 		mcpTool := toMCPTool(reg.meta, pool)
 
-		server.AddTool(mcpTool, withRecovery(reg.name, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		server.AddTool(mcpTool, withRecovery(reg.name, panicRecoveryEnabled, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var params map[string]any
 			if err := json.Unmarshal(req.Params.Arguments, &params); err != nil {
 				return nil, fmt.Errorf("parsing tool arguments: %w", err)
@@ -164,7 +193,10 @@ func toMCPAnnotations(a Annotations) *mcp.ToolAnnotations {
 // RegisterListBrokers registers a list-brokers discovery tool that returns all
 // configured broker aliases. This is a standalone tool, not a ToolHandler
 // implementation — it does not call SEMP or require broker resolution.
-func RegisterListBrokers(server *mcp.Server, pool *semp.BrokerPool) {
+// The panicRecoveryEnabled gate shares the single OBS_PANIC_RECOVERY_ENABLED
+// flag with RegisterWithServer and the HTTP middleware; list-brokers is wrapped
+// by withRecovery too. See withRecovery for the ON/OFF semantics.
+func RegisterListBrokers(server *mcp.Server, pool *semp.BrokerPool, panicRecoveryEnabled bool) {
 	server.AddTool(
 		&mcp.Tool{
 			Name:        "list-brokers",
@@ -187,7 +219,7 @@ func RegisterListBrokers(server *mcp.Server, pool *semp.BrokerPool) {
 				ReadOnlyHint: true,
 			},
 		},
-		withRecovery("list-brokers", func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
+		withRecovery("list-brokers", panicRecoveryEnabled, func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
 			// This handler does not flow through ToolManager.CallTool, so it
 			// emits the "tool invoked" audit line itself — every tool
 			// invocation must reach the audit surface (no broker attr: this

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -110,7 +110,7 @@ func TestRegisterWithServer(t *testing.T) {
 	mgr.Register(newStubHandler("test-tool"))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true)
+	RegisterWithServer(mgr, server, pool, true, true)
 
 	// No panic = tools registered successfully. The MCP SDK doesn't expose
 	// a way to list registered tools directly, so we verify by checking
@@ -164,7 +164,7 @@ func TestRegisterWithServer_WriteGated(t *testing.T) {
 			mgr.Register(destructiveWrite)
 
 			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-			RegisterWithServer(mgr, server, pool, enableWriteTools)
+			RegisterWithServer(mgr, server, pool, enableWriteTools, true)
 			// No panic; gate behavior verified at integration layer via tools/list.
 		})
 	}
@@ -174,8 +174,123 @@ func TestRegisterListBrokers(t *testing.T) {
 	pool := newRegTestPool(t)
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
 
-	RegisterListBrokers(server, pool)
+	RegisterListBrokers(server, pool, true)
 	// No panic = registered successfully.
+}
+
+// panicHandler returns an mcp.ToolHandler that always panics with the given
+// value. Used to drive both branches of the withRecovery gate.
+func panicHandler(v any) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		panic(v)
+	}
+}
+
+// TestWithRecovery_EnabledRecovers covers SOL-151287 Decision A with the
+// OBS_PANIC_RECOVERY_ENABLED gate ON (the default): withRecovery must trap the
+// panic and return a sanitized IsError result rather than letting it escape.
+// The input domain is swept across panic value types — string, int, struct,
+// error, and nil-pointer-deref-shaped — because the recover path formats the
+// value's Go type and must not assume a string.
+func TestWithRecovery_EnabledRecovers(t *testing.T) {
+	type customPanic struct{ Code int }
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{"string value", "boom"},
+		{"int value", 42},
+		{"struct value", customPanic{Code: 7}},
+		{"error value", fmt.Errorf("wrapped boom")},
+		{"runtime error", nil}, // handled specially below: a genuine nil dereference
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			oldLogger := slog.Default()
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+			defer slog.SetDefault(oldLogger)
+
+			var h mcp.ToolHandler
+			if tc.name == "runtime error" {
+				h = func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					var p *int
+					_ = *p // genuine nil dereference -> runtime.Error panic
+					return nil, nil
+				}
+			} else {
+				h = panicHandler(tc.value)
+			}
+
+			wrapped := withRecovery("panic-tool", true, h)
+
+			result, err := wrapped(context.Background(), &mcp.CallToolRequest{})
+			if err != nil {
+				t.Fatalf("withRecovery(enabled) returned err=%v, want nil (panic must become a result)", err)
+			}
+			if result == nil || !result.IsError {
+				t.Fatalf("withRecovery(enabled) result = %v, want non-nil IsError result", result)
+			}
+			if got := result.StructuredContent.(map[string]any)["error"]; got != serverInternalErrorMessage {
+				t.Errorf("sanitized error = %v, want %q", got, serverInternalErrorMessage)
+			}
+			// The panic was logged at ERROR with the value's Go type, never its text.
+			if !containsStr(logBuf.String(), "tool handler panicked") {
+				t.Errorf("expected panic log line; got: %s", logBuf.String())
+			}
+			if containsStr(logBuf.String(), "boom") || containsStr(logBuf.String(), "wrapped boom") {
+				t.Errorf("raw panic value leaked into logs: %s", logBuf.String())
+			}
+		})
+	}
+}
+
+// TestWithRecovery_DisabledPropagates covers Decision A with the gate OFF: the
+// wrapper must return the handler unchanged so a panic propagates, reintroducing
+// the pre-SOL-150685 crash. This is the documented dev/debug affordance for
+// obtaining the real crash stack. The deferred recover() here is the test's own
+// safety net asserting the panic escaped withRecovery.
+func TestWithRecovery_DisabledPropagates(t *testing.T) {
+	wrapped := withRecovery("panic-tool", false, panicHandler("boom"))
+
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("withRecovery(disabled) swallowed the panic; want propagation")
+			}
+			if r != "boom" {
+				t.Errorf("recovered value = %v, want original panic value %q", r, "boom")
+			}
+		}()
+		_, _ = wrapped(context.Background(), &mcp.CallToolRequest{})
+		t.Fatal("handler returned normally; expected panic to propagate")
+	}()
+}
+
+// TestRegisterWithServer_PanicGateOff verifies the gate threads through
+// RegisterWithServer end-to-end: with panic recovery OFF, a panicking handler's
+// panic is NOT converted to a sanitized result by our wrapper. The SDK runs the
+// handler on its own goroutine, so we assert at the wrapper level (above) and
+// here only that registration with the flag OFF is wired without our recover.
+func TestRegisterWithServer_PanicGateOff(t *testing.T) {
+	pool := newRegTestPool(t)
+	mgr := NewToolManager(pool)
+	mgr.Register(newStubHandler("test-tool"))
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	// No panic at registration with the gate OFF.
+	RegisterWithServer(mgr, server, pool, true, false)
+}
+
+// TestRegisterListBrokers_PanicGateOff verifies list-brokers registration
+// honors the gate OFF without panicking at wire time. list-brokers is wrapped
+// by withRecovery too, so it shares the single flag.
+func TestRegisterListBrokers_PanicGateOff(t *testing.T) {
+	pool := newRegTestPool(t)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	RegisterListBrokers(server, pool, false)
 }
 
 // auditLines decodes every JSON log line in buf with msg "tool invoked" for
@@ -222,7 +337,7 @@ func TestPanicAuditedAsError(t *testing.T) {
 	mgr.Register(panicking)
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true)
+	RegisterWithServer(mgr, server, pool, true, true)
 
 	ctx := context.Background()
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
@@ -273,7 +388,7 @@ func TestListBrokersEmitsAuditLog(t *testing.T) {
 
 	pool := newRegTestPool(t)
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterListBrokers(server, pool)
+	RegisterListBrokers(server, pool, true)
 
 	ctx := context.Background()
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()


### PR DESCRIPTION
## What

Gates the existing tool-path panic recovery (`withRecovery`) behind the single **`OBS_PANIC_RECOVERY_ENABLED`** flag, so one flag now governs panic recovery on **both** the HTTP path (Story 12, #120) and the tool path.

Part of the **Observability & Telemetry epic** ([SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791)). Story: [SOL-151287](https://sol-jira.atlassian.net/browse/SOL-151287).

## Why

Tool-path recovery already shipped under SOL-150685 (the SDK runs each tool handler on its own goroutine with no `recover()`, so one panicking tool would otherwise crash the process). It was unconditional. The KA decision is a single flag for both paths with no per-tool sub-switches, so this brings the tool path under that flag:

- **ON (default):** unchanged — panic recovered, sanitized `IsError` result, logged with type + stack.
- **OFF:** the wrapper is not installed and a panic propagates (reintroducing the pre-SOL-150685 crash). A deliberate dev/debug affordance to get the real crash stack. Default-ON preserves the safety fix.

## How

- `withRecovery(toolName string, panicRecoveryEnabled bool, h mcp.ToolHandler)` — when `false`, returns `h` unchanged.
- `main()` computes `recovery.Enabled(cfg.Observability)` once and threads it into `RegisterWithServer` and `RegisterListBrokers`. No `internal/tools` → `recovery` coupling.
- Fixed the now-stale `manager.go` comments so they're accurate whether the flag is on or off (the `CallTool` defer still audits `error_type=panic` during unwinding either way; the panic then either gets sanitized by `withRecovery` or propagates).

## Tests

- Flag ON: panic → sanitized `IsError` result, logged; swept across string/int/struct/error and a real nil-deref panic; raw value never leaks.
- Flag OFF: deferred `recover()` asserts the panic actually propagates (original value), not just absence of an error result.
- Both `RegisterWithServer` and `RegisterListBrokers` honor the gate; `TestPanicAuditedAsError` still confirms the manager defer records the panic.
- `make check` green (build + vet + golangci-lint + `-race`).

## Notes / scope

- **Stacked on #120** (Story 12) — base is `aross/sol-151286-http-panic-recovery`. Merge #118 → #120 → this, in order.
- **Counter deferred to Story 15** (no metrics infra yet) — `TODO` only, no fabricated API.
- **Goroutine-safety AC is forward-looking:** the OTel exporter and self-stats emitter goroutines are later tracing stories and don't exist yet. Documented the discipline (every future background goroutine installs its own `recover()`); nothing wired now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151287]: https://sol-jira.atlassian.net/browse/SOL-151287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ