### PR TITLE
SOL-151288: SIGTERM in-process drain (/readyz 503 → sleep → graceful shutdown) + terminationGracePeriodSeconds

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -352,6 +352,18 @@ func drainAndShutdown(srv shutdowner, readiness *health.ReadinessState, drainDel
 	return gracefulShutdown(srv, shutdownTimeout)
 }
 
+// drainDelayForSignal returns the drain delay to apply for the received
+// shutdown signal. SIGTERM (orchestrator-initiated, e.g. Kubernetes) gets the
+// configured drain window so the orchestrator can deregister the pod before we
+// stop accepting. SIGINT (os.Interrupt, a local Ctrl-C) skips the drain
+// entirely — there is no orchestrator to wait for — so it returns 0.
+func drainDelayForSignal(sig os.Signal, configured time.Duration) time.Duration {
+	if sig == os.Interrupt { // syscall.SIGINT
+		return 0
+	}
+	return configured
+}
+
 // shutdowner is the subset of *http.Server that gracefulShutdown drives. It
 // exists so a test can substitute a fake that captures the deadline of the
 // context handed to Shutdown — proving the full timeout budget is granted at
@@ -683,15 +695,22 @@ func main() {
 
 	var startupErr error
 	var fromSignal bool
+	var receivedSignal os.Signal
 	select {
-	case <-done:
-		// SIGTERM (or Ctrl-C): drain before shutting down. The drain (flip
+	case sig := <-done:
+		// Shutdown signal received: drain before shutting down. The drain (flip
 		// /readyz, sleep the propagation window, then graceful shutdown) runs in
-		// drainAndShutdown below. The shutdown-timeout context is NOT built here;
-		// gracefulShutdown builds it after the drain sleep so Shutdown gets the
-		// full budget (see drainAndShutdown / gracefulShutdown).
+		// drainAndShutdown below. SIGTERM (orchestrator-initiated) honors the
+		// configured drain window; SIGINT (a local Ctrl-C) skips it via
+		// drainDelayForSignal — there is no orchestrator to wait for. The
+		// shutdown-timeout context is NOT built here; gracefulShutdown builds it
+		// after the drain sleep so Shutdown gets the full budget (see
+		// drainAndShutdown / gracefulShutdown).
 		fromSignal = true
-		slog.Info("server shutting down", slog.String("reason", "signal"))
+		receivedSignal = sig
+		slog.Info("server shutting down",
+			slog.String("reason", "signal"),
+			slog.String("signal", sig.String()))
 	case startupErr = <-serverErr:
 		// Error already logged in startServer. Capture it so future telemetry
 		// hooks (e.g., metrics flush, error reporting) have access to the value,
@@ -708,7 +727,7 @@ func main() {
 	shutdownTimeout := time.Duration(defaults.DefaultShutdownTimeoutSeconds) * time.Second
 
 	if fromSignal {
-		drainDelay := time.Duration(cfg.Observability.ShutdownDrainDelayS) * time.Second
+		drainDelay := drainDelayForSignal(receivedSignal, time.Duration(cfg.Observability.ShutdownDrainDelayS)*time.Second)
 		_ = drainAndShutdown(httpServer, readiness, drainDelay, shutdownTimeout)
 	} else {
 		_ = gracefulShutdown(httpServer, shutdownTimeout)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -317,6 +317,51 @@ func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error 
 	return errCh
 }
 
+// drainAndShutdown performs the SIGTERM graceful-drain sequence (SOL-151288).
+// In strict order it:
+//
+//  1. SetShuttingDown FIRST, so /readyz flips to 503 ("shutting_down")
+//     immediately — within AC #5's 1s budget, before any sleep — and the
+//     orchestrator stops routing new traffic to this pod.
+//  2. sleeps drainDelay (the propagation window) so K8s observes the not-ready
+//     state and deregisters the pod from its endpoint set. The distroless image
+//     has no shell, so there is no preStop hook; this delay runs IN-PROCESS.
+//  3. gracefully shuts the HTTP server down so in-flight requests drain.
+//
+// Step 1 happens before the sleep so readiness flips with no dependence on the
+// drain delay (verified by the zero-delay test). drainDelay <= 0 skips the
+// sleep but still flips readiness and shuts down. This is the signal-path only;
+// the startup-error path calls gracefulShutdown directly and does NOT drain
+// (a process that never began serving has nothing to drain and no reason to
+// advertise a propagation window).
+func drainAndShutdown(ctx context.Context, srv *http.Server, readiness *health.ReadinessState, drainDelay time.Duration) error {
+	readiness.SetShuttingDown()
+	slog.Info("draining before shutdown",
+		slog.String("reason", "signal"),
+		slog.Duration("drain_delay", drainDelay))
+	if drainDelay > 0 {
+		time.Sleep(drainDelay)
+	}
+	return gracefulShutdown(ctx, srv)
+}
+
+// gracefulShutdown shuts srv down within ctx's deadline, falling back to a
+// forced Close if the graceful shutdown times out (so the process is never
+// wedged by a connection that refuses to drain). It returns the Shutdown error
+// for the caller's exit-status decision; the forced-close fallback is handled
+// internally. This is the shared shutdown step for both the signal path (via
+// drainAndShutdown) and the startup-error path (called directly, no drain).
+func gracefulShutdown(ctx context.Context, srv *http.Server) error {
+	err := srv.Shutdown(ctx)
+	if err != nil {
+		slog.Error("shutdown timed out, forcing close", slog.String("error", err.Error()))
+		if closeErr := srv.Close(); closeErr != nil {
+			slog.Error("forced close failed", slog.String("error", closeErr.Error()))
+		}
+	}
+	return err
+}
+
 // newBrokerReachabilityProbe returns a probe function that checks whether a
 // broker's SEMP port is accepting TCP connections. The returned function
 // resolves the broker alias against cfg, parses the URL, defaults the port
@@ -610,28 +655,32 @@ func main() {
 	readiness.SetInitialized()
 
 	var startupErr error
+	var fromSignal bool
 	select {
 	case <-done:
-		// TODO(SOL-151288 / Story 31a): call readiness.SetShuttingDown() here on
-		// SIGTERM, before httpServer.Shutdown, so /readyz reports "shutting_down"
-		// during graceful drain. The mechanism exists on ReadinessState today;
-		// wiring it to the signal is Story 31a's scope.
+		// SIGTERM (or Ctrl-C): drain before shutting down. The drain (flip
+		// /readyz, sleep the propagation window, then graceful shutdown) is
+		// deferred to drainAndShutdown below so it runs after the shutdown-
+		// timeout context is built.
+		fromSignal = true
 		slog.Info("server shutting down", slog.String("reason", "signal"))
 	case startupErr = <-serverErr:
 		// Error already logged in startServer. Capture it so future telemetry
 		// hooks (e.g., metrics flush, error reporting) have access to the value,
-		// then run cleanup before exiting non-zero.
+		// then run cleanup before exiting non-zero. This path does NOT drain:
+		// the server never began serving traffic, so there is nothing to drain
+		// and no orchestrator routing to wait out.
 	}
 
 	shutdownTimeout := time.Duration(defaults.DefaultShutdownTimeoutSeconds) * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
-	if err := httpServer.Shutdown(ctx); err != nil {
-		slog.Error("shutdown timed out, forcing close", slog.String("error", err.Error()))
-		if closeErr := httpServer.Close(); closeErr != nil {
-			slog.Error("forced close failed", slog.String("error", closeErr.Error()))
-		}
+	if fromSignal {
+		drainDelay := time.Duration(cfg.Observability.ShutdownDrainDelayS) * time.Second
+		_ = drainAndShutdown(ctx, httpServer, readiness, drainDelay)
+	} else {
+		_ = gracefulShutdown(ctx, httpServer)
 	}
 
 	slog.Info("server stopped")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -334,7 +334,14 @@ func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error 
 // the startup-error path calls gracefulShutdown directly and does NOT drain
 // (a process that never began serving has nothing to drain and no reason to
 // advertise a propagation window).
-func drainAndShutdown(ctx context.Context, srv *http.Server, readiness *health.ReadinessState, drainDelay time.Duration) error {
+//
+// The shutdownTimeout budget is passed through to gracefulShutdown, which
+// builds its own timeout context AFTER this function's drain sleep returns. The
+// drain delay therefore does NOT eat into the shutdown budget: Shutdown gets
+// the full shutdownTimeout to drain in-flight requests, exactly as the K8s
+// terminationGracePeriodSeconds calculation in deploy/kubernetes/deployment.yaml
+// assumes (grace = drainDelay + shutdownTimeout + buffer).
+func drainAndShutdown(srv shutdowner, readiness *health.ReadinessState, drainDelay, shutdownTimeout time.Duration) error {
 	readiness.SetShuttingDown()
 	slog.Info("draining before shutdown",
 		slog.String("reason", "signal"),
@@ -342,16 +349,36 @@ func drainAndShutdown(ctx context.Context, srv *http.Server, readiness *health.R
 	if drainDelay > 0 {
 		time.Sleep(drainDelay)
 	}
-	return gracefulShutdown(ctx, srv)
+	return gracefulShutdown(srv, shutdownTimeout)
 }
 
-// gracefulShutdown shuts srv down within ctx's deadline, falling back to a
-// forced Close if the graceful shutdown times out (so the process is never
-// wedged by a connection that refuses to drain). It returns the Shutdown error
-// for the caller's exit-status decision; the forced-close fallback is handled
-// internally. This is the shared shutdown step for both the signal path (via
-// drainAndShutdown) and the startup-error path (called directly, no drain).
-func gracefulShutdown(ctx context.Context, srv *http.Server) error {
+// shutdowner is the subset of *http.Server that gracefulShutdown drives. It
+// exists so a test can substitute a fake that captures the deadline of the
+// context handed to Shutdown — proving the full timeout budget is granted at
+// the moment Shutdown is called, after the drain sleep
+// (TestDrainAndShutdown_ShutdownGetsFullBudgetAfterDrain). *http.Server
+// satisfies it; production always passes the real server.
+type shutdowner interface {
+	Shutdown(ctx context.Context) error
+	Close() error
+}
+
+// gracefulShutdown shuts srv down within a fresh timeout-bounded context,
+// falling back to a forced Close if the graceful shutdown times out (so the
+// process is never wedged by a connection that refuses to drain). It returns
+// the Shutdown error for the caller's exit-status decision; the forced-close
+// fallback is handled internally. This is the shared shutdown step for both the
+// signal path (via drainAndShutdown) and the startup-error path (called
+// directly, no drain).
+//
+// gracefulShutdown OWNS the timeout context: it creates it here, immediately
+// before srv.Shutdown, so the deadline always covers the FULL timeout from the
+// moment Shutdown begins. On the signal path this happens AFTER drainAndShutdown
+// has already slept the drain delay, so the drain delay never consumes any of
+// the shutdown budget.
+func gracefulShutdown(srv shutdowner, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	err := srv.Shutdown(ctx)
 	if err != nil {
 		slog.Error("shutdown timed out, forcing close", slog.String("error", err.Error()))
@@ -659,9 +686,10 @@ func main() {
 	select {
 	case <-done:
 		// SIGTERM (or Ctrl-C): drain before shutting down. The drain (flip
-		// /readyz, sleep the propagation window, then graceful shutdown) is
-		// deferred to drainAndShutdown below so it runs after the shutdown-
-		// timeout context is built.
+		// /readyz, sleep the propagation window, then graceful shutdown) runs in
+		// drainAndShutdown below. The shutdown-timeout context is NOT built here;
+		// gracefulShutdown builds it after the drain sleep so Shutdown gets the
+		// full budget (see drainAndShutdown / gracefulShutdown).
 		fromSignal = true
 		slog.Info("server shutting down", slog.String("reason", "signal"))
 	case startupErr = <-serverErr:
@@ -672,15 +700,18 @@ func main() {
 		// and no orchestrator routing to wait out.
 	}
 
+	// The shutdown-timeout budget is a DURATION, not a pre-built context: the
+	// shutdown helpers create their own timeout context immediately before
+	// srv.Shutdown so the deadline always covers the full budget. On the signal
+	// path that context is built AFTER the drain sleep, so the drain delay does
+	// not eat into the budget Shutdown gets to drain in-flight requests.
 	shutdownTimeout := time.Duration(defaults.DefaultShutdownTimeoutSeconds) * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-	defer cancel()
 
 	if fromSignal {
 		drainDelay := time.Duration(cfg.Observability.ShutdownDrainDelayS) * time.Second
-		_ = drainAndShutdown(ctx, httpServer, readiness, drainDelay)
+		_ = drainAndShutdown(httpServer, readiness, drainDelay, shutdownTimeout)
 	} else {
-		_ = gracefulShutdown(ctx, httpServer)
+		_ = gracefulShutdown(httpServer, shutdownTimeout)
 	}
 
 	slog.Info("server stopped")

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -1,0 +1,147 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
+)
+
+// TestDrainAndShutdown_FlipsReadyzBeforeDelay proves the SIGTERM drain order
+// required by SOL-151288 AC #2 and AC #5: SetShuttingDown happens FIRST (so
+// /readyz reports 503 immediately, well within the 1s budget), the propagation
+// window is honored, and only THEN is the server shut down.
+//
+// We assert the order without a multi-second sleep by using a short drain delay
+// (30ms) and sampling IsShuttingDown from a watcher goroutine that fires almost
+// immediately. The watcher observes "shutting down" while drainAndShutdown is
+// still inside its delay, proving SetShuttingDown ran before Shutdown.
+func TestDrainAndShutdown_FlipsReadyzBeforeDelay(t *testing.T) {
+	srv, addr := startTestServer(t)
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+
+	if readiness.IsShuttingDown() {
+		t.Fatal("precondition: readiness must not be shutting down before drain")
+	}
+
+	const drainDelay = 100 * time.Millisecond
+
+	// Sample readiness shortly after drain begins but well before the delay
+	// elapses. At that point SetShuttingDown must already have run (it is the
+	// first thing drainAndShutdown does) AND the server must still be accepting
+	// connections (Shutdown only runs after the delay). The 10ms sample vs the
+	// 100ms drain leaves a wide margin so CI scheduling jitter can't flip it.
+	var midDrainShuttingDown, midDrainAccepting atomic.Bool
+	sampled := make(chan struct{})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		midDrainShuttingDown.Store(readiness.IsShuttingDown())
+		midDrainAccepting.Store(canConnect(addr))
+		close(sampled)
+	}()
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := drainAndShutdown(ctx, srv, readiness, drainDelay); err != nil {
+		t.Fatalf("drainAndShutdown returned error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	<-sampled
+
+	if !midDrainShuttingDown.Load() {
+		t.Error("IsShuttingDown was false mid-drain; SetShuttingDown must run FIRST, before the delay")
+	}
+	if !midDrainAccepting.Load() {
+		t.Error("server stopped accepting mid-drain; Shutdown must run AFTER the delay, not before")
+	}
+	if elapsed < drainDelay {
+		t.Errorf("drainAndShutdown returned after %v, want at least the drain delay %v", elapsed, drainDelay)
+	}
+
+	// After drainAndShutdown returns, the server has shut down and no longer
+	// accepts connections.
+	if canConnect(addr) {
+		t.Error("server still accepting connections after drainAndShutdown returned")
+	}
+}
+
+// TestDrainAndShutdown_SetsShuttingDownEvenWithZeroDelay proves the readiness
+// flip is unconditional on the drain delay: with a zero delay it still happens.
+func TestDrainAndShutdown_SetsShuttingDownEvenWithZeroDelay(t *testing.T) {
+	srv, _ := startTestServer(t)
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := drainAndShutdown(ctx, srv, readiness, 0); err != nil {
+		t.Fatalf("drainAndShutdown returned error: %v", err)
+	}
+	if !readiness.IsShuttingDown() {
+		t.Error("IsShuttingDown is false after drainAndShutdown with zero delay")
+	}
+}
+
+// startTestServer starts a real *http.Server on a loopback ephemeral port and
+// returns it with its address. It is registered for cleanup so a test that does
+// not shut it down itself does not leak the goroutine.
+func startTestServer(t *testing.T) (*http.Server, string) {
+	t.Helper()
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler:           http.NotFoundHandler(),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	addr := ln.Addr().String()
+	// Wait until the listener is actually accepting before returning so the
+	// mid-drain "still accepting" assertion is meaningful.
+	deadline := time.Now().Add(time.Second)
+	for !canConnect(addr) {
+		if time.Now().After(deadline) {
+			t.Fatalf("test server never started accepting on %s", addr)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return srv, addr
+}
+
+// canConnect reports whether a TCP connection to addr can be established.
+func canConnect(addr string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -60,9 +60,7 @@ func TestDrainAndShutdown_FlipsReadyzBeforeDelay(t *testing.T) {
 	}()
 
 	start := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := drainAndShutdown(ctx, srv, readiness, drainDelay); err != nil {
+	if err := drainAndShutdown(srv, readiness, drainDelay, 5*time.Second); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 	elapsed := time.Since(start)
@@ -93,13 +91,115 @@ func TestDrainAndShutdown_SetsShuttingDownEvenWithZeroDelay(t *testing.T) {
 	readiness := health.NewReadinessState()
 	readiness.SetInitialized()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := drainAndShutdown(ctx, srv, readiness, 0); err != nil {
+	if err := drainAndShutdown(srv, readiness, 0, 5*time.Second); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 	if !readiness.IsShuttingDown() {
 		t.Error("IsShuttingDown is false after drainAndShutdown with zero delay")
+	}
+}
+
+// captureShutdowner is a test seam standing in for *http.Server. It records the
+// remaining time on the context handed to Shutdown, measured at the instant
+// Shutdown is called, so a test can assert how much of the timeout budget is
+// actually available then.
+type captureShutdowner struct {
+	shutdownCalledAt time.Time
+	deadline         time.Time
+	hadDeadline      bool
+	shutdownErr      error // returned from Shutdown to exercise the fallback when set
+	closeCalled      bool
+}
+
+func (c *captureShutdowner) Shutdown(ctx context.Context) error {
+	c.shutdownCalledAt = time.Now()
+	c.deadline, c.hadDeadline = ctx.Deadline()
+	return c.shutdownErr
+}
+
+func (c *captureShutdowner) Close() error {
+	c.closeCalled = true
+	return nil
+}
+
+// remainingBudgetAtShutdown returns how much time was left on the Shutdown
+// context at the moment Shutdown was invoked.
+func (c *captureShutdowner) remainingBudgetAtShutdown() time.Duration {
+	return c.deadline.Sub(c.shutdownCalledAt)
+}
+
+// TestDrainAndShutdown_ShutdownGetsFullBudgetAfterDrain proves the fix for the
+// Copilot finding (SOL-151288): the shutdown-timeout budget is created AFTER the
+// drain sleep, so the drain delay does NOT eat into the time Shutdown gets to
+// drain in-flight requests.
+//
+// Under the old code the timeout context was built before the drain sleep, so
+// at the moment Shutdown was called only (shutdownTimeout - drainDelay) of the
+// budget remained. Using a deadline-capturing seam we assert the budget present
+// AT THE SHUTDOWN CALL is the FULL shutdownTimeout (not shutdownTimeout minus
+// the drain), with a wide lower bound that tolerates context-creation overhead.
+// ms-scale drain delay; no multi-second sleeps.
+func TestDrainAndShutdown_ShutdownGetsFullBudgetAfterDrain(t *testing.T) {
+	const (
+		drainDelay      = 40 * time.Millisecond
+		shutdownTimeout = 30 * time.Second // the production default
+	)
+
+	cs := &captureShutdowner{}
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+
+	start := time.Now()
+	if err := drainAndShutdown(cs, readiness, drainDelay, shutdownTimeout); err != nil {
+		t.Fatalf("drainAndShutdown returned error: %v", err)
+	}
+
+	// Readiness still flips, and Shutdown ran only after the drain delay.
+	if !readiness.IsShuttingDown() {
+		t.Error("IsShuttingDown is false after drainAndShutdown")
+	}
+	if cs.shutdownCalledAt.Sub(start) < drainDelay {
+		t.Errorf("Shutdown was called %v after start, before the %v drain delay elapsed",
+			cs.shutdownCalledAt.Sub(start), drainDelay)
+	}
+	if !cs.hadDeadline {
+		t.Fatal("Shutdown context had no deadline; the timeout budget was not applied")
+	}
+
+	// The core assertion: the budget available when Shutdown is called is the
+	// FULL shutdownTimeout, NOT shutdownTimeout - drainDelay. The old bug would
+	// leave at most (shutdownTimeout - drainDelay). We require the remaining
+	// budget to exceed that buggy ceiling by a wide margin, while staying just
+	// under the full timeout (only context-creation overhead is lost).
+	remaining := cs.remainingBudgetAtShutdown()
+	buggyCeiling := shutdownTimeout - drainDelay
+	if remaining <= buggyCeiling {
+		t.Errorf("Shutdown got only %v of budget (<= %v), so the %v drain consumed the budget; "+
+			"the timeout context must be created AFTER the drain sleep", remaining, buggyCeiling, drainDelay)
+	}
+	// Sanity upper bound: never more than the full timeout.
+	if remaining > shutdownTimeout {
+		t.Errorf("Shutdown budget %v exceeds the full timeout %v", remaining, shutdownTimeout)
+	}
+	// And it should be within a small slack of the full timeout.
+	if shutdownTimeout-remaining > time.Second {
+		t.Errorf("Shutdown budget %v is more than 1s short of the full %v timeout", remaining, shutdownTimeout)
+	}
+}
+
+// TestGracefulShutdown_ForcedCloseFallback proves the Shutdown→Close fallback is
+// preserved: when Shutdown returns an error, gracefulShutdown forces Close and
+// propagates the original error.
+func TestGracefulShutdown_ForcedCloseFallback(t *testing.T) {
+	wantErr := context.DeadlineExceeded
+	cs := &captureShutdowner{shutdownErr: wantErr}
+
+	err := gracefulShutdown(cs, 50*time.Millisecond)
+	if err != wantErr {
+		t.Errorf("gracefulShutdown returned %v, want the original Shutdown error %v", err, wantErr)
+	}
+	if !cs.closeCalled {
+		t.Error("forced Close was not called after Shutdown failed; the fallback is missing")
 	}
 }
 

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -18,12 +18,53 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"os"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/health"
 )
+
+// TestDrainDelayForSignal proves the SIGINT-vs-SIGTERM drain policy (reviewer
+// non-blocking comment #1, SOL-151288): SIGTERM (orchestrator-initiated) honors
+// the configured drain window so K8s can deregister the pod; SIGINT (a local
+// Ctrl-C) skips the drain entirely because there is no orchestrator to wait for.
+func TestDrainDelayForSignal(t *testing.T) {
+	tests := []struct {
+		name       string
+		sig        os.Signal
+		configured time.Duration
+		want       time.Duration
+	}{
+		{
+			name:       "SIGINT skips the drain regardless of configured delay",
+			sig:        os.Interrupt,
+			configured: 10 * time.Second,
+			want:       0,
+		},
+		{
+			name:       "SIGTERM honors the configured drain window",
+			sig:        syscall.SIGTERM,
+			configured: 10 * time.Second,
+			want:       10 * time.Second,
+		},
+		{
+			name:       "SIGTERM with a zero configured delay stays zero",
+			sig:        syscall.SIGTERM,
+			configured: 0,
+			want:       0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := drainDelayForSignal(tt.sig, tt.configured); got != tt.want {
+				t.Errorf("drainDelayForSignal(%v, %v) = %v, want %v", tt.sig, tt.configured, got, tt.want)
+			}
+		})
+	}
+}
 
 // TestDrainAndShutdown_FlipsReadyzBeforeDelay proves the SIGTERM drain order
 // required by SOL-151288 AC #2 and AC #5: SetShuttingDown happens FIRST (so

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -14,6 +14,24 @@ spec:
       labels:
         app.kubernetes.io/name: solace-broker-mcp
     spec:
+      # Graceful-shutdown budget (SOL-151288). On SIGTERM the server flips
+      # /readyz to 503, sleeps obs.shutdown_drain_delay_s (default 10s) so K8s
+      # deregisters the pod, then gracefully drains in-flight requests for up to
+      # DefaultShutdownTimeoutSeconds (30s). This drain runs IN-PROCESS: the
+      # distroless image has no shell, so there is NO preStop hook. The grace
+      # period must cover both phases plus a small buffer, or K8s SIGKILLs
+      # mid-drain and causes the 502s this design prevents:
+      #   terminationGracePeriodSeconds = shutdown_drain_delay_s (10)
+      #                                 + DefaultShutdownTimeoutSeconds (30)
+      #                                 + 5s buffer = 45
+      # If you raise obs.shutdown_drain_delay_s, raise this value to match.
+      #
+      # Note: the readinessProbe below still targets /health (always 200);
+      # rewiring it to /readyz so SetShuttingDown is probe-visible is Story 11
+      # (SOL-151285). Until then this in-process drain + grace period prevent
+      # 502s on their own — kube-proxy deregisters the pod on Terminating, and
+      # the sleep gives it time before in-flight requests are drained.
+      terminationGracePeriodSeconds: 45
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532  # distroless nonroot UID (gcr.io/distroless/static-debian12:nonroot)

--- a/internal/config/observability.go
+++ b/internal/config/observability.go
@@ -63,6 +63,12 @@ type ObservabilityConfig struct {
 	SaturationThresholdMs     int `yaml:"saturation_threshold_ms"`
 	ProgressSignalThresholdMs int `yaml:"progress_signal_threshold_ms"`
 	OTelSelfStatsIntervalS    int `yaml:"otel_self_stats_interval_s"`
+	// ShutdownDrainDelayS is the propagation window, in seconds, the server
+	// waits after flipping /readyz to 503 on SIGTERM before it begins graceful
+	// HTTP shutdown. It gives the orchestrator time to deregister the pod from
+	// its endpoint set so no new traffic is routed to a draining pod (SOL-151288).
+	// Defaulted to DefaultShutdownDrainDelayS; a non-positive value re-defaults.
+	ShutdownDrainDelayS int `yaml:"shutdown_drain_delay_s"`
 }
 
 // Observability env var names. Capability on/off switches; the v1 defaults
@@ -143,5 +149,8 @@ func applyObservabilityDefaults(cfg *ServerConfig) {
 	}
 	if o.OTelSelfStatsIntervalS <= 0 {
 		o.OTelSelfStatsIntervalS = defaults.DefaultOTelSelfStatsIntervalS
+	}
+	if o.ShutdownDrainDelayS <= 0 {
+		o.ShutdownDrainDelayS = defaults.DefaultShutdownDrainDelayS
 	}
 }

--- a/internal/config/observability_test.go
+++ b/internal/config/observability_test.go
@@ -229,6 +229,9 @@ func TestObservability_NumericDefaults(t *testing.T) {
 	if o.OTelSelfStatsIntervalS != defaults.DefaultOTelSelfStatsIntervalS {
 		t.Errorf("OTelSelfStatsIntervalS = %d, want %d", o.OTelSelfStatsIntervalS, defaults.DefaultOTelSelfStatsIntervalS)
 	}
+	if o.ShutdownDrainDelayS != defaults.DefaultShutdownDrainDelayS {
+		t.Errorf("ShutdownDrainDelayS = %d, want %d", o.ShutdownDrainDelayS, defaults.DefaultShutdownDrainDelayS)
+	}
 }
 
 // TestObservability_NumericFromYAML proves the numeric tunables parse from the
@@ -243,6 +246,7 @@ observability:
   saturation_threshold_ms: 25
   progress_signal_threshold_ms: 8000
   otel_self_stats_interval_s: ${OTEL_INTERVAL}
+  shutdown_drain_delay_s: 7
 `
 	cfg, err := LoadConfig(writeTemp(t, yamlBody))
 	if err != nil {
@@ -259,6 +263,9 @@ observability:
 	if o.OTelSelfStatsIntervalS != 120 {
 		t.Errorf("OTelSelfStatsIntervalS = %d, want 120 (from ${OTEL_INTERVAL})", o.OTelSelfStatsIntervalS)
 	}
+	if o.ShutdownDrainDelayS != 7 {
+		t.Errorf("ShutdownDrainDelayS = %d, want 7", o.ShutdownDrainDelayS)
+	}
 }
 
 // TestObservability_NonPositiveNumericsAreReDefaulted proves a stray
@@ -271,6 +278,7 @@ observability:
   saturation_threshold_ms: -1
   progress_signal_threshold_ms: 0
   otel_self_stats_interval_s: -42
+  shutdown_drain_delay_s: -3
 `
 	cfg, err := LoadConfig(writeTemp(t, yamlBody))
 	if err != nil {
@@ -286,5 +294,8 @@ observability:
 	}
 	if o.OTelSelfStatsIntervalS != defaults.DefaultOTelSelfStatsIntervalS {
 		t.Errorf("OTelSelfStatsIntervalS = %d, want default %d (negative re-defaulted)", o.OTelSelfStatsIntervalS, defaults.DefaultOTelSelfStatsIntervalS)
+	}
+	if o.ShutdownDrainDelayS != defaults.DefaultShutdownDrainDelayS {
+		t.Errorf("ShutdownDrainDelayS = %d, want default %d (negative re-defaulted)", o.ShutdownDrainDelayS, defaults.DefaultShutdownDrainDelayS)
 	}
 }

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -24,6 +24,26 @@ const DefaultPort = 9090
 // the shutdown window. Accepted in favor of bounded, predictable shutdown.
 const DefaultShutdownTimeoutSeconds = 30
 
+// DefaultShutdownDrainDelayS is the propagation window, in seconds, the server
+// waits after flipping /readyz to 503 (shutting_down) on SIGTERM, BEFORE it
+// begins gracefully shutting down the HTTP server. The delay lets the
+// orchestrator observe the not-ready state and deregister the pod from its
+// endpoint set, so no NEW traffic is routed to the draining pod while in-flight
+// requests finish — avoiding 502s during a rolling update.
+//
+// Decided: 10 seconds.
+// Reasoning: covers a typical kube-proxy / endpoint-controller propagation lag
+// (a few hundred ms to a few seconds) with margin, while keeping total pod
+// termination bounded. The drain runs IN-PROCESS: the distroless image has no
+// shell, so there is no preStop hook to sleep for us (SOL-151288).
+// Trade-off: every shutdown takes at least this long even when no traffic is in
+// flight. Accepted as the cost of a 502-free rolling update.
+//
+// The pod's terminationGracePeriodSeconds must be at least
+// DefaultShutdownDrainDelayS + DefaultShutdownTimeoutSeconds plus a small buffer
+// so K8s does not SIGKILL the process mid-drain (see deploy/kubernetes/deployment.yaml).
+const DefaultShutdownDrainDelayS = 10
+
 // DefaultSEMPRequestTimeoutDuration is the per-request timeout for individual
 // SEMP API calls to a broker. Matches the story spec default and the Solace
 // Terraform provider convention.

--- a/internal/observability/health/readiness.go
+++ b/internal/observability/health/readiness.go
@@ -48,7 +48,7 @@ type listenerProbe struct {
 //
 //  1. initialized   — startup completed (SetInitialized).
 //  2. shuttingDown  — graceful drain has begun (SetShuttingDown). The mechanism
-//     lives here; wiring it to SIGTERM is Story 31a (SOL-151288).
+//     lives here; cmd/server wires it to SIGTERM in drainAndShutdown (SOL-151288).
 //  3. listeners      — required-listener probes (RegisterListener) that report
 //     whether each listener is bound.
 //
@@ -79,8 +79,8 @@ func (s *ReadinessState) SetInitialized() {
 // SetShuttingDown marks that graceful drain has begun. Once set, Evaluate
 // reports "shutting_down" regardless of initialization or listener state, so an
 // orchestrator stops routing new traffic to this instance. This is the
-// mechanism only; it is intentionally NOT wired to SIGTERM here (see Story 31a
-// / SOL-151288).
+// mechanism; cmd/server calls it from the SIGTERM handler (drainAndShutdown,
+// SOL-151288) before sleeping the drain window and shutting down.
 func (s *ReadinessState) SetShuttingDown() {
 	s.shuttingDown.Store(true)
 }


### PR DESCRIPTION
## What
Makes pod shutdown drain cleanly on rolling restarts: on SIGTERM the server flips `/readyz` to 503, sleeps a propagation window so the orchestrator stops routing new traffic, then gracefully drains in-flight requests — and `terminationGracePeriodSeconds` is sized to cover the whole sequence so K8s never SIGKILLs mid-drain.

Part of the Observability & Telemetry epic ([SOL-149791](https://sol-jira.atlassian.net/browse/SOL-149791)). Story: [SOL-151288](https://sol-jira.atlassian.net/browse/SOL-151288). **This completes the MUST epic.**

## How
- New `drainAndShutdown(ctx, srv, readiness, drainDelay)` helper: `SetShuttingDown()` first (so `/readyz` → 503 immediately), then sleep `drainDelay`, then graceful `Shutdown`. Runs **only on the SIGTERM path** — a startup error shuts down without draining.
- The existing `Shutdown`→forced-`Close` fallback and `os.Exit(1)`-on-startup-error are preserved unchanged (extracted into `gracefulShutdown`).
- New `obs.shutdown_drain_delay_s` config tunable (default 10s), following the existing YAML-int pattern + `<=0` re-default.
- `deployment.yaml`: `terminationGracePeriodSeconds: 45` (= `shutdown_drain_delay_s` 10 + `DefaultShutdownTimeoutSeconds` 30 + 5 buffer). In-process drain, **no preStop** (distroless image has no shell).

## Dependency / scope note
The readiness *flip* (`SetShuttingDown` → `/readyz` 503) only becomes **probe-visible** once the K8s `readinessProbe` is rewired from `/health` to `/readyz` — that rewiring is **Story 11 (#127 / SOL-151285)**, which owns the probe blocks. I deliberately did **not** touch the probe paths here (avoids a conflict with #127). Until #127 lands, this PR still prevents 502s on its own: the in-process drain sleep + grace period give kube-proxy time to deregister the pod on `Terminating` before in-flight requests are drained. Once #127 merges, the two compose into full readiness-gated deregistration.

## Tests
`drainAndShutdown` ordering against a real server: readiness flips before the drain completes (sampled mid-drain), the server is still accepting mid-drain, and `Shutdown` runs only after the delay — with ms-scale delays (wide margin, race-clean). Zero-delay path still flips readiness. Config default/0/negative/explicit covered. `make check` green (build + vet + lint + `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-149791]: https://sol-jira.atlassian.net/browse/SOL-149791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151288]: https://sol-jira.atlassian.net/browse/SOL-151288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ