### PR TITLE
SOL-151284: /readyz endpoint reflecting MCP-server readiness (decoupled from broker)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,8 +181,8 @@ func buildMux(aliases func() []string, probeBroker func(ctx context.Context, bro
 // to disable.
 //
 // Recovery wraps the WHOLE mux, so it covers every route — the standalone
-// /livez, /health, /ready probes (and future /readyz, /metrics), the catch-all
-// 404, and the authenticated /mcp chain — sitting OUTSIDE the per-route
+// /livez, /health, /ready, /readyz probes (and the future /metrics), the
+// catch-all 404, and the authenticated /mcp chain — sitting OUTSIDE the per-route
 // correlation.Middleware that main() installs only on /mcp. The two are
 // different layers and never conflict: recovery wraps the mux; correlation
 // wraps a handler inside it.
@@ -601,8 +601,12 @@ func main() {
 
 	serverErr := startServer(httpServer, cfg.TLSCertFile, cfg.TLSKeyFile)
 
-	// Startup is complete and the server is listening: flip /readyz to ready.
-	// SetInitialized is idempotent.
+	// Startup is complete and the serving goroutine has been launched:
+	// SetInitialized flips /readyz to ready. startServer only starts the
+	// goroutine; it does not confirm the listener has bound, so there is a brief
+	// window where the socket may not yet be accepting. That is acceptable for
+	// MCP-only readiness, which reflects the server's own initialization rather
+	// than listener bind state. SetInitialized is idempotent.
 	readiness.SetInitialized()
 
 	var startupErr error

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -90,7 +90,10 @@ func newSlogHandler(level slog.Level) slog.Handler {
 //
 // aliases returns the list of broker names to check.
 // probeBroker tests connectivity to a single broker; it returns nil on success.
-func buildMux(aliases func() []string, probeBroker func(ctx context.Context, broker string) error) *http.ServeMux {
+// readiness backs the /readyz endpoint, which reflects the MCP server's OWN
+// readiness and is decoupled from the broker (it consults neither aliases nor
+// probeBroker).
+func buildMux(aliases func() []string, probeBroker func(ctx context.Context, broker string) error, readiness *health.ReadinessState) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Liveness probe. /livez is the canonical liveness endpoint and returns
@@ -102,7 +105,15 @@ func buildMux(aliases func() []string, probeBroker func(ctx context.Context, bro
 	mux.Handle("/livez", health.LivezHandler())
 	mux.Handle("/health", health.HealthHandler())
 
-	// TODO(SOL-151285/SOL-151284): /ready is still a large inline handler here; it will be superseded by the MCP-server-only /readyz and moved into the health package in the readiness story.
+	// Readiness probe. /readyz reflects the MCP server's OWN readiness only
+	// (initialized, not draining, required listeners bound) and is decoupled
+	// from broker reachability (ADR-004 / ISSUE-026) — it makes no broker calls.
+	// Like /livez it is unconditional (no flag).
+	mux.Handle("/readyz", health.ReadyzHandler(readiness))
+
+	// TODO(SOL-151285 / Story 11): /readyz now exists (MCP-server-only readiness).
+	// /ready below is still the legacy broker-coupled inline handler; Story 11
+	// will alias /ready to /readyz and drop the broker dial.
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -523,7 +534,12 @@ func main() {
 	slog.Info("all tools registered")
 
 	// 8. Set up HTTP routes
-	mux := buildMux(pool.Aliases, newBrokerReachabilityProbe(cfg))
+	//
+	// readiness backs /readyz. It starts in the "starting" state; we mark it
+	// initialized once the server begins listening (below). It is decoupled from
+	// the broker and is NOT flag-gated.
+	readiness := health.NewReadinessState()
+	mux := buildMux(pool.Aliases, newBrokerReachabilityProbe(cfg), readiness)
 
 	// Create MCP handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
@@ -585,9 +601,17 @@ func main() {
 
 	serverErr := startServer(httpServer, cfg.TLSCertFile, cfg.TLSKeyFile)
 
+	// Startup is complete and the server is listening: flip /readyz to ready.
+	// SetInitialized is idempotent.
+	readiness.SetInitialized()
+
 	var startupErr error
 	select {
 	case <-done:
+		// TODO(SOL-151288 / Story 31a): call readiness.SetShuttingDown() here on
+		// SIGTERM, before httpServer.Shutdown, so /readyz reports "shutting_down"
+		// during graceful drain. The mechanism exists on ReadinessState today;
+		// wiring it to the signal is Story 31a's scope.
 		slog.Info("server shutting down", slog.String("reason", "signal"))
 	case startupErr = <-serverErr:
 		// Error already logged in startServer. Capture it so future telemetry

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -39,7 +40,9 @@ func testMux() *http.ServeMux {
 		Name:    "solace-broker-mcp",
 		Version: version.Version(),
 	}, nil)
-	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil })
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, readiness)
 
 	// Register /mcp endpoint for testing (without auth middleware)
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
@@ -379,7 +382,7 @@ func TestHealthConfigFromFile_PartialTLSIsHTTP(t *testing.T) {
 }
 
 func TestReady_POST_ReturnsMethodNotAllowed(t *testing.T) {
-	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil })
+	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, health.NewReadinessState())
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/ready", nil)
 	rec := httptest.NewRecorder()
 
@@ -395,6 +398,7 @@ func TestReady_GET_AllBrokersReachable(t *testing.T) {
 	mux := buildMux(
 		func() []string { return brokers },
 		func(_ context.Context, _ string) error { return nil },
+		health.NewReadinessState(),
 	)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
 	rec := httptest.NewRecorder()
@@ -437,6 +441,7 @@ func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
 			}
 			return nil
 		},
+		health.NewReadinessState(),
 	)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
 	rec := httptest.NewRecorder()
@@ -462,6 +467,76 @@ func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
 	want := "prod-2: unreachable"
 	if body.Errors[0] != want {
 		t.Errorf("errors[0] = %q, want %q", body.Errors[0], want)
+	}
+}
+
+// TestReadyz_BeforeInit_Returns503 pins that /readyz wired through the real
+// buildMux returns 503 {"status":"starting"} before SetInitialized.
+func TestReadyz_BeforeInit_Returns503(t *testing.T) {
+	readiness := health.NewReadinessState() // not initialized
+	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, readiness)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("GET /readyz status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if rec.Body.String() != `{"status":"starting"}` {
+		t.Errorf("GET /readyz body = %q, want %q", rec.Body.String(), `{"status":"starting"}`)
+	}
+}
+
+// TestReadyz_AfterInit_Returns200 pins that /readyz wired through the real
+// buildMux returns 200 {"status":"ready"} once SetInitialized has been called.
+func TestReadyz_AfterInit_Returns200(t *testing.T) {
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, readiness)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /readyz status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != `{"status":"ready"}` {
+		t.Errorf("GET /readyz body = %q, want %q", rec.Body.String(), `{"status":"ready"}`)
+	}
+}
+
+// TestReadyz_BrokerUnreachable_StillReady proves AC #4 through the real mux:
+// even when the broker probe always errors (every broker unreachable), /readyz
+// returns 200 once initialized and not draining, because readiness is decoupled
+// from broker reachability. The same mux's /ready endpoint returns 503 for the
+// same unreachable broker, demonstrating the two endpoints are independent.
+func TestReadyz_BrokerUnreachable_StillReady(t *testing.T) {
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+	alwaysFail := func(_ context.Context, broker string) error {
+		return errors.New("connection refused")
+	}
+	mux := buildMux(func() []string { return []string{"prod-1"} }, alwaysFail, readiness)
+
+	// /readyz ignores the broker entirely → 200 ready.
+	readyzReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+	readyzRec := httptest.NewRecorder()
+	mux.ServeHTTP(readyzRec, readyzReq)
+	if readyzRec.Code != http.StatusOK {
+		t.Errorf("GET /readyz status = %d, want %d (readiness must not depend on broker reachability)", readyzRec.Code, http.StatusOK)
+	}
+	if readyzRec.Body.String() != `{"status":"ready"}` {
+		t.Errorf("GET /readyz body = %q, want %q", readyzRec.Body.String(), `{"status":"ready"}`)
+	}
+
+	// /ready (legacy, broker-coupled) reflects the unreachable broker → 503.
+	readyReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
+	readyRec := httptest.NewRecorder()
+	mux.ServeHTTP(readyRec, readyReq)
+	if readyRec.Code != http.StatusServiceUnavailable {
+		t.Errorf("GET /ready status = %d, want %d (legacy probe is broker-coupled)", readyRec.Code, http.StatusServiceUnavailable)
 	}
 }
 

--- a/cmd/server/panic_recovery_test.go
+++ b/cmd/server/panic_recovery_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
 )
 
 // obsConfig builds an ObservabilityConfig with the correlation flag this story
@@ -46,7 +47,7 @@ func get(handler http.Handler, path string) *httptest.ResponseRecorder {
 // shared buildMux keeps the probe routes identical to production, so the test
 // proves they still resolve through the recovery wrapper.
 func muxWithPanicRoute() *http.ServeMux {
-	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil })
+	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil }, health.NewReadinessState())
 	mux.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
 		panic("boom from a route inside the mux")
 	})
@@ -107,7 +108,7 @@ func TestChainOrder_CorrelationInsideRecovery(t *testing.T) {
 
 	// Assemble /mcp through the SAME function main() uses, so a production
 	// reorder of the route-local chain breaks this test.
-	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil })
+	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil }, health.NewReadinessState())
 	mux.Handle("/mcp", buildMCPEndpoint(authedHandler, cfg.CorrelationIDEnabled))
 	mux.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
 		panic("boom")

--- a/internal/observability/health/health.go
+++ b/internal/observability/health/health.go
@@ -19,11 +19,15 @@
 // Scope note: liveness (/livez) and readiness (/readyz) are UNCONDITIONAL by
 // design — there is no flag to disable them, and this package does NOT gate
 // them. /livez is the canonical liveness endpoint and returns
-// {"status":"alive"}; /readyz is the canonical readiness name the next story
-// implements. /health is retained for backward compatibility and preserves its
-// original {"status":"healthy"} body — it is NOT a body-identical alias of
-// /livez and is served by its own handler (HealthHandler). The single accessor
-// here, SaturationEventsEnabled, gates only the opt-in saturation-event signal
+// {"status":"alive"}. /readyz is the canonical readiness endpoint and reflects
+// the MCP server's OWN readiness only: it is built from ReadinessState
+// (initialized flag, shutting-down flag, required-listener probes) via
+// ReadyzHandler and is decoupled from broker reachability (ADR-004 /
+// ISSUE-026) — it makes no broker calls and reads no broker state. /health is
+// retained for backward compatibility and preserves its original
+// {"status":"healthy"} body — it is NOT a body-identical alias of /livez and is
+// served by its own handler (HealthHandler). The single accessor here,
+// SaturationEventsEnabled, gates only the opt-in saturation-event signal
 // layered on top of those probes. The v1 default for that signal is OFF
 // (door-closing policy).
 //

--- a/internal/observability/health/readiness.go
+++ b/internal/observability/health/readiness.go
@@ -17,6 +17,7 @@ package health
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -99,6 +100,12 @@ func (s *ReadinessState) IsShuttingDown() bool {
 // yet. The mechanism is built now so that story can register its probe without
 // re-plumbing readiness.
 func (s *ReadinessState) RegisterListener(name string, status func() error) {
+	// Fail safe on a nil probe: a nil status would panic when Evaluate calls it.
+	// Substitute a probe that always reports an error so /readyz surfaces the
+	// misconfiguration as "unready" (naming the listener) instead of crashing.
+	if status == nil {
+		status = func() error { return fmt.Errorf("listener %q has no status probe", name) }
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.listeners = append(s.listeners, listenerProbe{name: name, status: status})
@@ -121,9 +128,18 @@ func (s *ReadinessState) Evaluate() (status string, ready bool, reason string) {
 		return "starting", false, ""
 	}
 
+	// Snapshot the listener slice under the read lock, then release it before
+	// invoking any probe. Probe callbacks are arbitrary code that may call back
+	// into ReadinessState (e.g. RegisterListener, which takes the write lock);
+	// running them under the read lock could deadlock and needlessly blocks
+	// RegisterListener while probes run. The snapshot preserves registration
+	// order, so "first failing listener wins" is unchanged.
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, l := range s.listeners {
+	probes := make([]listenerProbe, len(s.listeners))
+	copy(probes, s.listeners)
+	s.mu.RUnlock()
+
+	for _, l := range probes {
 		if err := l.status(); err != nil {
 			return "unready", false, fmt.Sprintf("%s: %v", l.name, err)
 		}
@@ -182,10 +198,14 @@ func ReadyzHandler(state *ReadinessState) http.Handler {
 	})
 }
 
-// writeBody writes the response body and surfaces a write failure as a 500 the
-// same way jsonProbeHandler does, keeping the probes' error handling uniform.
+// writeBody writes the response body best-effort. The caller has already called
+// WriteHeader, so the status line and headers are committed: a write error here
+// cannot be turned into a different response. Attempting a second http.Error
+// would only append a stray body to an already-committed response. We therefore
+// log the failure at debug and return — the no-double-write convention for any
+// handler that has already committed its status.
 func writeBody(w http.ResponseWriter, body []byte) {
 	if _, err := w.Write(body); err != nil {
-		http.Error(w, "failed to write response", http.StatusInternalServerError)
+		slog.Debug("readyz: failed to write response body", slog.String("error", err.Error()))
 	}
 }

--- a/internal/observability/health/readiness.go
+++ b/internal/observability/health/readiness.go
@@ -1,0 +1,191 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// Fixed /readyz response bodies. These statuses carry no variable data, so they
+// are constant strings. The unready body is built with json.Marshal instead
+// (see ReadyzHandler) because its reason is dynamic and may contain characters
+// that require escaping.
+const (
+	readyBody        = `{"status":"ready"}`
+	startingBody     = `{"status":"starting"}`
+	shuttingDownBody = `{"status":"shutting_down"}`
+)
+
+// listenerProbe pairs a required-listener name with its status function. The
+// status function returns nil when the listener is bound and serving, or a
+// non-nil error describing why it is not ready.
+type listenerProbe struct {
+	name   string
+	status func() error
+}
+
+// ReadinessState tracks the MCP server's OWN readiness and nothing else. It is
+// deliberately decoupled from broker reachability (ADR-004 / ISSUE-026): it
+// holds no broker client, makes no broker calls, and runs no background
+// goroutine. Readiness is a function of three local facts only:
+//
+//  1. initialized   — startup completed (SetInitialized).
+//  2. shuttingDown  — graceful drain has begun (SetShuttingDown). The mechanism
+//     lives here; wiring it to SIGTERM is Story 31a (SOL-151288).
+//  3. listeners      — required-listener probes (RegisterListener) that report
+//     whether each listener is bound.
+//
+// ReadinessState is safe for concurrent use. The /readyz handler reads it under
+// load while startup and shutdown write it. initialized and shuttingDown are
+// atomic booleans; the listener slice is guarded by an RWMutex.
+type ReadinessState struct {
+	initialized  atomic.Bool
+	shuttingDown atomic.Bool
+
+	mu        sync.RWMutex
+	listeners []listenerProbe
+}
+
+// NewReadinessState returns a ReadinessState in the not-initialized,
+// not-shutting-down state with no registered listeners. In that state Evaluate
+// reports "starting".
+func NewReadinessState() *ReadinessState {
+	return &ReadinessState{}
+}
+
+// SetInitialized marks startup as complete. It is idempotent — calling it more
+// than once has no additional effect.
+func (s *ReadinessState) SetInitialized() {
+	s.initialized.Store(true)
+}
+
+// SetShuttingDown marks that graceful drain has begun. Once set, Evaluate
+// reports "shutting_down" regardless of initialization or listener state, so an
+// orchestrator stops routing new traffic to this instance. This is the
+// mechanism only; it is intentionally NOT wired to SIGTERM here (see Story 31a
+// / SOL-151288).
+func (s *ReadinessState) SetShuttingDown() {
+	s.shuttingDown.Store(true)
+}
+
+// IsShuttingDown reports whether graceful drain has begun.
+func (s *ReadinessState) IsShuttingDown() bool {
+	return s.shuttingDown.Load()
+}
+
+// RegisterListener registers a required-listener probe. status must return nil
+// when the listener is bound and serving, or a non-nil error describing why it
+// is not. Once initialized and not draining, /readyz is unready while any
+// registered probe returns an error.
+//
+// This is forward-looking: no listener is registered today. The only planned
+// required listener is the /metrics listener (Story 15), which does not exist
+// yet. The mechanism is built now so that story can register its probe without
+// re-plumbing readiness.
+func (s *ReadinessState) RegisterListener(name string, status func() error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listeners = append(s.listeners, listenerProbe{name: name, status: status})
+}
+
+// Evaluate computes the current readiness verdict. Decision order:
+//
+//  1. shutting down  → ("shutting_down", false, "")   — takes precedence.
+//  2. not initialized → ("starting", false, "")
+//  3. first listener whose status() != nil → ("unready", false, "<name>: <err>")
+//  4. otherwise       → ("ready", true, "")
+//
+// The shutting-down check is first by design: a draining instance must report
+// not-ready even if it is fully initialized with all listeners bound.
+func (s *ReadinessState) Evaluate() (status string, ready bool, reason string) {
+	if s.IsShuttingDown() {
+		return "shutting_down", false, ""
+	}
+	if !s.initialized.Load() {
+		return "starting", false, ""
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, l := range s.listeners {
+		if err := l.status(); err != nil {
+			return "unready", false, fmt.Sprintf("%s: %v", l.name, err)
+		}
+	}
+	return "ready", true, ""
+}
+
+// ReadyzHandler returns the unconditional /readyz handler reflecting the MCP
+// server's OWN readiness. It is UNCONDITIONAL by design — there is no flag to
+// disable it (no OBS_READYZ_STRICT_ENABLED). It is decoupled from the broker:
+// it is constructed solely from ReadinessState and therefore makes no broker
+// calls and reads no broker state (ADR-004 / ISSUE-026).
+//
+// GET responds with application/json and:
+//   - 200 {"status":"ready"}                       when ready
+//   - 503 {"status":"starting"}                    before SetInitialized
+//   - 503 {"status":"shutting_down"}               while draining (precedence)
+//   - 503 {"status":"unready","reason":"<...>"}    when a required listener is down
+//
+// Any non-GET method responds 405, mirroring the liveness/health probes.
+func ReadyzHandler(state *ReadinessState) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		status, ready, reason := state.Evaluate()
+		w.Header().Set("Content-Type", "application/json")
+
+		if ready {
+			w.WriteHeader(http.StatusOK)
+			writeBody(w, []byte(readyBody))
+			return
+		}
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+		switch status {
+		case "starting":
+			writeBody(w, []byte(startingBody))
+		case "shutting_down":
+			writeBody(w, []byte(shuttingDownBody))
+		default: // "unready" — reason is dynamic, so encode it safely.
+			body, err := json.Marshal(struct {
+				Status string `json:"status"`
+				Reason string `json:"reason"`
+			}{Status: "unready", Reason: reason})
+			if err != nil {
+				// reason is a plain string, so marshalling cannot realistically
+				// fail; fall back to a reason-less body rather than emitting
+				// malformed JSON.
+				body = []byte(`{"status":"unready"}`)
+			}
+			writeBody(w, body)
+		}
+	})
+}
+
+// writeBody writes the response body and surfaces a write failure as a 500 the
+// same way jsonProbeHandler does, keeping the probes' error handling uniform.
+func writeBody(w http.ResponseWriter, body []byte) {
+	if _, err := w.Write(body); err != nil {
+		http.Error(w, "failed to write response", http.StatusInternalServerError)
+	}
+}

--- a/internal/observability/health/readiness_test.go
+++ b/internal/observability/health/readiness_test.go
@@ -176,19 +176,68 @@ func TestReadinessState_Concurrent(t *testing.T) {
 	wg.Wait()
 }
 
-// TestReadyzHandler_StatusMatrix pins the full /readyz status/body matrix:
-// starting (503), ready (200), shutting_down precedence (503), unready with
-// reason (503), and non-GET (405).
+// TestReadinessState_ProbeRunsOutsideLock proves Evaluate does not hold the
+// internal RWMutex while invoking a listener probe. The probe calls back into
+// the same ReadinessState (RegisterListener, which takes the write lock); if
+// Evaluate still held the read lock, that re-entrant call would deadlock. The
+// test therefore deadlocks (and the package test binary times out) on a
+// regression, and passes when probes run on a snapshot taken outside the lock.
+func TestReadinessState_ProbeRunsOutsideLock(t *testing.T) {
+	t.Parallel()
+	s := NewReadinessState()
+	s.SetInitialized()
+
+	probed := make(chan struct{}, 1)
+	s.RegisterListener("reentrant", func() error {
+		// Re-enter the state while the probe runs. This needs the write lock,
+		// which would block forever if Evaluate held the read lock here.
+		s.RegisterListener("added-during-probe", func() error { return nil })
+		probed <- struct{}{}
+		return nil
+	})
+
+	status, ready, _ := s.Evaluate()
+	if status != "ready" || !ready {
+		t.Errorf("Evaluate() = (%q, %v), want (\"ready\", true)", status, ready)
+	}
+	select {
+	case <-probed:
+	default:
+		t.Fatal("probe was not invoked")
+	}
+}
+
+// TestReadinessState_NilProbeFailsSafe proves RegisterListener with a nil status
+// probe does not panic in Evaluate and instead reports unready with a reason
+// that names the misconfigured listener, surfacing the misconfiguration on
+// /readyz rather than crashing the handler.
+func TestReadinessState_NilProbeFailsSafe(t *testing.T) {
+	t.Parallel()
+	s := NewReadinessState()
+	s.SetInitialized()
+	s.RegisterListener("metrics-listener", nil)
+
+	status, ready, reason := s.Evaluate() // must not panic
+	if status != "unready" || ready {
+		t.Errorf("Evaluate() = (%q, %v), want (\"unready\", false)", status, ready)
+	}
+	if !strings.Contains(reason, "metrics-listener") {
+		t.Errorf("reason = %q, want it to name the listener", reason)
+	}
+}
+
+// TestReadyzHandler_StatusMatrix pins the fixed-body /readyz cases — those whose
+// response body is a constant string: starting (503), ready (200), and
+// shutting_down precedence (503). The dynamic-reason unready case is covered by
+// TestReadyzHandler_UnreadyReasonSafeJSON and non-GET by TestReadyzHandler_NonGET.
 func TestReadyzHandler_StatusMatrix(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		setup      func(s *ReadinessState)
-		wantCode   int
-		wantBody   string // exact body for fixed-status cases; empty when checked structurally
-		wantStatus string // expected .status field when wantBody is empty
-		reasonHas  string // expected substring of .reason when set
+		name     string
+		setup    func(s *ReadinessState)
+		wantCode int
+		wantBody string // exact response body for these fixed-status cases
 	}{
 		{
 			name:     "before init returns 503 starting",

--- a/internal/observability/health/readiness_test.go
+++ b/internal/observability/health/readiness_test.go
@@ -1,0 +1,312 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestReadinessState_Evaluate exercises the full decision domain of
+// ReadinessState.Evaluate: starting (not initialized), ready, shutting_down
+// precedence over both starting and ready, and an unready required listener.
+func TestReadinessState_Evaluate(t *testing.T) {
+	t.Parallel()
+
+	failing := func(name string) (string, func() error) {
+		return name, func() error { return errors.New("not bound") }
+	}
+	ok := func(name string) (string, func() error) {
+		return name, func() error { return nil }
+	}
+
+	tests := []struct {
+		name       string
+		setup      func(s *ReadinessState)
+		wantStatus string
+		wantReady  bool
+		// reasonHas, when non-empty, must be a substring of the returned reason.
+		reasonHas string
+	}{
+		{
+			name:       "not initialized yields starting",
+			setup:      func(_ *ReadinessState) {},
+			wantStatus: "starting",
+			wantReady:  false,
+		},
+		{
+			name:       "initialized with no listeners yields ready",
+			setup:      func(s *ReadinessState) { s.SetInitialized() },
+			wantStatus: "ready",
+			wantReady:  true,
+		},
+		{
+			name: "shutting down takes precedence over starting",
+			setup: func(s *ReadinessState) {
+				s.SetShuttingDown()
+			},
+			wantStatus: "shutting_down",
+			wantReady:  false,
+		},
+		{
+			name: "shutting down takes precedence over ready",
+			setup: func(s *ReadinessState) {
+				s.SetInitialized()
+				s.SetShuttingDown()
+			},
+			wantStatus: "shutting_down",
+			wantReady:  false,
+		},
+		{
+			name: "initialized with a failing listener yields unready naming the listener",
+			setup: func(s *ReadinessState) {
+				s.SetInitialized()
+				s.RegisterListener(failing("metrics-listener"))
+			},
+			wantStatus: "unready",
+			wantReady:  false,
+			reasonHas:  "metrics-listener",
+		},
+		{
+			name: "first failing listener wins",
+			setup: func(s *ReadinessState) {
+				s.SetInitialized()
+				s.RegisterListener(ok("first-ok"))
+				s.RegisterListener(failing("second-bad"))
+				s.RegisterListener(failing("third-bad"))
+			},
+			wantStatus: "unready",
+			wantReady:  false,
+			reasonHas:  "second-bad",
+		},
+		{
+			name: "all listeners healthy yields ready",
+			setup: func(s *ReadinessState) {
+				s.SetInitialized()
+				s.RegisterListener(ok("a"))
+				s.RegisterListener(ok("b"))
+			},
+			wantStatus: "ready",
+			wantReady:  true,
+		},
+		{
+			name: "not initialized but a failing listener still reports starting",
+			setup: func(s *ReadinessState) {
+				s.RegisterListener(failing("metrics-listener"))
+			},
+			wantStatus: "starting",
+			wantReady:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewReadinessState()
+			tt.setup(s)
+
+			gotStatus, gotReady, gotReason := s.Evaluate()
+			if gotStatus != tt.wantStatus {
+				t.Errorf("status = %q, want %q", gotStatus, tt.wantStatus)
+			}
+			if gotReady != tt.wantReady {
+				t.Errorf("ready = %v, want %v", gotReady, tt.wantReady)
+			}
+			if tt.reasonHas != "" && !strings.Contains(gotReason, tt.reasonHas) {
+				t.Errorf("reason = %q, want substring %q", gotReason, tt.reasonHas)
+			}
+		})
+	}
+}
+
+// TestReadinessState_SetInitializedIdempotent confirms SetInitialized can be
+// called repeatedly without changing the outcome.
+func TestReadinessState_SetInitializedIdempotent(t *testing.T) {
+	t.Parallel()
+	s := NewReadinessState()
+	s.SetInitialized()
+	s.SetInitialized()
+	if status, ready, _ := s.Evaluate(); status != "ready" || !ready {
+		t.Errorf("after double SetInitialized: status=%q ready=%v, want ready/true", status, ready)
+	}
+}
+
+// TestReadinessState_Concurrent exercises concurrent writers and readers under
+// -race: SetInitialized, SetShuttingDown, RegisterListener, and Evaluate run
+// simultaneously. The assertion is the absence of a data race; the final state
+// is non-deterministic by design.
+func TestReadinessState_Concurrent(t *testing.T) {
+	t.Parallel()
+	s := NewReadinessState()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	wg.Add(workers * 4)
+
+	for i := 0; i < workers; i++ {
+		go func() { defer wg.Done(); s.SetInitialized() }()
+		go func() { defer wg.Done(); s.SetShuttingDown() }()
+		go func() {
+			defer wg.Done()
+			s.RegisterListener("l", func() error { return nil })
+		}()
+		go func() {
+			defer wg.Done()
+			_, _, _ = s.Evaluate()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestReadyzHandler_StatusMatrix pins the full /readyz status/body matrix:
+// starting (503), ready (200), shutting_down precedence (503), unready with
+// reason (503), and non-GET (405).
+func TestReadyzHandler_StatusMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func(s *ReadinessState)
+		wantCode   int
+		wantBody   string // exact body for fixed-status cases; empty when checked structurally
+		wantStatus string // expected .status field when wantBody is empty
+		reasonHas  string // expected substring of .reason when set
+	}{
+		{
+			name:     "before init returns 503 starting",
+			setup:    func(_ *ReadinessState) {},
+			wantCode: http.StatusServiceUnavailable,
+			wantBody: `{"status":"starting"}`,
+		},
+		{
+			name:     "after init returns 200 ready",
+			setup:    func(s *ReadinessState) { s.SetInitialized() },
+			wantCode: http.StatusOK,
+			wantBody: `{"status":"ready"}`,
+		},
+		{
+			name: "draining returns 503 shutting_down even when initialized",
+			setup: func(s *ReadinessState) {
+				s.SetInitialized()
+				s.SetShuttingDown()
+			},
+			wantCode: http.StatusServiceUnavailable,
+			wantBody: `{"status":"shutting_down"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewReadinessState()
+			tt.setup(s)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+			ReadyzHandler(s).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantCode)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+			if got := rec.Body.String(); got != tt.wantBody {
+				t.Errorf("body = %q, want %q", got, tt.wantBody)
+			}
+		})
+	}
+}
+
+// TestReadyzHandler_UnreadyReasonSafeJSON asserts the unready body is 503,
+// valid JSON, names the failing listener, and that a listener error message
+// containing a double quote is safely encoded (not hand-concatenated).
+func TestReadyzHandler_UnreadyReasonSafeJSON(t *testing.T) {
+	t.Parallel()
+	s := NewReadinessState()
+	s.SetInitialized()
+	// Error text intentionally contains a double quote to prove safe encoding.
+	s.RegisterListener("metrics-listener", func() error {
+		return errors.New(`bind failed on "0.0.0.0:9090"`)
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+	ReadyzHandler(s).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	var body struct {
+		Status string `json:"status"`
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v (raw=%q)", err, rec.Body.String())
+	}
+	if body.Status != "unready" {
+		t.Errorf("status = %q, want %q", body.Status, "unready")
+	}
+	if !strings.Contains(body.Reason, "metrics-listener") {
+		t.Errorf("reason = %q, want it to name the listener", body.Reason)
+	}
+	if !strings.Contains(body.Reason, `"0.0.0.0:9090"`) {
+		t.Errorf("reason = %q, want the quoted error text preserved (safe encoding)", body.Reason)
+	}
+}
+
+// TestReadyzHandler_NonGET pins that any non-GET method is rejected with 405,
+// mirroring the liveness/health probes.
+func TestReadyzHandler_NonGET(t *testing.T) {
+	t.Parallel()
+	s := NewReadinessState()
+	s.SetInitialized()
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodHead} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), method, "/readyz", nil)
+		ReadyzHandler(s).ServeHTTP(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s status = %d, want %d", method, rec.Code, http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// TestReadyzHandler_NoBrokerDependency proves AC #4 structurally: ReadyzHandler
+// is constructed solely from ReadinessState — it accepts no broker client,
+// alias func, or probe func — so it cannot read broker state or make broker
+// calls. An initialized, non-draining handler returns 200 with no broker in
+// scope.
+func TestReadyzHandler_NoBrokerDependency(t *testing.T) {
+	t.Parallel()
+	s := NewReadinessState()
+	s.SetInitialized()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+	ReadyzHandler(s).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (readiness must not depend on any broker)", rec.Code, http.StatusOK)
+	}
+	if got := rec.Body.String(); got != `{"status":"ready"}` {
+		t.Errorf("body = %q, want %q", got, `{"status":"ready"}`)
+	}
+}


### PR DESCRIPTION
## What

Adds **`/readyz`** — a readiness probe that reflects the **MCP server's own readiness and nothing else**. It returns 200 `{"status":"ready"}` only when the server is initialized, not draining, and any required listeners are bound; otherwise 503 with the failing condition (`starting` / `shutting_down` / `unready`). Crucially, it makes **no broker calls and reads no broker state** — a broker being unreachable never makes the pod unready.

Part of the Observability & Telemetry epic ([SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791)). Story: [SOL-151284](https://sol-jira.atlassian.net/browse/SOL-151284). Implements the broker/MCP health-decoupling decision (ADR-004).

## Why

The old `/ready` dials every broker, so one unreachable broker ejects an otherwise-healthy pod from the K8s endpoint set — exactly the failure mode we want to avoid. `/readyz` answers the right question for traffic routing and rolling restarts: *can this MCP server serve?* Broker reachability is separate observability (a `/metrics` gauge, later story), not a readiness gate.

## How

- `health.ReadinessState` — concurrency-safe (`atomic.Bool` flags + RWMutex-guarded listener probes): `SetInitialized`, `SetShuttingDown`/`IsShuttingDown`, `RegisterListener`, and `Evaluate() → (status, ready, reason)`.
- `ReadyzHandler(state)` — GET-only; checks shutting-down first, then initialized, then listeners; the dynamic `unready` reason is JSON-encoded via `json.Marshal` (never string-concatenated).
- Wired in `main()`: `/readyz` registered in `buildMux`; `SetInitialized()` called once startup completes.
- Unconditional — no `OBS_READYZ_STRICT_ENABLED` flag.

## Scope boundaries (deliberate)

- The **SIGTERM → `SetShuttingDown()` wiring is Story 31a's** (SOL-151288); this PR ships the mechanism + a TODO at the signal site, not the flip.
- **No listener is registered today** — the only planned one is the `/metrics` listener (metrics story); the mechanism is built and tested with stubs.
- The legacy `/ready` handler is **untouched**; aliasing `/ready` → `/readyz` and repointing the k8s `readinessProbe` (currently on `/health`) are **Story 11's** (SOL-151285).

## Tests

- Status matrix (ready / starting / shutting_down / unready+reason / 405); shutting-down precedence; `-race` concurrency test; safe-JSON test with an embedded-quote reason.
- **Decoupling proof:** drives the real `buildMux` with an always-failing broker probe and asserts `/readyz` → 200 while `/ready` → 503 — on the same mux.
- `make check` green (build + vet + lint + race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151284]: https://sol-jira.atlassian.net/browse/SOL-151284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ