### PR TITLE
SOL-151281: forward correlation ID to SEMPv1/v2 broker requests

### DIFF
--- a/internal/observability/correlation/middleware.go
+++ b/internal/observability/correlation/middleware.go
@@ -24,12 +24,13 @@ import (
 	"time"
 )
 
-// Header names for inbound correlation. traceparent is the W3C Trace Context
-// header (https://www.w3.org/TR/trace-context/); X-Correlation-ID is the
-// fallback when no W3C trace is present.
+// Header names for inbound correlation, aliasing the exported header contract in
+// w3ctraceid.go so the literals live in exactly one place. traceparent is the
+// W3C Trace Context header (https://www.w3.org/TR/trace-context/);
+// X-Correlation-ID is the fallback when no W3C trace is present.
 const (
-	headerTraceparent   = "traceparent"
-	headerCorrelationID = "X-Correlation-ID"
+	headerTraceparent   = HeaderTraceparent
+	headerCorrelationID = HeaderCorrelationID
 )
 
 // maxIDLen caps the length of an accepted correlation ID. The value flows into
@@ -125,7 +126,7 @@ func traceIDFromTraceparent(h string) (string, bool) {
 		return "", false
 	}
 	version, traceID, spanID, flags := parts[0], parts[1], parts[2], parts[3]
-	if len(version) != 2 || len(traceID) != 32 || len(spanID) != 16 || len(flags) != 2 {
+	if len(version) != 2 || len(spanID) != 16 || len(flags) != 2 {
 		return "", false
 	}
 	// Version ff is reserved/invalid per the spec.
@@ -138,11 +139,12 @@ func traceIDFromTraceparent(h string) (string, bool) {
 	if version == "00" && len(parts) != 4 {
 		return "", false
 	}
-	if !isLowerHex(version) || !isLowerHex(traceID) || !isLowerHex(spanID) || !isLowerHex(flags) {
+	if !isLowerHex(version) || !isLowerHex(spanID) || !isLowerHex(flags) {
 		return "", false
 	}
-	// All-zero trace-id is invalid per the spec.
-	if traceID == "00000000000000000000000000000000" {
+	// The trace-id must be a valid W3C trace-id (32 lowercase hex, non-all-zero);
+	// the shared check enforces length, hex, and the all-zero rule in one place.
+	if !ValidTraceID(traceID) {
 		return "", false
 	}
 	return traceID, true

--- a/internal/observability/correlation/w3ctraceid.go
+++ b/internal/observability/correlation/w3ctraceid.go
@@ -1,0 +1,40 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package correlation
+
+// Exported header names — the single definition of the inbound/outbound header
+// contract. The inbound middleware reads these and the outbound correlationhdr
+// package writes them, so an ID received on one hop is forwarded under the same
+// names on the next. traceparent is the W3C Trace Context header
+// (https://www.w3.org/TR/trace-context/); X-Correlation-ID carries the
+// correlation identity for non-trace IDs and as a stable companion to traceparent.
+const (
+	HeaderTraceparent   = "traceparent"
+	HeaderCorrelationID = "X-Correlation-ID"
+)
+
+// TraceIDLen is the length in characters of a W3C trace-id: 32 lowercase hex.
+const TraceIDLen = 32
+
+// zeroTraceID is the all-zero trace-id the W3C Trace Context spec defines as invalid.
+const zeroTraceID = "00000000000000000000000000000000"
+
+// ValidTraceID reports whether s is a valid W3C trace-id: exactly TraceIDLen (32)
+// lowercase hex characters and not the all-zero value. Single shared definition used
+// by the inbound middleware (parsing a received traceparent) and the outbound
+// correlationhdr package (deciding whether to emit a traceparent), so both validate identically.
+func ValidTraceID(s string) bool {
+	return len(s) == TraceIDLen && s != zeroTraceID && isLowerHex(s)
+}

--- a/internal/semp/correlationhdr/correlationhdr.go
+++ b/internal/semp/correlationhdr/correlationhdr.go
@@ -89,14 +89,31 @@ func isTraceID(id string) bool {
 }
 
 // newSpanID returns a fresh 16-hex-char W3C span-id sourced from crypto/rand,
-// and ok=false if the (unreachable on modern Go — a failing entropy source
-// crashes the runtime internally) read fails. On !ok the caller omits the
-// traceparent entirely rather than emit a span that looks real but isn't; the
-// X-Correlation-ID header still carries the correlation ID, so cross-system
-// correlation is preserved without a fabricated span.
+// and ok=false when no valid span-id can be produced. ok=false in two cases:
+//   - the read fails (unreachable on modern Go — a failing entropy source
+//     crashes the runtime internally), and
+//   - the read succeeds but yields all-zero bytes. The all-zero span-id is
+//     invalid per W3C Trace Context, so we reject it rather than emit
+//     "0000000000000000". This is astronomically rare (1 in 2^64) but a real
+//     possibility, so we fold it into the same omit-the-traceparent path.
+//
+// On !ok the caller omits the traceparent entirely rather than emit a span that
+// looks real but isn't; the X-Correlation-ID header still carries the
+// correlation ID, so cross-system correlation is preserved without a fabricated
+// span.
 func newSpanID() (string, bool) {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
+		return "", false
+	}
+	allZero := true
+	for _, v := range b {
+		if v != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
 		return "", false
 	}
 	return hex.EncodeToString(b[:]), true

--- a/internal/semp/correlationhdr/correlationhdr.go
+++ b/internal/semp/correlationhdr/correlationhdr.go
@@ -1,0 +1,103 @@
+// Package correlationhdr attaches request-correlation headers to outbound SEMP
+// HTTP requests so a single MCP call can be traced across the MCP server's logs
+// and the broker's logs.
+//
+// It is a small leaf package imported by both the SEMPv1 and SEMPv2 clients so
+// that header spelling and formatting logic live in exactly one place. Placing
+// the logic in the parent internal/semp package would create an import cycle
+// (internal/semp imports sempv1 and sempv2; those clients would then need to
+// import internal/semp), so the shared code lives here instead. This package
+// imports only the correlation reader and the standard library; it imports
+// neither sempv1/sempv2 nor their parent, so it is cycle-safe.
+package correlationhdr
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+)
+
+// Header names attached to outbound SEMP requests. traceparent is the W3C Trace
+// Context header (https://www.w3.org/TR/trace-context/); X-Correlation-ID
+// carries the correlation identity for non-trace IDs and as a stable companion
+// to traceparent. These match the inbound header names the correlation
+// middleware reads, so an ID received on one hop is forwarded under the same
+// names on the next.
+const (
+	headerTraceparent   = "traceparent"
+	headerCorrelationID = "X-Correlation-ID"
+)
+
+// traceIDLen is the length, in characters, of a W3C trace-id (32 lowercase hex).
+const traceIDLen = 32
+
+// allZeroTraceID is the trace-id the W3C spec defines as invalid; we never emit
+// a traceparent built from it.
+const allZeroTraceID = "00000000000000000000000000000000"
+
+// Set attaches correlation headers to req based on the correlation ID stored on
+// ctx. It must be called AFTER the authenticator has run, so it cannot clobber
+// or be clobbered by auth headers.
+//
+// Behavior:
+//   - No correlation ID on ctx (correlation.From returns ""): attach nothing.
+//     This is the capability-off path — when the correlation middleware is not
+//     wired, From returns "", so gating transitively honors
+//     OBS_CORRELATION_ID_ENABLED without this package reading any config.
+//   - A 32-lowercase-hex, non-all-zero trace-id: set X-Correlation-ID to the id
+//     verbatim AND set traceparent to "00-<id>-<spanid>-01", where <spanid> is a
+//     fresh 16-hex-char value. A new child span per outbound hop is correct W3C
+//     behavior.
+//   - Any other non-empty id (UUIDv7, or an arbitrary sanitized
+//     X-Correlation-ID value): set only X-Correlation-ID to the id verbatim. We
+//     do NOT emit a traceparent, because the id is not a valid W3C trace-id and
+//     a malformed trace-id would be worse than none.
+func Set(ctx context.Context, req *http.Request) {
+	id := correlation.From(ctx)
+	if id == "" {
+		return
+	}
+
+	req.Header.Set(headerCorrelationID, id)
+
+	if isTraceID(id) {
+		if span, ok := newSpanID(); ok {
+			req.Header.Set(headerTraceparent, "00-"+id+"-"+span+"-01")
+		}
+	}
+}
+
+// isTraceID reports whether id is a valid W3C trace-id: exactly 32 lowercase
+// hex characters and not the all-zero value. This mirrors the validation the
+// correlation package applies to an inbound traceparent's trace-id segment; we
+// reimplement it here (rather than import an unexported helper) because that
+// package owns its internals and is being edited in parallel.
+func isTraceID(id string) bool {
+	if len(id) != traceIDLen || id == allZeroTraceID {
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// newSpanID returns a fresh 16-hex-char W3C span-id sourced from crypto/rand,
+// and ok=false if the (unreachable on modern Go — a failing entropy source
+// crashes the runtime internally) read fails. On !ok the caller omits the
+// traceparent entirely rather than emit a span that looks real but isn't; the
+// X-Correlation-ID header still carries the correlation ID, so cross-system
+// correlation is preserved without a fabricated span.
+func newSpanID() (string, bool) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", false
+	}
+	return hex.EncodeToString(b[:]), true
+}

--- a/internal/semp/correlationhdr/correlationhdr.go
+++ b/internal/semp/correlationhdr/correlationhdr.go
@@ -3,7 +3,10 @@
 // and the broker's logs.
 //
 // It is a small leaf package imported by both the SEMPv1 and SEMPv2 clients so
-// that header spelling and formatting logic live in exactly one place. Placing
+// that the outbound-header formatting logic lives in exactly one place. The
+// header names and the W3C trace-id validation come from the correlation
+// package (the single definition shared with the inbound middleware), so an ID
+// received on one hop is forwarded under the same names on the next. Placing
 // the logic in the parent internal/semp package would create an import cycle
 // (internal/semp imports sempv1 and sempv2; those clients would then need to
 // import internal/semp), so the shared code lives here instead. This package
@@ -20,23 +23,10 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 )
 
-// Header names attached to outbound SEMP requests. traceparent is the W3C Trace
-// Context header (https://www.w3.org/TR/trace-context/); X-Correlation-ID
-// carries the correlation identity for non-trace IDs and as a stable companion
-// to traceparent. These match the inbound header names the correlation
-// middleware reads, so an ID received on one hop is forwarded under the same
-// names on the next.
-const (
-	headerTraceparent   = "traceparent"
-	headerCorrelationID = "X-Correlation-ID"
-)
-
-// traceIDLen is the length, in characters, of a W3C trace-id (32 lowercase hex).
-const traceIDLen = 32
-
-// allZeroTraceID is the trace-id the W3C spec defines as invalid; we never emit
-// a traceparent built from it.
-const allZeroTraceID = "00000000000000000000000000000000"
+// randRead is the entropy source for span-ids. It is a package var (not a direct
+// crypto/rand.Read call) so a test can force the all-zero and error draws that
+// newSpanID must reject — draws otherwise unreachable (~1 in 2^64). Production never reassigns it.
+var randRead = rand.Read
 
 // Set attaches correlation headers to req based on the correlation ID stored on
 // ctx. It must be called AFTER the authenticator has run, so it cannot clobber
@@ -61,31 +51,13 @@ func Set(ctx context.Context, req *http.Request) {
 		return
 	}
 
-	req.Header.Set(headerCorrelationID, id)
+	req.Header.Set(correlation.HeaderCorrelationID, id)
 
-	if isTraceID(id) {
+	if correlation.ValidTraceID(id) {
 		if span, ok := newSpanID(); ok {
-			req.Header.Set(headerTraceparent, "00-"+id+"-"+span+"-01")
+			req.Header.Set(correlation.HeaderTraceparent, "00-"+id+"-"+span+"-01")
 		}
 	}
-}
-
-// isTraceID reports whether id is a valid W3C trace-id: exactly 32 lowercase
-// hex characters and not the all-zero value. This mirrors the validation the
-// correlation package applies to an inbound traceparent's trace-id segment; we
-// reimplement it here (rather than import an unexported helper) because that
-// package owns its internals and is being edited in parallel.
-func isTraceID(id string) bool {
-	if len(id) != traceIDLen || id == allZeroTraceID {
-		return false
-	}
-	for i := 0; i < len(id); i++ {
-		c := id[i]
-		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
-			return false
-		}
-	}
-	return true
 }
 
 // newSpanID returns a fresh 16-hex-char W3C span-id sourced from crypto/rand,
@@ -103,7 +75,7 @@ func isTraceID(id string) bool {
 // span.
 func newSpanID() (string, bool) {
 	var b [8]byte
-	if _, err := rand.Read(b[:]); err != nil {
+	if _, err := randRead(b[:]); err != nil {
 		return "", false
 	}
 	allZero := true

--- a/internal/semp/correlationhdr/correlationhdr_test.go
+++ b/internal/semp/correlationhdr/correlationhdr_test.go
@@ -1,0 +1,129 @@
+package correlationhdr_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/correlationhdr"
+)
+
+// newReq builds a throwaway request to receive headers; the URL is irrelevant.
+func newReq(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://broker.invalid/SEMP", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	return req
+}
+
+// isLowerHexLen reports whether s is exactly n lowercase-hex chars.
+func isLowerHexLen(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSet_EmptyContext_NoHeaders pins that with no correlation ID on the
+// context (capability off / middleware not wired), neither header is attached.
+func TestSet_EmptyContext_NoHeaders(t *testing.T) {
+	req := newReq(t)
+	correlationhdr.Set(context.Background(), req)
+
+	if got := req.Header.Get("X-Correlation-ID"); got != "" {
+		t.Errorf("X-Correlation-ID = %q, want absent", got)
+	}
+	if got := req.Header.Get("traceparent"); got != "" {
+		t.Errorf("traceparent = %q, want absent", got)
+	}
+}
+
+// TestSet_TraceID_EmitsTraceparent pins that a 32-hex W3C trace-id yields both
+// X-Correlation-ID (verbatim) and a well-formed traceparent with a fresh span.
+func TestSet_TraceID_EmitsTraceparent(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	ctx := correlation.With(context.Background(), traceID)
+	req := newReq(t)
+	correlationhdr.Set(ctx, req)
+
+	if got := req.Header.Get("X-Correlation-ID"); got != traceID {
+		t.Errorf("X-Correlation-ID = %q, want %q", got, traceID)
+	}
+
+	tp := req.Header.Get("traceparent")
+	parts := strings.Split(tp, "-")
+	if len(parts) != 4 {
+		t.Fatalf("traceparent = %q, want 4 hyphen-separated fields", tp)
+	}
+	if parts[0] != "00" {
+		t.Errorf("traceparent version = %q, want 00", parts[0])
+	}
+	if parts[1] != traceID {
+		t.Errorf("traceparent trace-id = %q, want %q", parts[1], traceID)
+	}
+	if !isLowerHexLen(parts[2], 16) {
+		t.Errorf("traceparent span-id = %q, want 16 lowercase-hex chars", parts[2])
+	}
+	if parts[2] == "0000000000000000" {
+		t.Errorf("traceparent span-id is all-zero, want a fresh non-zero span")
+	}
+	if parts[3] != "01" {
+		t.Errorf("traceparent flags = %q, want 01", parts[3])
+	}
+}
+
+// TestSet_FreshSpanPerCall pins that each call mints a new span-id, matching
+// correct W3C behavior of a new child span per outbound hop.
+func TestSet_FreshSpanPerCall(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	ctx := correlation.With(context.Background(), traceID)
+
+	req1 := newReq(t)
+	correlationhdr.Set(ctx, req1)
+	req2 := newReq(t)
+	correlationhdr.Set(ctx, req2)
+
+	span1 := strings.Split(req1.Header.Get("traceparent"), "-")[2]
+	span2 := strings.Split(req2.Header.Get("traceparent"), "-")[2]
+	if span1 == span2 {
+		t.Errorf("span-ids equal across calls (%q); want a fresh span each call", span1)
+	}
+}
+
+// TestSet_NonTraceIDs_NoTraceparent pins that any ID that is not a 32-hex
+// trace-id sets only X-Correlation-ID and never emits a (malformed) traceparent.
+func TestSet_NonTraceIDs_NoTraceparent(t *testing.T) {
+	cases := map[string]string{
+		"uuidv7":         "0190f3a1-7c2e-7b3d-9f1a-2c4e6a8b0d1f",
+		"arbitrary":      "order-12345-abc",
+		"allZeroTraceID": "00000000000000000000000000000000",
+		"uppercaseHex":   "4BF92F3577B34DA6A3CE929D0E0E4736",
+		"shortHex":       "4bf92f3577b34da6a3ce929d0e0e473",   // 31 chars
+		"longHex":        "4bf92f3577b34da6a3ce929d0e0e47360", // 33 chars
+		"nonHex32":       "4bf92f3577b34da6a3ce929d0e0e473g",  // has 'g'
+	}
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := correlation.With(context.Background(), id)
+			req := newReq(t)
+			correlationhdr.Set(ctx, req)
+
+			if got := req.Header.Get("X-Correlation-ID"); got != id {
+				t.Errorf("X-Correlation-ID = %q, want %q", got, id)
+			}
+			if got := req.Header.Get("traceparent"); got != "" {
+				t.Errorf("traceparent = %q, want absent for non-trace-id %q", got, id)
+			}
+		})
+	}
+}

--- a/internal/semp/correlationhdr/correlationhdr_test.go
+++ b/internal/semp/correlationhdr/correlationhdr_test.go
@@ -100,43 +100,6 @@ func TestSet_FreshSpanPerCall(t *testing.T) {
 	}
 }
 
-// TestSet_SpanNeverAllZero pins that the minted span-id is always a valid,
-// non-all-zero W3C span-id. Set omits the traceparent on the (1-in-2^64,
-// astronomically rare) all-zero draw, so when a traceparent IS present its
-// span must be 16 lowercase-hex chars and never "0000000000000000". Many
-// iterations exercise distinct random draws so the assertion cannot pass by
-// luck of a single draw.
-func TestSet_SpanNeverAllZero(t *testing.T) {
-	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
-	ctx := correlation.With(context.Background(), traceID)
-
-	for i := 0; i < 1000; i++ {
-		req := newReq(t)
-		correlationhdr.Set(ctx, req)
-
-		// X-Correlation-ID is always emitted, independent of the span draw.
-		if got := req.Header.Get("X-Correlation-ID"); got != traceID {
-			t.Fatalf("iter %d: X-Correlation-ID = %q, want %q", i, got, traceID)
-		}
-
-		tp := req.Header.Get("traceparent")
-		if tp == "" {
-			// Only legitimate when the span draw was all-zero (omit path).
-			continue
-		}
-		parts := strings.Split(tp, "-")
-		if len(parts) != 4 {
-			t.Fatalf("iter %d: traceparent = %q, want 4 fields", i, tp)
-		}
-		if !isLowerHexLen(parts[2], 16) {
-			t.Fatalf("iter %d: span-id = %q, want 16 lowercase-hex chars", i, parts[2])
-		}
-		if parts[2] == "0000000000000000" {
-			t.Fatalf("iter %d: span-id is all-zero; W3C-invalid span must never be emitted", i)
-		}
-	}
-}
-
 // TestSet_NonTraceIDs_NoTraceparent pins that any ID that is not a 32-hex
 // trace-id sets only X-Correlation-ID and never emits a (malformed) traceparent.
 func TestSet_NonTraceIDs_NoTraceparent(t *testing.T) {

--- a/internal/semp/correlationhdr/correlationhdr_test.go
+++ b/internal/semp/correlationhdr/correlationhdr_test.go
@@ -100,6 +100,43 @@ func TestSet_FreshSpanPerCall(t *testing.T) {
 	}
 }
 
+// TestSet_SpanNeverAllZero pins that the minted span-id is always a valid,
+// non-all-zero W3C span-id. Set omits the traceparent on the (1-in-2^64,
+// astronomically rare) all-zero draw, so when a traceparent IS present its
+// span must be 16 lowercase-hex chars and never "0000000000000000". Many
+// iterations exercise distinct random draws so the assertion cannot pass by
+// luck of a single draw.
+func TestSet_SpanNeverAllZero(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	ctx := correlation.With(context.Background(), traceID)
+
+	for i := 0; i < 1000; i++ {
+		req := newReq(t)
+		correlationhdr.Set(ctx, req)
+
+		// X-Correlation-ID is always emitted, independent of the span draw.
+		if got := req.Header.Get("X-Correlation-ID"); got != traceID {
+			t.Fatalf("iter %d: X-Correlation-ID = %q, want %q", i, got, traceID)
+		}
+
+		tp := req.Header.Get("traceparent")
+		if tp == "" {
+			// Only legitimate when the span draw was all-zero (omit path).
+			continue
+		}
+		parts := strings.Split(tp, "-")
+		if len(parts) != 4 {
+			t.Fatalf("iter %d: traceparent = %q, want 4 fields", i, tp)
+		}
+		if !isLowerHexLen(parts[2], 16) {
+			t.Fatalf("iter %d: span-id = %q, want 16 lowercase-hex chars", i, parts[2])
+		}
+		if parts[2] == "0000000000000000" {
+			t.Fatalf("iter %d: span-id is all-zero; W3C-invalid span must never be emitted", i)
+		}
+	}
+}
+
 // TestSet_NonTraceIDs_NoTraceparent pins that any ID that is not a 32-hex
 // trace-id sets only X-Correlation-ID and never emits a (malformed) traceparent.
 func TestSet_NonTraceIDs_NoTraceparent(t *testing.T) {

--- a/internal/semp/correlationhdr/span_internal_test.go
+++ b/internal/semp/correlationhdr/span_internal_test.go
@@ -1,0 +1,67 @@
+package correlationhdr
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+)
+
+// newReqInternal builds a throwaway request to receive headers; the URL is
+// irrelevant. The black-box test file has its own newReq helper; this internal
+// test file (package correlationhdr) needs its own copy.
+func newReqInternal(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://broker.invalid/SEMP", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	return req
+}
+
+// TestSet_AllZeroSpanDraw_OmitsTraceparent forces the randRead seam to yield an
+// all-zero span-id — the W3C-invalid draw that is otherwise ~1 in 2^64 — and
+// pins that Set still emits X-Correlation-ID verbatim but omits the traceparent
+// rather than fabricating a "0000000000000000" span.
+func TestSet_AllZeroSpanDraw_OmitsTraceparent(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	orig := randRead
+	t.Cleanup(func() { randRead = orig })
+	// Leave b untouched (zero-valued) and report success, so newSpanID sees an
+	// all-zero draw.
+	randRead = func(b []byte) (int, error) { return len(b), nil }
+
+	ctx := correlation.With(context.Background(), traceID)
+	req := newReqInternal(t)
+	Set(ctx, req)
+
+	if got := req.Header.Get(correlation.HeaderCorrelationID); got != traceID {
+		t.Errorf("X-Correlation-ID = %q, want %q", got, traceID)
+	}
+	if got := req.Header.Get(correlation.HeaderTraceparent); got != "" {
+		t.Errorf("traceparent = %q, want absent on all-zero span draw", got)
+	}
+}
+
+// TestSet_RandReadError_OmitsTraceparent forces the randRead seam to return an
+// error — unreachable in production on modern Go — and pins that Set still emits
+// X-Correlation-ID verbatim but omits the traceparent.
+func TestSet_RandReadError_OmitsTraceparent(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	orig := randRead
+	t.Cleanup(func() { randRead = orig })
+	randRead = func(b []byte) (int, error) { return 0, errors.New("forced entropy failure") }
+
+	ctx := correlation.With(context.Background(), traceID)
+	req := newReqInternal(t)
+	Set(ctx, req)
+
+	if got := req.Header.Get(correlation.HeaderCorrelationID); got != traceID {
+		t.Errorf("X-Correlation-ID = %q, want %q", got, traceID)
+	}
+	if got := req.Header.Get(correlation.HeaderTraceparent); got != "" {
+		t.Errorf("traceparent = %q, want absent on randRead error", got)
+	}
+}

--- a/internal/semp/sempv1/client.go
+++ b/internal/semp/sempv1/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/correlationhdr"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 )
@@ -177,6 +178,11 @@ func (c *HTTPClient) Execute(ctx context.Context, xml string) (*Result, error) {
 	if err := c.authenticator.AddAuth(ctx, req); err != nil {
 		return nil, fmt.Errorf("applying SEMPv1 auth: %w", err)
 	}
+
+	// Forward the request-correlation ID (if any) as outbound headers, strictly
+	// after auth so it cannot clobber or be clobbered by auth headers. No-op
+	// when correlation is off (From(ctx) == "").
+	correlationhdr.Set(ctx, req)
 
 	// Attach operation ID for the Sender's logging context.
 	ctx = context.WithValue(ctx, resilience.OperationIDKey{}, "SEMPv1")

--- a/internal/semp/sempv1/correlation_test.go
+++ b/internal/semp/sempv1/correlation_test.go
@@ -38,21 +38,22 @@ func newTestClientWithRetries(t *testing.T, srv *httptest.Server, maxRetries int
 	return client
 }
 
-// captureHeaders returns a handler that records the headers of every inbound
-// request (one entry per attempt) and replies with a successful SEMPv1
-// envelope. The returned slice is guarded by mu for the retry test.
-func captureSEMPv1(t *testing.T) (http.HandlerFunc, *[]http.Header, *sync.Mutex) {
+// captureSEMPv1 returns a handler that records the headers of each inbound
+// request and replies with a successful SEMPv1 envelope. Captured headers are
+// delivered over a buffered channel: the handler runs on the httptest server
+// goroutine and the test reads from the test goroutine, so the channel's
+// send-before-receive ordering establishes the happens-before edge that makes
+// the cross-goroutine read race-free. The buffer (size 4) lets the handler
+// return without blocking on the rare extra request.
+func captureSEMPv1(t *testing.T) (http.HandlerFunc, chan http.Header) {
 	t.Helper()
-	var mu sync.Mutex
-	var seen []http.Header
+	captured := make(chan http.Header, 4)
 	h := func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		seen = append(seen, r.Header.Clone())
-		mu.Unlock()
+		captured <- r.Header.Clone()
 		w.Header().Set("Content-Type", "application/xml")
 		_, _ = w.Write([]byte(successEnvelope))
 	}
-	return h, &seen, &mu
+	return h, captured
 }
 
 // TestExecute_CorrelationHeaders_TraceID verifies that a 32-hex trace-id on the
@@ -60,7 +61,7 @@ func captureSEMPv1(t *testing.T) (http.HandlerFunc, *[]http.Header, *sync.Mutex)
 // traceparent, and that auth headers survive alongside them.
 func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
 	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
-	h, seen, _ := captureSEMPv1(t)
+	h, captured := captureSEMPv1(t)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 	client := newTestClient(t, srv)
@@ -71,10 +72,7 @@ func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 
-	if len(*seen) != 1 {
-		t.Fatalf("got %d requests, want 1", len(*seen))
-	}
-	hdr := (*seen)[0]
+	hdr := <-captured
 	if got := hdr.Get("X-Correlation-ID"); got != traceID {
 		t.Errorf("X-Correlation-ID = %q, want %q", got, traceID)
 	}
@@ -91,7 +89,7 @@ func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
 // TestExecute_CorrelationHeaders_Empty verifies that with no correlation ID on
 // the context, neither correlation header is attached.
 func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
-	h, seen, _ := captureSEMPv1(t)
+	h, captured := captureSEMPv1(t)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 	client := newTestClient(t, srv)
@@ -100,7 +98,7 @@ func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
 	if _, err := client.Execute(context.Background(), "<rpc><show><version/></show></rpc>"); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	hdr := (*seen)[0]
+	hdr := <-captured
 	if got := hdr.Get("X-Correlation-ID"); got != "" {
 		t.Errorf("X-Correlation-ID = %q, want absent", got)
 	}
@@ -113,7 +111,7 @@ func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
 // sets only X-Correlation-ID, never a traceparent.
 func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
 	const id = "0190f3a1-7c2e-7b3d-9f1a-2c4e6a8b0d1f"
-	h, seen, _ := captureSEMPv1(t)
+	h, captured := captureSEMPv1(t)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 	client := newTestClient(t, srv)
@@ -123,7 +121,7 @@ func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
 	if _, err := client.Execute(ctx, "<rpc><show><version/></show></rpc>"); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	hdr := (*seen)[0]
+	hdr := <-captured
 	if got := hdr.Get("X-Correlation-ID"); got != id {
 		t.Errorf("X-Correlation-ID = %q, want %q", got, id)
 	}

--- a/internal/semp/sempv1/correlation_test.go
+++ b/internal/semp/sempv1/correlation_test.go
@@ -130,10 +130,15 @@ func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
 	}
 }
 
-// TestExecute_CorrelationHeaders_RetryReuse verifies that every retry attempt
-// carries the SAME X-Correlation-ID. The server fails the first attempts with
-// 503 (retryable for a read-only <show>) then succeeds.
-func TestExecute_CorrelationHeaders_RetryReuse(t *testing.T) {
+// TestExecute_CorrelationHeaders_PresentOnEveryRetryAttempt verifies the
+// forwarded X-Correlation-ID is present and identical on every attempt the
+// broker sees. The server fails the first attempt with 503 (retryable for a
+// read-only <show>) then succeeds, so the handler observes more than one
+// attempt. Cross-retry survival is provided by retryablehttp replaying the same
+// *http.Request object, not by per-attempt application logic; the basic
+// single-attempt forwarding contract is covered by the other
+// TestExecute_CorrelationHeaders_* tests.
+func TestExecute_CorrelationHeaders_PresentOnEveryRetryAttempt(t *testing.T) {
 	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
 	var mu sync.Mutex
 	var seen []http.Header

--- a/internal/semp/sempv1/correlation_test.go
+++ b/internal/semp/sempv1/correlation_test.go
@@ -1,0 +1,177 @@
+package sempv1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
+)
+
+// newTestClientWithRetries builds a client whose Sender allows up to maxRetries
+// retries, so the retry-reuse test can drive multiple attempts.
+func newTestClientWithRetries(t *testing.T, srv *httptest.Server, maxRetries int) *HTTPClient {
+	t.Helper()
+	brokerCfg := &config.BrokerConfig{
+		URL:  srv.URL,
+		Auth: config.AuthConfig{Mode: config.AuthModeBasic},
+	}
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		RequestTimeoutDuration: 2 * time.Second,
+		Retries:                &maxRetries,
+		RequestMinInterval:     &minInterval,
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       5 * time.Millisecond,
+	}
+	client, err := NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("user", "pass"))
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	return client
+}
+
+// captureHeaders returns a handler that records the headers of every inbound
+// request (one entry per attempt) and replies with a successful SEMPv1
+// envelope. The returned slice is guarded by mu for the retry test.
+func captureSEMPv1(t *testing.T) (http.HandlerFunc, *[]http.Header, *sync.Mutex) {
+	t.Helper()
+	var mu sync.Mutex
+	var seen []http.Header
+	h := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Clone())
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(successEnvelope))
+	}
+	return h, &seen, &mu
+}
+
+// TestExecute_CorrelationHeaders_TraceID verifies that a 32-hex trace-id on the
+// context produces both X-Correlation-ID (verbatim) and a well-formed
+// traceparent, and that auth headers survive alongside them.
+func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	h, seen, _ := captureSEMPv1(t)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	client := newTestClient(t, srv)
+	defer client.Close()
+
+	ctx := correlation.With(context.Background(), traceID)
+	if _, err := client.Execute(ctx, "<rpc><show><version/></show></rpc>"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(*seen) != 1 {
+		t.Fatalf("got %d requests, want 1", len(*seen))
+	}
+	hdr := (*seen)[0]
+	if got := hdr.Get("X-Correlation-ID"); got != traceID {
+		t.Errorf("X-Correlation-ID = %q, want %q", got, traceID)
+	}
+	tp := hdr.Get("traceparent")
+	if !strings.HasPrefix(tp, "00-"+traceID+"-") || !strings.HasSuffix(tp, "-01") {
+		t.Errorf("traceparent = %q, want 00-%s-<span>-01", tp, traceID)
+	}
+	// Auth preserved: BasicAuthenticator sets Authorization.
+	if hdr.Get("Authorization") == "" {
+		t.Error("Authorization header missing; correlation headers must not displace auth")
+	}
+}
+
+// TestExecute_CorrelationHeaders_Empty verifies that with no correlation ID on
+// the context, neither correlation header is attached.
+func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
+	h, seen, _ := captureSEMPv1(t)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	client := newTestClient(t, srv)
+	defer client.Close()
+
+	if _, err := client.Execute(context.Background(), "<rpc><show><version/></show></rpc>"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	hdr := (*seen)[0]
+	if got := hdr.Get("X-Correlation-ID"); got != "" {
+		t.Errorf("X-Correlation-ID = %q, want absent", got)
+	}
+	if got := hdr.Get("traceparent"); got != "" {
+		t.Errorf("traceparent = %q, want absent", got)
+	}
+}
+
+// TestExecute_CorrelationHeaders_NonTraceID verifies a non-trace-id (UUIDv7)
+// sets only X-Correlation-ID, never a traceparent.
+func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
+	const id = "0190f3a1-7c2e-7b3d-9f1a-2c4e6a8b0d1f"
+	h, seen, _ := captureSEMPv1(t)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	client := newTestClient(t, srv)
+	defer client.Close()
+
+	ctx := correlation.With(context.Background(), id)
+	if _, err := client.Execute(ctx, "<rpc><show><version/></show></rpc>"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	hdr := (*seen)[0]
+	if got := hdr.Get("X-Correlation-ID"); got != id {
+		t.Errorf("X-Correlation-ID = %q, want %q", got, id)
+	}
+	if got := hdr.Get("traceparent"); got != "" {
+		t.Errorf("traceparent = %q, want absent for non-trace-id", got)
+	}
+}
+
+// TestExecute_CorrelationHeaders_RetryReuse verifies that every retry attempt
+// carries the SAME X-Correlation-ID. The server fails the first attempts with
+// 503 (retryable for a read-only <show>) then succeeds.
+func TestExecute_CorrelationHeaders_RetryReuse(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	var mu sync.Mutex
+	var seen []http.Header
+	attempt := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Clone())
+		attempt++
+		n := attempt
+		mu.Unlock()
+		if n < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(successEnvelope))
+	}))
+	defer srv.Close()
+
+	client := newTestClientWithRetries(t, srv, 3)
+	defer client.Close()
+
+	ctx := correlation.With(context.Background(), traceID)
+	// Use a read-only <show> so the Sender marks the request retry-safe.
+	if _, err := client.Execute(ctx, "<rpc><show><version/></show></rpc>"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) < 2 {
+		t.Fatalf("got %d attempts, want >=2 (a retry must have occurred)", len(seen))
+	}
+	for i, hdr := range seen {
+		if got := hdr.Get("X-Correlation-ID"); got != traceID {
+			t.Errorf("attempt %d X-Correlation-ID = %q, want %q", i, got, traceID)
+		}
+	}
+}

--- a/internal/semp/sempv2/client.go
+++ b/internal/semp/sempv2/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/correlationhdr"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 )
@@ -152,6 +153,11 @@ func (c *HTTPClient) Execute(ctx context.Context, op *Operation, args map[string
 	if err := c.authenticator.AddAuth(ctx, req); err != nil {
 		return nil, fmt.Errorf("applying auth for %s: %w", op.ID, err)
 	}
+
+	// Forward the request-correlation ID (if any) as outbound headers, strictly
+	// after auth so it cannot clobber or be clobbered by auth headers. No-op
+	// when correlation is off (From(ctx) == "").
+	correlationhdr.Set(ctx, req)
 
 	// Attach operation ID for the Sender's logging context.
 	ctx = context.WithValue(ctx, resilience.OperationIDKey{}, op.ID)

--- a/internal/semp/sempv2/correlation_test.go
+++ b/internal/semp/sempv2/correlation_test.go
@@ -138,10 +138,15 @@ func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
 	}
 }
 
-// TestExecute_CorrelationHeaders_RetryReuse verifies every retry attempt
-// carries the SAME X-Correlation-ID. The server 503s the first attempt (a
-// retryable status for the idempotent GET) then succeeds.
-func TestExecute_CorrelationHeaders_RetryReuse(t *testing.T) {
+// TestExecute_CorrelationHeaders_PresentOnEveryRetryAttempt verifies the
+// forwarded X-Correlation-ID is present and identical on every attempt the
+// broker sees. The server 503s the first attempt (a retryable status for the
+// idempotent GET) then succeeds, so the handler observes more than one attempt.
+// Cross-retry survival is provided by retryablehttp replaying the same
+// *http.Request object, not by per-attempt application logic; the basic
+// single-attempt forwarding contract is covered by the other
+// TestExecute_CorrelationHeaders_* tests.
+func TestExecute_CorrelationHeaders_PresentOnEveryRetryAttempt(t *testing.T) {
 	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
 	var mu sync.Mutex
 	var seen []http.Header

--- a/internal/semp/sempv2/correlation_test.go
+++ b/internal/semp/sempv2/correlation_test.go
@@ -48,9 +48,12 @@ func newTestClientRetries(t *testing.T, maxRetries int, handler http.HandlerFunc
 // traceparent, alongside the preserved auth header.
 func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
 	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
-	var captured http.Header
+	// captured is written by the httptest server goroutine and read by the test
+	// goroutine. A buffered channel hands the headers across with a clean
+	// happens-before edge (send before recv), so the read needs no extra lock.
+	captured := make(chan http.Header, 1)
 	client, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		captured = r.Header.Clone()
+		captured <- r.Header.Clone()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(okJSON))
 	})
@@ -64,14 +67,15 @@ func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 
-	if got := captured.Get("X-Correlation-ID"); got != traceID {
+	hdr := <-captured
+	if got := hdr.Get("X-Correlation-ID"); got != traceID {
 		t.Errorf("X-Correlation-ID = %q, want %q", got, traceID)
 	}
-	tp := captured.Get("traceparent")
+	tp := hdr.Get("traceparent")
 	if !strings.HasPrefix(tp, "00-"+traceID+"-") || !strings.HasSuffix(tp, "-01") {
 		t.Errorf("traceparent = %q, want 00-%s-<span>-01", tp, traceID)
 	}
-	if captured.Get("Authorization") == "" {
+	if hdr.Get("Authorization") == "" {
 		t.Error("Authorization header missing; correlation headers must not displace auth")
 	}
 }
@@ -79,9 +83,11 @@ func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
 // TestExecute_CorrelationHeaders_Empty verifies that with no correlation ID,
 // neither correlation header is attached.
 func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
-	var captured http.Header
+	// Buffered channel hands the captured headers from the server goroutine to
+	// the test goroutine with a happens-before edge, so the read is race-free.
+	captured := make(chan http.Header, 1)
 	client, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		captured = r.Header.Clone()
+		captured <- r.Header.Clone()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(okJSON))
 	})
@@ -93,10 +99,11 @@ func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
 	if _, err := client.Execute(context.Background(), op, args); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if got := captured.Get("X-Correlation-ID"); got != "" {
+	hdr := <-captured
+	if got := hdr.Get("X-Correlation-ID"); got != "" {
 		t.Errorf("X-Correlation-ID = %q, want absent", got)
 	}
-	if got := captured.Get("traceparent"); got != "" {
+	if got := hdr.Get("traceparent"); got != "" {
 		t.Errorf("traceparent = %q, want absent", got)
 	}
 }
@@ -105,9 +112,11 @@ func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
 // X-Correlation-ID and never a traceparent.
 func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
 	const id = "order-12345-abc"
-	var captured http.Header
+	// Buffered channel hands the captured headers from the server goroutine to
+	// the test goroutine with a happens-before edge, so the read is race-free.
+	captured := make(chan http.Header, 1)
 	client, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		captured = r.Header.Clone()
+		captured <- r.Header.Clone()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(okJSON))
 	})
@@ -120,10 +129,11 @@ func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
 	if _, err := client.Execute(ctx, op, args); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if got := captured.Get("X-Correlation-ID"); got != id {
+	hdr := <-captured
+	if got := hdr.Get("X-Correlation-ID"); got != id {
 		t.Errorf("X-Correlation-ID = %q, want %q", got, id)
 	}
-	if got := captured.Get("traceparent"); got != "" {
+	if got := hdr.Get("traceparent"); got != "" {
 		t.Errorf("traceparent = %q, want absent for non-trace-id", got)
 	}
 }

--- a/internal/semp/sempv2/correlation_test.go
+++ b/internal/semp/sempv2/correlation_test.go
@@ -1,0 +1,172 @@
+package sempv2_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/resilience"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
+)
+
+// okJSON is a minimal successful SEMPv2 response body.
+const okJSON = `{"data":{},"meta":{}}`
+
+// newTestClientRetries builds a client whose Sender allows up to maxRetries
+// retries, so the retry-reuse test can drive multiple attempts.
+func newTestClientRetries(t *testing.T, maxRetries int, handler http.HandlerFunc) (*sempv2.HTTPClient, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	brokerCfg := &config.BrokerConfig{
+		URL:  server.URL,
+		Auth: config.AuthConfig{Mode: "basic"},
+	}
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		RequestTimeoutDuration: 5 * time.Second,
+		Retries:                &maxRetries,
+		RequestMinInterval:     &minInterval,
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       5 * time.Millisecond,
+	}
+	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret"))
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	return client, server
+}
+
+// TestExecute_CorrelationHeaders_TraceID verifies that a 32-hex trace-id on the
+// context produces both X-Correlation-ID (verbatim) and a well-formed
+// traceparent, alongside the preserved auth header.
+func TestExecute_CorrelationHeaders_TraceID(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	var captured http.Header
+	client, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(okJSON))
+	})
+	defer srv.Close()
+	defer client.Close()
+
+	ctx := correlation.With(context.Background(), traceID)
+	op := testOp(http.MethodGet)
+	args := map[string]any{"msgVpnName": "default", "queueName": "q1"}
+	if _, err := client.Execute(ctx, op, args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := captured.Get("X-Correlation-ID"); got != traceID {
+		t.Errorf("X-Correlation-ID = %q, want %q", got, traceID)
+	}
+	tp := captured.Get("traceparent")
+	if !strings.HasPrefix(tp, "00-"+traceID+"-") || !strings.HasSuffix(tp, "-01") {
+		t.Errorf("traceparent = %q, want 00-%s-<span>-01", tp, traceID)
+	}
+	if captured.Get("Authorization") == "" {
+		t.Error("Authorization header missing; correlation headers must not displace auth")
+	}
+}
+
+// TestExecute_CorrelationHeaders_Empty verifies that with no correlation ID,
+// neither correlation header is attached.
+func TestExecute_CorrelationHeaders_Empty(t *testing.T) {
+	var captured http.Header
+	client, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(okJSON))
+	})
+	defer srv.Close()
+	defer client.Close()
+
+	op := testOp(http.MethodGet)
+	args := map[string]any{"msgVpnName": "default", "queueName": "q1"}
+	if _, err := client.Execute(context.Background(), op, args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := captured.Get("X-Correlation-ID"); got != "" {
+		t.Errorf("X-Correlation-ID = %q, want absent", got)
+	}
+	if got := captured.Get("traceparent"); got != "" {
+		t.Errorf("traceparent = %q, want absent", got)
+	}
+}
+
+// TestExecute_CorrelationHeaders_NonTraceID verifies a non-trace-id sets only
+// X-Correlation-ID and never a traceparent.
+func TestExecute_CorrelationHeaders_NonTraceID(t *testing.T) {
+	const id = "order-12345-abc"
+	var captured http.Header
+	client, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(okJSON))
+	})
+	defer srv.Close()
+	defer client.Close()
+
+	ctx := correlation.With(context.Background(), id)
+	op := testOp(http.MethodGet)
+	args := map[string]any{"msgVpnName": "default", "queueName": "q1"}
+	if _, err := client.Execute(ctx, op, args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := captured.Get("X-Correlation-ID"); got != id {
+		t.Errorf("X-Correlation-ID = %q, want %q", got, id)
+	}
+	if got := captured.Get("traceparent"); got != "" {
+		t.Errorf("traceparent = %q, want absent for non-trace-id", got)
+	}
+}
+
+// TestExecute_CorrelationHeaders_RetryReuse verifies every retry attempt
+// carries the SAME X-Correlation-ID. The server 503s the first attempt (a
+// retryable status for the idempotent GET) then succeeds.
+func TestExecute_CorrelationHeaders_RetryReuse(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	var mu sync.Mutex
+	var seen []http.Header
+	attempt := 0
+	client, srv := newTestClientRetries(t, 3, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Clone())
+		attempt++
+		n := attempt
+		mu.Unlock()
+		if n < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(okJSON))
+	})
+	defer srv.Close()
+	defer client.Close()
+
+	ctx := correlation.With(context.Background(), traceID)
+	op := testOp(http.MethodGet)
+	args := map[string]any{"msgVpnName": "default", "queueName": "q1"}
+	if _, err := client.Execute(ctx, op, args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) < 2 {
+		t.Fatalf("got %d attempts, want >=2 (a retry must have occurred)", len(seen))
+	}
+	for i, hdr := range seen {
+		if got := hdr.Get("X-Correlation-ID"); got != traceID {
+			t.Errorf("attempt %d X-Correlation-ID = %q, want %q", i, got, traceID)
+		}
+	}
+}


### PR DESCRIPTION
## What
Forwards the request's correlation ID to the broker on **both SEMP API versions**: every outbound SEMPv1 and SEMPv2 request now carries `X-Correlation-ID` (always) and a `traceparent` (only when the ID is a valid W3C 32-hex trace-id), so a single MCP call can be traced across MCP logs and broker logs.

Part of the Observability & Telemetry epic ([SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791)). Story: [SOL-151281](https://sol-jira.atlassian.net/browse/SOL-151281).

## How
- Shared `internal/semp/correlationhdr.Set(ctx, req)` (cycle-safe leaf package) called by both clients **after `auth.AddAuth`**, so the header keys are identical and auth is untouched.
- Gated transitively: headers attach only when `correlation.From(ctx) != ""`, which is empty when `OBS_CORRELATION_ID_ENABLED` is off — no config plumbed into the clients.
- `traceparent` is emitted only for a valid 32-hex trace-id (`00-<id>-<fresh-span>-01`); for a UUIDv7 / arbitrary ID only `X-Correlation-ID` is sent (no malformed trace context). On the unreachable `crypto/rand` failure, `traceparent` is omitted rather than faked.
- Retries reuse the same ID (read once from ctx; the same request is replayed).

## Tests
Symmetry across both clients (both headers on / none off), traceparent shape for 32-hex vs none for non-trace IDs, retry-reuse (≥2 attempts, same ID), auth preserved. `make check` green.

## Note
Acceptance gate **Q-010** (owner Andrea Ross): end-to-end value depends on the broker surfacing the forwarded header in its command log — code is complete and tested; broker-side confirmation is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151281]: https://sol-jira.atlassian.net/browse/SOL-151281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ