### PR TITLE
SOL-151285: k8s split probes + startupProbe; alias /ready to /readyz

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,18 +17,14 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -100,12 +96,10 @@ func newSlogHandler(level slog.Level) slog.Handler {
 // The /mcp route is registered separately in main() with auth middleware.
 // Both main() and tests use this function to avoid route drift.
 //
-// aliases returns the list of broker names to check.
-// probeBroker tests connectivity to a single broker; it returns nil on success.
-// readiness backs the /readyz endpoint, which reflects the MCP server's OWN
-// readiness and is decoupled from the broker (it consults neither aliases nor
-// probeBroker).
-func buildMux(aliases func() []string, probeBroker func(ctx context.Context, broker string) error, readiness *health.ReadinessState) *http.ServeMux {
+// readiness backs the /readyz endpoint (and its /ready alias), which reflects
+// the MCP server's OWN readiness and is decoupled from the broker — it makes no
+// broker calls.
+func buildMux(readiness *health.ReadinessState) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Liveness probe. /livez is the canonical liveness endpoint and returns
@@ -121,68 +115,14 @@ func buildMux(aliases func() []string, probeBroker func(ctx context.Context, bro
 	// (initialized, not draining, required listeners bound) and is decoupled
 	// from broker reachability (ADR-004 / ISSUE-026) — it makes no broker calls.
 	// Like /livez it is unconditional (no flag).
-	mux.Handle("/readyz", health.ReadyzHandler(readiness))
+	readyz := health.ReadyzHandler(readiness)
+	mux.Handle("/readyz", readyz)
 
-	// TODO(SOL-151285 / Story 11): /readyz now exists (MCP-server-only readiness).
-	// /ready below is still the legacy broker-coupled inline handler; Story 11
-	// will alias /ready to /readyz and drop the broker dial.
-	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-
-		// Config validation ensures there is at least one broker configured, so aliases()
-		// is never empty in production.
-		brokers := aliases()
-		type brokerResult struct {
-			broker string
-			err    error
-		}
-		results := make(chan brokerResult, len(brokers))
-
-		var wg sync.WaitGroup
-		wg.Add(len(brokers))
-
-		// Probe each broker concurrently, then collect in configured order.
-		for _, broker := range brokers {
-			go func(broker string) {
-				defer wg.Done()
-				timeout := time.Duration(defaults.DefaultReadinessProbeTimeoutSeconds) * time.Second
-				reqCtx, cancel := context.WithTimeout(r.Context(), timeout)
-				defer cancel()
-				results <- brokerResult{broker: broker, err: probeBroker(reqCtx, broker)}
-			}(broker)
-		}
-
-		wg.Wait()
-		close(results)
-
-		resultsByBroker := make(map[string]error, len(brokers))
-		for res := range results {
-			resultsByBroker[res.broker] = res.err
-		}
-		readyBrokers := []string{}
-		errs := []string{}
-		for _, broker := range brokers {
-			if err := resultsByBroker[broker]; err != nil {
-				errs = append(errs, fmt.Sprintf("%s: unreachable", broker))
-			} else {
-				readyBrokers = append(readyBrokers, broker)
-			}
-		}
-
-		if len(errs) > 0 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			resp, _ := json.Marshal(map[string]any{"ready": false, "errors": errs})
-			_, _ = w.Write(resp)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		resp, _ := json.Marshal(map[string]any{"ready": true, "brokers": readyBrokers})
-		_, _ = w.Write(resp)
-	})
+	// /ready is a body-identical alias of /readyz (SOL-151285 / Story 11). It
+	// shares the SAME handler instance, so GET /ready and GET /readyz return
+	// identical status and body. The legacy broker-dialing /ready handler was
+	// removed: readiness is the MCP server's own state, not broker reachability.
+	mux.Handle("/ready", readyz)
 
 	return mux
 }
@@ -413,42 +353,6 @@ func gracefulShutdown(srv shutdowner, timeout time.Duration) error {
 	return err
 }
 
-// newBrokerReachabilityProbe returns a probe function that checks whether a
-// broker's SEMP port is accepting TCP connections. The returned function
-// resolves the broker alias against cfg, parses the URL, defaults the port
-// (443 for HTTPS, 80 otherwise), and performs a TCP dial. It is the
-// production implementation of buildMux's probeBroker parameter.
-func newBrokerReachabilityProbe(cfg *config.ServerConfig) func(context.Context, string) error {
-	return func(ctx context.Context, broker string) error {
-		brokerCfg, ok := cfg.Broker(broker)
-		if !ok {
-			return fmt.Errorf("unknown broker %q", broker)
-		}
-		u, err := url.Parse(brokerCfg.URL)
-		if err != nil {
-			return fmt.Errorf("broker %q: invalid URL: %w", broker, err)
-		}
-		host := u.Hostname()
-		port := u.Port()
-		if port == "" {
-			if u.Scheme == "https" {
-				port = "443"
-			} else {
-				port = "80"
-			}
-		}
-		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(host, port))
-		if err != nil {
-			slog.Warn("broker TCP connectivity check failed",
-				slog.String("broker", broker),
-				slog.String("error", err.Error()))
-			return err
-		}
-		_ = conn.Close()
-		return nil
-	}
-}
-
 // registerSEMPv1Tools attaches every Go-native SEMPv1 tool handler to mgr.
 // New SEMPv1 tools should be added here as they land — this is the single
 // source of truth for which v1 tools the server exposes. The handlers flow
@@ -651,7 +555,7 @@ func main() {
 	// initialized once the server begins listening (below). It is decoupled from
 	// the broker and is NOT flag-gated.
 	readiness := health.NewReadinessState()
-	mux := buildMux(pool.Aliases, newBrokerReachabilityProbe(cfg), readiness)
+	mux := buildMux(readiness)
 
 	// Create MCP handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -16,9 +16,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
 	"github.com/SolaceDev/solace-broker-mcp/internal/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -42,7 +38,7 @@ func testMux() *http.ServeMux {
 	}, nil)
 	readiness := health.NewReadinessState()
 	readiness.SetInitialized()
-	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, readiness)
+	mux := buildMux(readiness)
 
 	// Register /mcp endpoint for testing (without auth middleware)
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
@@ -382,7 +378,7 @@ func TestHealthConfigFromFile_PartialTLSIsHTTP(t *testing.T) {
 }
 
 func TestReady_POST_ReturnsMethodNotAllowed(t *testing.T) {
-	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, health.NewReadinessState())
+	mux := buildMux(health.NewReadinessState())
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/ready", nil)
 	rec := httptest.NewRecorder()
 
@@ -393,80 +389,84 @@ func TestReady_POST_ReturnsMethodNotAllowed(t *testing.T) {
 	}
 }
 
-func TestReady_GET_AllBrokersReachable(t *testing.T) {
-	brokers := []string{"prod-1", "prod-2"}
-	mux := buildMux(
-		func() []string { return brokers },
-		func(_ context.Context, _ string) error { return nil },
-		health.NewReadinessState(),
-	)
+// TestReady_BeforeInit_Returns503Starting pins that /ready is now a
+// body-identical alias of /readyz: before SetInitialized it returns
+// 503 {"status":"starting"}. The legacy broker-coupled behaviour (ready=true /
+// per-broker errors array) is gone — /ready no longer dials any broker.
+func TestReady_BeforeInit_Returns503Starting(t *testing.T) {
+	readiness := health.NewReadinessState() // not initialized
+	mux := buildMux(readiness)
+
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
 	rec := httptest.NewRecorder()
-
-	mux.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Errorf("GET /ready status = %d, want %d", rec.Code, http.StatusOK)
-	}
-	if contentType := rec.Header().Get("Content-Type"); contentType != "application/json" {
-		t.Errorf("GET /ready Content-Type = %q, want %q", contentType, "application/json")
-	}
-	var body struct {
-		Ready   bool     `json:"ready"`
-		Brokers []string `json:"brokers"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("response is not valid JSON: %v", err)
-	}
-	if !body.Ready {
-		t.Errorf("ready = %v, want true", body.Ready)
-	}
-	if len(body.Brokers) != len(brokers) {
-		t.Errorf("brokers len = %d, want %d", len(body.Brokers), len(brokers))
-	}
-	for i, expectedBroker := range brokers {
-		if body.Brokers[i] != expectedBroker {
-			t.Errorf("brokers[%d] = %q, want %q", i, body.Brokers[i], expectedBroker)
-		}
-	}
-}
-
-func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
-	brokers := []string{"prod-1", "prod-2"}
-	mux := buildMux(
-		func() []string { return brokers },
-		func(_ context.Context, broker string) error {
-			if broker == "prod-2" {
-				return errors.New("connection refused")
-			}
-			return nil
-		},
-		health.NewReadinessState(),
-	)
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
-	rec := httptest.NewRecorder()
-
 	mux.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("GET /ready status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
 	}
-	var body struct {
-		Ready  bool     `json:"ready"`
-		Errors []string `json:"errors"`
+	if rec.Body.String() != `{"status":"starting"}` {
+		t.Errorf("GET /ready body = %q, want %q", rec.Body.String(), `{"status":"starting"}`)
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("response is not valid JSON: %v", err)
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("GET /ready Content-Type = %q, want %q", ct, "application/json")
 	}
-	if body.Ready {
-		t.Errorf("ready = %v, want false", body.Ready)
+}
+
+// TestReady_AfterInit_Returns200Ready pins that once SetInitialized has been
+// called, /ready returns 200 {"status":"ready"} — the same MCP-server-only
+// readiness signal as /readyz.
+func TestReady_AfterInit_Returns200Ready(t *testing.T) {
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+	mux := buildMux(readiness)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /ready status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if len(body.Errors) == 0 {
-		t.Fatal("errors array is empty, want at least one entry")
+	if rec.Body.String() != `{"status":"ready"}` {
+		t.Errorf("GET /ready body = %q, want %q", rec.Body.String(), `{"status":"ready"}`)
 	}
-	want := "prod-2: unreachable"
-	if body.Errors[0] != want {
-		t.Errorf("errors[0] = %q, want %q", body.Errors[0], want)
+}
+
+// TestReadyAndReadyzBodiesIdentical proves the alias contract: /ready and
+// /readyz return byte-identical status and body for both the pre-init and the
+// post-init states. They are the SAME handler, so a future change to readiness
+// semantics applies to both endpoints automatically.
+func TestReadyAndReadyzBodiesIdentical(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		initialized bool
+	}{
+		{"before init", false},
+		{"after init", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			readiness := health.NewReadinessState()
+			if tc.initialized {
+				readiness.SetInitialized()
+			}
+			mux := buildMux(readiness)
+
+			readyRec := httptest.NewRecorder()
+			mux.ServeHTTP(readyRec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil))
+			readyzRec := httptest.NewRecorder()
+			mux.ServeHTTP(readyzRec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil))
+
+			if readyRec.Code != readyzRec.Code {
+				t.Errorf("status /ready=%d /readyz=%d, want equal", readyRec.Code, readyzRec.Code)
+			}
+			if readyRec.Body.String() != readyzRec.Body.String() {
+				t.Errorf("body /ready=%q /readyz=%q, want identical", readyRec.Body.String(), readyzRec.Body.String())
+			}
+			if readyRec.Header().Get("Content-Type") != readyzRec.Header().Get("Content-Type") {
+				t.Errorf("Content-Type /ready=%q /readyz=%q, want equal",
+					readyRec.Header().Get("Content-Type"), readyzRec.Header().Get("Content-Type"))
+			}
+		})
 	}
 }
 
@@ -474,7 +474,7 @@ func TestReady_GET_OneBrokerUnreachable(t *testing.T) {
 // buildMux returns 503 {"status":"starting"} before SetInitialized.
 func TestReadyz_BeforeInit_Returns503(t *testing.T) {
 	readiness := health.NewReadinessState() // not initialized
-	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, readiness)
+	mux := buildMux(readiness)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
@@ -493,7 +493,7 @@ func TestReadyz_BeforeInit_Returns503(t *testing.T) {
 func TestReadyz_AfterInit_Returns200(t *testing.T) {
 	readiness := health.NewReadinessState()
 	readiness.SetInitialized()
-	mux := buildMux(func() []string { return nil }, func(_ context.Context, _ string) error { return nil }, readiness)
+	mux := buildMux(readiness)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
@@ -504,116 +504,5 @@ func TestReadyz_AfterInit_Returns200(t *testing.T) {
 	}
 	if rec.Body.String() != `{"status":"ready"}` {
 		t.Errorf("GET /readyz body = %q, want %q", rec.Body.String(), `{"status":"ready"}`)
-	}
-}
-
-// TestReadyz_BrokerUnreachable_StillReady proves AC #4 through the real mux:
-// even when the broker probe always errors (every broker unreachable), /readyz
-// returns 200 once initialized and not draining, because readiness is decoupled
-// from broker reachability. The same mux's /ready endpoint returns 503 for the
-// same unreachable broker, demonstrating the two endpoints are independent.
-func TestReadyz_BrokerUnreachable_StillReady(t *testing.T) {
-	readiness := health.NewReadinessState()
-	readiness.SetInitialized()
-	alwaysFail := func(_ context.Context, broker string) error {
-		return errors.New("connection refused")
-	}
-	mux := buildMux(func() []string { return []string{"prod-1"} }, alwaysFail, readiness)
-
-	// /readyz ignores the broker entirely → 200 ready.
-	readyzReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
-	readyzRec := httptest.NewRecorder()
-	mux.ServeHTTP(readyzRec, readyzReq)
-	if readyzRec.Code != http.StatusOK {
-		t.Errorf("GET /readyz status = %d, want %d (readiness must not depend on broker reachability)", readyzRec.Code, http.StatusOK)
-	}
-	if readyzRec.Body.String() != `{"status":"ready"}` {
-		t.Errorf("GET /readyz body = %q, want %q", readyzRec.Body.String(), `{"status":"ready"}`)
-	}
-
-	// /ready (legacy, broker-coupled) reflects the unreachable broker → 503.
-	readyReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ready", nil)
-	readyRec := httptest.NewRecorder()
-	mux.ServeHTTP(readyRec, readyReq)
-	if readyRec.Code != http.StatusServiceUnavailable {
-		t.Errorf("GET /ready status = %d, want %d (legacy probe is broker-coupled)", readyRec.Code, http.StatusServiceUnavailable)
-	}
-}
-
-// probeTestConfig writes a minimal YAML config with the given brokers and
-// returns the loaded *config.ServerConfig. Each broker entry is an
-// (alias, url) pair.
-// probeTestConfig writes a minimal YAML config with the given brokers and
-// returns the loaded *config.ServerConfig. Each entry is an [alias, url] pair.
-func probeTestConfig(t *testing.T, brokers ...[2]string) *config.ServerConfig {
-	t.Helper()
-	var yamlContent string
-	yamlContent += "mcp_client_auth:\n  mode: disabled\nbrokers:\n"
-	for _, broker := range brokers {
-		alias, brokerURL := broker[0], broker[1]
-		yamlContent += fmt.Sprintf("  %s:\n    url: %s\n    auth:\n      mode: basic\n      username: admin\n      password: secret\n", alias, brokerURL)
-	}
-	path := filepath.Join(t.TempDir(), "broker-config.yaml")
-	if err := os.WriteFile(path, []byte(yamlContent), os.FileMode(0o600)); err != nil {
-		t.Fatalf("writing test config: %v", err)
-	}
-	cfg, err := config.LoadConfig(path)
-	if err != nil {
-		t.Fatalf("LoadConfig: %v", err)
-	}
-	return cfg
-}
-
-func TestNewBrokerReachabilityProbe_UnknownBroker(t *testing.T) {
-	cfg := probeTestConfig(t, [2]string{"existing", "http://127.0.0.1:8080"})
-	probe := newBrokerReachabilityProbe(cfg)
-
-	err := probe(context.Background(), "no-such-broker")
-	if err == nil {
-		t.Fatal("expected error for unknown broker, got nil")
-	}
-	if want := `unknown broker "no-such-broker"`; err.Error() != want {
-		t.Errorf("error = %q, want %q", err.Error(), want)
-	}
-}
-
-func TestNewBrokerReachabilityProbe_ExplicitPort(t *testing.T) {
-	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer l.Close()
-
-	addr := l.Addr().String()
-	_, port, _ := net.SplitHostPort(addr)
-	cfg := probeTestConfig(t, [2]string{"broker-a", "http://127.0.0.1:" + port})
-	probe := newBrokerReachabilityProbe(cfg)
-
-	if err := probe(context.Background(), "broker-a"); err != nil {
-		t.Errorf("expected success for reachable broker, got: %v", err)
-	}
-}
-
-func TestNewBrokerReachabilityProbe_HTTPSDefaultsTo443(t *testing.T) {
-	cfg := probeTestConfig(t, [2]string{"broker-a", "https://192.0.2.1"})
-	probe := newBrokerReachabilityProbe(cfg)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	err := probe(ctx, "broker-a")
-	if err == nil {
-		t.Fatal("expected dial error to 192.0.2.1:443, got nil")
-	}
-}
-
-func TestNewBrokerReachabilityProbe_HTTPDefaultsTo80(t *testing.T) {
-	cfg := probeTestConfig(t, [2]string{"broker-a", "http://192.0.2.1"})
-	probe := newBrokerReachabilityProbe(cfg)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	err := probe(ctx, "broker-a")
-	if err == nil {
-		t.Fatal("expected dial error to 192.0.2.1:80, got nil")
 	}
 }

--- a/cmd/server/panic_recovery_test.go
+++ b/cmd/server/panic_recovery_test.go
@@ -47,7 +47,7 @@ func get(handler http.Handler, path string) *httptest.ResponseRecorder {
 // shared buildMux keeps the probe routes identical to production, so the test
 // proves they still resolve through the recovery wrapper.
 func muxWithPanicRoute() *http.ServeMux {
-	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil }, health.NewReadinessState())
+	mux := buildMux(health.NewReadinessState())
 	mux.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
 		panic("boom from a route inside the mux")
 	})
@@ -108,7 +108,7 @@ func TestChainOrder_CorrelationInsideRecovery(t *testing.T) {
 
 	// Assemble /mcp through the SAME function main() uses, so a production
 	// reorder of the route-local chain breaks this test.
-	mux := buildMux(func() []string { return nil }, func(context.Context, string) error { return nil }, health.NewReadinessState())
+	mux := buildMux(health.NewReadinessState())
 	mux.Handle("/mcp", buildMCPEndpoint(authedHandler, cfg.CorrelationIDEnabled))
 	mux.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
 		panic("boom")

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -53,17 +53,34 @@ spec:
               mountPath: /etc/mcp-server/config.yaml
               subPath: config.yaml
               readOnly: true
+          # startupProbe gates liveness/readiness until the MCP server has
+          # finished cold-start init. /readyz reflects the server's OWN
+          # readiness (it makes no broker calls), so it flips ready as soon as
+          # init completes — there is no unbounded waiting on broker
+          # reachability. failureThreshold 30 x periodSeconds 2s allows ~60s
+          # for a normal cold start before Kubernetes treats startup as failed.
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 30
+          # /livez is the canonical liveness endpoint and governs restarts.
           livenessProbe:
             httpGet:
-              path: /health
+              path: /livez
               port: http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 3
             failureThreshold: 3
+          # /readyz reflects MCP-server readiness only (decoupled from broker
+          # reachability); a not-ready pod is pulled from Service endpoints but
+          # not restarted.
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: http
             initialDelaySeconds: 3
             periodSeconds: 10

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -26,11 +26,11 @@ spec:
       #                                 + 5s buffer = 45
       # If you raise obs.shutdown_drain_delay_s, raise this value to match.
       #
-      # Note: the readinessProbe below still targets /health (always 200);
-      # rewiring it to /readyz so SetShuttingDown is probe-visible is Story 11
-      # (SOL-151285). Until then this in-process drain + grace period prevent
-      # 502s on their own — kube-proxy deregisters the pod on Terminating, and
-      # the sleep gives it time before in-flight requests are drained.
+      # The readinessProbe below targets /readyz, so on SIGTERM the server's
+      # SetShuttingDown flip makes the pod report not-ready and kube-proxy
+      # deregisters it from Service endpoints within one readiness period. The
+      # drain window above is sized to cover exactly that: orchestrator
+      # deregistration finishes before in-flight requests are drained.
       terminationGracePeriodSeconds: 45
       securityContext:
         runAsNonRoot: true
@@ -67,11 +67,12 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 30
           # /livez is the canonical liveness endpoint and governs restarts.
+          # No initialDelaySeconds: startupProbe above gates liveness until
+          # cold-start init completes, so an initial delay here is never observed.
           livenessProbe:
             httpGet:
               path: /livez
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 3
             failureThreshold: 3
@@ -82,7 +83,6 @@ spec:
             httpGet:
               path: /readyz
               port: http
-            initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3

--- a/docs/oauth/token-exchange-SOL-150070/architecture-plan.md
+++ b/docs/oauth/token-exchange-SOL-150070/architecture-plan.md
@@ -907,8 +907,14 @@ This is acceptable because:
 A separate ticket could later introduce a **background readiness probe** that:
 
 - Fetches the IdP's discovery doc on a timer (e.g., every 30s).
-- Affects `/ready` (so traffic isn't routed until the IdP is reachable) but **not** `/health` (so the pod isn't killed by k8s).
 - Logs WARN on first failure, ERROR on sustained failure.
+
+> Note (SOL-151285): `/ready` is now a body-identical alias of `/readyz` and
+> reflects the MCP server's OWN readiness only — it is decoupled from broker and
+> IdP reachability and makes no outbound calls. A future IdP-reachability probe
+> would need its own dedicated endpoint or a registered readiness listener
+> (`ReadinessState.RegisterListener`), not the old broker-style coupling on
+> `/ready`.
 
 This gives operators a clear signal without coupling boot. It's not in SOL-150070's scope. Recording the future option here so it's discoverable when the time comes.
 

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -174,15 +174,6 @@ const DefaultReadTimeoutSeconds = 30
 // idle sockets — neither perfect, but the alternative breaks the product.
 const DefaultIdleTimeoutSeconds = 120
 
-// DefaultReadinessProbeTimeoutSeconds is the per-broker timeout for the TCP
-// connectivity check performed by the /ready endpoint.
-//
-// Decided: 2 seconds.
-// Reasoning: the probe only opens and closes a TCP connection — no TLS
-// handshake, no SEMP request. 2s is generous for an in-cluster dial while
-// keeping the /ready response snappy for orchestrator liveness probes.
-const DefaultReadinessProbeTimeoutSeconds = 2
-
 // DefaultConfigPathSystem is the production-install location for the config
 // file. Tried when CONFIG_FILE is not set. Follows the conventional Linux
 // /etc/<app>/config.yaml layout used by Linux services, K8s, and Docker.

--- a/internal/middleware/recovery/middleware.go
+++ b/internal/middleware/recovery/middleware.go
@@ -63,10 +63,11 @@ const internalErrorBody = `{"error":"internal_error","error_description":"the se
 // middleware. There is no flag to disable it.
 //
 // Scope: recover() catches only panics on the request's own goroutine. A panic
-// on a goroutine that a handler SPAWNS (e.g. the per-broker probe goroutines in
-// the /ready handler) is NOT caught here — that class must be recovered at the
-// point of goroutine creation. The SDK tool-handler goroutine is covered
-// separately by withRecovery in internal/tools/register.go.
+// on a goroutine that a handler SPAWNS is NOT caught here — that class must be
+// recovered at the point of goroutine creation. No probe handler spawns
+// goroutines today (the /ready and /readyz handlers are synchronous), and the
+// SDK tool-handler goroutine is covered separately by withRecovery in
+// internal/tools/register.go.
 //
 // http.ErrAbortHandler is exempt: net/http documents it as a sentinel meaning
 // "abort this request, do not log, do not send a response". We re-raise it

--- a/test/health/test-health.sh
+++ b/test/health/test-health.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-# Standalone e2e tests for /health and /ready endpoints.
+# Standalone e2e tests for /livez, /health, /ready and /readyz endpoints.
 # Manages its own docker containers and MCP server — can be run independently
 # of the full e2e suite.
+#
+# Readiness model (SOL-151285): /ready is a body-identical alias of /readyz and
+# reflects the MCP server's OWN readiness only — it makes no broker calls. An
+# unreachable broker therefore does NOT make /ready (or /readyz) return 503.
 
 set -euo pipefail
 source "$(dirname "$0")/../e2e-basic-mcp/helpers.sh"
@@ -13,7 +17,8 @@ SECONDARY_CONFIG=""
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-# Wait for a TCP port to accept connections — mirrors exactly what /ready uses internally.
+# Wait for a TCP port to accept connections. Used to confirm the brokers are up
+# before the MCP server starts; /ready no longer dials brokers itself.
 wait_for_tcp() {
     local host="$1" port="$2" label="$3"
     local max=30
@@ -92,15 +97,37 @@ test_health() {
     assert_json_field "$response" ".status" "healthy" "/health should return status=healthy (legacy back-compat body)"
 }
 
-test_ready_both_reachable() {
+test_readyz() {
+    # /readyz reflects MCP-server readiness only. Once the server is up it is
+    # ready (it makes no broker calls).
     local response
-    response=$(curl -sf "$MCP_URL/ready")
-    assert_json_field "$response" ".ready" "true" "/ready should return ready=true" || return 1
-    assert_contains "$response" "broker-a" "/ready should list broker-a" || return 1
-    assert_contains "$response" "broker-b" "/ready should list broker-b" || return 1
+    response=$(curl -sf "$MCP_URL/readyz")
+    assert_json_field "$response" ".status" "ready" "/readyz should return status=ready"
 }
 
-test_ready_unreachable_broker() {
+test_ready_aliases_readyz() {
+    # /ready is a body-identical alias of /readyz: same status code and body.
+    local ready_body readyz_body ready_code readyz_code
+    ready_body=$(curl -s "$MCP_URL/ready")
+    readyz_body=$(curl -s "$MCP_URL/readyz")
+    ready_code=$(curl -s -o /dev/null -w "%{http_code}" "$MCP_URL/ready")
+    readyz_code=$(curl -s -o /dev/null -w "%{http_code}" "$MCP_URL/readyz")
+
+    assert_json_field "$ready_body" ".status" "ready" "/ready should return status=ready" || return 1
+    if [ "$ready_body" != "$readyz_body" ]; then
+        log_fail "/ready body ($ready_body) != /readyz body ($readyz_body)"
+        return 1
+    fi
+    if [ "$ready_code" != "$readyz_code" ]; then
+        log_fail "/ready HTTP $ready_code != /readyz HTTP $readyz_code"
+        return 1
+    fi
+    log_info "  /ready and /readyz returned identical body and status ($ready_code)"
+}
+
+test_ready_decoupled_from_broker() {
+    # An unreachable broker MUST NOT make /ready return 503 — readiness is the
+    # MCP server's own state, decoupled from broker reachability (SOL-151285).
     SECONDARY_CONFIG=$(mktemp /tmp/e2e-secondary-XXXXXX)
     cat > "$SECONDARY_CONFIG" <<EOF
 mcp_client_auth:
@@ -139,10 +166,10 @@ EOF
     if [ "$ready" -eq 1 ]; then
         local http_code
         http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$SECONDARY_MCP_PORT/ready")
-        if [ "$http_code" = "503" ]; then
-            log_info "  /ready correctly returned 503 — TCP dial to localhost:19999 failed as expected"
+        if [ "$http_code" = "200" ]; then
+            log_info "  /ready correctly returned 200 despite unreachable broker — readiness is broker-decoupled"
         else
-            log_fail "/ready returned HTTP $http_code, want 503 for unreachable broker"
+            log_fail "/ready returned HTTP $http_code, want 200 (readiness must not depend on broker reachability)"
             result=1
         fi
     else
@@ -162,7 +189,8 @@ EOF
 
 run_test "Livez endpoint"                      test_livez
 run_test "Health endpoint (legacy back-compat body)"  test_health
-run_test "Ready endpoint (brokers reachable)"  test_ready_both_reachable
-run_test "Ready endpoint (broker unreachable)" test_ready_unreachable_broker
+run_test "Readyz endpoint (MCP-server readiness)"     test_readyz
+run_test "Ready aliases readyz (identical body)"      test_ready_aliases_readyz
+run_test "Ready decoupled from broker reachability"   test_ready_decoupled_from_broker
 
 print_summary "Health/Readiness"

--- a/test/health/test-health.sh
+++ b/test/health/test-health.sh
@@ -39,6 +39,29 @@ wait_for_tcp() {
     return 1
 }
 
+# Wait until a /readyz-style endpoint returns HTTP 200 before asserting its body.
+# start_server() only waits for /health, which returns 200 as soon as the HTTP
+# server is up; /readyz (and its /ready alias) returns 503 {"status":"starting"}
+# until SetInitialized() runs at the end of startup. Polling here closes that
+# brief "starting" window so the readiness assertions don't flake.
+wait_for_ready() {
+    local url="$1" label="$2"
+    local max=20
+    local attempt=0
+    local http_code body
+    while [ $attempt -lt $max ]; do
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+        if [ "$http_code" = "200" ]; then
+            return 0
+        fi
+        sleep 0.5
+        attempt=$((attempt + 1))
+    done
+    body=$(curl -s "$url")
+    log_fail "$label ($url) not ready after $((max / 2))s (last HTTP $http_code, body: $body)"
+    return 1
+}
+
 cleanup() {
     log_info "Running cleanup ..."
     stop_server
@@ -100,6 +123,7 @@ test_health() {
 test_readyz() {
     # /readyz reflects MCP-server readiness only. Once the server is up it is
     # ready (it makes no broker calls).
+    wait_for_ready "$MCP_URL/readyz" "/readyz" || return 1
     local response
     response=$(curl -sf "$MCP_URL/readyz")
     assert_json_field "$response" ".status" "ready" "/readyz should return status=ready"
@@ -107,6 +131,7 @@ test_readyz() {
 
 test_ready_aliases_readyz() {
     # /ready is a body-identical alias of /readyz: same status code and body.
+    wait_for_ready "$MCP_URL/readyz" "/readyz" || return 1
     local ready_body readyz_body ready_code readyz_code
     ready_body=$(curl -s "$MCP_URL/ready")
     readyz_body=$(curl -s "$MCP_URL/readyz")
@@ -164,6 +189,10 @@ EOF
 
     local result=0
     if [ "$ready" -eq 1 ]; then
+        # /health (polled above) is up before SetInitialized() runs, so wait for
+        # /ready to leave the "starting" window before asserting it is 200. The
+        # explicit assertion below remains the source of truth for pass/fail.
+        wait_for_ready "http://localhost:$SECONDARY_MCP_PORT/ready" "/ready (secondary)" || true
         local http_code
         http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$SECONDARY_MCP_PORT/ready")
         if [ "$http_code" = "200" ]; then


### PR DESCRIPTION
## What
Operationalizes the decoupled readiness model in Kubernetes and retires the legacy broker-dialing `/ready`:
- `livenessProbe` → `/livez`, `readinessProbe` → `/readyz`, plus a cold-start `startupProbe` → `/readyz`.
- `/ready` is now a body-identical **alias of `/readyz`** (broker-dial removed); a broker being unreachable no longer marks the pod unready.

Part of the Observability & Telemetry epic ([SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791)). Story: [SOL-151285](https://sol-jira.atlassian.net/browse/SOL-151285).

## How
- `deploy/kubernetes/deployment.yaml`: probe paths repointed; `startupProbe` (period 2s × failureThreshold 30 ≈ 60s) covers normal cold start; liveness/readiness timings unchanged; `/livez` governs restart.
- `/ready` and `/readyz` share the same `health.ReadyzHandler` instance (identical body/status).
- `buildMux` simplified to `buildMux(readiness)` — the now-unused broker-dial code (`newBrokerReachabilityProbe`, probe goroutines, `DefaultReadinessProbeTimeoutSeconds`) removed; all callers updated.
- `/health` retained as the back-compat `{"status":"healthy"}` endpoint.

## Tests
`/ready` == `/readyz` (status+body+Content-Type, before and after init); decoupled-from-broker (200 with an unreachable broker); e2e shell suite updated to the new contract. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151285]: https://sol-jira.atlassian.net/browse/SOL-151285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ