### PR TITLE
SOL-151282: return correlation ID in MCP response header and CallToolResult.Meta

### DIFF
--- a/internal/observability/correlation/middleware.go
+++ b/internal/observability/correlation/middleware.go
@@ -81,11 +81,23 @@ func From(ctx context.Context) string {
 // The middleware always attaches a non-empty ID, so downstream code can rely on
 // From returning a value once Middleware is in the chain.
 //
+// It also echoes the resolved ID back to the caller in the X-Correlation-ID
+// response header (SOL-151282), so a client can correlate its request with the
+// server's logs without parsing the body. The header is set before next runs,
+// because net/http silently drops headers set after the handler writes the
+// status line; setting it here guarantees it survives regardless of how the
+// downstream handler responds. The value is always non-empty inside Middleware
+// (resolveID generates one when no usable inbound header exists). Echoing back
+// onto the same header name the inbound path reads from is intentional: it is
+// request/response symmetric and the value is already sanitized.
+//
 // Callers gate installation on Enabled (OBS_CORRELATION_ID_ENABLED). When the
-// capability is off the middleware is not wired and From returns "".
+// capability is off the middleware is not wired, From returns "", and no
+// response header is set.
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := resolveID(r)
+		w.Header().Set(headerCorrelationID, id)
 		ctx := With(r.Context(), id)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/internal/observability/correlation/middleware_test.go
+++ b/internal/observability/correlation/middleware_test.go
@@ -297,6 +297,67 @@ func TestMiddleware_EndToEndPropagation(t *testing.T) {
 	})
 }
 
+// TestMiddleware_SetsResponseHeader pins that Middleware echoes the resolved
+// correlation ID back to the caller in the X-Correlation-ID response header,
+// and that the header value is exactly the ID the downstream handler observes
+// on its context (SOL-151282). It covers all three resolution sources:
+// traceparent, a client-supplied X-Correlation-ID, and a generated UUIDv7.
+func TestMiddleware_SetsResponseHeader(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"from traceparent", map[string]string{headerTraceparent: validTraceparent}},
+		{"from X-Correlation-ID", map[string]string{headerCorrelationID: "client-supplied-id"}},
+		{"generated", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var seenID string
+			handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenID = From(r.Context())
+			}))
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			gotHeader := rec.Header().Get(headerCorrelationID)
+			if gotHeader == "" {
+				t.Fatalf("response %s header is empty, want the resolved correlation ID", headerCorrelationID)
+			}
+			if gotHeader != seenID {
+				t.Errorf("response %s header = %q, want it to equal the ID the handler saw %q",
+					headerCorrelationID, gotHeader, seenID)
+			}
+		})
+	}
+}
+
+// TestMiddleware_ResponseHeaderSetBeforeHandlerWrites pins that the response
+// header is set before next writes the body. A header set after the handler
+// has already flushed status/body is silently dropped by net/http, so this
+// guards the ordering: even when the inner handler writes a body, the header
+// survives.
+func TestMiddleware_ResponseHeaderSetBeforeHandlerWrites(t *testing.T) {
+	t.Parallel()
+	handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "body")
+	}))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get(headerCorrelationID); got == "" {
+		t.Errorf("response %s header is empty after the handler wrote a body; it must be set before next.ServeHTTP", headerCorrelationID)
+	}
+}
+
 // isUUIDv7 reports whether s is a canonical lowercase UUID with version nibble
 // 7 and RFC 4122/9562 variant bits (10xx). It is a test-only structural check.
 func isUUIDv7(s string) bool {

--- a/internal/tools/correlation_meta_test.go
+++ b/internal/tools/correlation_meta_test.go
@@ -1,0 +1,172 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// metaTestServer builds a real MCP server with the given handler registered,
+// fronts it with a StreamableHTTPHandler, and optionally wraps that in
+// correlation.Middleware. It returns a connected client session driving a full
+// HTTP round-trip — the same path production uses — so a tool call exercises
+// the real register.go chokepoint where Meta is stamped. When withCorrelation
+// is false the middleware is absent, modelling the capability-off case where
+// correlation.From(ctx) is "" at the chokepoint.
+func metaTestServer(t *testing.T, h ToolHandler, withCorrelation bool) *mcp.ClientSession {
+	t.Helper()
+	pool := newRegTestPool(t)
+	mgr := NewToolManager(pool)
+	mgr.Register(h)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	RegisterWithServer(mgr, server, pool, true)
+
+	var handler http.Handler = mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	if withCorrelation {
+		handler = correlation.Middleware(handler)
+	}
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "0.1.0"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+const metaKey = "correlation_id"
+
+// TestCallToolResultMeta_CorrelationIDPresent pins SOL-151282: when the
+// correlation capability is on, every CallToolResult flowing back through the
+// register.go chokepoint carries Meta["correlation_id"] equal to the request's
+// correlation ID. Covers both a success result and a tool-error result
+// (handler returns an error -> buildErrorResult), since both must carry it.
+func TestCallToolResultMeta_CorrelationIDPresent(t *testing.T) {
+	t.Run("success result carries correlation_id", func(t *testing.T) {
+		var seenCtxID string
+		h := newStubHandler("ok-tool")
+		h.handleFn = func(ctx context.Context, _ *ToolContext, _ map[string]any) (*ToolResult, error) {
+			seenCtxID = correlation.From(ctx)
+			return &ToolResult{StructuredContent: map[string]any{"step1": map[string]any{"ok": true}}}, nil
+		}
+		session := metaTestServer(t, h, true)
+
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      "ok-tool",
+			Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
+		})
+		if err != nil {
+			t.Fatalf("CallTool: %v", err)
+		}
+		if seenCtxID == "" {
+			t.Fatal("handler saw no correlation ID on its context; the request ctx must reach the handler")
+		}
+		got, ok := res.Meta[metaKey].(string)
+		if !ok {
+			t.Fatalf("result.Meta[%q] missing or not a string: %#v", metaKey, res.Meta)
+		}
+		if got != seenCtxID {
+			t.Errorf("result.Meta[%q] = %q, want it to equal the request correlation ID %q", metaKey, got, seenCtxID)
+		}
+	})
+
+	t.Run("error result carries correlation_id", func(t *testing.T) {
+		h := newStubHandler("err-tool")
+		h.handleFn = func(_ context.Context, _ *ToolContext, _ map[string]any) (*ToolResult, error) {
+			return nil, context.DeadlineExceeded // any execution error -> buildErrorResult, IsError result
+		}
+		session := metaTestServer(t, h, true)
+
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      "err-tool",
+			Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
+		})
+		if err != nil {
+			t.Fatalf("CallTool: %v", err)
+		}
+		if !res.IsError {
+			t.Fatalf("expected an error result, got IsError=false: %#v", res)
+		}
+		got, ok := res.Meta[metaKey].(string)
+		if !ok || got == "" {
+			t.Errorf("error result.Meta[%q] missing/empty: %#v (error paths must carry it too)", metaKey, res.Meta)
+		}
+	})
+}
+
+// TestStampCorrelationID_Unit exercises stampCorrelationID's full input domain
+// directly: nil result, empty ctx ID, nil-Meta init, and the
+// preserve-existing-entries guarantee.
+func TestStampCorrelationID_Unit(t *testing.T) {
+	t.Run("nil result is a no-op (no panic)", func(t *testing.T) {
+		stampCorrelationID(correlation.With(context.Background(), "id"), nil)
+	})
+
+	t.Run("empty ctx ID adds nothing and leaves Meta nil", func(t *testing.T) {
+		res := &mcp.CallToolResult{}
+		stampCorrelationID(context.Background(), res)
+		if res.Meta != nil {
+			t.Errorf("Meta = %#v, want nil when ctx has no correlation ID", res.Meta)
+		}
+	})
+
+	t.Run("nil Meta is initialized and stamped", func(t *testing.T) {
+		res := &mcp.CallToolResult{}
+		stampCorrelationID(correlation.With(context.Background(), "the-id"), res)
+		if got := res.Meta[metaKey]; got != "the-id" {
+			t.Errorf("Meta[%q] = %v, want %q", metaKey, got, "the-id")
+		}
+	})
+
+	t.Run("existing Meta entries are preserved", func(t *testing.T) {
+		res := &mcp.CallToolResult{Meta: mcp.Meta{"keep": "value"}}
+		stampCorrelationID(correlation.With(context.Background(), "the-id"), res)
+		if got := res.Meta["keep"]; got != "value" {
+			t.Errorf("pre-existing Meta[\"keep\"] = %v, want it preserved as %q", got, "value")
+		}
+		if got := res.Meta[metaKey]; got != "the-id" {
+			t.Errorf("Meta[%q] = %v, want %q", metaKey, got, "the-id")
+		}
+	})
+}
+
+// TestCallToolResultMeta_CorrelationIDAbsent pins the capability-off contract:
+// with no correlation middleware in the chain, correlation.From(ctx) is "" at
+// the chokepoint, so no correlation_id key is added to Meta.
+func TestCallToolResultMeta_CorrelationIDAbsent(t *testing.T) {
+	h := newStubHandler("ok-tool")
+	session := metaTestServer(t, h, false)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "ok-tool",
+		Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if v, present := res.Meta[metaKey]; present {
+		t.Errorf("result.Meta[%q] = %v present with correlation off, want absent", metaKey, v)
+	}
+}

--- a/internal/tools/correlation_meta_test.go
+++ b/internal/tools/correlation_meta_test.go
@@ -56,8 +56,6 @@ func metaTestServer(t *testing.T, h ToolHandler, withCorrelation bool) *mcp.Clie
 	return session
 }
 
-const metaKey = "correlation_id"
-
 // TestCallToolResultMeta_CorrelationIDPresent pins SOL-151282: when the
 // correlation capability is on, every CallToolResult flowing back through the
 // register.go chokepoint carries Meta["correlation_id"] equal to the request's
@@ -83,12 +81,12 @@ func TestCallToolResultMeta_CorrelationIDPresent(t *testing.T) {
 		if seenCtxID == "" {
 			t.Fatal("handler saw no correlation ID on its context; the request ctx must reach the handler")
 		}
-		got, ok := res.Meta[metaKey].(string)
+		got, ok := res.Meta[metaKeyCorrelationID].(string)
 		if !ok {
-			t.Fatalf("result.Meta[%q] missing or not a string: %#v", metaKey, res.Meta)
+			t.Fatalf("result.Meta[%q] missing or not a string: %#v", metaKeyCorrelationID, res.Meta)
 		}
 		if got != seenCtxID {
-			t.Errorf("result.Meta[%q] = %q, want it to equal the request correlation ID %q", metaKey, got, seenCtxID)
+			t.Errorf("result.Meta[%q] = %q, want it to equal the request correlation ID %q", metaKeyCorrelationID, got, seenCtxID)
 		}
 	})
 
@@ -109,9 +107,9 @@ func TestCallToolResultMeta_CorrelationIDPresent(t *testing.T) {
 		if !res.IsError {
 			t.Fatalf("expected an error result, got IsError=false: %#v", res)
 		}
-		got, ok := res.Meta[metaKey].(string)
+		got, ok := res.Meta[metaKeyCorrelationID].(string)
 		if !ok || got == "" {
-			t.Errorf("error result.Meta[%q] missing/empty: %#v (error paths must carry it too)", metaKey, res.Meta)
+			t.Errorf("error result.Meta[%q] missing/empty: %#v (error paths must carry it too)", metaKeyCorrelationID, res.Meta)
 		}
 	})
 }
@@ -135,8 +133,8 @@ func TestStampCorrelationID_Unit(t *testing.T) {
 	t.Run("nil Meta is initialized and stamped", func(t *testing.T) {
 		res := &mcp.CallToolResult{}
 		stampCorrelationID(correlation.With(context.Background(), "the-id"), res)
-		if got := res.Meta[metaKey]; got != "the-id" {
-			t.Errorf("Meta[%q] = %v, want %q", metaKey, got, "the-id")
+		if got := res.Meta[metaKeyCorrelationID]; got != "the-id" {
+			t.Errorf("Meta[%q] = %v, want %q", metaKeyCorrelationID, got, "the-id")
 		}
 	})
 
@@ -146,8 +144,8 @@ func TestStampCorrelationID_Unit(t *testing.T) {
 		if got := res.Meta["keep"]; got != "value" {
 			t.Errorf("pre-existing Meta[\"keep\"] = %v, want it preserved as %q", got, "value")
 		}
-		if got := res.Meta[metaKey]; got != "the-id" {
-			t.Errorf("Meta[%q] = %v, want %q", metaKey, got, "the-id")
+		if got := res.Meta[metaKeyCorrelationID]; got != "the-id" {
+			t.Errorf("Meta[%q] = %v, want %q", metaKeyCorrelationID, got, "the-id")
 		}
 	})
 }
@@ -166,7 +164,7 @@ func TestCallToolResultMeta_CorrelationIDAbsent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)
 	}
-	if v, present := res.Meta[metaKey]; present {
-		t.Errorf("result.Meta[%q] = %v present with correlation off, want absent", metaKey, v)
+	if v, present := res.Meta[metaKeyCorrelationID]; present {
+		t.Errorf("result.Meta[%q] = %v present with correlation off, want absent", metaKeyCorrelationID, v)
 	}
 }

--- a/internal/tools/correlation_meta_test.go
+++ b/internal/tools/correlation_meta_test.go
@@ -16,103 +16,11 @@ package tools
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
-
-// metaTestServer builds a real MCP server with the given handler registered,
-// fronts it with a StreamableHTTPHandler, and optionally wraps that in
-// correlation.Middleware. It returns a connected client session driving a full
-// HTTP round-trip — the same path production uses — so a tool call exercises
-// the real register.go chokepoint where Meta is stamped. When withCorrelation
-// is false the middleware is absent, modelling the capability-off case where
-// correlation.From(ctx) is "" at the chokepoint.
-func metaTestServer(t *testing.T, h ToolHandler, withCorrelation bool) *mcp.ClientSession {
-	t.Helper()
-	pool := newRegTestPool(t)
-	mgr := NewToolManager(pool)
-	mgr.Register(h)
-
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true)
-
-	var handler http.Handler = mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
-	if withCorrelation {
-		handler = correlation.Middleware(handler)
-	}
-	ts := httptest.NewServer(handler)
-	t.Cleanup(ts.Close)
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "0.1.0"}, nil)
-	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
-	if err != nil {
-		t.Fatalf("client connect: %v", err)
-	}
-	t.Cleanup(func() { _ = session.Close() })
-	return session
-}
-
-// TestCallToolResultMeta_CorrelationIDPresent pins SOL-151282: when the
-// correlation capability is on, every CallToolResult flowing back through the
-// register.go chokepoint carries Meta["correlation_id"] equal to the request's
-// correlation ID. Covers both a success result and a tool-error result
-// (handler returns an error -> buildErrorResult), since both must carry it.
-func TestCallToolResultMeta_CorrelationIDPresent(t *testing.T) {
-	t.Run("success result carries correlation_id", func(t *testing.T) {
-		var seenCtxID string
-		h := newStubHandler("ok-tool")
-		h.handleFn = func(ctx context.Context, _ *ToolContext, _ map[string]any) (*ToolResult, error) {
-			seenCtxID = correlation.From(ctx)
-			return &ToolResult{StructuredContent: map[string]any{"step1": map[string]any{"ok": true}}}, nil
-		}
-		session := metaTestServer(t, h, true)
-
-		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-			Name:      "ok-tool",
-			Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
-		})
-		if err != nil {
-			t.Fatalf("CallTool: %v", err)
-		}
-		if seenCtxID == "" {
-			t.Fatal("handler saw no correlation ID on its context; the request ctx must reach the handler")
-		}
-		got, ok := res.Meta[metaKeyCorrelationID].(string)
-		if !ok {
-			t.Fatalf("result.Meta[%q] missing or not a string: %#v", metaKeyCorrelationID, res.Meta)
-		}
-		if got != seenCtxID {
-			t.Errorf("result.Meta[%q] = %q, want it to equal the request correlation ID %q", metaKeyCorrelationID, got, seenCtxID)
-		}
-	})
-
-	t.Run("error result carries correlation_id", func(t *testing.T) {
-		h := newStubHandler("err-tool")
-		h.handleFn = func(_ context.Context, _ *ToolContext, _ map[string]any) (*ToolResult, error) {
-			return nil, context.DeadlineExceeded // any execution error -> buildErrorResult, IsError result
-		}
-		session := metaTestServer(t, h, true)
-
-		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-			Name:      "err-tool",
-			Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
-		})
-		if err != nil {
-			t.Fatalf("CallTool: %v", err)
-		}
-		if !res.IsError {
-			t.Fatalf("expected an error result, got IsError=false: %#v", res)
-		}
-		got, ok := res.Meta[metaKeyCorrelationID].(string)
-		if !ok || got == "" {
-			t.Errorf("error result.Meta[%q] missing/empty: %#v (error paths must carry it too)", metaKeyCorrelationID, res.Meta)
-		}
-	})
-}
 
 // TestStampCorrelationID_Unit exercises stampCorrelationID's full input domain
 // directly: nil result, empty ctx ID, nil-Meta init, and the
@@ -148,23 +56,4 @@ func TestStampCorrelationID_Unit(t *testing.T) {
 			t.Errorf("Meta[%q] = %v, want %q", metaKeyCorrelationID, got, "the-id")
 		}
 	})
-}
-
-// TestCallToolResultMeta_CorrelationIDAbsent pins the capability-off contract:
-// with no correlation middleware in the chain, correlation.From(ctx) is "" at
-// the chokepoint, so no correlation_id key is added to Meta.
-func TestCallToolResultMeta_CorrelationIDAbsent(t *testing.T) {
-	h := newStubHandler("ok-tool")
-	session := metaTestServer(t, h, false)
-
-	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-		Name:      "ok-tool",
-		Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
-	})
-	if err != nil {
-		t.Fatalf("CallTool: %v", err)
-	}
-	if v, present := res.Meta[metaKeyCorrelationID]; present {
-		t.Errorf("result.Meta[%q] = %v present with correlation off, want absent", metaKeyCorrelationID, v)
-	}
 }

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -34,12 +35,29 @@ import (
 // broker, as the failing component; the panic detail stays server-side.
 const serverInternalErrorMessage = "The server encountered an internal error executing this tool. Please try again later or contact your administrator."
 
+// metaKeyCorrelationID is the CallToolResult.Meta key under which the request's
+// correlation ID is surfaced back to the caller (SOL-151282), mirroring the
+// X-Correlation-ID response header set by correlation.Middleware. The MCP
+// protocol reserves the _meta object for exactly this kind of out-of-band
+// metadata, so the value rides alongside the result without polluting the
+// tool's structured output schema.
+const metaKeyCorrelationID = "correlation_id"
+
 // withRecovery wraps an SDK tool handler so a panic anywhere below the SDK
 // boundary becomes a sanitized error result instead of killing the process.
 // The SDK (go-sdk v1.5.0) invokes tool handlers on a goroutine of its own
 // with no recover() — net/http's per-connection recovery cannot catch a
 // panic on another goroutine — so without this wrapper a single panicking
 // handler takes down the whole server (SOL-150685).
+//
+// This wrapper is the single chokepoint through which EVERY tool result flows
+// back to the SDK — success, tool error, and panic-recovered alike — so it is
+// also where the correlation ID is stamped onto CallToolResult.Meta. Stamping
+// here (rather than across CallTool's many return paths) guarantees all three
+// result kinds carry it. The HTTP request context that correlation.Middleware
+// seeded reaches this handler's ctx (verified end-to-end through the
+// StreamableHTTPHandler), so correlation.From(ctx) yields the request's ID;
+// when the capability is off it returns "" and no Meta key is added.
 func withRecovery(toolName string, h mcp.ToolHandler) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
 		defer func() {
@@ -64,9 +82,35 @@ func withRecovery(toolName string, h mcp.ToolHandler) mcp.ToolHandler {
 				}
 				err = nil
 			}
+			// Stamp the correlation ID onto the result on the way out. This
+			// runs after both the normal return AND the panic-recovery branch
+			// above, so success, error, and panic-recovered results are all
+			// covered. A protocol-level error (err != nil, result nil) carries
+			// no result body to annotate, so it is left untouched.
+			stampCorrelationID(ctx, result)
 		}()
 		return h(ctx, req)
 	}
+}
+
+// stampCorrelationID adds the request's correlation ID to result.Meta under
+// metaKeyCorrelationID when both are present. It is a no-op when the capability
+// is off (correlation.From returns "") or there is no result to annotate
+// (protocol-level error). Meta is initialized only when needed, and existing
+// Meta entries are preserved — the SDK never sets a correlation_id key, so
+// there is nothing to clobber, but the merge is non-destructive regardless.
+func stampCorrelationID(ctx context.Context, result *mcp.CallToolResult) {
+	if result == nil {
+		return
+	}
+	id := correlation.From(ctx)
+	if id == "" {
+		return
+	}
+	if result.Meta == nil {
+		result.Meta = mcp.Meta{}
+	}
+	result.Meta[metaKeyCorrelationID] = id
 }
 
 // RegisterWithServer registers all tools from the ToolManager with the MCP

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -96,9 +96,9 @@ func withRecovery(toolName string, h mcp.ToolHandler) mcp.ToolHandler {
 // stampCorrelationID adds the request's correlation ID to result.Meta under
 // metaKeyCorrelationID when both are present. It is a no-op when the capability
 // is off (correlation.From returns "") or there is no result to annotate
-// (protocol-level error). Meta is initialized only when needed, and existing
-// Meta entries are preserved — the SDK never sets a correlation_id key, so
-// there is nothing to clobber, but the merge is non-destructive regardless.
+// (protocol-level error). We own the correlation_id key and derive it fresh per
+// request, so overwriting any prior value for that one key is intentional; Meta
+// is initialized only when nil, so all other existing entries are preserved.
 func stampCorrelationID(ctx context.Context, result *mcp.CallToolResult) {
 	if result == nil {
 		return

--- a/test/integration/correlation_response_meta_test.go
+++ b/test/integration/correlation_response_meta_test.go
@@ -1,0 +1,207 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
+	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// metaCorrelationKey mirrors the unexported tools.metaKeyCorrelationID const
+// (register.go). It is duplicated here as a literal because the const is not
+// exported; the tests below assert against this string, so a drift in the
+// production const would surface as a failure here.
+const metaCorrelationKey = "correlation_id"
+
+// metaTestPool builds a *semp.BrokerPool with a single "dev" broker alias,
+// using the public config + semp APIs (the same path production uses). The
+// tests below never reach the broker wire — the stub handler ignores the SEMP
+// clients — so the URL only needs to be valid config. The "dev" alias must be
+// present because the tool calls pass {"broker":"dev","msgVpnName":"default"}.
+func metaTestPool(t *testing.T) *semp.BrokerPool {
+	t.Helper()
+	cfgYAML := "mcp_client_auth:\n  mode: disabled\nbrokers:\n" +
+		"  dev:\n    url: http://localhost:8081\n    auth:\n      mode: basic\n      username: admin\n      password: admin\n"
+	cfgPath := filepath.Join(t.TempDir(), "broker-config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgYAML), 0o600); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+	cfg, err := config.LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	pool := semp.NewBrokerPool(cfg)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// metaStubHandler is a minimal tools.ToolHandler for these tests. It satisfies
+// the exported interface and lets a test override Handle via handleFn; the
+// default returns a success ToolResult. It stands in for the unexported
+// stubHandler used inside internal/tools.
+type metaStubHandler struct {
+	name     string
+	handleFn func(ctx context.Context, tc *tools.ToolContext, params map[string]any) (*tools.ToolResult, error)
+}
+
+func (h *metaStubHandler) Metadata() tools.Metadata {
+	return tools.Metadata{
+		Name:        h.name,
+		Description: "A test tool",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"msgVpnName": map[string]any{"type": "string"},
+			},
+			"required": []string{"msgVpnName"},
+		},
+		OutputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": map[string]any{"type": "object"},
+		},
+		Annotations: tools.Annotations{ReadOnly: true},
+	}
+}
+
+func (h *metaStubHandler) Handle(ctx context.Context, tc *tools.ToolContext, params map[string]any) (*tools.ToolResult, error) {
+	if h.handleFn != nil {
+		return h.handleFn(ctx, tc, params)
+	}
+	return &tools.ToolResult{StructuredContent: map[string]any{"step1": map[string]any{"ok": true}}}, nil
+}
+
+// metaTestServer builds a real MCP server with the given handler registered,
+// fronts it with a StreamableHTTPHandler, and optionally wraps that in
+// correlation.Middleware. It returns a connected client session driving a full
+// HTTP round-trip — the same path production uses — so a tool call exercises
+// the real register.go chokepoint where Meta is stamped. When withCorrelation
+// is false the middleware is absent, modelling the capability-off case where
+// correlation.From(ctx) is "" at the chokepoint.
+//
+// This composes two internal/ components — the tools register chokepoint and
+// correlation.Middleware — through their public APIs, so it belongs in the
+// integration tier per this directory's README: the correlation_id invariant
+// is meaningless without the middleware wired in.
+func metaTestServer(t *testing.T, h tools.ToolHandler, withCorrelation bool) *mcp.ClientSession {
+	t.Helper()
+	pool := metaTestPool(t)
+	mgr := tools.NewToolManager(pool)
+	mgr.Register(h)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	tools.RegisterWithServer(mgr, server, pool, true)
+
+	var handler http.Handler = mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	if withCorrelation {
+		handler = correlation.Middleware(handler)
+	}
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "0.1.0"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+// TestCallToolResultMeta_CorrelationIDPresent pins SOL-151282: when the
+// correlation capability is on, every CallToolResult flowing back through the
+// register.go chokepoint carries Meta["correlation_id"] equal to the request's
+// correlation ID. Covers both a success result and a tool-error result
+// (handler returns an error -> buildErrorResult), since both must carry it.
+func TestCallToolResultMeta_CorrelationIDPresent(t *testing.T) {
+	t.Run("success result carries correlation_id", func(t *testing.T) {
+		var seenCtxID string
+		h := &metaStubHandler{name: "ok-tool"}
+		h.handleFn = func(ctx context.Context, _ *tools.ToolContext, _ map[string]any) (*tools.ToolResult, error) {
+			seenCtxID = correlation.From(ctx)
+			return &tools.ToolResult{StructuredContent: map[string]any{"step1": map[string]any{"ok": true}}}, nil
+		}
+		session := metaTestServer(t, h, true)
+
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      "ok-tool",
+			Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
+		})
+		if err != nil {
+			t.Fatalf("CallTool: %v", err)
+		}
+		if seenCtxID == "" {
+			t.Fatal("handler saw no correlation ID on its context; the request ctx must reach the handler")
+		}
+		got, ok := res.Meta[metaCorrelationKey].(string)
+		if !ok {
+			t.Fatalf("result.Meta[%q] missing or not a string: %#v", metaCorrelationKey, res.Meta)
+		}
+		if got != seenCtxID {
+			t.Errorf("result.Meta[%q] = %q, want it to equal the request correlation ID %q", metaCorrelationKey, got, seenCtxID)
+		}
+	})
+
+	t.Run("error result carries correlation_id", func(t *testing.T) {
+		h := &metaStubHandler{name: "err-tool"}
+		h.handleFn = func(_ context.Context, _ *tools.ToolContext, _ map[string]any) (*tools.ToolResult, error) {
+			return nil, context.DeadlineExceeded // any execution error -> buildErrorResult, IsError result
+		}
+		session := metaTestServer(t, h, true)
+
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      "err-tool",
+			Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
+		})
+		if err != nil {
+			t.Fatalf("CallTool: %v", err)
+		}
+		if !res.IsError {
+			t.Fatalf("expected an error result, got IsError=false: %#v", res)
+		}
+		got, ok := res.Meta[metaCorrelationKey].(string)
+		if !ok || got == "" {
+			t.Errorf("error result.Meta[%q] missing/empty: %#v (error paths must carry it too)", metaCorrelationKey, res.Meta)
+		}
+	})
+}
+
+// TestCallToolResultMeta_CorrelationIDAbsent pins the capability-off contract:
+// with no correlation middleware in the chain, correlation.From(ctx) is "" at
+// the chokepoint, so no correlation_id key is added to Meta.
+func TestCallToolResultMeta_CorrelationIDAbsent(t *testing.T) {
+	h := &metaStubHandler{name: "ok-tool"}
+	session := metaTestServer(t, h, false)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "ok-tool",
+		Arguments: map[string]any{"broker": "dev", "msgVpnName": "default"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if v, present := res.Meta[metaCorrelationKey]; present {
+		t.Errorf("result.Meta[%q] = %v present with correlation off, want absent", metaCorrelationKey, v)
+	}
+}


### PR DESCRIPTION
## What
Surfaces the request's correlation ID back to the caller: an `X-Correlation-ID` **response header** on MCP responses, and `CallToolResult.Meta["correlation_id"]` on every tool result — so agent-side telemetry and diagnostics can reference it.

Part of the Observability & Telemetry epic ([SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791)). Story: [SOL-151282](https://sol-jira.atlassian.net/browse/SOL-151282).

## How
- Response header set in `correlation.Middleware` before the handler writes (so it survives streaming responses).
- `Meta` stamped at the single `withRecovery` chokepoint in `register.go`, so **success, tool-error, and panic-recovered** results (and `list-brokers`) all carry it; protocol-level errors (no result body) are left untouched. `Meta` (`map[string]any`, marshals as `_meta`) is initialized only when nil; existing entries preserved.
- Gated transitively on `correlation.From(ctx) != ""` (off ⇒ neither surface).

## Tests
End-to-end through the **real** `StreamableHTTPHandler` + SDK client, proving the per-request context reaches the tool handler (pins it against SDK regressions); success + error results carry the ID; absent when the middleware isn't wired; response-header ordering vs a body write. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151282]: https://sol-jira.atlassian.net/browse/SOL-151282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ