### PR TITLE
SOL-151280: emit correlation_id as a slog attribute on every request-scoped log line

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,7 +69,7 @@ import (
 func newSlogHandler(level slog.Level) slog.Handler {
 	redactedKeys := []string{"password", "token", "secret", "authorization", "credential", "api_key", "private_key"}
 
-	return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+	jsonHandler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: level,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			key := strings.ToLower(a.Key)
@@ -82,6 +82,17 @@ func newSlogHandler(level slog.Level) slog.Handler {
 			return a
 		},
 	})
+
+	// Wrap the JSON handler so every request-scoped log line carries a
+	// correlation_id attribute (SOL-151280). The wrapper is installed
+	// unconditionally; gating is transitive: correlation.From(ctx) returns "" when
+	// the correlation middleware is not wired (OBS_CORRELATION_ID_ENABLED off) or
+	// for startup/non-request logs, so no correlation_id is emitted and output
+	// matches today exactly. This also covers the pre-config bootstrap handler,
+	// which is built before cfg is available and so cannot consult Enabled(cfg).
+	// Redaction is preserved: the wrapper delegates Handle to jsonHandler, which
+	// still owns and runs the ReplaceAttr filter above.
+	return correlation.NewSlogHandler(jsonHandler)
 }
 
 // buildMux creates the HTTP route multiplexer with basic routes.

--- a/internal/observability/correlation/sloghandler.go
+++ b/internal/observability/correlation/sloghandler.go
@@ -86,10 +86,12 @@ func (h *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 // non-empty correlation ID AND the record does not already carry a
 // correlation_id attribute, then delegates to next.
 //
-// The no-overwrite rule (AC #3) is enforced by scanning the record's attributes
-// for an existing correlation_id key before adding one; an explicitly logged
-// correlation_id always wins and is never duplicated. When there is no ID to add
-// and no recorded goa steps, the record is passed through untouched, so
+// The no-overwrite rule (AC #3) is enforced by checking for an existing
+// root-level correlation_id before adding one: either on the record itself
+// (hasCorrelationID) or bound on the logger at root via .With(...) before any
+// group was opened (hasRootCorrelationID). In both cases the caller's explicit
+// correlation_id wins and is never duplicated at the root. When there is no ID
+// to add and no recorded goa steps, the record is passed through untouched, so
 // absent-ID output matches the unwrapped handler exactly.
 //
 // With recorded goa steps, the delivery handler is rebuilt from the ungrouped
@@ -98,7 +100,7 @@ func (h *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 // their grouping while correlation_id stays at the top level.
 func (h *slogHandler) Handle(ctx context.Context, rec slog.Record) error {
 	id := From(ctx)
-	addID := id != "" && !h.hasCorrelationID(rec)
+	addID := id != "" && !h.hasCorrelationID(rec) && !h.hasRootCorrelationID()
 
 	if len(h.goas) == 0 {
 		if !addID {
@@ -142,6 +144,35 @@ func (h *slogHandler) hasCorrelationID(rec slog.Record) bool {
 		return true
 	})
 	return found
+}
+
+// hasRootCorrelationID reports whether a correlation_id was already bound on the
+// logger at the ROOT level via .With(...)/WithAttrs, recorded in goas. The
+// wrapper always injects its correlation_id at the root (bound on the ungrouped
+// next before any goa step is replayed), so a duplicate root key arises only
+// when a root-level correlation_id already exists. Returning true here suppresses
+// that injection so the caller's explicit value wins with no duplicate (AC #3).
+//
+// Only attrs bound BEFORE the first WithGroup land at the root; attrs bound after
+// a group nest under that group (a different key path) and must NOT suppress the
+// root injection. So the scan walks goas in order and stops at the first group
+// step: any correlation_id in an attr step seen before that is root-level; a
+// correlation_id only appearing in attrs after a group is nested and is ignored
+// here (still inject at root). With no goas (the common case) this returns false.
+func (h *slogHandler) hasRootCorrelationID() bool {
+	for _, g := range h.goas {
+		if g.group != "" {
+			// First group opened: subsequent attrs nest under it, so no further
+			// step can introduce a root-level correlation_id.
+			return false
+		}
+		for _, a := range g.attrs {
+			if a.Key == attrKey {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // WithAttrs returns a new slogHandler that records the attrs as a goa step. It

--- a/internal/observability/correlation/sloghandler.go
+++ b/internal/observability/correlation/sloghandler.go
@@ -44,10 +44,28 @@ const attrKey = "correlation_id"
 // instead of at the root, defeating a top-level grep. To keep correlation_id at
 // the root regardless of grouping, the wrapper does NOT delegate WithAttrs and
 // WithGroup to next immediately. It records each call as a "group or attrs" (goa)
-// step in order. In Handle it adds correlation_id to the UNGROUPED root handler
-// first, then replays the recorded goa steps onto next, so the user's own attrs
-// land in their groups while correlation_id stays at the root. With no goa steps
-// (the common case) this collapses to a single delegated Add.
+// step in order. When it must inject correlation_id under groups, Handle adds
+// correlation_id to the UNGROUPED root handler first, then replays the recorded
+// goa steps onto next, so the user's own attrs land in their groups while
+// correlation_id stays at the root. With no goa steps (the common case) this
+// collapses to a single delegated Add.
+//
+// Caching. Two things are fixed for a given handler (they depend only on next
+// and goas, which never change after construction) and are computed once when
+// the handler is derived, not on every Handle:
+//   - built is next with all goas applied — the static delivery chain WITHOUT
+//     correlation_id. For the root handler (no goas) built is just next. It
+//     serves every log line that does NOT need a per-record ID injected,
+//     avoiding a per-call rebuild of the WithGroup/WithAttrs chain.
+//   - rootHasID is whether a correlation_id is already bound at the root via
+//     .With(...) before any group (the hasRootCorrelationID walk over goas),
+//     used to suppress a duplicate root injection (AC #3).
+//
+// Only the inject-under-groups path (per-record ID present, groups open) still
+// builds per record: the ID comes from THIS record's context and must be bound
+// at the root before the caller's groups are reopened, and slog handlers are
+// immutable, so that root attr cannot be pre-applied onto the cached chain
+// without nesting under a group. See Handle for that path.
 type slogHandler struct {
 	next slog.Handler
 	// goas records WithGroup/WithAttrs calls in the order they were made, so
@@ -55,6 +73,16 @@ type slogHandler struct {
 	// empty in the common case (no .With/.WithGroup on the default logger), which
 	// makes Handle take the cheap delegated path.
 	goas []goa
+	// built is next with all goas already applied: the static delivery chain
+	// WITHOUT correlation_id, computed once at construction. It is exactly next
+	// for the root handler (no goas). Handle uses it to deliver any record that
+	// does not need a per-record correlation_id injected, so the group/attr chain
+	// is not rebuilt on every call.
+	built slog.Handler
+	// rootHasID caches hasRootCorrelationID(goas): true when a correlation_id is
+	// bound at the root before any group. Computed once at construction; used to
+	// suppress a duplicate root injection.
+	rootHasID bool
 }
 
 // goa is one recorded "group or attrs" operation: exactly one of group (a
@@ -72,7 +100,30 @@ type goa struct {
 // middleware is not wired (capability off) or for startup/non-request logs, so
 // in those cases no correlation_id attribute is emitted and output is unchanged.
 func NewSlogHandler(next slog.Handler) slog.Handler {
-	return &slogHandler{next: next}
+	return newSlogHandler(next, nil)
+}
+
+// newSlogHandler constructs a slogHandler and computes the cached fields (built,
+// rootHasID) once from next and goas. Every derived handler (WithAttrs,
+// WithGroup) routes through here so the cache is always consistent with goas and
+// no cache computation happens in Handle.
+func newSlogHandler(next slog.Handler, goas []goa) *slogHandler {
+	// built is the static delivery chain WITHOUT correlation_id: next with every
+	// goa applied. For the root handler (no goas) it is exactly next.
+	built := next
+	for _, g := range goas {
+		if g.group != "" {
+			built = built.WithGroup(g.group)
+		} else {
+			built = built.WithAttrs(g.attrs)
+		}
+	}
+	return &slogHandler{
+		next:      next,
+		goas:      goas,
+		built:     built,
+		rootHasID: hasRootCorrelationID(goas),
+	}
 }
 
 // Enabled delegates to next; the wrapper does not change level filtering. Groups
@@ -91,33 +142,48 @@ func (h *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 // (hasCorrelationID) or bound on the logger at root via .With(...) before any
 // group was opened (hasRootCorrelationID). In both cases the caller's explicit
 // correlation_id wins and is never duplicated at the root. When there is no ID
-// to add and no recorded goa steps, the record is passed through untouched, so
-// absent-ID output matches the unwrapped handler exactly.
+// to add, the record is delivered through the cached built chain untouched; with
+// no recorded goa steps built is exactly next, so absent-ID output matches the
+// unwrapped handler exactly.
 //
-// With recorded goa steps, the delivery handler is rebuilt from the ungrouped
-// root: correlation_id is bound at the root first, then the goa steps are
-// replayed (groups reopened, attrs rebound) so the record's own attributes keep
-// their grouping while correlation_id stays at the top level.
+// When correlation_id must be injected under recorded goa steps, the delivery
+// handler is rebuilt per record from the ungrouped root: correlation_id is bound
+// at the root first, then the goa steps are replayed (groups reopened, attrs
+// rebound) so the record's own attributes keep their grouping while
+// correlation_id stays at the top level. Every other case is served by the
+// cached delivery chain, which is not rebuilt per call.
 func (h *slogHandler) Handle(ctx context.Context, rec slog.Record) error {
 	id := From(ctx)
-	addID := id != "" && !h.hasCorrelationID(rec) && !h.hasRootCorrelationID()
+	// rootHasID is cached (fixed for this handler); only hasCorrelationID depends
+	// on the record and is checked per call.
+	addID := id != "" && !hasCorrelationID(rec) && !h.rootHasID
+
+	if !addID {
+		// No per-record ID to inject: deliver through the cached chain. For the
+		// root handler (no goas) built is exactly next, preserving the byte-for-byte
+		// unwrapped output for absent-ID / no-goas logs. For a grouped/attrs handler
+		// built already has all goas applied, so no chain is rebuilt here.
+		return h.built.Handle(ctx, rec)
+	}
 
 	if len(h.goas) == 0 {
-		if !addID {
-			return h.next.Handle(ctx, rec)
-		}
-		// Clone before mutating: slog may pass the same Record to more than one
-		// handler, and rec.Add appends to the Record's own attribute slice, so
-		// cloning keeps our added correlation_id local to this delivery.
+		// Fast path: no groups, so correlation_id is naturally at the root. Clone
+		// before mutating: slog may pass the same Record to more than one handler,
+		// and rec.Add appends to the Record's own attribute slice, so cloning keeps
+		// our added correlation_id local to this delivery.
 		rec = rec.Clone()
 		rec.Add(slog.String(attrKey, id))
 		return h.next.Handle(ctx, rec)
 	}
 
-	delivery := h.next
-	if addID {
-		delivery = delivery.WithAttrs([]slog.Attr{slog.String(attrKey, id)})
-	}
+	// Inject-under-groups path: this is the ONLY path that must build per record,
+	// and it cannot be precomputed. The ID comes from THIS record's context, and
+	// it must be bound at the ROOT before the caller's groups are reopened. slog
+	// handlers are immutable, so we cannot pre-apply a per-record root attr onto
+	// the cached (already-grouped) built chain without the attr nesting under a
+	// group. So bind correlation_id on the ungrouped next first, then replay the
+	// goa steps.
+	delivery := h.next.WithAttrs([]slog.Attr{slog.String(attrKey, id)})
 	for _, g := range h.goas {
 		if g.group != "" {
 			delivery = delivery.WithGroup(g.group)
@@ -133,8 +199,9 @@ func (h *slogHandler) Handle(ctx context.Context, rec slog.Record) error {
 // the record's own attributes are scanned; attributes bound earlier via
 // WithAttrs are held in goas and are not part of the per-record set, which is
 // the correct scope: a correlation_id attached to the record itself is the one a
-// caller explicitly chose to set for that line.
-func (h *slogHandler) hasCorrelationID(rec slog.Record) bool {
+// caller explicitly chose to set for that line. It takes no handler state, so it
+// is a package function called per record.
+func hasCorrelationID(rec slog.Record) bool {
 	found := false
 	rec.Attrs(func(a slog.Attr) bool {
 		if a.Key == attrKey {
@@ -159,8 +226,11 @@ func (h *slogHandler) hasCorrelationID(rec slog.Record) bool {
 // step: any correlation_id in an attr step seen before that is root-level; a
 // correlation_id only appearing in attrs after a group is nested and is ignored
 // here (still inject at root). With no goas (the common case) this returns false.
-func (h *slogHandler) hasRootCorrelationID() bool {
-	for _, g := range h.goas {
+//
+// It depends only on goas (fixed for a handler), so it is computed once at
+// construction and cached in slogHandler.rootHasID rather than run per Handle.
+func hasRootCorrelationID(goas []goa) bool {
+	for _, g := range goas {
 		if g.group != "" {
 			// First group opened: subsequent attrs nest under it, so no further
 			// step can introduce a root-level correlation_id.
@@ -185,7 +255,7 @@ func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	if len(attrs) == 0 {
 		return h
 	}
-	return &slogHandler{next: h.next, goas: appendGoa(h.goas, goa{attrs: attrs})}
+	return newSlogHandler(h.next, appendGoa(h.goas, goa{attrs: attrs}))
 }
 
 // WithGroup returns a new slogHandler that records the opened group as a goa
@@ -197,7 +267,7 @@ func (h *slogHandler) WithGroup(name string) slog.Handler {
 	if name == "" {
 		return h
 	}
-	return &slogHandler{next: h.next, goas: appendGoa(h.goas, goa{group: name})}
+	return newSlogHandler(h.next, appendGoa(h.goas, goa{group: name}))
 }
 
 // appendGoa returns a new slice with g appended, copying the existing steps so

--- a/internal/observability/correlation/sloghandler.go
+++ b/internal/observability/correlation/sloghandler.go
@@ -1,0 +1,180 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package correlation
+
+import (
+	"context"
+	"log/slog"
+)
+
+// attrKey is the slog attribute key under which the correlation ID is stamped on
+// every request-scoped log line. It matches the field name an operator greps for
+// to follow a single request across all of its log output.
+const attrKey = "correlation_id"
+
+// slogHandler is a slog.Handler decorator that stamps the request's correlation
+// ID onto every emitted record. It reads the ID from the record's context (where
+// the correlation middleware seeded it via With) rather than from a fixed value,
+// so a single handler instance serves all requests: the ID is derived per record
+// in Handle, not captured at construction.
+//
+// Redaction is preserved automatically: the wrapper does no formatting and owns
+// no ReplaceAttr. It delegates Handle to next (the JSON handler that owns the
+// credential-redaction ReplaceAttr filter), so every attribute — including the
+// correlation_id this wrapper adds — still flows through ReplaceAttr. The added
+// correlation_id key is not a credential pattern, so it passes through intact
+// while passwords/tokens/etc. are still redacted by next.
+//
+// Top-level placement under groups. slog's built-in handlers nest every record
+// attribute (and WithAttrs-bound attribute) under any group opened via
+// WithGroup. If the wrapper just added correlation_id after delegating groups to
+// next, the ID would nest inside the group (e.g. {"g":{"correlation_id":...}})
+// instead of at the root, defeating a top-level grep. To keep correlation_id at
+// the root regardless of grouping, the wrapper does NOT delegate WithAttrs and
+// WithGroup to next immediately. It records each call as a "group or attrs" (goa)
+// step in order. In Handle it adds correlation_id to the UNGROUPED root handler
+// first, then replays the recorded goa steps onto next, so the user's own attrs
+// land in their groups while correlation_id stays at the root. With no goa steps
+// (the common case) this collapses to a single delegated Add.
+type slogHandler struct {
+	next slog.Handler
+	// goas records WithGroup/WithAttrs calls in the order they were made, so
+	// Handle can replay them after injecting correlation_id at the root. It is
+	// empty in the common case (no .With/.WithGroup on the default logger), which
+	// makes Handle take the cheap delegated path.
+	goas []goa
+}
+
+// goa is one recorded "group or attrs" operation: exactly one of group (a
+// WithGroup call) or attrs (a WithAttrs call) is set. This is the standard slog
+// decorator technique for deferring grouping so a decorator can inject an
+// attribute at the root before reopening the caller's groups.
+type goa struct {
+	group string
+	attrs []slog.Attr
+}
+
+// NewSlogHandler wraps next so that any log emitted within a request context
+// automatically includes a correlation_id attribute. Install it once over the
+// base handler; gating is transitive: From returns "" when the correlation
+// middleware is not wired (capability off) or for startup/non-request logs, so
+// in those cases no correlation_id attribute is emitted and output is unchanged.
+func NewSlogHandler(next slog.Handler) slog.Handler {
+	return &slogHandler{next: next}
+}
+
+// Enabled delegates to next; the wrapper does not change level filtering. Groups
+// and attrs do not affect a level-only decision, so delegating to the (possibly
+// ungrouped) next is correct.
+func (h *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+// Handle stamps correlation_id onto the record when the context carries a
+// non-empty correlation ID AND the record does not already carry a
+// correlation_id attribute, then delegates to next.
+//
+// The no-overwrite rule (AC #3) is enforced by scanning the record's attributes
+// for an existing correlation_id key before adding one; an explicitly logged
+// correlation_id always wins and is never duplicated. When there is no ID to add
+// and no recorded goa steps, the record is passed through untouched, so
+// absent-ID output matches the unwrapped handler exactly.
+//
+// With recorded goa steps, the delivery handler is rebuilt from the ungrouped
+// root: correlation_id is bound at the root first, then the goa steps are
+// replayed (groups reopened, attrs rebound) so the record's own attributes keep
+// their grouping while correlation_id stays at the top level.
+func (h *slogHandler) Handle(ctx context.Context, rec slog.Record) error {
+	id := From(ctx)
+	addID := id != "" && !h.hasCorrelationID(rec)
+
+	if len(h.goas) == 0 {
+		if !addID {
+			return h.next.Handle(ctx, rec)
+		}
+		// Clone before mutating: slog may pass the same Record to more than one
+		// handler, and rec.Add appends to the Record's own attribute slice, so
+		// cloning keeps our added correlation_id local to this delivery.
+		rec = rec.Clone()
+		rec.Add(slog.String(attrKey, id))
+		return h.next.Handle(ctx, rec)
+	}
+
+	delivery := h.next
+	if addID {
+		delivery = delivery.WithAttrs([]slog.Attr{slog.String(attrKey, id)})
+	}
+	for _, g := range h.goas {
+		if g.group != "" {
+			delivery = delivery.WithGroup(g.group)
+		} else {
+			delivery = delivery.WithAttrs(g.attrs)
+		}
+	}
+	return delivery.Handle(ctx, rec)
+}
+
+// hasCorrelationID reports whether rec already carries a correlation_id
+// attribute, so an existing one is never overwritten or duplicated (AC #3). Only
+// the record's own attributes are scanned; attributes bound earlier via
+// WithAttrs are held in goas and are not part of the per-record set, which is
+// the correct scope: a correlation_id attached to the record itself is the one a
+// caller explicitly chose to set for that line.
+func (h *slogHandler) hasCorrelationID(rec slog.Record) bool {
+	found := false
+	rec.Attrs(func(a slog.Attr) bool {
+		if a.Key == attrKey {
+			found = true
+			return false // stop iterating
+		}
+		return true
+	})
+	return found
+}
+
+// WithAttrs returns a new slogHandler that records the attrs as a goa step. It
+// MUST re-wrap rather than return the bare next: slog clones the handler on
+// every logger.With(...) call, and returning the unwrapped inner handler would
+// strip the correlation behavior from the derived logger. Recording (rather than
+// delegating to next.WithAttrs) keeps the replay ordering correct relative to
+// any interleaved WithGroup calls.
+func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return &slogHandler{next: h.next, goas: appendGoa(h.goas, goa{attrs: attrs})}
+}
+
+// WithGroup returns a new slogHandler that records the opened group as a goa
+// step. Like WithAttrs it re-wraps so correlation behavior survives
+// logger.WithGroup(...), and it defers the actual grouping to Handle so
+// correlation_id can be injected at the root before the group is reopened.
+func (h *slogHandler) WithGroup(name string) slog.Handler {
+	// An empty group name is a no-op per the slog.Handler contract.
+	if name == "" {
+		return h
+	}
+	return &slogHandler{next: h.next, goas: appendGoa(h.goas, goa{group: name})}
+}
+
+// appendGoa returns a new slice with g appended, copying the existing steps so
+// derived handlers never share (and so cannot mutate) a parent's goa backing
+// array — sibling loggers derived from the same parent must stay independent.
+func appendGoa(existing []goa, g goa) []goa {
+	out := make([]goa, 0, len(existing)+1)
+	out = append(out, existing...)
+	out = append(out, g)
+	return out
+}

--- a/internal/observability/correlation/sloghandler_test.go
+++ b/internal/observability/correlation/sloghandler_test.go
@@ -187,7 +187,8 @@ func TestSlogHandler_InjectsRootWhenWithBoundCorrelationIDIsNested(t *testing.T)
 // AC #2: redaction is preserved because the wrapper delegates to the inner JSON
 // handler that owns ReplaceAttr. A password attr is redacted, and the
 // correlation_id added by the wrapper passes through ReplaceAttr intact (it is
-// not a credential key).
+// not a credential key). This proves correlation_id is NOT accidentally caught
+// by a realistic credential filter while credentials ARE still redacted.
 func TestSlogHandler_PreservesRedaction(t *testing.T) {
 	var buf bytes.Buffer
 	logger := newRedactingLogger(&buf)
@@ -201,6 +202,68 @@ func TestSlogHandler_PreservesRedaction(t *testing.T) {
 	}
 	if got := m["correlation_id"]; got != "abc" {
 		t.Errorf("correlation_id = %v, want %q", got, "abc")
+	}
+}
+
+// AC #2 (real coverage): the wrapper-injected correlation_id MUST flow through
+// next's ReplaceAttr. This uses a base handler whose ReplaceAttr rewrites the
+// correlation_id value to a sentinel. If the wrapper ever bypassed next for the
+// attr it injects (e.g. formatted it itself), the sentinel would not appear and
+// this fails. Unlike TestSlogHandler_PreservesRedaction — where correlation_id
+// is deliberately NOT a redacted key, so its presence proves nothing about the
+// ReplaceAttr path — this asserts the injected attr is actually transformed by
+// next's ReplaceAttr.
+func TestSlogHandler_InjectedCorrelationIDFlowsThroughReplaceAttr(t *testing.T) {
+	var buf bytes.Buffer
+	json := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == attrKey {
+				a.Value = slog.StringValue("[CID_REDACTED]")
+			}
+			return a
+		},
+	})
+	logger := slog.New(NewSlogHandler(json))
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hello")
+
+	// The raw line proves the injected attr passed through next's ReplaceAttr:
+	// the "abc" value was rewritten to the sentinel by the base handler.
+	if line := buf.String(); !strings.Contains(line, `"correlation_id":"[CID_REDACTED]"`) {
+		t.Errorf("injected correlation_id did not flow through next's ReplaceAttr: %s", line)
+	}
+}
+
+// Comment 2 regression guard for the cached no-add delivery path. A grouped
+// logger (goas present) with a correlation_id already bound at the root must be
+// delivered via the cached static chain (built) WITHOUT the wrapper injecting a
+// second root ID. This exercises addID==false with goas!=nil: if the optimized
+// path mis-cached the chain or lost the rootHasID suppression, the root ID would
+// be wrong, duplicated, or the grouped attrs misplaced.
+func TestSlogHandler_CachedDeliveryWithBoundRootIDUnderGroup(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).
+		With(slog.String("correlation_id", "explicit")).
+		WithGroup("g")
+
+	ctx := With(context.Background(), "from-ctx")
+	logger.InfoContext(ctx, "hello", slog.String("k", "v"))
+
+	m := parseLine(t, &buf)
+	if got := m["correlation_id"]; got != "explicit" {
+		t.Errorf("root correlation_id = %v, want %q (bound root value wins, no injection)", got, "explicit")
+	}
+	if n := strings.Count(buf.String(), `"correlation_id"`); n != 1 {
+		t.Errorf("expected exactly one correlation_id occurrence, got %d in: %s", n, buf.String())
+	}
+	g, ok := m["g"].(map[string]any)
+	if !ok {
+		t.Fatalf("group g missing or not an object: %v", m)
+	}
+	if got := g["k"]; got != "v" {
+		t.Errorf("g.k = %v, want %q (record attr nested under group via cached chain)", got, "v")
 	}
 }
 

--- a/internal/observability/correlation/sloghandler_test.go
+++ b/internal/observability/correlation/sloghandler_test.go
@@ -1,0 +1,272 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package correlation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// newJSONLogger returns a slog.Logger whose output is captured in buf, with the
+// correlation wrapper installed over a plain JSON handler. It is the baseline
+// fixture: no ReplaceAttr, just the wrapper over JSON, so tests can assert how
+// the correlation_id attribute lands in the emitted record.
+func newJSONLogger(buf *bytes.Buffer) *slog.Logger {
+	json := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(NewSlogHandler(json))
+}
+
+// newRedactingLogger mirrors cmd/server/main.go newSlogHandler: a JSON handler
+// carrying the SAME credential-redaction ReplaceAttr, wrapped by the correlation
+// handler. It proves the wrapper delegates through ReplaceAttr (AC #2).
+func newRedactingLogger(buf *bytes.Buffer) *slog.Logger {
+	redactedKeys := []string{"password", "token", "secret", "authorization", "credential", "api_key", "private_key"}
+	json := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			key := strings.ToLower(a.Key)
+			for _, redacted := range redactedKeys {
+				if strings.Contains(key, redacted) {
+					a.Value = slog.StringValue("[REDACTED]")
+					return a
+				}
+			}
+			return a
+		},
+	})
+	return slog.New(NewSlogHandler(json))
+}
+
+// parseLine decodes the single JSON log line captured in buf.
+func parseLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		t.Fatalf("no log output captured")
+	}
+	if strings.Contains(line, "\n") {
+		t.Fatalf("expected exactly one log line, got:\n%s", line)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		t.Fatalf("log line is not valid JSON: %v\nline: %s", err, line)
+	}
+	return m
+}
+
+// AC #1: a request-scoped context carrying a correlation ID stamps
+// correlation_id onto the emitted record.
+func TestSlogHandler_AddsCorrelationIDFromContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf)
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hello")
+
+	m := parseLine(t, &buf)
+	if got := m["correlation_id"]; got != "abc" {
+		t.Errorf("correlation_id = %v, want %q", got, "abc")
+	}
+}
+
+// AC #4 / transitive-off: a context with no correlation ID (the steady state
+// when the middleware is not wired, or for startup/non-request logs) emits no
+// correlation_id key, so output matches today exactly.
+func TestSlogHandler_NoIDWhenAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf)
+
+	logger.InfoContext(context.Background(), "hello")
+
+	m := parseLine(t, &buf)
+	if _, present := m["correlation_id"]; present {
+		t.Errorf("correlation_id unexpectedly present: %v", m)
+	}
+}
+
+// AC #4: an empty-string ID on the context is treated as absent (From returns
+// "" both when unset and when explicitly empty).
+func TestSlogHandler_EmptyIDNotEmitted(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf)
+
+	ctx := With(context.Background(), "")
+	logger.InfoContext(ctx, "hello")
+
+	m := parseLine(t, &buf)
+	if _, present := m["correlation_id"]; present {
+		t.Errorf("correlation_id unexpectedly present for empty id: %v", m)
+	}
+}
+
+// AC #3: a record that already carries a correlation_id attribute is NOT
+// overwritten, and no duplicate is added. We log an explicit correlation_id that
+// differs from the context value and assert the explicit value survives.
+func TestSlogHandler_DoesNotOverwriteExisting(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf)
+
+	ctx := With(context.Background(), "from-ctx")
+	logger.InfoContext(ctx, "hello", slog.String("correlation_id", "explicit"))
+
+	m := parseLine(t, &buf)
+	if got := m["correlation_id"]; got != "explicit" {
+		t.Errorf("correlation_id = %v, want %q (existing attr must win)", got, "explicit")
+	}
+
+	// Assert no duplicate key was emitted: a duplicated attribute would show as
+	// two occurrences in the raw line.
+	if n := strings.Count(buf.String(), `"correlation_id"`); n != 1 {
+		t.Errorf("expected exactly one correlation_id occurrence, got %d in: %s", n, buf.String())
+	}
+}
+
+// AC #2: redaction is preserved because the wrapper delegates to the inner JSON
+// handler that owns ReplaceAttr. A password attr is redacted, and the
+// correlation_id added by the wrapper passes through ReplaceAttr intact (it is
+// not a credential key).
+func TestSlogHandler_PreservesRedaction(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newRedactingLogger(&buf)
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hello", slog.String("password", "hunter2"))
+
+	m := parseLine(t, &buf)
+	if got := m["password"]; got != "[REDACTED]" {
+		t.Errorf("password = %v, want %q", got, "[REDACTED]")
+	}
+	if got := m["correlation_id"]; got != "abc" {
+		t.Errorf("correlation_id = %v, want %q", got, "abc")
+	}
+}
+
+// WithAttrs must re-wrap so correlation behavior survives .With(...). After
+// adding a base attr, a log on a correlation-bearing context still gets
+// correlation_id.
+func TestSlogHandler_WithAttrsPreservesCorrelation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).With(slog.String("component", "test"))
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hello")
+
+	m := parseLine(t, &buf)
+	if got := m["component"]; got != "test" {
+		t.Errorf("component = %v, want %q", got, "test")
+	}
+	if got := m["correlation_id"]; got != "abc" {
+		t.Errorf("correlation_id = %v, want %q", got, "abc")
+	}
+}
+
+// WithGroup must re-wrap so correlation behavior survives .WithGroup(...). The
+// correlation_id is added at the record's top level (not inside the group),
+// because rec.Add on the wrapped record is independent of the group set on the
+// inner handler.
+func TestSlogHandler_WithGroupPreservesCorrelation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).WithGroup("g")
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hello", slog.String("k", "v"))
+
+	m := parseLine(t, &buf)
+	if got := m["correlation_id"]; got != "abc" {
+		t.Errorf("correlation_id = %v, want %q (must survive WithGroup)", got, "abc")
+	}
+}
+
+// Under an open group, the record's own attributes nest inside the group while
+// correlation_id stays at the root (a top-level field an operator can grep). The
+// raw line is inspected because parseLine flattens to a map and the nesting
+// matters here.
+func TestSlogHandler_WithGroupKeepsCorrelationAtRoot(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).WithGroup("g")
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hello", slog.String("k", "v"))
+
+	line := buf.String()
+	if !strings.Contains(line, `"correlation_id":"abc"`) {
+		t.Errorf("correlation_id not at root: %s", line)
+	}
+	if !strings.Contains(line, `"g":{"k":"v"}`) {
+		t.Errorf("record attr not nested under group: %s", line)
+	}
+}
+
+// Interleaved With/WithGroup/With: pre-group attrs and correlation_id land at
+// the root; post-group attrs and the record's own attrs nest under the group.
+// This locks the goa replay ordering.
+func TestSlogHandler_MixedWithAndGroup(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).
+		With(slog.String("base", "b")).
+		WithGroup("g").
+		With(slog.String("ingroup", "x"))
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hi", slog.String("rec", "r"))
+
+	line := buf.String()
+	for _, want := range []string{`"correlation_id":"abc"`, `"base":"b"`, `"ingroup":"x"`, `"rec":"r"`} {
+		if !strings.Contains(line, want) {
+			t.Errorf("missing %s in: %s", want, line)
+		}
+	}
+	// ingroup and rec must be inside group g; base and correlation_id must not.
+	if !strings.Contains(line, `"g":{"ingroup":"x","rec":"r"}`) {
+		t.Errorf("grouped attrs not nested correctly: %s", line)
+	}
+}
+
+// Nested groups: correlation_id stays at the root while the record's own attrs
+// nest under the full group path. Locks the replay loop against future refactors.
+func TestSlogHandler_NestedGroups(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).WithGroup("a").WithGroup("b")
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "hi", slog.String("rec", "r"))
+
+	line := buf.String()
+	if !strings.Contains(line, `"correlation_id":"abc"`) {
+		t.Errorf("correlation_id not at root: %s", line)
+	}
+	if !strings.Contains(line, `"a":{"b":{"rec":"r"}}`) {
+		t.Errorf("record attr not nested under a.b: %s", line)
+	}
+}
+
+// Enabled delegates to the inner handler: a level below the handler threshold is
+// dropped, proving the wrapper does not break level filtering.
+func TestSlogHandler_EnabledDelegates(t *testing.T) {
+	var buf bytes.Buffer
+	json := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	logger := slog.New(NewSlogHandler(json))
+
+	ctx := With(context.Background(), "abc")
+	logger.InfoContext(ctx, "below threshold")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for sub-threshold level, got: %s", buf.String())
+	}
+}

--- a/internal/observability/correlation/sloghandler_test.go
+++ b/internal/observability/correlation/sloghandler_test.go
@@ -137,6 +137,53 @@ func TestSlogHandler_DoesNotOverwriteExisting(t *testing.T) {
 	}
 }
 
+// AC #3: a correlation_id bound on the LOGGER at the root via .With(...) (held in
+// goas, not on the record) must also win over the context ID — the wrapper must
+// not inject a second root correlation_id. Without the goas root-level check, the
+// context ID would be added at the root alongside the explicit one, producing a
+// duplicate root key.
+func TestSlogHandler_DoesNotDuplicateWithBoundRootCorrelationID(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).With(slog.String("correlation_id", "explicit"))
+
+	ctx := With(context.Background(), "from-ctx")
+	logger.InfoContext(ctx, "hello")
+
+	m := parseLine(t, &buf)
+	if got := m["correlation_id"]; got != "explicit" {
+		t.Errorf("correlation_id = %v, want %q (With-bound root value must win)", got, "explicit")
+	}
+	// Exactly one root correlation_id: the context ID must not be injected.
+	if n := strings.Count(buf.String(), `"correlation_id"`); n != 1 {
+		t.Errorf("expected exactly one correlation_id occurrence, got %d in: %s", n, buf.String())
+	}
+}
+
+// AC #3 boundary: a correlation_id bound via .With(...) AFTER a WithGroup nests
+// under that group (a different key path), so it does NOT collide with the root.
+// The wrapper must still inject the context ID at the root: the result has the
+// context ID at root AND the explicit value nested under the group, no duplicate
+// at any single level.
+func TestSlogHandler_InjectsRootWhenWithBoundCorrelationIDIsNested(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newJSONLogger(&buf).WithGroup("g").With(slog.String("correlation_id", "nested"))
+
+	ctx := With(context.Background(), "from-ctx")
+	logger.InfoContext(ctx, "hello")
+
+	m := parseLine(t, &buf)
+	if got := m["correlation_id"]; got != "from-ctx" {
+		t.Errorf("root correlation_id = %v, want %q (context ID injected at root)", got, "from-ctx")
+	}
+	g, ok := m["g"].(map[string]any)
+	if !ok {
+		t.Fatalf("group g missing or not an object: %v", m)
+	}
+	if got := g["correlation_id"]; got != "nested" {
+		t.Errorf("g.correlation_id = %v, want %q (nested explicit value preserved)", got, "nested")
+	}
+}
+
 // AC #2: redaction is preserved because the wrapper delegates to the inner JSON
 // handler that owns ReplaceAttr. A password attr is redacted, and the
 // correlation_id added by the wrapper passes through ReplaceAttr intact (it is
@@ -226,15 +273,23 @@ func TestSlogHandler_MixedWithAndGroup(t *testing.T) {
 	ctx := With(context.Background(), "abc")
 	logger.InfoContext(ctx, "hi", slog.String("rec", "r"))
 
-	line := buf.String()
-	for _, want := range []string{`"correlation_id":"abc"`, `"base":"b"`, `"ingroup":"x"`, `"rec":"r"`} {
-		if !strings.Contains(line, want) {
-			t.Errorf("missing %s in: %s", want, line)
-		}
+	m := parseLine(t, &buf)
+	// correlation_id and base land at the root; ingroup and rec nest under g.
+	if got := m["correlation_id"]; got != "abc" {
+		t.Errorf("correlation_id = %v, want %q (root level)", got, "abc")
 	}
-	// ingroup and rec must be inside group g; base and correlation_id must not.
-	if !strings.Contains(line, `"g":{"ingroup":"x","rec":"r"}`) {
-		t.Errorf("grouped attrs not nested correctly: %s", line)
+	if got := m["base"]; got != "b" {
+		t.Errorf("base = %v, want %q (root level)", got, "b")
+	}
+	g, ok := m["g"].(map[string]any)
+	if !ok {
+		t.Fatalf("group g missing or not an object: %v", m)
+	}
+	if got := g["ingroup"]; got != "x" {
+		t.Errorf("g.ingroup = %v, want %q", got, "x")
+	}
+	if got := g["rec"]; got != "r" {
+		t.Errorf("g.rec = %v, want %q", got, "r")
 	}
 }
 
@@ -247,12 +302,20 @@ func TestSlogHandler_NestedGroups(t *testing.T) {
 	ctx := With(context.Background(), "abc")
 	logger.InfoContext(ctx, "hi", slog.String("rec", "r"))
 
-	line := buf.String()
-	if !strings.Contains(line, `"correlation_id":"abc"`) {
-		t.Errorf("correlation_id not at root: %s", line)
+	m := parseLine(t, &buf)
+	if got := m["correlation_id"]; got != "abc" {
+		t.Errorf("correlation_id = %v, want %q (root level)", got, "abc")
 	}
-	if !strings.Contains(line, `"a":{"b":{"rec":"r"}}`) {
-		t.Errorf("record attr not nested under a.b: %s", line)
+	a, ok := m["a"].(map[string]any)
+	if !ok {
+		t.Fatalf("group a missing or not an object: %v", m)
+	}
+	b, ok := a["b"].(map[string]any)
+	if !ok {
+		t.Fatalf("group a.b missing or not an object: %v", m)
+	}
+	if got := b["rec"]; got != "r" {
+		t.Errorf("a.b.rec = %v, want %q", got, "r")
 	}
 }
 


### PR DESCRIPTION
## What
Every request-scoped log line now carries `correlation_id`, so an operator can `grep` all logs for one failed call.

Part of the Observability & Telemetry epic ([SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791)). Story: [SOL-151280](https://sol-jira.atlassian.net/browse/SOL-151280).

## How
- New `slog.Handler` decorator (`correlation.NewSlogHandler`) that, in `Handle(ctx, rec)`, reads `correlation.From(ctx)` and adds `correlation_id` when present — wired into `newSlogHandler` so both the bootstrap and user-level loggers get it.
- Preserves the existing `ReplaceAttr` credential redaction (the wrapper does no formatting; it delegates to the inner JSON handler that owns the filter).
- Does not overwrite an existing `correlation_id` attribute, and clones the record before adding so shared records are never mutated.
- Gated transitively: `From(ctx)` is empty when the correlation middleware isn't wired (`OBS_CORRELATION_ID_ENABLED` off) or for startup/non-request logs, so output matches today exactly when the capability is off.
- `WithGroup`/`WithAttrs` re-wrap correctly so `correlation_id` stays at the **root** of the log line even after `.WithGroup(...)`, while the record's own attrs nest under the group (a real slog gotcha, handled and tested across orderings incl. nested groups).

## Tests
ID added from context / absent when no ID / empty ID / not-overwritten / redaction preserved / `WithAttrs` + `WithGroup` (single, mixed, and nested) keep `correlation_id` at root. `make check` green (build + vet + lint + `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151280]: https://sol-jira.atlassian.net/browse/SOL-151280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ