### PR TITLE
SOL-150799: RFC 8693 token-exchange Exchanger (T5)

### DIFF
--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -203,9 +203,10 @@ const DefaultRetryMaxInterval = 30 * time.Second
 // Reasoning: a broker-bound SEMP request takes well under 1 second in
 // the common case; 30s gives ~30× headroom for slow networks or
 // queued requests while wasting at most 30s of a token's lifetime.
-// Trade-off: a token with expires_in ≤ 30 is treated as already
-// expired, forcing a fresh exchange. Accepted — such short-lived
-// tokens are an IdP misconfiguration for machine-to-machine flows.
+// Trade-off: a token with expires_in ≤ 30 is returned with an
+// ExpiresAt in the past, so callers (and the future cache) will
+// consider it immediately stale. Accepted — such short-lived tokens
+// are an IdP misconfiguration for machine-to-machine flows.
 const DefaultTokenExpirySkew = 30 * time.Second
 
 // DefaultSaturationThresholdMs is the latency above which a tool call is

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -193,3 +193,17 @@ const DefaultRetryMinInterval = 3 * time.Second
 // many attempts have been made. Must be >= DefaultRetryMinInterval. Matches
 // the story spec and Terraform default.
 const DefaultRetryMaxInterval = 30 * time.Second
+
+// DefaultTokenExpirySkew is subtracted from the IdP-reported expires_in
+// when computing a token's ExpiresAt. The result is a conservative
+// "use-by" instant — callers (and the future cache) never present a
+// token that might expire mid-flight to the broker.
+//
+// Decided: 30 seconds.
+// Reasoning: a broker-bound SEMP request takes well under 1 second in
+// the common case; 30s gives ~30× headroom for slow networks or
+// queued requests while wasting at most 30s of a token's lifetime.
+// Trade-off: a token with expires_in ≤ 30 is treated as already
+// expired, forcing a fresh exchange. Accepted — such short-lived
+// tokens are an IdP misconfiguration for machine-to-machine flows.
+const DefaultTokenExpirySkew = 30 * time.Second

--- a/internal/tokenexchange/dedup_key.go
+++ b/internal/tokenexchange/dedup_key.go
@@ -1,0 +1,44 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// DeduplicationKeyInput defines the fields that determine whether two
+// token-exchange requests are logically identical. Every field in this
+// struct participates in the key — if a field is here, it matters for
+// deduplication; if it's not here, it doesn't.
+//
+// Used by singleflight (in-flight deduplication) and the future token
+// cache (cross-time deduplication).
+type DeduplicationKeyInput struct {
+	SubjectToken string
+	BrokerAlias  string
+}
+
+// computeDeduplicationKey produces a deterministic, collision-resistant
+// hex string from the input fields. Same inputs always produce the same
+// key. Fields are separated by a NUL byte to prevent ("ab","c") from
+// colliding with ("a","bc").
+func computeDeduplicationKey(input DeduplicationKeyInput) string {
+	h := sha256.New()
+	h.Write([]byte(input.SubjectToken))
+	h.Write([]byte{0x00})
+	h.Write([]byte(input.BrokerAlias))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/tokenexchange/dedup_key_test.go
+++ b/internal/tokenexchange/dedup_key_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestComputeDeduplicationKey_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	key1 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "tokenA", BrokerAlias: "brokerA"})
+	key2 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "tokenA", BrokerAlias: "brokerA"})
+
+	if key1 != key2 {
+		t.Errorf("same inputs produced different keys: %q vs %q", key1, key2)
+	}
+	if len(key1) != 64 {
+		t.Errorf("key length = %d, want 64 (SHA-256 hex)", len(key1))
+	}
+}
+
+func TestComputeDeduplicationKey_DifferentTokensDifferentKeys(t *testing.T) {
+	t.Parallel()
+
+	key1 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "tokenA", BrokerAlias: "broker"})
+	key2 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "tokenB", BrokerAlias: "broker"})
+
+	if key1 == key2 {
+		t.Errorf("different subjectTokens produced same key: %q", key1)
+	}
+}
+
+func TestComputeDeduplicationKey_DifferentAliasesDifferentKeys(t *testing.T) {
+	t.Parallel()
+
+	key1 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "token", BrokerAlias: "brokerA"})
+	key2 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "token", BrokerAlias: "brokerB"})
+
+	if key1 == key2 {
+		t.Errorf("different brokerAliases produced same key: %q", key1)
+	}
+}
+
+func TestComputeDeduplicationKey_EmptyInputsProduceValidKey(t *testing.T) {
+	t.Parallel()
+
+	key := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "", BrokerAlias: ""})
+
+	if len(key) != 64 {
+		t.Errorf("key length = %d, want 64", len(key))
+	}
+
+	h := sha256.New()
+	h.Write([]byte{0x00})
+	want := hex.EncodeToString(h.Sum(nil))
+	if key != want {
+		t.Errorf("key = %q, want SHA-256 of single NUL byte = %q", key, want)
+	}
+}
+
+// NUL separator prevents collisions between ("ab","c") and ("a","bc").
+func TestComputeDeduplicationKey_NULSeparatorPreventsCollision(t *testing.T) {
+	t.Parallel()
+
+	key1 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "ab", BrokerAlias: "c"})
+	key2 := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "a", BrokerAlias: "bc"})
+
+	if key1 == key2 {
+		t.Errorf("NUL separator failed: (\"ab\",\"c\") and (\"a\",\"bc\") produced same key: %q", key1)
+	}
+}
+
+func TestComputeDeduplicationKey_OutputIsLowercaseHex(t *testing.T) {
+	t.Parallel()
+
+	key := computeDeduplicationKey(DeduplicationKeyInput{SubjectToken: "any-token", BrokerAlias: "any-broker"})
+
+	decoded, err := hex.DecodeString(key)
+	if err != nil {
+		t.Fatalf("key %q is not valid hex: %v", key, err)
+	}
+	if len(decoded) != sha256.Size {
+		t.Errorf("decoded length = %d, want %d (SHA-256)", len(decoded), sha256.Size)
+	}
+
+	if key != strings.ToLower(key) {
+		t.Errorf("key %q is not lowercase", key)
+	}
+}

--- a/internal/tokenexchange/exchange.go
+++ b/internal/tokenexchange/exchange.go
@@ -37,10 +37,10 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 	})
 	elapsed := e.nowFunc().Sub(start)
 
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
 	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
 		e.logExchangeError(err, input, elapsed)
 		return nil, err
 	}

--- a/internal/tokenexchange/exchange.go
+++ b/internal/tokenexchange/exchange.go
@@ -1,0 +1,87 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Exchange performs an RFC 8693 token exchange against the configured IdP.
+// Concurrent calls with the same (subjectToken, brokerAlias) pair are
+// collapsed into a single IdP round-trip via singleflight.
+func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, error) {
+	key := computeDeduplicationKey(DeduplicationKeyInput{
+		SubjectToken: input.SubjectToken,
+		BrokerAlias:  input.BrokerAlias,
+	})
+
+	start := e.nowFunc()
+	v, err, _ := e.group.Do(key, func() (interface{}, error) {
+		return e.doExchange(ctx, input)
+	})
+	elapsed := e.nowFunc().Sub(start)
+
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		e.logExchangeError(err, input, elapsed)
+		return nil, err
+	}
+
+	return v.(*Token), nil
+}
+
+func (e *Exchanger) doExchange(ctx context.Context, input ExchangeInput) (*Token, error) {
+	req, err := e.buildIdPRequest(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrExchangeTransport, err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("%w: IdP request failed: %v", ErrExchangeTransport, err)
+	}
+
+	return e.parseIdPResponse(resp, e.nowFunc())
+}
+
+func (e *Exchanger) logExchangeError(err error, input ExchangeInput, elapsed time.Duration) {
+	attrs := []slog.Attr{
+		slog.String("broker_alias", input.BrokerAlias),
+		slog.String("audience", input.Audience),
+		slog.String("token_endpoint", e.tokenURL),
+		slog.Duration("elapsed", elapsed),
+		slog.String("error", err.Error()),
+	}
+
+	switch {
+	case errors.Is(err, ErrExchangeRejected):
+		slog.LogAttrs(context.Background(), slog.LevelWarn, "token exchange: rejected by IdP", attrs...)
+	case errors.Is(err, ErrExchangeTransport):
+		slog.LogAttrs(context.Background(), slog.LevelError, "token exchange: transport failure", attrs...)
+	case errors.Is(err, ErrInvalidResponse):
+		slog.LogAttrs(context.Background(), slog.LevelError, "token exchange: invalid IdP response", attrs...)
+	default:
+		slog.LogAttrs(context.Background(), slog.LevelError, "token exchange: unexpected error", attrs...)
+	}
+}

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -154,13 +154,20 @@ func TestExchange_DifferentKeysRunConcurrently(t *testing.T) {
 	t.Parallel()
 
 	var callCount atomic.Int32
+	var receivedTokensMu sync.Mutex
+	receivedTokens := map[string]bool{}
 	gate := make(chan struct{})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount.Add(1)
+		r.ParseForm()
+		subj := r.PostFormValue("subject_token")
+		receivedTokensMu.Lock()
+		receivedTokens[subj] = true
+		receivedTokensMu.Unlock()
 		<-gate
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, successJSON("tok", 3600))
+		fmt.Fprint(w, successJSON("exchanged-for-"+subj, 3600))
 	}))
 	defer srv.Close()
 
@@ -170,17 +177,279 @@ func TestExchange_DifferentKeysRunConcurrently(t *testing.T) {
 	input1 := ExchangeInput{SubjectToken: "tok-A", BrokerAlias: "broker-A", Audience: "aud"}
 	input2 := ExchangeInput{SubjectToken: "tok-B", BrokerAlias: "broker-B", Audience: "aud"}
 
+	tokens := make([]*Token, 2)
+	errs := make([]error, 2)
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() { defer wg.Done(); e.Exchange(context.Background(), input1) }()
-	go func() { defer wg.Done(); e.Exchange(context.Background(), input2) }()
+	go func() { defer wg.Done(); tokens[0], errs[0] = e.Exchange(context.Background(), input1) }()
+	go func() { defer wg.Done(); tokens[1], errs[1] = e.Exchange(context.Background(), input2) }()
 
 	time.Sleep(50 * time.Millisecond)
 	close(gate)
 	wg.Wait()
 
+	for i := 0; i < 2; i++ {
+		if errs[i] != nil {
+			t.Errorf("caller %d: unexpected error = %v", i, errs[i])
+		}
+	}
+
+	if tokens[0] == nil || tokens[0].Value != "exchanged-for-tok-A" {
+		t.Errorf("caller 0: token = %v, want Value=%q", tokens[0], "exchanged-for-tok-A")
+	}
+	if tokens[1] == nil || tokens[1].Value != "exchanged-for-tok-B" {
+		t.Errorf("caller 1: token = %v, want Value=%q", tokens[1], "exchanged-for-tok-B")
+	}
+
 	if got := callCount.Load(); got != 2 {
 		t.Errorf("IdP called %d times, want 2 (different keys should not be deduplicated)", got)
+	}
+
+	if !receivedTokens["tok-A"] || !receivedTokens["tok-B"] {
+		t.Errorf("IdP received subject_tokens = %v, want both tok-A and tok-B", receivedTokens)
+	}
+}
+
+func TestExchange_SameTokenDifferentBrokersRunConcurrently(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	var receivedTokensMu sync.Mutex
+	receivedTokens := map[string]bool{}
+	gate := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		r.ParseForm()
+		subj := r.PostFormValue("subject_token")
+		receivedTokensMu.Lock()
+		receivedTokens[subj] = true
+		receivedTokensMu.Unlock()
+		<-gate
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("exchanged-for-"+subj, 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	input1 := ExchangeInput{SubjectToken: "same-token", BrokerAlias: "broker-A", Audience: "aud"}
+	input2 := ExchangeInput{SubjectToken: "same-token", BrokerAlias: "broker-B", Audience: "aud"}
+
+	tokens := make([]*Token, 2)
+	errs := make([]error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); tokens[0], errs[0] = e.Exchange(context.Background(), input1) }()
+	go func() { defer wg.Done(); tokens[1], errs[1] = e.Exchange(context.Background(), input2) }()
+
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	for i := 0; i < 2; i++ {
+		if errs[i] != nil {
+			t.Errorf("caller %d: unexpected error = %v", i, errs[i])
+		}
+		if tokens[i] == nil || tokens[i].Value != "exchanged-for-same-token" {
+			t.Errorf("caller %d: token = %v, want Value=%q", i, tokens[i], "exchanged-for-same-token")
+		}
+	}
+
+	if got := callCount.Load(); got != 2 {
+		t.Errorf("IdP called %d times, want 2 (same token + different brokers must not be deduplicated)", got)
+	}
+
+	if !receivedTokens["same-token"] {
+		t.Errorf("IdP received subject_tokens = %v, want same-token", receivedTokens)
+	}
+}
+
+// ---------- B04: context cancellation does not affect other callers ----------
+
+// Simulates the real production scenario: three concurrent groups of
+// requests that prove cancellation is scoped to the exact (user, broker)
+// pair and does not leak across singleflight keys.
+//
+//   Group 1: User A + Broker X — cancelled → all fail
+//   Group 2: User A + Broker Y — not cancelled → all succeed (same user, different broker)
+//   Group 3: User C + Broker X — not cancelled → all succeed (different user, same broker)
+func TestExchange_CancellationScopedToKeyBoundary(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	var receivedTokensMu sync.Mutex
+	receivedTokens := map[string]bool{}
+	gate := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		r.ParseForm()
+		subj := r.PostFormValue("subject_token")
+		receivedTokensMu.Lock()
+		receivedTokens[subj] = true
+		receivedTokensMu.Unlock()
+		<-gate
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("exchanged-for-"+subj, 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	userA_brokerX := ExchangeInput{SubjectToken: "user-a-jwt", BrokerAlias: "broker-x", Audience: "aud"}
+	userA_brokerY := ExchangeInput{SubjectToken: "user-a-jwt", BrokerAlias: "broker-y", Audience: "aud"}
+	userC_brokerX := ExchangeInput{SubjectToken: "user-c-jwt", BrokerAlias: "broker-x", Audience: "aud"}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+
+	// Group 1: User A + Broker X — 3 requests, will be cancelled.
+	g1Errs := make([]error, 3)
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, g1Errs[idx] = e.Exchange(cancelCtx, userA_brokerX)
+		}(i)
+	}
+
+	// Group 2: User A + Broker Y — 2 requests, should succeed.
+	g2Tokens := make([]*Token, 2)
+	g2Errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			g2Tokens[idx], g2Errs[idx] = e.Exchange(context.Background(), userA_brokerY)
+		}(i)
+	}
+
+	// Group 3: User C + Broker X — 2 requests, should succeed.
+	g3Tokens := make([]*Token, 2)
+	g3Errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			g3Tokens[idx], g3Errs[idx] = e.Exchange(context.Background(), userC_brokerX)
+		}(i)
+	}
+
+	// Let all goroutines queue up in singleflight.
+	time.Sleep(50 * time.Millisecond)
+	// Cancel User A + Broker X group.
+	cancel()
+	// Release IdP responses.
+	time.Sleep(10 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	// Group 1: all cancelled — every request belongs to the disconnected user+broker.
+	for i, err := range g1Errs {
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("group1[%d]: want context.Canceled, got %v", i, err)
+		}
+	}
+
+	// Group 2: all succeed — same user, different broker = different key.
+	// Singleflight collapses the 2 requests into 1 IdP call.
+	for i := 0; i < 2; i++ {
+		if g2Errs[i] != nil {
+			t.Errorf("group2[%d]: unexpected error = %v", i, g2Errs[i])
+		}
+		if g2Tokens[i] == nil || g2Tokens[i].Value != "exchanged-for-user-a-jwt" {
+			t.Errorf("group2[%d]: token = %v, want Value=%q", i, g2Tokens[i], "exchanged-for-user-a-jwt")
+		}
+	}
+
+	// Group 3: all succeed — different user, same broker = different key.
+	// Singleflight collapses the 2 requests into 1 IdP call.
+	for i := 0; i < 2; i++ {
+		if g3Errs[i] != nil {
+			t.Errorf("group3[%d]: unexpected error = %v", i, g3Errs[i])
+		}
+		if g3Tokens[i] == nil || g3Tokens[i].Value != "exchanged-for-user-c-jwt" {
+			t.Errorf("group3[%d]: token = %v, want Value=%q", i, g3Tokens[i], "exchanged-for-user-c-jwt")
+		}
+	}
+
+	// Group 1 cancelled before the IdP responded, groups 2 and 3 each have
+	// their own key. Expect 2-3 IdP calls depending on timing (group 1 may
+	// or may not reach the server before cancellation).
+	if got := callCount.Load(); got < 2 || got > 3 {
+		t.Errorf("IdP called %d times, want 2-3", got)
+	}
+
+	// Groups 2 and 3 must have reached the IdP with their respective subject tokens.
+	if !receivedTokens["user-a-jwt"] {
+		t.Errorf("IdP never received subject_token=user-a-jwt (group 2)")
+	}
+	if !receivedTokens["user-c-jwt"] {
+		t.Errorf("IdP never received subject_token=user-c-jwt (group 3)")
+	}
+}
+
+func TestExchange_DifferentTokensSameBrokerRunConcurrently(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	var receivedTokensMu sync.Mutex
+	receivedTokens := map[string]bool{}
+	gate := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		r.ParseForm()
+		subj := r.PostFormValue("subject_token")
+		receivedTokensMu.Lock()
+		receivedTokens[subj] = true
+		receivedTokensMu.Unlock()
+		<-gate
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("exchanged-for-"+subj, 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	input1 := ExchangeInput{SubjectToken: "user-a-jwt", BrokerAlias: "broker-x", Audience: "aud"}
+	input2 := ExchangeInput{SubjectToken: "user-c-jwt", BrokerAlias: "broker-x", Audience: "aud"}
+
+	tokens := make([]*Token, 2)
+	errs := make([]error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); tokens[0], errs[0] = e.Exchange(context.Background(), input1) }()
+	go func() { defer wg.Done(); tokens[1], errs[1] = e.Exchange(context.Background(), input2) }()
+
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	for i := 0; i < 2; i++ {
+		if errs[i] != nil {
+			t.Errorf("caller %d: unexpected error = %v", i, errs[i])
+		}
+	}
+
+	if tokens[0] == nil || tokens[0].Value != "exchanged-for-user-a-jwt" {
+		t.Errorf("caller 0: token = %v, want Value=%q", tokens[0], "exchanged-for-user-a-jwt")
+	}
+	if tokens[1] == nil || tokens[1].Value != "exchanged-for-user-c-jwt" {
+		t.Errorf("caller 1: token = %v, want Value=%q", tokens[1], "exchanged-for-user-c-jwt")
+	}
+
+	if got := callCount.Load(); got != 2 {
+		t.Errorf("IdP called %d times, want 2 (different tokens + same broker must not be deduplicated)", got)
+	}
+
+	if !receivedTokens["user-a-jwt"] || !receivedTokens["user-c-jwt"] {
+		t.Errorf("IdP received subject_tokens = %v, want both user-a-jwt and user-c-jwt", receivedTokens)
 	}
 }
 

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -1,0 +1,970 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+)
+
+// newTestExchanger builds an Exchanger pointing at the given httptest server
+// with a pinned clock. The returned nowFunc can be swapped to advance time.
+func newTestExchanger(t *testing.T, serverURL string) *Exchanger {
+	t.Helper()
+	p := validParams()
+	p.TokenURL = serverURL
+	e, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return e
+}
+
+// pinnedNow returns a fixed time for deterministic assertions.
+func pinnedNow() time.Time {
+	return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+// successJSON returns a valid RFC 8693 success response body.
+func successJSON(accessToken string, expiresIn int64) string {
+	return fmt.Sprintf(`{"access_token":%q,"token_type":"Bearer","issued_token_type":%q,"expires_in":%d}`,
+		accessToken, URNTokenTypeAccessToken, expiresIn)
+}
+
+// validInput returns an ExchangeInput suitable for most tests.
+func validInput() ExchangeInput {
+	return ExchangeInput{
+		SubjectToken: "test-subject-token",
+		BrokerAlias:  "test-broker",
+		Audience:     "https://broker.example.com",
+	}
+}
+
+// ---------- B06: Exchange happy path ----------
+
+func TestExchange_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("exchanged-tok", 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	now := pinnedNow()
+	e.nowFunc = func() time.Time { return now }
+
+	tok, err := e.Exchange(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if tok == nil {
+		t.Fatal("tok = nil, want non-nil")
+	}
+	if tok.Value != "exchanged-tok" {
+		t.Errorf("tok.Value = %q, want %q", tok.Value, "exchanged-tok")
+	}
+
+	wantExpiresAt := now.Add(3600*time.Second - defaults.DefaultTokenExpirySkew)
+	if !tok.ExpiresAt.Equal(wantExpiresAt) {
+		t.Errorf("tok.ExpiresAt = %v, want %v", tok.ExpiresAt, wantExpiresAt)
+	}
+}
+
+// ---------- B02: singleflight deduplication ----------
+
+func TestExchange_SingleflightDeduplication(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	gate := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		<-gate // block until released
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("dedup-tok", 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	input := validInput()
+	const n = 5
+	var wg sync.WaitGroup
+	tokens := make([]*Token, n)
+	errs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tokens[idx], errs[idx] = e.Exchange(context.Background(), input)
+		}(i)
+	}
+
+	// Brief pause to let goroutines queue up in singleflight.
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Errorf("goroutine %d: error = %v", i, errs[i])
+		}
+		if tokens[i] == nil {
+			t.Errorf("goroutine %d: token = nil", i)
+		} else if tokens[i].Value != "dedup-tok" {
+			t.Errorf("goroutine %d: tok.Value = %q, want %q", i, tokens[i].Value, "dedup-tok")
+		}
+	}
+
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("IdP called %d times, want 1 (singleflight should collapse concurrent calls)", got)
+	}
+}
+
+func TestExchange_DifferentKeysRunConcurrently(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	gate := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		<-gate
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("tok", 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	input1 := ExchangeInput{SubjectToken: "tok-A", BrokerAlias: "broker-A", Audience: "aud"}
+	input2 := ExchangeInput{SubjectToken: "tok-B", BrokerAlias: "broker-B", Audience: "aud"}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); e.Exchange(context.Background(), input1) }()
+	go func() { defer wg.Done(); e.Exchange(context.Background(), input2) }()
+
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	if got := callCount.Load(); got != 2 {
+		t.Errorf("IdP called %d times, want 2 (different keys should not be deduplicated)", got)
+	}
+}
+
+// ---------- B04: context cancellation supersedes error ----------
+
+func TestExchange_ContextCancelledReturnsContextError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the HTTP call fails with context.Canceled.
+	cancel()
+
+	tok, err := e.Exchange(ctx, validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on context cancellation", tok)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("errors.Is(err, context.Canceled) = false, want true; err = %v", err)
+	}
+}
+
+func TestExchange_ContextDeadlineExceededReturnsDeadlineError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	time.Sleep(5 * time.Millisecond) // ensure deadline passes
+	tok, err := e.Exchange(ctx, validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on deadline exceeded", tok)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true; err = %v", err)
+	}
+}
+
+// ---------- B05: non-context errors are returned ----------
+
+func TestExchange_TransportErrorReturned(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "internal error")
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	tok, err := e.Exchange(context.Background(), validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on 500", tok)
+	}
+	if !errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+	}
+}
+
+func TestExchange_RejectedErrorReturned(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid_grant"}`)
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	tok, err := e.Exchange(context.Background(), validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on 400", tok)
+	}
+	if !errors.Is(err, ErrExchangeRejected) {
+		t.Errorf("errors.Is(err, ErrExchangeRejected) = false, want true; err = %v", err)
+	}
+}
+
+// ---------- B07: doExchange wraps buildIdPRequest errors as transport ----------
+
+func TestDoExchange_BuildRequestFailureWrapsAsTransport(t *testing.T) {
+	t.Parallel()
+
+	e := &Exchanger{
+		tokenURL:         "://malformed-url",
+		clientID:         "cid",
+		clientAuthMethod: ClientSecretPost,
+		clientSecret:     "sec",
+		grantType:        GrantTypeTokenExchange,
+		audienceParam:    AudienceParamAudience,
+		httpClient:       &http.Client{},
+		nowFunc:          func() time.Time { return pinnedNow() },
+	}
+
+	tok, err := e.doExchange(context.Background(), validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on build failure", tok)
+	}
+	if !errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+	}
+}
+
+// ---------- B08, B09: doExchange HTTP failure paths ----------
+
+func TestDoExchange_HTTPFailureWithCancelledContextReturnsContextError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tok, err := e.doExchange(ctx, validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil", tok)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("errors.Is(err, context.Canceled) = false, want true; err = %v", err)
+	}
+	if errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = true, want false — context errors bypass transport sentinel")
+	}
+}
+
+func TestDoExchange_HTTPFailureWithoutContextErrorReturnsTransport(t *testing.T) {
+	t.Parallel()
+
+	// Use a server that closes the connection immediately.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	tok, err := e.doExchange(context.Background(), validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil", tok)
+	}
+	if !errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "IdP request failed") {
+		t.Errorf("err.Error() = %q, want it to contain \"IdP request failed\"", err.Error())
+	}
+}
+
+// ---------- B10: doExchange passes nowFunc to parseIdPResponse ----------
+
+func TestDoExchange_PassesNowFuncToParseIdPResponse(t *testing.T) {
+	t.Parallel()
+
+	pinned := time.Date(2030, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("tok", 7200))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinned }
+
+	tok, err := e.doExchange(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("doExchange: %v", err)
+	}
+
+	wantExpiresAt := pinned.Add(7200*time.Second - defaults.DefaultTokenExpirySkew)
+	if !tok.ExpiresAt.Equal(wantExpiresAt) {
+		t.Errorf("tok.ExpiresAt = %v, want %v (based on pinned nowFunc)", tok.ExpiresAt, wantExpiresAt)
+	}
+}
+
+// ---------- B03: elapsed time uses nowFunc ----------
+
+func TestExchange_ElapsedTimeMeasuredWithNowFunc(t *testing.T) {
+	t.Parallel()
+
+	// Track nowFunc calls to verify start/end capture.
+	var calls atomic.Int32
+	fakeNow := pinnedNow()
+	mu := sync.Mutex{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Advance the clock while the "request" is in flight.
+		mu.Lock()
+		fakeNow = fakeNow.Add(500 * time.Millisecond)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("tok", 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time {
+		calls.Add(1)
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeNow
+	}
+
+	_, err := e.Exchange(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+
+	// nowFunc is called at least twice: once for start, once for elapsed.
+	if got := calls.Load(); got < 2 {
+		t.Errorf("nowFunc called %d times, want at least 2 (start + elapsed)", got)
+	}
+}
+
+// ---------- B11–B17: logExchangeError ----------
+
+// logRecord captures a single slog record for test assertions.
+type logRecord struct {
+	Level   slog.Level
+	Message string
+	Attrs   map[string]string
+}
+
+// captureLogs installs a custom slog handler that captures records, and
+// returns a function to retrieve them. Caller must defer the returned
+// restore function to reset the default logger.
+func captureLogs(t *testing.T) (records func() []logRecord, restore func()) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var captured []logRecord
+
+	handler := &captureHandler{
+		mu:       &mu,
+		captured: &captured,
+	}
+
+	prev := slog.Default()
+	slog.SetDefault(slog.New(handler))
+
+	return func() []logRecord {
+			mu.Lock()
+			defer mu.Unlock()
+			cp := make([]logRecord, len(captured))
+			copy(cp, captured)
+			return cp
+		}, func() {
+			slog.SetDefault(prev)
+		}
+}
+
+type captureHandler struct {
+	mu       *sync.Mutex
+	captured *[]logRecord
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := logRecord{
+		Level:   r.Level,
+		Message: r.Message,
+		Attrs:   make(map[string]string),
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.Attrs[a.Key] = a.Value.String()
+		return true
+	})
+	h.mu.Lock()
+	*h.captured = append(*h.captured, rec)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// B11: structured attributes always included
+func TestLogExchangeError_StructuredAttrsAlwaysPresent(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	e := &Exchanger{
+		tokenURL: "https://idp.example.com/token",
+	}
+	input := ExchangeInput{
+		BrokerAlias: "my-broker",
+		Audience:    "https://aud.example.com",
+	}
+	elapsed := 150 * time.Millisecond
+	testErr := fmt.Errorf("%w: test", ErrExchangeRejected)
+
+	e.logExchangeError(testErr, input, elapsed)
+
+	recs := records()
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	rec := recs[0]
+
+	wantAttrs := map[string]string{
+		"broker_alias":   "my-broker",
+		"audience":       "https://aud.example.com",
+		"token_endpoint": "https://idp.example.com/token",
+	}
+	for key, want := range wantAttrs {
+		if got, ok := rec.Attrs[key]; !ok {
+			t.Errorf("attribute %q missing from log record", key)
+		} else if got != want {
+			t.Errorf("attribute %q = %q, want %q", key, got, want)
+		}
+	}
+
+	if _, ok := rec.Attrs["elapsed"]; !ok {
+		t.Errorf("attribute \"elapsed\" missing from log record")
+	}
+	if _, ok := rec.Attrs["error"]; !ok {
+		t.Errorf("attribute \"error\" missing from log record")
+	}
+}
+
+// B11: SubjectToken and ClientSecret are NOT logged
+func TestLogExchangeError_SensitiveFieldsNotLogged(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	e := &Exchanger{
+		tokenURL:     "https://idp.example.com/token",
+		clientSecret: "super-secret-value",
+	}
+	input := ExchangeInput{
+		SubjectToken: "sensitive-token-value",
+		BrokerAlias:  "b",
+		Audience:     "a",
+	}
+
+	e.logExchangeError(ErrExchangeTransport, input, time.Second)
+
+	recs := records()
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+
+	for key, val := range recs[0].Attrs {
+		if strings.Contains(val, "sensitive-token-value") {
+			t.Errorf("attribute %q = %q leaks SubjectToken", key, val)
+		}
+		if strings.Contains(val, "super-secret-value") {
+			t.Errorf("attribute %q = %q leaks clientSecret", key, val)
+		}
+	}
+}
+
+// B12: ErrExchangeRejected → WARN
+func TestLogExchangeError_RejectedLogsAtWarn(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	e := &Exchanger{tokenURL: "https://idp.example.com/token"}
+	e.logExchangeError(
+		fmt.Errorf("%w: invalid_grant", ErrExchangeRejected),
+		ExchangeInput{BrokerAlias: "b", Audience: "a"},
+		time.Second,
+	)
+
+	recs := records()
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	if recs[0].Level != slog.LevelWarn {
+		t.Errorf("level = %v, want WARN for ErrExchangeRejected", recs[0].Level)
+	}
+	if !strings.Contains(recs[0].Message, "rejected by IdP") {
+		t.Errorf("message = %q, want to contain \"rejected by IdP\"", recs[0].Message)
+	}
+}
+
+// B13: ErrExchangeTransport → ERROR
+func TestLogExchangeError_TransportLogsAtError(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	e := &Exchanger{tokenURL: "https://idp.example.com/token"}
+	e.logExchangeError(
+		fmt.Errorf("%w: connection refused", ErrExchangeTransport),
+		ExchangeInput{BrokerAlias: "b", Audience: "a"},
+		time.Second,
+	)
+
+	recs := records()
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	if recs[0].Level != slog.LevelError {
+		t.Errorf("level = %v, want ERROR for ErrExchangeTransport", recs[0].Level)
+	}
+	if !strings.Contains(recs[0].Message, "transport failure") {
+		t.Errorf("message = %q, want to contain \"transport failure\"", recs[0].Message)
+	}
+}
+
+// B14: ErrInvalidResponse → ERROR
+func TestLogExchangeError_InvalidResponseLogsAtError(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	e := &Exchanger{tokenURL: "https://idp.example.com/token"}
+	e.logExchangeError(
+		fmt.Errorf("%w: bad body", ErrInvalidResponse),
+		ExchangeInput{BrokerAlias: "b", Audience: "a"},
+		time.Second,
+	)
+
+	recs := records()
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	if recs[0].Level != slog.LevelError {
+		t.Errorf("level = %v, want ERROR for ErrInvalidResponse", recs[0].Level)
+	}
+	if !strings.Contains(recs[0].Message, "invalid IdP response") {
+		t.Errorf("message = %q, want to contain \"invalid IdP response\"", recs[0].Message)
+	}
+}
+
+// B15: unknown error → ERROR "unexpected error"
+func TestLogExchangeError_UnknownErrorLogsAtError(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	e := &Exchanger{tokenURL: "https://idp.example.com/token"}
+	e.logExchangeError(
+		errors.New("something completely unknown"),
+		ExchangeInput{BrokerAlias: "b", Audience: "a"},
+		time.Second,
+	)
+
+	recs := records()
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	if recs[0].Level != slog.LevelError {
+		t.Errorf("level = %v, want ERROR for unknown error", recs[0].Level)
+	}
+	if !strings.Contains(recs[0].Message, "unexpected error") {
+		t.Errorf("message = %q, want to contain \"unexpected error\"", recs[0].Message)
+	}
+}
+
+// B04 (log aspect): context errors are NOT logged
+func TestExchange_ContextErrorNotLogged(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	e.Exchange(ctx, validInput())
+
+	recs := records()
+	for _, rec := range recs {
+		if strings.Contains(rec.Message, "token exchange") {
+			t.Errorf("context cancellation should not produce token exchange log, got: %q", rec.Message)
+		}
+	}
+}
+
+// ---------- Integration: Exchange end-to-end with various IdP responses ----------
+
+func TestExchange_InvalidResponseError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Missing access_token.
+		fmt.Fprint(w, `{"token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`)
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	tok, err := e.Exchange(context.Background(), validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on invalid response", tok)
+	}
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+	}
+}
+
+// Verify that the request body sent to the IdP contains expected form fields.
+func TestExchange_RequestBodyContainsExpectedFields(t *testing.T) {
+	t.Parallel()
+
+	var capturedForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		capturedForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("tok", 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	input := ExchangeInput{
+		SubjectToken: "my-jwt",
+		BrokerAlias:  "my-broker",
+		Audience:     "https://broker.example.com",
+		Scopes:       []string{"read", "write"},
+	}
+
+	_, err := e.Exchange(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+
+	checks := map[string]string{
+		"grant_type":         URNGrantTypeTokenExchange,
+		"subject_token":      "my-jwt",
+		"subject_token_type": URNTokenTypeAccessToken,
+		"audience":           "https://broker.example.com",
+		"scope":              "read write",
+	}
+	for key, want := range checks {
+		if got := capturedForm.Get(key); got != want {
+			t.Errorf("form[%q] = %q, want %q", key, got, want)
+		}
+	}
+
+	// BrokerAlias must NOT appear in the request.
+	for _, key := range []string{"broker_alias", "broker", "alias"} {
+		if capturedForm.Get(key) != "" {
+			t.Errorf("form[%q] = %q, BrokerAlias must not appear in IdP request", key, capturedForm.Get(key))
+		}
+	}
+}
+
+// ---------- B07 variant: unknown grant type through Exchange ----------
+
+func TestExchange_UnknownGrantTypeReturnsTransportError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("IdP should not be called for unknown grant type")
+	}))
+	defer srv.Close()
+
+	e := &Exchanger{
+		tokenURL:         srv.URL,
+		clientID:         "cid",
+		clientAuthMethod: ClientSecretPost,
+		clientSecret:     "sec",
+		grantType:        GrantType(99),
+		audienceParam:    AudienceParamAudience,
+		httpClient:       &http.Client{},
+		nowFunc:          func() time.Time { return pinnedNow() },
+	}
+
+	tok, err := e.Exchange(context.Background(), validInput())
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil for unknown grant type", tok)
+	}
+	if !errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+	}
+}
+
+// ---------- Verify singleflight shares errors too ----------
+
+func TestExchange_SingleflightSharesErrors(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	gate := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		<-gate
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "server error")
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	e.nowFunc = func() time.Time { return pinnedNow() }
+
+	input := validInput()
+	const n = 3
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx] = e.Exchange(context.Background(), input)
+		}(i)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if !errors.Is(errs[i], ErrExchangeTransport) {
+			t.Errorf("goroutine %d: errors.Is(err, ErrExchangeTransport) = false; err = %v", i, errs[i])
+		}
+	}
+
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("IdP called %d times, want 1 (singleflight shares errors too)", got)
+	}
+}
+
+// ---------- Verify JSON response fields passed through correctly ----------
+
+func TestExchange_ResponseFieldsPreserved(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name        string
+		respJSON    string
+		wantValue   string
+		wantExpires time.Time
+	}
+
+	now := pinnedNow()
+	tests := []testCase{
+		{
+			name:        "standard token",
+			respJSON:    successJSON("standard-tok", 1800),
+			wantValue:   "standard-tok",
+			wantExpires: now.Add(1800*time.Second - defaults.DefaultTokenExpirySkew),
+		},
+		{
+			name: "extra fields ignored",
+			respJSON: `{"access_token":"extra-tok","token_type":"Bearer","issued_token_type":"` +
+				URNTokenTypeAccessToken + `","expires_in":600,"refresh_token":"ignored","scope":"openid"}`,
+			wantValue:   "extra-tok",
+			wantExpires: now.Add(600*time.Second - defaults.DefaultTokenExpirySkew),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tc.respJSON)
+			}))
+			defer srv.Close()
+
+			e := newTestExchanger(t, srv.URL)
+			e.nowFunc = func() time.Time { return now }
+
+			tok, err := e.Exchange(context.Background(), validInput())
+			if err != nil {
+				t.Fatalf("Exchange: %v", err)
+			}
+			if tok.Value != tc.wantValue {
+				t.Errorf("tok.Value = %q, want %q", tok.Value, tc.wantValue)
+			}
+			if !tok.ExpiresAt.Equal(tc.wantExpires) {
+				t.Errorf("tok.ExpiresAt = %v, want %v", tok.ExpiresAt, tc.wantExpires)
+			}
+		})
+	}
+}
+
+// ---------- Verify logExchangeError marshals the error string ----------
+
+func TestLogExchangeError_ErrorAttrContainsErrorMessage(t *testing.T) {
+	records, restore := captureLogs(t)
+	defer restore()
+
+	e := &Exchanger{tokenURL: "https://idp.example.com/token"}
+	testErr := fmt.Errorf("%w: specific failure detail", ErrExchangeTransport)
+
+	e.logExchangeError(testErr, ExchangeInput{BrokerAlias: "b", Audience: "a"}, time.Second)
+
+	recs := records()
+	if len(recs) != 1 {
+		t.Fatalf("got %d log records, want 1", len(recs))
+	}
+	errorAttr := recs[0].Attrs["error"]
+	if !strings.Contains(errorAttr, "specific failure detail") {
+		t.Errorf("error attr = %q, want it to contain \"specific failure detail\"", errorAttr)
+	}
+}
+
+// ---------- Verify JSON error response integration ----------
+
+func TestExchange_FourxxWithOAuthError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantSentinel error
+	}{
+		{"401 invalid_token", 401, `{"error":"invalid_token"}`, ErrExchangeRejected},
+		{"400 invalid_grant", 400, `{"error":"invalid_grant"}`, ErrExchangeRejected},
+		{"403 WAF HTML", 403, `<html>Denied</html>`, ErrExchangeTransport},
+		{"500 server error", 500, `Internal Server Error`, ErrExchangeTransport},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+			defer srv.Close()
+
+			e := newTestExchanger(t, srv.URL)
+			e.nowFunc = func() time.Time { return pinnedNow() }
+
+			tok, err := e.Exchange(context.Background(), validInput())
+
+			if tok != nil {
+				t.Errorf("tok = %v, want nil", tok)
+			}
+			if !errors.Is(err, tc.wantSentinel) {
+				t.Errorf("errors.Is(err, %v) = false, want true; err = %v", tc.wantSentinel, err)
+			}
+		})
+	}
+}
+

--- a/internal/tokenexchange/exchanger.go
+++ b/internal/tokenexchange/exchanger.go
@@ -1,0 +1,62 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"errors"
+	"net/http"
+)
+
+// Exchanger executes RFC 8693 token exchange against a single IdP. One
+// instance per process: every field is written once at construction and
+// never mutated, so concurrent calls from many goroutines are safe by
+// virtue of effectively-immutable state plus the goroutine-safety of
+// *http.Client and (when wired) the singleflight group. Per-broker
+// values (audience, scopes) and per-user values (subject token) flow
+// through Exchange's ExchangeInput, never onto the struct.
+type Exchanger struct {
+	tokenURL         string
+	clientID         string
+	clientAuthMethod ClientAuthMethod
+	clientSecret     string
+	grantType        GrantType
+	audienceParam    AudienceFormat
+	httpClient       *http.Client
+}
+
+// New constructs an Exchanger from Params. The config validator
+// (internal/config.validateBrokerOAuthConfig) has already enforced
+// every non-runtime field at startup, so this constructor only checks
+// runtime-wired dependencies the validator cannot see — specifically
+// that HTTPClient is non-nil.
+//
+// Tests that build Params{...} directly without going through FromConfig
+// are responsible for supplying valid enum values; bad values surface at
+// request-construction time via the switch default branches in the
+// wire-building helpers.
+func New(p Params) (*Exchanger, error) {
+	if p.HTTPClient == nil {
+		return nil, errors.New("tokenexchange: HTTPClient is required")
+	}
+	return &Exchanger{
+		tokenURL:         p.TokenURL,
+		clientID:         p.ClientID,
+		clientAuthMethod: p.ClientAuthMethod,
+		clientSecret:     p.ClientSecret,
+		grantType:        p.GrantType,
+		audienceParam:    p.AudienceParam,
+		httpClient:       p.HTTPClient,
+	}, nil
+}

--- a/internal/tokenexchange/exchanger.go
+++ b/internal/tokenexchange/exchanger.go
@@ -17,15 +17,18 @@ package tokenexchange
 import (
 	"errors"
 	"net/http"
+	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // Exchanger executes RFC 8693 token exchange against a single IdP. One
-// instance per process: every field is written once at construction and
-// never mutated, so concurrent calls from many goroutines are safe by
-// virtue of effectively-immutable state plus the goroutine-safety of
-// *http.Client and (when wired) the singleflight group. Per-broker
-// values (audience, scopes) and per-user values (subject token) flow
-// through Exchange's ExchangeInput, never onto the struct.
+// instance per process, shared by all per-request goroutines.
+//
+// INVARIANT: every field is written once in New() and never mutated
+// afterward. Do not assign to any field from any method. Concurrency
+// safety depends on this — fields are read from hundreds of goroutines
+// without synchronization. The race detector enforces this at test time.
 type Exchanger struct {
 	tokenURL         string
 	clientID         string
@@ -34,6 +37,8 @@ type Exchanger struct {
 	grantType        GrantType
 	audienceParam    AudienceFormat
 	httpClient       *http.Client
+	group            singleflight.Group
+	nowFunc          func() time.Time
 }
 
 // New constructs an Exchanger from Params. The config validator
@@ -58,5 +63,6 @@ func New(p Params) (*Exchanger, error) {
 		grantType:        p.GrantType,
 		audienceParam:    p.AudienceParam,
 		httpClient:       p.HTTPClient,
+		nowFunc:          time.Now,
 	}, nil
 }

--- a/internal/tokenexchange/exchanger_test.go
+++ b/internal/tokenexchange/exchanger_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// validParams returns a Params struct with every field set to a value
+// that would survive every layer of validation. Tests start from this
+// and mutate one field at a time to exercise specific cases.
+func validParams() Params {
+	return Params{
+		TokenURL:         "https://idp.example.com/token",
+		ClientID:         "solace-mcp-server",
+		ClientAuthMethod: ClientSecretPost,
+		ClientSecret:     "test-secret",
+		GrantType:        GrantTypeTokenExchange,
+		AudienceParam:    AudienceParamAudience,
+		HTTPClient:       &http.Client{},
+	}
+}
+
+// TestNew_HTTPClientNilRejected pins the only runtime check New performs.
+// Every other field is trusted (config validator enforced it at startup),
+// but HTTPClient is wired at runtime from outside config and must be
+// non-nil for the Exchanger to function. A nil here is a programming
+// error in main's wiring — fail fast, do not ship a half-built Exchanger.
+func TestNew_HTTPClientNilRejected(t *testing.T) {
+	p := validParams()
+	p.HTTPClient = nil
+
+	ex, err := New(p)
+	if err == nil {
+		t.Fatal("expected error for nil HTTPClient")
+	}
+	if ex != nil {
+		t.Errorf("expected nil Exchanger on error, got %#v", ex)
+	}
+	if !strings.Contains(err.Error(), "HTTPClient") {
+		t.Errorf("error message should mention HTTPClient, got: %v", err)
+	}
+}
+
+// TestNew_HappyPath verifies that a fully-populated Params yields a
+// non-nil Exchanger with no error.
+func TestNew_HappyPath(t *testing.T) {
+	ex, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if ex == nil {
+		t.Fatal("expected non-nil Exchanger")
+	}
+}
+
+// TestNew_FieldsAreCopied verifies that New copies Params fields onto
+// the Exchanger and that subsequent mutation of the Params struct does
+// not affect the constructed Exchanger. Effectively-immutable state is
+// the foundation of the concurrency safety story (Decision 8).
+func TestNew_FieldsAreCopied(t *testing.T) {
+	p := validParams()
+	ex, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Mutate the original Params struct.
+	p.TokenURL = "https://changed.example.com/token"
+	p.ClientID = "changed"
+	p.ClientSecret = "changed"
+
+	if ex.tokenURL == p.TokenURL {
+		t.Error("Exchanger.tokenURL aliased to caller's Params after mutation")
+	}
+	if ex.clientID == p.ClientID {
+		t.Error("Exchanger.clientID aliased to caller's Params after mutation")
+	}
+	if ex.clientSecret == p.ClientSecret {
+		t.Error("Exchanger.clientSecret aliased to caller's Params after mutation")
+	}
+}

--- a/internal/tokenexchange/from_config.go
+++ b/internal/tokenexchange/from_config.go
@@ -94,9 +94,9 @@ func resolveAudienceParam(ap string) (AudienceFormat, error) {
 	case config.AudienceParamAudience:
 		return AudienceParamAudience, nil
 	case config.AudienceParamScope:
-		return 0, fmt.Errorf("tokenexchange: audience_parameter_name %q is schema-accepted but not yet implemented; see docs/oauth/keycloak-requirements.md", ap)
+		return 0, fmt.Errorf("tokenexchange: audience_parameter_name %q is schema-accepted but not yet implemented", ap)
 	case config.AudienceParamResource:
-		return 0, fmt.Errorf("tokenexchange: audience_parameter_name %q is schema-accepted but not yet implemented; see docs/oauth/keycloak-requirements.md", ap)
+		return 0, fmt.Errorf("tokenexchange: audience_parameter_name %q is schema-accepted but not yet implemented", ap)
 	default:
 		return 0, fmt.Errorf("tokenexchange: unsupported audience_parameter_name %q", ap)
 	}

--- a/internal/tokenexchange/from_config.go
+++ b/internal/tokenexchange/from_config.go
@@ -1,0 +1,103 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+)
+
+// FromConfig constructs an Exchanger from the validated broker_oauth
+// config block and a pre-built HTTP client (typically from
+// idpclient.NewHTTPClient). This is the only file in the package that
+// imports internal/config — tests use New(Params) directly.
+//
+// The config validator (internal/config.validateBrokerOAuthConfig) has
+// already enforced structural validity at startup: non-empty fields,
+// exactly-one client-auth sub-block, grant_type and audience_parameter_name
+// in their respective allowlists. FromConfig translates the validated
+// YAML-level types (strings, discriminated unions) into the typed Params
+// enums the Exchanger expects.
+func FromConfig(cfg *config.BrokerOAuthConfig, httpClient *http.Client) (*Exchanger, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("tokenexchange: broker_oauth config is nil")
+	}
+
+	authMethod, secret, err := resolveClientAuth(cfg.ClientAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	grantType, err := resolveGrantType(cfg.GrantType)
+	if err != nil {
+		return nil, err
+	}
+
+	audienceParam, err := resolveAudienceParam(cfg.AudienceParam)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(Params{
+		TokenURL:         cfg.TokenURL,
+		ClientID:         cfg.ClientID,
+		ClientAuthMethod: authMethod,
+		ClientSecret:     secret,
+		GrantType:        grantType,
+		AudienceParam:    audienceParam,
+		HTTPClient:       httpClient,
+	})
+}
+
+// resolveClientAuth determines the client auth method and extracts the
+// secret from the populated sub-block. The config validator already
+// enforced exactly-one-sub-block at startup, so the both-nil / both-set
+// cases are programming errors, not operator errors.
+func resolveClientAuth(auth config.BrokerClientAuth) (ClientAuthMethod, string, error) {
+	switch {
+	case auth.ClientSecretBasic != nil && auth.ClientSecretPost != nil:
+		return 0, "", fmt.Errorf("tokenexchange: both client_secret_basic and client_secret_post are populated")
+	case auth.ClientSecretBasic != nil:
+		return ClientSecretBasic, auth.ClientSecretBasic.Secret, nil
+	case auth.ClientSecretPost != nil:
+		return ClientSecretPost, auth.ClientSecretPost.Secret, nil
+	default:
+		return 0, "", fmt.Errorf("tokenexchange: no client auth method configured")
+	}
+}
+
+func resolveGrantType(gt string) (GrantType, error) {
+	switch gt {
+	case config.GrantTypeTokenExchange:
+		return GrantTypeTokenExchange, nil
+	default:
+		return 0, fmt.Errorf("tokenexchange: unsupported grant_type %q", gt)
+	}
+}
+
+func resolveAudienceParam(ap string) (AudienceFormat, error) {
+	switch ap {
+	case config.AudienceParamAudience:
+		return AudienceParamAudience, nil
+	case config.AudienceParamScope:
+		return 0, fmt.Errorf("tokenexchange: audience_parameter_name %q is schema-accepted but not yet implemented; see docs/oauth/keycloak-requirements.md", ap)
+	case config.AudienceParamResource:
+		return 0, fmt.Errorf("tokenexchange: audience_parameter_name %q is schema-accepted but not yet implemented; see docs/oauth/keycloak-requirements.md", ap)
+	default:
+		return 0, fmt.Errorf("tokenexchange: unsupported audience_parameter_name %q", ap)
+	}
+}

--- a/internal/tokenexchange/from_config_test.go
+++ b/internal/tokenexchange/from_config_test.go
@@ -1,0 +1,227 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+)
+
+func validBrokerOAuthConfig() *config.BrokerOAuthConfig {
+	return &config.BrokerOAuthConfig{
+		TokenURL: "https://idp.example.com/token",
+		ClientID: "mcp-server",
+		ClientAuth: config.BrokerClientAuth{
+			ClientSecretPost: &config.ClientSecretAuth{Secret: "test-secret"},
+		},
+		GrantType:     config.GrantTypeTokenExchange,
+		AudienceParam: config.AudienceParamAudience,
+	}
+}
+
+func TestFromConfig_ClientSecretPostResolvesCorrectly(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	e, err := FromConfig(cfg, &http.Client{})
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+
+	if e.clientAuthMethod != ClientSecretPost {
+		t.Errorf("clientAuthMethod = %v, want ClientSecretPost", e.clientAuthMethod)
+	}
+	if e.clientSecret != "test-secret" {
+		t.Errorf("clientSecret = %q, want %q", e.clientSecret, "test-secret")
+	}
+	if e.tokenURL != "https://idp.example.com/token" {
+		t.Errorf("tokenURL = %q, want %q", e.tokenURL, "https://idp.example.com/token")
+	}
+	if e.clientID != "mcp-server" {
+		t.Errorf("clientID = %q, want %q", e.clientID, "mcp-server")
+	}
+}
+
+func TestFromConfig_ClientSecretBasicResolvesCorrectly(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	cfg.ClientAuth = config.BrokerClientAuth{
+		ClientSecretBasic: &config.ClientSecretAuth{Secret: "basic-secret"},
+	}
+
+	e, err := FromConfig(cfg, &http.Client{})
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+
+	if e.clientAuthMethod != ClientSecretBasic {
+		t.Errorf("clientAuthMethod = %v, want ClientSecretBasic", e.clientAuthMethod)
+	}
+	if e.clientSecret != "basic-secret" {
+		t.Errorf("clientSecret = %q, want %q", e.clientSecret, "basic-secret")
+	}
+}
+
+func TestFromConfig_NilConfigReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := FromConfig(nil, &http.Client{})
+	if err == nil {
+		t.Fatal("FromConfig(nil) = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Errorf("error = %q, want it to mention nil", err.Error())
+	}
+}
+
+func TestFromConfig_NilHTTPClientReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := FromConfig(validBrokerOAuthConfig(), nil)
+	if err == nil {
+		t.Fatal("FromConfig with nil HTTPClient = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "HTTPClient") {
+		t.Errorf("error = %q, want it to mention HTTPClient", err.Error())
+	}
+}
+
+func TestFromConfig_NoClientAuthMethodReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	cfg.ClientAuth = config.BrokerClientAuth{}
+
+	_, err := FromConfig(cfg, &http.Client{})
+	if err == nil {
+		t.Fatal("FromConfig with no client auth = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "no client auth") {
+		t.Errorf("error = %q, want it to mention no client auth method", err.Error())
+	}
+}
+
+func TestFromConfig_BothClientAuthMethodsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	cfg.ClientAuth = config.BrokerClientAuth{
+		ClientSecretBasic: &config.ClientSecretAuth{Secret: "a"},
+		ClientSecretPost:  &config.ClientSecretAuth{Secret: "b"},
+	}
+
+	_, err := FromConfig(cfg, &http.Client{})
+	if err == nil {
+		t.Fatal("FromConfig with both client auth methods = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "both") {
+		t.Errorf("error = %q, want it to mention both methods", err.Error())
+	}
+}
+
+func TestFromConfig_UnknownGrantTypeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	cfg.GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+	_, err := FromConfig(cfg, &http.Client{})
+	if err == nil {
+		t.Fatal("FromConfig with unknown grant type = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "jwt-bearer") {
+		t.Errorf("error = %q, want it to mention the unsupported grant type", err.Error())
+	}
+}
+
+func TestFromConfig_AudienceParamScopeNotYetImplemented(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	cfg.AudienceParam = config.AudienceParamScope
+
+	_, err := FromConfig(cfg, &http.Client{})
+	if err == nil {
+		t.Fatal("FromConfig with audience_parameter_name=scope = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Errorf("error = %q, want it to mention not yet implemented", err.Error())
+	}
+}
+
+func TestFromConfig_AudienceParamResourceNotYetImplemented(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	cfg.AudienceParam = config.AudienceParamResource
+
+	_, err := FromConfig(cfg, &http.Client{})
+	if err == nil {
+		t.Fatal("FromConfig with audience_parameter_name=resource = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Errorf("error = %q, want it to mention not yet implemented", err.Error())
+	}
+}
+
+func TestFromConfig_UnknownAudienceParamReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	cfg.AudienceParam = "custom_param"
+
+	_, err := FromConfig(cfg, &http.Client{})
+	if err == nil {
+		t.Fatal("FromConfig with unknown audience param = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "custom_param") {
+		t.Errorf("error = %q, want it to mention the unsupported param name", err.Error())
+	}
+}
+
+func TestFromConfig_GrantTypeAndAudienceParamMapToCorrectEnums(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	e, err := FromConfig(cfg, &http.Client{})
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+
+	if e.grantType != GrantTypeTokenExchange {
+		t.Errorf("grantType = %v, want GrantTypeTokenExchange", e.grantType)
+	}
+	if e.audienceParam != AudienceParamAudience {
+		t.Errorf("audienceParam = %v, want AudienceParamAudience", e.audienceParam)
+	}
+}
+
+func TestFromConfig_NowFuncIsSet(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBrokerOAuthConfig()
+	e, err := FromConfig(cfg, &http.Client{})
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+
+	if e.nowFunc == nil {
+		t.Error("nowFunc = nil, want time.Now (set by New)")
+	}
+}

--- a/internal/tokenexchange/request.go
+++ b/internal/tokenexchange/request.go
@@ -1,0 +1,146 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// buildIdPRequest assembles a POST to the IdP token endpoint. Each
+// concern — grant-type wire shape, subject token, client authentication,
+// audience format, scopes — is handled by its own method so new grant
+// types or auth methods grow in isolation.
+//
+// The request is built first with an empty body. Setters receive both
+// the form (for body fields) and the request (for headers), so each
+// setter can fully own its concern without leaking work back to the
+// orchestrator. The form is encoded into the request body last.
+func (e *Exchanger) buildIdPRequest(ctx context.Context, input ExchangeInput) (*http.Request, error) {
+	form := url.Values{}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.tokenURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("tokenexchange: building IdP request: %w", err)
+	}
+
+	if err := e.setGrantFields(form); err != nil {
+		return nil, err
+	}
+	if err := e.setSubjectToken(form, input); err != nil {
+		return nil, err
+	}
+	e.setSubjectTokenType(form)
+	if err := e.setClientAuth(form, req); err != nil {
+		return nil, err
+	}
+	if err := e.setAudience(form, input); err != nil {
+		return nil, err
+	}
+	e.setScopes(form, input)
+
+	encoded := form.Encode()
+	req.Body = io.NopCloser(strings.NewReader(encoded))
+	req.ContentLength = int64(len(encoded))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req, nil
+}
+
+// setGrantFields sets the grant_type URN. The grant type acts as a
+// protocol selector (RFC 8693 vs RFC 7523) — each protocol defines its
+// own URN. Per-request values (the user's JWT) and IdP-specific
+// metadata (subject_token_type) are handled by setSubjectToken.
+func (e *Exchanger) setGrantFields(form url.Values) error {
+	switch e.grantType {
+	case GrantTypeTokenExchange:
+		form.Set("grant_type", URNGrantTypeTokenExchange)
+	default:
+		return fmt.Errorf("tokenexchange: unknown GrantType %d (programming error — Params built outside FromConfig)", e.grantType)
+	}
+	return nil
+}
+
+// setSubjectToken places the user's inbound JWT into the form field
+// appropriate for the configured protocol. The parameter name is
+// protocol-defined (RFC 8693: "subject_token"; RFC 7523: "assertion")
+// and switches on grant type. The subject_token_type is an independent
+// axis that varies across IdPs within the same protocol (Keycloak:
+// only access_token; Okta: also id_token) and will become its own
+// config field.
+func (e *Exchanger) setSubjectToken(form url.Values, input ExchangeInput) error {
+	switch e.grantType {
+	case GrantTypeTokenExchange:
+		form.Set("subject_token", input.SubjectToken)
+	default:
+		return fmt.Errorf("tokenexchange: unknown GrantType %d for subject token placement", e.grantType)
+	}
+	return nil
+}
+
+// setSubjectTokenType sets the subject_token_type form field (required
+// by RFC 8693 §2.1 whenever subject_token is present). The value is an
+// architectural invariant, not an operator choice: Hop 1 receives the
+// subject token as a Bearer credential (RFC 6750), which is by
+// definition an access token. The MCP server never receives an ID
+// token in the Authorization header, so subject_token_type is always
+// access_token regardless of IdP.
+func (e *Exchanger) setSubjectTokenType(form url.Values) {
+	form.Set("subject_token_type", URNTokenTypeAccessToken)
+}
+
+// setClientAuth places client credentials in exactly one location:
+// the Authorization header (client_secret_basic) or the form body
+// (client_secret_post). Some IdPs treat credentials in both locations
+// as a protocol violation, so the two paths are mutually exclusive.
+func (e *Exchanger) setClientAuth(form url.Values, req *http.Request) error {
+	switch e.clientAuthMethod {
+	case ClientSecretBasic:
+		req.SetBasicAuth(e.clientID, e.clientSecret)
+	case ClientSecretPost:
+		form.Set("client_id", e.clientID)
+		form.Set("client_secret", e.clientSecret)
+	default:
+		return fmt.Errorf("tokenexchange: unknown ClientAuthMethod %d (programming error — Params built outside FromConfig)", e.clientAuthMethod)
+	}
+	return nil
+}
+
+// setAudience places the per-broker audience value into the form field
+// selected by the configured AudienceFormat. V1 implements only the
+// canonical RFC 8693 "audience" parameter.
+func (e *Exchanger) setAudience(form url.Values, input ExchangeInput) error {
+	switch e.audienceParam {
+	case AudienceParamAudience:
+		if input.Audience != "" {
+			form.Set("audience", input.Audience)
+		}
+	default:
+		return fmt.Errorf("tokenexchange: unknown AudienceFormat %d (programming error — Params built outside FromConfig)", e.audienceParam)
+	}
+	return nil
+}
+
+// setScopes adds the space-joined scope field per RFC 6749 §3.3.
+// Omitted when the caller passed an empty slice so the IdP applies
+// its per-client default scopes.
+func (e *Exchanger) setScopes(form url.Values, input ExchangeInput) {
+	if len(input.Scopes) > 0 {
+		form.Set("scope", strings.Join(input.Scopes, " "))
+	}
+}

--- a/internal/tokenexchange/request_test.go
+++ b/internal/tokenexchange/request_test.go
@@ -1,0 +1,716 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// readFormBody reads req.Body and parses it as an application/x-www-form-urlencoded
+// body. Fatals on any read or parse error. Used by the body-asserting tests.
+func readFormBody(t *testing.T, req *http.Request) url.Values {
+	t.Helper()
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	form, err := url.ParseQuery(string(bodyBytes))
+	if err != nil {
+		t.Fatalf("ParseQuery: %v", err)
+	}
+	return form
+}
+
+// TestBuildIdPRequest_MandatoryRFCFields verifies that grant_type,
+// subject_token, and subject_token_type are present with exact RFC 8693 URN
+// values on every call, regardless of auth method or optional fields.
+func TestBuildIdPRequest_MandatoryRFCFields(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	input := ExchangeInput{
+		SubjectToken: "tok-abc",
+		Audience:     "https://broker.example.com",
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), input)
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	form := readFormBody(t, req)
+
+	if got := form.Get("grant_type"); got != URNGrantTypeTokenExchange {
+		t.Errorf("grant_type = %q, want %q", got, URNGrantTypeTokenExchange)
+	}
+	if got := form.Get("subject_token"); got != "tok-abc" {
+		t.Errorf("subject_token = %q, want %q", got, "tok-abc")
+	}
+	if got := form.Get("subject_token_type"); got != URNTokenTypeAccessToken {
+		t.Errorf("subject_token_type = %q, want %q", got, URNTokenTypeAccessToken)
+	}
+}
+
+// TestBuildIdPRequest_ClientSecretPost verifies that client_id and
+// client_secret appear in the form body and the Authorization header is
+// absent when ClientSecretPost is configured.
+func TestBuildIdPRequest_ClientSecretPost(t *testing.T) {
+	t.Parallel()
+
+	p := validParams()
+	p.ClientAuthMethod = ClientSecretPost
+	p.ClientID = "my-client"
+	p.ClientSecret = "my-secret"
+	e, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		Audience:     "aud",
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	form := readFormBody(t, req)
+
+	if got := form.Get("client_id"); got != "my-client" {
+		t.Errorf("client_id = %q, want %q", got, "my-client")
+	}
+	if got := form.Get("client_secret"); got != "my-secret" {
+		t.Errorf("client_secret = %q, want %q", got, "my-secret")
+	}
+	if auth := req.Header.Get("Authorization"); auth != "" {
+		t.Errorf("Authorization header = %q, want absent for ClientSecretPost", auth)
+	}
+}
+
+// TestBuildIdPRequest_ClientSecretBasic verifies that client_id and
+// client_secret are encoded in the Basic Authorization header and do NOT
+// appear in the form body when ClientSecretBasic is configured.
+func TestBuildIdPRequest_ClientSecretBasic(t *testing.T) {
+	t.Parallel()
+
+	p := validParams()
+	p.ClientAuthMethod = ClientSecretBasic
+	p.ClientID = "my-client"
+	p.ClientSecret = "my-secret"
+	e, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		Audience:     "aud",
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Basic ") {
+		t.Errorf("Authorization = %q, want Basic scheme", auth)
+	}
+	// net/http.SetBasicAuth writes "Basic <base64.StdEncoding>" — Go stdlib guarantee.
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+	if err != nil {
+		t.Fatalf("base64 decode Authorization: %v", err)
+	}
+	if string(decoded) != "my-client:my-secret" {
+		t.Errorf("Basic credentials = %q, want %q", string(decoded), "my-client:my-secret")
+	}
+
+	form := readFormBody(t, req)
+
+	if form.Get("client_id") != "" {
+		t.Errorf("client_id in form body for ClientSecretBasic, want absent")
+	}
+	if form.Get("client_secret") != "" {
+		t.Errorf("client_secret in form body for ClientSecretBasic, want absent")
+	}
+}
+
+// TestBuildIdPRequest_NeverBothCredentials verifies the mutual-exclusion
+// invariant: for any valid auth method, credentials appear in exactly one
+// location — either the Basic header or the form body, never both and
+// never neither.
+func TestBuildIdPRequest_NeverBothCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method ClientAuthMethod
+	}{
+		{"ClientSecretPost", ClientSecretPost},
+		{"ClientSecretBasic", ClientSecretBasic},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := validParams()
+			p.ClientAuthMethod = tc.method
+			p.ClientID = "cid"
+			p.ClientSecret = "csec"
+			e, err := New(p)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+				SubjectToken: "tok",
+				Audience:     "aud",
+			})
+			if err != nil {
+				t.Fatalf("buildIdPRequest: %v", err)
+			}
+
+			form := readFormBody(t, req)
+
+			hasBasic := strings.HasPrefix(req.Header.Get("Authorization"), "Basic ")
+			hasFormCID := form.Get("client_id") != ""
+
+			if hasBasic && hasFormCID {
+				t.Errorf("both Basic header and client_id form field set — never-both invariant violated")
+			}
+			if !hasBasic && !hasFormCID {
+				t.Errorf("neither Basic header nor client_id form field set — credentials missing")
+			}
+		})
+	}
+}
+
+// TestBuildIdPRequest_UnknownGrantType verifies that any GrantType value
+// outside the defined constants returns an error mentioning "GrantType"
+// and a nil request. The grant-type switch fires before auth-method and
+// audience switches.
+func TestBuildIdPRequest_UnknownGrantType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		grantType GrantType
+	}{
+		{"zero value", 0},
+		{"negative", -1},
+		{"large unknown", 99},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e := &Exchanger{
+				tokenURL:         "https://idp.example.com/token",
+				clientID:         "cid",
+				clientAuthMethod: ClientSecretPost,
+				clientSecret:     "sec",
+				grantType:        tc.grantType,
+				audienceParam:    AudienceParamAudience,
+			}
+			req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+				SubjectToken: "tok",
+				Audience:     "aud",
+			})
+
+			if err == nil {
+				t.Fatal("expected error for unknown GrantType, got nil")
+			}
+			if req != nil {
+				t.Errorf("expected nil request on error, got non-nil")
+			}
+			if !strings.Contains(err.Error(), "GrantType") {
+				t.Errorf("error = %q, want mention of GrantType", err.Error())
+			}
+		})
+	}
+}
+
+// TestBuildIdPRequest_UnknownClientAuthMethod verifies that any
+// ClientAuthMethod value outside the defined constants returns an error
+// mentioning "ClientAuthMethod" and a nil request. audienceParam is set
+// to AudienceParamAudience so the audience switch stays valid and the
+// auth-method error fires first.
+func TestBuildIdPRequest_UnknownClientAuthMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method ClientAuthMethod
+	}{
+		{"zero value", 0},
+		{"negative", -1},
+		{"large unknown", 99},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e := &Exchanger{
+				tokenURL:         "https://idp.example.com/token",
+				clientID:         "cid",
+				clientAuthMethod: tc.method,
+				clientSecret:     "sec",
+				grantType:        GrantTypeTokenExchange,  // REQUIRED: passes grant-type switch
+				audienceParam:    AudienceParamAudience,   // REQUIRED: keeps audience switch valid so the auth-method error fires first
+			}
+			req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+				SubjectToken: "tok",
+				Audience:     "aud",
+			})
+
+			if err == nil {
+				t.Fatal("expected error for unknown ClientAuthMethod, got nil")
+			}
+			if req != nil {
+				t.Errorf("expected nil request on error, got non-nil")
+			}
+			if !strings.Contains(err.Error(), "ClientAuthMethod") {
+				t.Errorf("error = %q, want mention of ClientAuthMethod", err.Error())
+			}
+		})
+	}
+}
+
+// TestBuildIdPRequest_UnknownAudienceFormat verifies that any
+// AudienceFormat value outside the defined constants returns an error
+// mentioning "AudienceFormat" and a nil request. clientAuthMethod is set
+// to ClientSecretPost so the auth switch passes and the audience-format
+// error fires.
+func TestBuildIdPRequest_UnknownAudienceFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		param AudienceFormat
+	}{
+		{"zero value", 0},
+		{"AudienceParamScope (unimplemented)", 2},
+		{"AudienceParamResource (unimplemented)", 3},
+		{"negative", -1},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e := &Exchanger{
+				tokenURL:         "https://idp.example.com/token",
+				clientID:         "cid",
+				clientAuthMethod: ClientSecretPost,        // REQUIRED: passes auth switch so the audience-format error fires
+				clientSecret:     "sec",
+				grantType:        GrantTypeTokenExchange,  // REQUIRED: passes grant-type switch
+				audienceParam:    tc.param,
+			}
+			req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+				SubjectToken: "tok",
+				Audience:     "aud",
+			})
+
+			if err == nil {
+				t.Fatal("expected error for unknown AudienceFormat, got nil")
+			}
+			if req != nil {
+				t.Errorf("expected nil request on error, got non-nil")
+			}
+			if !strings.Contains(err.Error(), "AudienceFormat") {
+				t.Errorf("error = %q, want mention of AudienceFormat", err.Error())
+			}
+		})
+	}
+}
+
+// TestBuildIdPRequest_AudienceConditional verifies that the "audience" form
+// field is present with the correct value when ExchangeInput.Audience is
+// non-empty, and absent when it is empty.
+func TestBuildIdPRequest_AudienceConditional(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		audience    string
+		wantPresent bool
+		wantValue   string
+	}{
+		{"non-empty audience", "https://broker.example.com", true, "https://broker.example.com"},
+		{"empty audience", "", false, ""},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e, err := New(validParams())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+				SubjectToken: "tok",
+				Audience:     tc.audience,
+			})
+			if err != nil {
+				t.Fatalf("buildIdPRequest: %v", err)
+			}
+
+			form := readFormBody(t, req)
+
+			_, present := form["audience"]
+			if present != tc.wantPresent {
+				t.Errorf("audience present = %v, want %v", present, tc.wantPresent)
+			}
+			if tc.wantPresent && form.Get("audience") != tc.wantValue {
+				t.Errorf("audience = %q, want %q", form.Get("audience"), tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestBuildIdPRequest_ScopeConditional verifies that the "scope" form field
+// is absent for nil or empty slices, and present with a space-joined value
+// (per RFC 6749 §3.3) for non-empty slices.
+func TestBuildIdPRequest_ScopeConditional(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		scopes      []string
+		wantPresent bool
+		wantValue   string
+	}{
+		{"nil scopes", nil, false, ""},
+		{"empty slice", []string{}, false, ""},
+		{"single scope", []string{"read"}, true, "read"},
+		{"multiple scopes", []string{"read", "write"}, true, "read write"},
+		{"three scopes", []string{"a", "b", "c"}, true, "a b c"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e, err := New(validParams())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+				SubjectToken: "tok",
+				Scopes:       tc.scopes,
+			})
+			if err != nil {
+				t.Fatalf("buildIdPRequest: %v", err)
+			}
+
+			form := readFormBody(t, req)
+
+			_, present := form["scope"]
+			if present != tc.wantPresent {
+				t.Errorf("scope present = %v, want %v", present, tc.wantPresent)
+			}
+			if tc.wantPresent && form.Get("scope") != tc.wantValue {
+				t.Errorf("scope = %q, want %q", form.Get("scope"), tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestBuildIdPRequest_ContentTypeAlwaysSet verifies that the Content-Type
+// header is "application/x-www-form-urlencoded" regardless of auth method.
+func TestBuildIdPRequest_ContentTypeAlwaysSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method ClientAuthMethod
+	}{
+		{"ClientSecretPost", ClientSecretPost},
+		{"ClientSecretBasic", ClientSecretBasic},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := validParams()
+			p.ClientAuthMethod = tc.method
+			e, err := New(p)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+				SubjectToken: "tok",
+				Audience:     "aud",
+			})
+			if err != nil {
+				t.Fatalf("buildIdPRequest: %v", err)
+			}
+
+			if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+				t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+			}
+		})
+	}
+}
+
+// TestBuildIdPRequest_ContextPropagation verifies that the context passed
+// to buildIdPRequest is the same context attached to the returned
+// *http.Request (pointer identity).
+func TestBuildIdPRequest_ContextPropagation(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := e.buildIdPRequest(ctx, ExchangeInput{
+		SubjectToken: "tok",
+		Audience:     "aud",
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	if req.Context() != ctx {
+		t.Errorf("req.Context() is not the supplied ctx — context propagation broken")
+	}
+}
+
+// TestBuildIdPRequest_MalformedTokenURL verifies that a malformed tokenURL
+// causes buildIdPRequest to return an error that wraps *url.Error (accessible
+// via errors.As) and contains "building IdP request". Direct struct literal
+// bypasses New because New does not validate TokenURL format.
+func TestBuildIdPRequest_MalformedTokenURL(t *testing.T) {
+	t.Parallel()
+
+	e := &Exchanger{
+		tokenURL:         "://not-a-valid-url",
+		clientID:         "cid",
+		clientAuthMethod: ClientSecretPost,
+		clientSecret:     "sec",
+		grantType:        GrantTypeTokenExchange,
+		audienceParam:    AudienceParamAudience,
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		Audience:     "aud",
+	})
+
+	if err == nil {
+		t.Fatal("expected error for malformed tokenURL, got nil")
+	}
+	if req != nil {
+		t.Errorf("expected nil request on error, got non-nil")
+	}
+	if !strings.Contains(err.Error(), "building IdP request") {
+		t.Errorf("error = %q, want 'building IdP request' prefix", err.Error())
+	}
+	// The error must be wrapped — the underlying url.Error must be accessible via errors.As.
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		t.Errorf("expected wrapped *url.Error via errors.As, got %T: %v", err, err)
+	}
+}
+
+// TestBuildIdPRequest_MethodIsPOST verifies that the returned request
+// uses the POST method.
+func TestBuildIdPRequest_MethodIsPOST(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		Audience:     "aud",
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	if req.Method != http.MethodPost {
+		t.Errorf("Method = %q, want POST", req.Method)
+	}
+}
+
+// TestBuildIdPRequest_URLEqualsTokenURL verifies that the URL on the
+// returned request equals the tokenURL set in Params — no path
+// manipulation or query-string injection.
+func TestBuildIdPRequest_URLEqualsTokenURL(t *testing.T) {
+	t.Parallel()
+
+	p := validParams()
+	p.TokenURL = "https://idp.example.com/v2/token"
+	e, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		Audience:     "aud",
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	if got := req.URL.String(); got != "https://idp.example.com/v2/token" {
+		t.Errorf("URL = %q, want %q", got, "https://idp.example.com/v2/token")
+	}
+}
+
+// TestBuildIdPRequest_BrokerAliasExcluded verifies that
+// ExchangeInput.BrokerAlias is a logging label only and never appears in
+// the IdP request body under any field name.
+func TestBuildIdPRequest_BrokerAliasExcluded(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		BrokerAlias:  "my-broker",
+		Audience:     "aud",
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	form := readFormBody(t, req)
+
+	for _, key := range []string{"broker_alias", "broker", "alias"} {
+		if form.Get(key) != "" {
+			t.Errorf("form field %q = %q present, BrokerAlias must not appear in IdP request", key, form.Get(key))
+		}
+	}
+}
+
+// TestBuildIdPRequest_EmptySubjectTokenPassThrough pins the current
+// behavior where buildIdPRequest does not validate that SubjectToken is
+// non-empty — it passes through to the form body as-is. If a guard is
+// added to reject empty SubjectToken, update this test simultaneously.
+func TestBuildIdPRequest_EmptySubjectTokenPassThrough(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "", // intentionally empty — pins current pass-through behavior
+		Audience:     "aud",
+	})
+
+	// Current behavior: no error returned for empty SubjectToken.
+	if err != nil {
+		t.Fatalf("expected no error for empty SubjectToken (current behavior), got: %v", err)
+	}
+	if req == nil {
+		t.Fatal("expected non-nil request for empty SubjectToken")
+	}
+
+	form := readFormBody(t, req)
+
+	// subject_token key must be present with empty value — not omitted.
+	if _, present := form["subject_token"]; !present {
+		t.Errorf("subject_token key absent for empty SubjectToken — expected present with empty value")
+	}
+	if got := form.Get("subject_token"); got != "" {
+		t.Errorf("subject_token = %q, want empty string", got)
+	}
+}
+
+// TestBuildIdPRequest_ScopeDuplicatesPreserved pins the current behavior
+// where buildIdPRequest does not deduplicate scope values — duplicates are
+// joined as-is into the "scope" form field.
+func TestBuildIdPRequest_ScopeDuplicatesPreserved(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		Scopes:       []string{"read", "read", "write"},
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	form := readFormBody(t, req)
+
+	// Current behavior: duplicates are joined as-is, not deduplicated.
+	if got := form.Get("scope"); got != "read read write" {
+		t.Errorf("scope = %q, want %q (duplicates preserved)", got, "read read write")
+	}
+}
+
+// TestBuildIdPRequest_BlankScopeElementProducesEmptyValue verifies the edge
+// case where Scopes: []string{""} has len == 1, so the scope branch fires
+// and strings.Join produces "". The form body contains "scope=" (key present,
+// value empty) which is NOT the same as the scope field being absent — some
+// IdPs treat an explicit empty scope as a parse error while omitting scope
+// causes the IdP to apply its default scopes.
+func TestBuildIdPRequest_BlankScopeElementProducesEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := e.buildIdPRequest(context.Background(), ExchangeInput{
+		SubjectToken: "tok",
+		Scopes:       []string{""}, // single blank-string element — enters scope branch
+	})
+	if err != nil {
+		t.Fatalf("buildIdPRequest: %v", err)
+	}
+
+	form := readFormBody(t, req)
+
+	// Blank element enters the scope branch — key is present, not omitted.
+	if _, present := form["scope"]; !present {
+		t.Errorf("scope key absent for Scopes: []string{\"\"} — expected present with empty value (blank element enters scope branch)")
+	}
+	// Value is empty string (not omitted field).
+	if got := form.Get("scope"); got != "" {
+		t.Errorf("scope = %q, want empty string (blank element joined to empty)", got)
+	}
+}

--- a/internal/tokenexchange/response.go
+++ b/internal/tokenexchange/response.go
@@ -1,0 +1,148 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+)
+
+const maxResponseBody = 1 << 20 // 1 MiB
+
+// Fields defined by RFC 8693 §2.2.1. access_token, token_type, and
+// issued_token_type are REQUIRED; expires_in is RECOMMENDED.
+type successResponse struct {
+	AccessToken     string `json:"access_token"`
+	TokenType       string `json:"token_type"`
+	IssuedTokenType string `json:"issued_token_type"`
+	ExpiresIn       int64  `json:"expires_in"`
+}
+
+// errorResponse parses RFC 6749 §5.2 error bodies. Only the "error"
+// code is used — "error_description" is deliberately ignored because
+// IdPs sometimes echo unsafe content that must never reach our logs.
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// parseIdPResponse classifies the IdP's HTTP response:
+//   - 2xx + non-JSON Content-Type → ErrInvalidResponse (SSO/proxy interception)
+//   - 2xx + valid JSON with required fields → *Token
+//   - 2xx + missing/unparseable fields → ErrInvalidResponse
+//   - 4xx + OAuth error JSON → ErrExchangeRejected (wraps error code)
+//   - 4xx + non-OAuth body → ErrExchangeTransport (possible proxy/WAF)
+//   - 5xx / network-level → ErrExchangeTransport
+func (e *Exchanger) parseIdPResponse(resp *http.Response, now time.Time) (*Token, error) {
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading IdP response body: %v", ErrExchangeTransport, err)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if ct := responseMediaType(resp); ct != "" && ct != "application/json" {
+			return nil, fmt.Errorf("%w: IdP returned HTTP %d with Content-Type %q (expected application/json — possible SSO/proxy interception)", ErrInvalidResponse, resp.StatusCode, ct)
+		}
+		return e.parseSuccessBody(body, now)
+	}
+
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		return nil, classifyClientError(body, resp.StatusCode)
+	}
+
+	return nil, fmt.Errorf("%w: IdP returned HTTP %d", ErrExchangeTransport, resp.StatusCode)
+}
+
+func (e *Exchanger) parseSuccessBody(body []byte, now time.Time) (*Token, error) {
+	var sr successResponse
+	if err := json.Unmarshal(body, &sr); err != nil {
+		return nil, fmt.Errorf("%w: unparseable IdP success response: %v", ErrInvalidResponse, err)
+	}
+
+	if sr.AccessToken == "" {
+		return nil, fmt.Errorf("%w: IdP success response missing access_token", ErrInvalidResponse)
+	}
+
+	if !strings.EqualFold(sr.TokenType, "Bearer") {
+		return nil, fmt.Errorf("%w: IdP returned token_type %q, expected \"Bearer\" — the MCP server only supports Bearer tokens", ErrInvalidResponse, sr.TokenType)
+	}
+
+	// issued_token_type is RFC 8693-specific; RFC 7523 responses don't include it.
+	if e.grantType == GrantTypeTokenExchange && sr.IssuedTokenType != URNTokenTypeAccessToken {
+		return nil, fmt.Errorf("%w: IdP returned issued_token_type %q, expected %q — the IdP may be misconfigured to issue a different token type", ErrInvalidResponse, sr.IssuedTokenType, URNTokenTypeAccessToken)
+	}
+
+	if sr.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("%w: IdP success response missing or non-positive expires_in — the IdP must return expires_in in token-exchange responses (configure token lifetimes on the IdP client)", ErrInvalidResponse)
+	}
+
+	// Prevents time.Duration overflow (int64 nanoseconds, max ~292 years).
+	if sr.ExpiresIn > maxExpiresInSeconds {
+		return nil, fmt.Errorf("%w: IdP returned expires_in %d which exceeds the safe arithmetic limit — likely a misbehaving IdP or intercepted response", ErrInvalidResponse, sr.ExpiresIn)
+	}
+
+	// TODO(Commit C): log WARN when sr.ExpiresIn <= int64(defaults.DefaultTokenExpirySkew.Seconds())
+	// — token is effectively expired at issuance, likely IdP misconfiguration.
+
+	return &Token{
+		Value: sr.AccessToken,
+		// TODO(Commit E): replace direct default with e.tokenExpirySkew struct field
+		ExpiresAt: now.Add(time.Duration(sr.ExpiresIn)*time.Second - defaults.DefaultTokenExpirySkew),
+	}, nil
+}
+
+func responseMediaType(resp *http.Response) string {
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		return ""
+	}
+	mediaType, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return ""
+	}
+	return mediaType
+}
+
+// maxExpiresInSeconds is the largest expires_in we accept before
+// treating the response as invalid. The limit is purely arithmetic:
+// time.Duration is int64 nanoseconds, so the maximum representable
+// duration is ~292 years ≈ 9.2e18 ns. We cap well below that at
+// ~100 years to leave headroom and catch obviously bogus values
+// (MITM, misbehaving IdP) without overriding legitimate operator-
+// configured token lifetimes.
+const maxExpiresInSeconds int64 = 100 * 365 * 24 * 3600 // ~100 years
+
+// Cap prevents log-line bloat from a misbehaving IdP's error code.
+const maxErrorCodeLen = 64
+
+func classifyClientError(body []byte, statusCode int) error {
+	var er errorResponse
+	if err := json.Unmarshal(body, &er); err == nil && er.Error != "" {
+		if len(er.Error) > maxErrorCodeLen {
+			return fmt.Errorf("%w: IdP returned HTTP %d with oversized error code (%d bytes) — not a standard OAuth error", ErrExchangeTransport, statusCode, len(er.Error))
+		}
+		return fmt.Errorf("%w: IdP error %q (HTTP %d)", ErrExchangeRejected, er.Error, statusCode)
+	}
+
+	return fmt.Errorf("%w: IdP returned HTTP %d with non-OAuth error body (possible proxy or WAF interception)", ErrExchangeTransport, statusCode)
+}

--- a/internal/tokenexchange/response_test.go
+++ b/internal/tokenexchange/response_test.go
@@ -1,0 +1,969 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenexchange
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// trackingBody is an io.ReadCloser that records whether Close was called.
+// Used by T01 and T02 to verify the defer resp.Body.Close() fires in
+// every code path through parseIdPResponse.
+//
+// T01 variant: Read always returns an error (simulates a broken body).
+// T02 variant: Read delegates to an embedded io.Reader (simulates success).
+
+type trackingBodyError struct {
+	closed bool
+}
+
+func (b *trackingBodyError) Read(_ []byte) (int, error) {
+	return 0, errors.New("simulated read error")
+}
+
+func (b *trackingBodyError) Close() error {
+	b.closed = true
+	return nil
+}
+
+type trackingBodyOK struct {
+	closed bool
+	r      io.Reader
+}
+
+func (b *trackingBodyOK) Read(p []byte) (int, error) {
+	return b.r.Read(p)
+}
+
+func (b *trackingBodyOK) Close() error {
+	b.closed = true
+	return nil
+}
+
+// T01: Body is closed even when the body read itself fails.
+func TestParseIdPResponse_BodyAlwaysClosedOnError(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	body := &trackingBodyError{}
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body:       body,
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on body read error", tok)
+	}
+	if !errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+	}
+	if !body.closed {
+		t.Errorf("body.closed = false, want true — body must be closed even on read error")
+	}
+}
+
+// T02: Body is closed on the happy-path success code path.
+func TestParseIdPResponse_BodyAlwaysClosedOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	jsonBody := `{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`
+	body := &trackingBodyOK{r: strings.NewReader(jsonBody)}
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       body,
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok == nil {
+		t.Fatal("tok = nil, want non-nil on success")
+	}
+	if !body.closed {
+		t.Errorf("body.closed = false, want true — body must be closed on success path")
+	}
+}
+
+// T03: Response body is capped at maxResponseBody (1 MiB); oversized bodies
+// are truncated. The truncated body is not valid JSON, so the error surfaces
+// as ErrInvalidResponse, not ErrExchangeTransport (the read itself succeeds).
+func TestParseIdPResponse_BodySizeCappedAt1MiB(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	oversized := bytes.Repeat([]byte("x"), maxResponseBody+1)
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(oversized)),
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err = e.parseIdPResponse(resp, now)
+
+	if errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = true, want false — body read succeeded; transport error must not fire")
+	}
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+	}
+}
+
+// T04: A non-JSON Content-Type on a 2xx response is treated as an SSO/proxy
+// interception and returns ErrInvalidResponse with the phrase "SSO/proxy interception".
+func TestParseIdPResponse_NonJSONContentTypeReturnsInvalidResponse(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+		Body:       io.NopCloser(strings.NewReader("<html>Login page</html>")),
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on non-JSON Content-Type", tok)
+	}
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "SSO/proxy interception") {
+		t.Errorf("err.Error() = %q, want it to contain \"SSO/proxy interception\"", err.Error())
+	}
+}
+
+// T05: A missing Content-Type header bypasses the content-type guard; if the
+// body is valid JSON the call succeeds.
+func TestParseIdPResponse_MissingContentTypeBypassesGuard(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	jsonBody := `{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{}, // no Content-Type
+		Body:       io.NopCloser(strings.NewReader(jsonBody)),
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if err != nil {
+		t.Fatalf("unexpected error for missing Content-Type: %v", err)
+	}
+	if tok == nil {
+		t.Errorf("tok = nil, want non-nil — missing Content-Type must bypass guard")
+	}
+}
+
+// T06: A malformed Content-Type (mime.ParseMediaType returns an error) produces
+// an empty media-type string, which bypasses the guard. Valid JSON succeeds.
+func TestParseIdPResponse_MalformedContentTypeBypassesGuard(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	jsonBody := `{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{";;;"}},
+		Body:       io.NopCloser(strings.NewReader(jsonBody)),
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if err != nil {
+		t.Fatalf("unexpected error for malformed Content-Type: %v", err)
+	}
+	if tok == nil {
+		t.Errorf("tok = nil, want non-nil — malformed Content-Type must bypass guard")
+	}
+}
+
+// T07: responseMediaType strips parameters (charset, boundary) from the
+// Content-Type header and returns only the bare media type.
+func TestResponseMediaType_StripsParameters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contentType string
+		want        string
+	}{
+		{"with charset", "application/json; charset=utf-8", "application/json"},
+		{"with boundary", "multipart/form-data; boundary=something", "multipart/form-data"},
+		{"bare", "application/json", "application/json"},
+		{"empty", "", ""},
+		{"malformed", ";;;", ""},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &http.Response{Header: http.Header{}}
+			if tc.contentType != "" {
+				resp.Header.Set("Content-Type", tc.contentType)
+			}
+
+			got := responseMediaType(resp)
+
+			if got != tc.want {
+				t.Errorf("responseMediaType(%q) = %q, want %q", tc.contentType, got, tc.want)
+			}
+		})
+	}
+}
+
+// T08: mime.ParseMediaType lowercases the media type — "Application/JSON"
+// normalizes to "application/json".
+func TestResponseMediaType_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"Application/JSON; charset=utf-8"}},
+	}
+
+	got := responseMediaType(resp)
+
+	if got != "application/json" {
+		t.Errorf("responseMediaType = %q, want %q", got, "application/json")
+	}
+}
+
+// T09: Invalid JSON in the success body surfaces as ErrInvalidResponse with
+// the phrase "unparseable IdP success response".
+func TestParseSuccessBody_InvalidJSONReturnsInvalidResponse(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseSuccessBody([]byte("not-json{{{"), now)
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil on invalid JSON", tok)
+	}
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "unparseable IdP success response") {
+		t.Errorf("err.Error() = %q, want it to contain \"unparseable IdP success response\"", err.Error())
+	}
+}
+
+// T10: A missing, null, or empty access_token field returns ErrInvalidResponse
+// with "missing access_token".
+func TestParseSuccessBody_MissingAccessTokenReturnsInvalidResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"absent", `{"token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`},
+		{"null", `{"access_token":null,"token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`},
+		{"empty string", `{"access_token":"","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, err := New(validParams())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			tok, err := e.parseSuccessBody([]byte(tc.body), now)
+
+			if tok != nil {
+				t.Errorf("tok = %v, want nil", tok)
+			}
+			if !errors.Is(err, ErrInvalidResponse) {
+				t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+			}
+			if !strings.Contains(err.Error(), "missing access_token") {
+				t.Errorf("err.Error() = %q, want it to contain \"missing access_token\"", err.Error())
+			}
+		})
+	}
+}
+
+// T11: token_type is matched case-insensitively against "Bearer"; non-Bearer
+// types return ErrInvalidResponse.
+func TestParseSuccessBody_TokenTypeCaseInsensitiveBearer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		tokenType string
+		wantErr   bool
+	}{
+		{"lowercase bearer", "bearer", false},
+		{"uppercase BEARER", "BEARER", false},
+		{"mixed Bearer", "Bearer", false},
+		{"wrong type", "MAC", true},
+		{"empty string", "", true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, err := New(validParams())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			body := fmt.Sprintf(`{"access_token":"tok","token_type":%q,"issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":3600}`, tc.tokenType)
+
+			tok, err := e.parseSuccessBody([]byte(body), now)
+
+			if tc.wantErr {
+				if tok != nil {
+					t.Errorf("tok = %v, want nil", tok)
+				}
+				if !errors.Is(err, ErrInvalidResponse) {
+					t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if tok == nil {
+					t.Errorf("tok = nil, want non-nil")
+				}
+			}
+		})
+	}
+}
+
+// T12: issued_token_type must exactly match the RFC 8693 access-token URN
+// for GrantTypeTokenExchange. The comparison is case-sensitive.
+func TestParseSuccessBody_IssuedTokenTypeExactMatchRequired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		issuedTokenType string
+		wantErr         bool
+	}{
+		{"correct URN", "urn:ietf:params:oauth:token-type:access_token", false},
+		{"wrong URN", "urn:ietf:params:oauth:token-type:jwt", true},
+		{"empty (absent field)", "", true},
+		{"uppercase URN (case-sensitive)", "URN:IETF:PARAMS:OAUTH:TOKEN-TYPE:ACCESS_TOKEN", true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, err := New(validParams()) // sets GrantTypeTokenExchange
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			body := fmt.Sprintf(`{"access_token":"tok","token_type":"Bearer","issued_token_type":%q,"expires_in":3600}`, tc.issuedTokenType)
+
+			tok, err := e.parseSuccessBody([]byte(body), now)
+
+			if tc.wantErr {
+				if tok != nil {
+					t.Errorf("tok = %v, want nil", tok)
+				}
+				if !errors.Is(err, ErrInvalidResponse) {
+					t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if tok == nil {
+					t.Errorf("tok = nil, want non-nil")
+				}
+			}
+		})
+	}
+}
+
+// T13: The issued_token_type check is skipped for any grant type other than
+// GrantTypeTokenExchange (e.g. jwt-bearer / Entra OBO flows that don't return
+// issued_token_type at all).
+func TestParseSuccessBody_IssuedTokenTypeSkippedForNonTokenExchangeGrant(t *testing.T) {
+	t.Parallel()
+
+	e := &Exchanger{
+		tokenURL:         "https://idp.example.com/token",
+		clientID:         "cid",
+		clientAuthMethod: ClientSecretPost,
+		clientSecret:     "sec",
+		grantType:        GrantType(99), // not GrantTypeTokenExchange (which is 1)
+		audienceParam:    AudienceParamAudience,
+		httpClient:       &http.Client{},
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Body intentionally omits issued_token_type.
+	body := `{"access_token":"tok","token_type":"Bearer","expires_in":3600}`
+
+	tok, err := e.parseSuccessBody([]byte(body), now)
+
+	if err != nil {
+		t.Fatalf("unexpected error — issued_token_type check must be skipped for non-TokenExchange grant: %v", err)
+	}
+	if tok == nil {
+		t.Errorf("tok = nil, want non-nil")
+	}
+}
+
+// T14: expires_in must be a positive integer. A missing (zero value), explicit
+// zero, or negative value returns ErrInvalidResponse with "missing or
+// non-positive expires_in".
+func TestParseSuccessBody_ExpiresInNonPositiveReturnsInvalidResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"absent", `{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token"}`},
+		{"zero", `{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":0}`},
+		{"negative", `{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":-1}`},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, err := New(validParams())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			tok, err := e.parseSuccessBody([]byte(tc.body), now)
+
+			if tok != nil {
+				t.Errorf("tok = %v, want nil", tok)
+			}
+			if !errors.Is(err, ErrInvalidResponse) {
+				t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+			}
+			if !strings.Contains(err.Error(), "missing or non-positive expires_in") {
+				t.Errorf("err.Error() = %q, want it to contain \"missing or non-positive expires_in\"", err.Error())
+			}
+		})
+	}
+}
+
+// T15: expires_in at exactly maxExpiresInSeconds is accepted; one over that
+// limit returns ErrInvalidResponse with "exceeds the safe arithmetic limit".
+func TestParseSuccessBody_ExpiresInOverflowGuard(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	boundaryBody := fmt.Sprintf(`{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":%d}`, maxExpiresInSeconds)
+	overBody := fmt.Sprintf(`{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":%d}`, maxExpiresInSeconds+1)
+
+	tok, err := e.parseSuccessBody([]byte(boundaryBody), now)
+
+	if err != nil {
+		t.Errorf("unexpected error at boundary value: %v", err)
+	}
+	if tok == nil {
+		t.Errorf("tok = nil, want non-nil at boundary value")
+	}
+
+	tok, err = e.parseSuccessBody([]byte(overBody), now)
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil for over-boundary value", tok)
+	}
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "exceeds the safe arithmetic limit") {
+		t.Errorf("err.Error() = %q, want it to contain \"exceeds the safe arithmetic limit\"", err.Error())
+	}
+}
+
+// T16: On a successful parse, Token.Value equals access_token and
+// Token.ExpiresAt equals now + expires_in - 30s (the 30-second skew).
+func TestParseSuccessBody_TokenConstructionAndExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	expiresIn := int64(3600)
+	body := fmt.Sprintf(`{"access_token":"my-token","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":%d}`, expiresIn)
+
+	tok, err := e.parseSuccessBody([]byte(body), now)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok == nil {
+		t.Fatal("tok = nil, want non-nil")
+	}
+	if tok.Value != "my-token" {
+		t.Errorf("tok.Value = %q, want %q", tok.Value, "my-token")
+	}
+	wantExpiresAt := now.Add(time.Duration(expiresIn)*time.Second - 30*time.Second)
+	if !tok.ExpiresAt.Equal(wantExpiresAt) {
+		t.Errorf("tok.ExpiresAt = %v, want %v", tok.ExpiresAt, wantExpiresAt)
+	}
+}
+
+// T17: A 4xx response with a valid RFC 6749 §5.2 JSON body returns
+// ErrExchangeRejected and includes the OAuth error code and status code in
+// the error message.
+func TestParseIdPResponse_FourxxOAuthErrorReturnsExchangeRejected(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp := &http.Response{
+		StatusCode: 400,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_grant"}`)),
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil", tok)
+	}
+	if !errors.Is(err, ErrExchangeRejected) {
+		t.Errorf("errors.Is(err, ErrExchangeRejected) = false, want true; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("err.Error() = %q, want it to contain \"invalid_grant\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("err.Error() = %q, want it to contain \"400\"", err.Error())
+	}
+}
+
+// T18: A 4xx response whose body is not a valid OAuth error JSON (e.g. an HTML
+// page from a WAF) returns ErrExchangeTransport with "proxy or WAF interception".
+func TestParseIdPResponse_FourxxNonOAuthBodyReturnsExchangeTransport(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp := &http.Response{
+		StatusCode: 403,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("<html>Access Denied</html>")),
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil", tok)
+	}
+	if !errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "proxy or WAF interception") {
+		t.Errorf("err.Error() = %q, want it to contain \"proxy or WAF interception\"", err.Error())
+	}
+}
+
+// T19: 3xx and 5xx status codes return ErrExchangeTransport with the status
+// code in the message (no special body parsing for these ranges).
+func TestParseIdPResponse_ThreexxAndFivexxReturnExchangeTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"301 Moved Permanently", 301},
+		{"302 Found", 302},
+		{"500 Internal Server Error", 500},
+		{"503 Service Unavailable", 503},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, err := New(validParams())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			resp := &http.Response{
+				StatusCode: tc.status,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader("error")),
+			}
+
+			tok, err := e.parseIdPResponse(resp, now)
+
+			if tok != nil {
+				t.Errorf("tok = %v, want nil", tok)
+			}
+			if !errors.Is(err, ErrExchangeTransport) {
+				t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("%d", tc.status)) {
+				t.Errorf("err.Error() = %q, want it to contain %q", err.Error(), fmt.Sprintf("%d", tc.status))
+			}
+		})
+	}
+}
+
+// T20: An oversized error code (> maxErrorCodeLen bytes) routes to
+// ErrExchangeTransport to prevent log-line bloat. A code at exactly
+// maxErrorCodeLen bytes routes to ErrExchangeRejected with the full code.
+func TestClassifyClientError_OversizedErrorCodeReturnsTransport(t *testing.T) {
+	t.Parallel()
+
+	longCode := strings.Repeat("a", maxErrorCodeLen+1) // 65 bytes
+	body := fmt.Sprintf(`{"error":%q}`, longCode)
+
+	exactCode := strings.Repeat("b", maxErrorCodeLen) // 64 bytes
+	exactBody := fmt.Sprintf(`{"error":%q}`, exactCode)
+
+	errOver := classifyClientError([]byte(body), 400)
+	errExact := classifyClientError([]byte(exactBody), 400)
+
+	// Oversized assertions.
+	if !errors.Is(errOver, ErrExchangeTransport) {
+		t.Errorf("errors.Is(errOver, ErrExchangeTransport) = false, want true; err = %v", errOver)
+	}
+	if errors.Is(errOver, ErrExchangeRejected) {
+		t.Errorf("errors.Is(errOver, ErrExchangeRejected) = true, want false — oversized must NOT be a rejection")
+	}
+	if !strings.Contains(errOver.Error(), "oversized error code") {
+		t.Errorf("errOver.Error() = %q, want it to contain \"oversized error code\"", errOver.Error())
+	}
+	if !strings.Contains(errOver.Error(), "65") {
+		t.Errorf("errOver.Error() = %q, want it to contain \"65\" (byte count)", errOver.Error())
+	}
+	if strings.Contains(errOver.Error(), longCode) {
+		t.Errorf("errOver.Error() contains the full longCode — must NOT include the oversized code in the message")
+	}
+
+	// Boundary assertions.
+	if !errors.Is(errExact, ErrExchangeRejected) {
+		t.Errorf("errors.Is(errExact, ErrExchangeRejected) = false, want true; err = %v", errExact)
+	}
+	if !strings.Contains(errExact.Error(), exactCode) {
+		t.Errorf("errExact.Error() = %q, want it to contain the full exactCode %q", errExact.Error(), exactCode)
+	}
+}
+
+// T21: error_description is deliberately excluded from the classified error
+// message to prevent unsafe IdP content from reaching logs.
+func TestClassifyClientError_ErrorDescriptionNotInMessage(t *testing.T) {
+	t.Parallel()
+
+	body := `{"error":"invalid_grant","error_description":"the token has expired and cannot be refreshed"}`
+
+	err := classifyClientError([]byte(body), 400)
+
+	if !errors.Is(err, ErrExchangeRejected) {
+		t.Fatalf("errors.Is(err, ErrExchangeRejected) = false, want true; err = %v", err)
+	}
+	if strings.Contains(err.Error(), "the token has expired") {
+		t.Errorf("err.Error() = %q, must NOT contain error_description text", err.Error())
+	}
+	if strings.Contains(err.Error(), "error_description") {
+		t.Errorf("err.Error() = %q, must NOT contain the field name \"error_description\"", err.Error())
+	}
+}
+
+// T22: Full happy-path integration through parseIdPResponse: 200 + JSON +
+// correct fields → Token with expected Value and ExpiresAt.
+func TestParseIdPResponse_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	jsonBody := `{"access_token":"exchanged-token","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":7200}`
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(jsonBody)),
+	}
+
+	tok, err := e.parseIdPResponse(resp, now)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok == nil {
+		t.Fatal("tok = nil, want non-nil")
+	}
+	if tok.Value != "exchanged-token" {
+		t.Errorf("tok.Value = %q, want %q", tok.Value, "exchanged-token")
+	}
+	wantExpiresAt := now.Add(7200*time.Second - 30*time.Second)
+	if !tok.ExpiresAt.Equal(wantExpiresAt) {
+		t.Errorf("tok.ExpiresAt = %v, want %v", tok.ExpiresAt, wantExpiresAt)
+	}
+}
+
+// T23: Short-lived tokens (expires_in <= 30s) are not an error; the ExpiresAt
+// computation may land in the past relative to now, but the function still
+// succeeds. Callers decide what to do with an already-expired token.
+func TestParseSuccessBody_ShortLivedTokenReturnsNonErrorTokenWithPastExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		expiresIn int64
+		wantSign  int // -1 = before now, 0 = equal, +1 = after now
+	}{
+		{"expires_in=1", int64(1), -1},  // ExpiresAt = now - 29s → before now
+		{"expires_in=30", int64(30), 0}, // ExpiresAt = now + 0s  → equal to now
+		{"expires_in=31", int64(31), 1}, // ExpiresAt = now + 1s  → after now
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, err := New(validParams())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			body := fmt.Sprintf(`{"access_token":"tok","token_type":"Bearer","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":%d}`, tc.expiresIn)
+
+			tok, err := e.parseSuccessBody([]byte(body), now)
+
+			if err != nil {
+				t.Fatalf("unexpected error — short-lived tokens must not be an error (current behavior): %v", err)
+			}
+			if tok == nil {
+				t.Fatal("tok = nil, want non-nil")
+			}
+
+			wantExpiresAt := now.Add(time.Duration(tc.expiresIn)*time.Second - 30*time.Second)
+			if !tok.ExpiresAt.Equal(wantExpiresAt) {
+				t.Errorf("tok.ExpiresAt = %v, want %v", tok.ExpiresAt, wantExpiresAt)
+			}
+
+			switch tc.wantSign {
+			case -1:
+				if !tok.ExpiresAt.Before(now) {
+					t.Errorf("tok.ExpiresAt = %v, want Before(now = %v)", tok.ExpiresAt, now)
+				}
+			case 0:
+				if !tok.ExpiresAt.Equal(now) {
+					t.Errorf("tok.ExpiresAt = %v, want Equal(now = %v)", tok.ExpiresAt, now)
+				}
+			case 1:
+				if !tok.ExpiresAt.After(now) {
+					t.Errorf("tok.ExpiresAt = %v, want After(now = %v)", tok.ExpiresAt, now)
+				}
+			}
+		})
+	}
+}
+
+// T24: An oversized body passed through parseIdPResponse is silently truncated
+// by io.LimitReader. The truncated body fails JSON parsing and surfaces as
+// ErrInvalidResponse — there is no explicit "body too large" or "1 MiB"
+// language in the error message.
+func TestParseIdPResponse_OversizedBodySurfacesAsInvalidResponseNotTransport(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	oversized := bytes.Repeat([]byte("x"), maxResponseBody+1)
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(oversized)),
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err = e.parseIdPResponse(resp, now)
+
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+	}
+	if strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("err.Error() = %q, must NOT contain \"exceeds\"", err.Error())
+	}
+	if strings.Contains(err.Error(), "limit") {
+		t.Errorf("err.Error() = %q, must NOT contain \"limit\"", err.Error())
+	}
+	if strings.Contains(err.Error(), "1 MiB") {
+		t.Errorf("err.Error() = %q, must NOT contain \"1 MiB\"", err.Error())
+	}
+}
+
+// T25: `null` is valid JSON but json.Unmarshal into a struct produces a zero
+// value (all fields empty). The access_token check fires and returns
+// ErrInvalidResponse with "missing access_token" — not the "unparseable" error.
+func TestParseSuccessBody_NullBodyTriggersAccessTokenMissingError(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tok, err := e.parseSuccessBody([]byte("null"), now)
+
+	if tok != nil {
+		t.Errorf("tok = %v, want nil", tok)
+	}
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Errorf("errors.Is(err, ErrInvalidResponse) = false, want true; err = %v", err)
+	}
+	if strings.Contains(err.Error(), "unparseable") {
+		t.Errorf("err.Error() = %q, must NOT contain \"unparseable\" — json.Unmarshal(\"null\") succeeds", err.Error())
+	}
+	if !strings.Contains(err.Error(), "missing access_token") {
+		t.Errorf("err.Error() = %q, want it to contain \"missing access_token\"", err.Error())
+	}
+}
+
+// T26: An explicit empty string in the "error" field falls through to the
+// transport-error path (no code to report), not the rejection path.
+func TestClassifyClientError_ExplicitEmptyErrorFieldRoutesToTransport(t *testing.T) {
+	t.Parallel()
+
+	err := classifyClientError([]byte(`{"error":""}`), 400)
+
+	if !errors.Is(err, ErrExchangeTransport) {
+		t.Errorf("errors.Is(err, ErrExchangeTransport) = false, want true; err = %v", err)
+	}
+	if errors.Is(err, ErrExchangeRejected) {
+		t.Errorf("errors.Is(err, ErrExchangeRejected) = true, want false — empty error field must NOT be a rejection")
+	}
+}
+
+// T27: Unknown fields in the success body are silently ignored — the JSON
+// decoder does not use DisallowUnknownFields, so extra fields from the IdP
+// are allowed without error.
+func TestParseSuccessBody_UnknownFieldsSilentlyIgnored(t *testing.T) {
+	t.Parallel()
+
+	e, err := New(validParams())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	body := `{
+		"access_token": "tok",
+		"token_type": "Bearer",
+		"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+		"expires_in": 3600,
+		"refresh_token": "reftok",
+		"scope": "openid profile",
+		"expires_on": 1234567890
+	}`
+
+	tok, err := e.parseSuccessBody([]byte(body), now)
+
+	if err != nil {
+		t.Fatalf("unexpected error — unknown fields must be silently ignored: %v", err)
+	}
+	if tok == nil {
+		t.Fatal("tok = nil, want non-nil")
+	}
+	if tok.Value != "tok" {
+		t.Errorf("tok.Value = %q, want %q", tok.Value, "tok")
+	}
+}

--- a/internal/tokenexchange/types.go
+++ b/internal/tokenexchange/types.go
@@ -80,6 +80,17 @@ const (
 	GrantTypeTokenExchange GrantType = iota + 1
 )
 
+// RFC 8693 wire-format URNs. Used in both request construction and
+// response validation — defined once to prevent drift across files.
+const (
+	// URNGrantTypeTokenExchange is the grant_type value for RFC 8693.
+	URNGrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+	// URNTokenTypeAccessToken is the subject_token_type and
+	// issued_token_type value for access tokens (RFC 8693 §3).
+	URNTokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
+)
+
 // Params are the construction-time inputs to New. Every field except
 // HTTPClient is sourced from validated config (broker_oauth.*) and is
 // trusted by the constructor — the config validator has already enforced

--- a/internal/tokenexchange/types.go
+++ b/internal/tokenexchange/types.go
@@ -84,11 +84,11 @@ const (
 // response validation — defined once to prevent drift across files.
 const (
 	// URNGrantTypeTokenExchange is the grant_type value for RFC 8693.
-	URNGrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+	URNGrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" // #nosec G101 -- public RFC 8693 grant-type URN, not a credential.
 
 	// URNTokenTypeAccessToken is the subject_token_type and
 	// issued_token_type value for access tokens (RFC 8693 §3).
-	URNTokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
+	URNTokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token" // #nosec G101 -- public RFC 8693 token-type URN, not a credential.
 )
 
 // Params are the construction-time inputs to New. Every field except

--- a/internal/tokenexchange/types.go
+++ b/internal/tokenexchange/types.go
@@ -1,0 +1,158 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tokenexchange implements RFC 8693 OAuth 2.0 token exchange against
+// a single IdP. The Exchanger is a process singleton: deployment-global
+// protocol state (IdP endpoint, MCP server client credentials, grant type,
+// audience-param wire format) lives on the struct; per-broker values
+// (subject token, audience, scopes) flow through the Exchange method.
+//
+// Two entry points: tokenexchange.New(Params) for tests, and
+// tokenexchange.FromConfig(*config.BrokerOAuthConfig, *http.Client) for
+// production wiring in cmd/server/main.go. Both eventually return the same
+// *Exchanger; FromConfig translates YAML schema (discriminated union of
+// client-auth methods, string-typed enums) into the typed Params shape.
+//
+// The Exchanger does not cache exchanged tokens (deferred to a follow-up
+// story), does not retry IdP failures, and does not fall back to a
+// secondary IdP. It builds RFC 8693 requests, parses responses, classifies
+// failures into three sentinel errors, and (optionally) deduplicates
+// concurrent identical exchanges via singleflight to protect the IdP from
+// stampedes.
+package tokenexchange
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// ClientAuthMethod identifies the OAuth client-authentication method the
+// MCP server uses when calling the IdP token endpoint. Values match the
+// IANA "OAuth Token Endpoint Authentication Methods" registry (RFC 7591).
+// V1 supports the two client_secret_* methods; private_key_jwt and the
+// two mTLS variants are tracked as follow-up work.
+type ClientAuthMethod int
+
+const (
+	// ClientSecretBasic puts client_id and client_secret in the HTTP Basic
+	// authorization header. RFC 6749 §2.3.1.
+	ClientSecretBasic ClientAuthMethod = iota + 1
+	// ClientSecretPost puts client_id and client_secret in the form body
+	// alongside the other token-exchange parameters. RFC 6749 §2.3.1.
+	ClientSecretPost
+)
+
+// AudienceFormat identifies the wire format the Exchanger uses to carry
+// the per-broker audience value to the IdP. Different IdP families expect
+// different parameter names; this enum selects between them.
+type AudienceFormat int
+
+const (
+	// AudienceParamAudience uses the RFC 8693 "audience" parameter — the
+	// canonical token-exchange spelling. The only V1-implemented format.
+	AudienceParamAudience AudienceFormat = iota + 1
+	// AudienceParamScope (Entra OBO style) and AudienceParamResource
+	// (RFC 8707) are schema-accepted in internal/config but not yet
+	// implemented at the wire-construction layer; FromConfig rejects
+	// them with a clear error pointing at this comment.
+)
+
+// GrantType identifies the OAuth grant-type URN sent in the form body.
+// V1 supports only RFC 8693 token exchange; Entra OBO's jwt-bearer is
+// tracked as follow-up work.
+type GrantType int
+
+const (
+	// GrantTypeTokenExchange is urn:ietf:params:oauth:grant-type:token-exchange
+	// (RFC 8693). The only V1-implemented grant type.
+	GrantTypeTokenExchange GrantType = iota + 1
+)
+
+// Params are the construction-time inputs to New. Every field except
+// HTTPClient is sourced from validated config (broker_oauth.*) and is
+// trusted by the constructor — the config validator has already enforced
+// non-empty values and allowlist membership at startup. HTTPClient is
+// runtime-wired and is the only field New rejects when invalid.
+type Params struct {
+	// TokenURL is the IdP token endpoint (broker_oauth.idp_token_endpoint).
+	TokenURL string
+	// ClientID is the MCP server's client identifier at the IdP.
+	ClientID string
+	// ClientAuthMethod selects between client_secret_basic and
+	// client_secret_post for authenticating to the token endpoint.
+	ClientAuthMethod ClientAuthMethod
+	// ClientSecret is the shared secret resolved from the populated
+	// sub-block of broker_oauth.mcp_server_client_auth. Never logged.
+	ClientSecret string
+	// GrantType is the OAuth grant-type URN. V1: GrantTypeTokenExchange.
+	GrantType GrantType
+	// AudienceParam selects the wire format for the per-broker audience.
+	// V1: AudienceParamAudience.
+	AudienceParam AudienceFormat
+	// HTTPClient is the IdP-bound HTTP client; typically built via
+	// idpclient.NewHTTPClient so the SOL-150219 timeout bound applies.
+	HTTPClient *http.Client
+}
+
+// ExchangeInput are the per-call inputs to Exchange. Subject token comes
+// from ctx via Hop 1's InjectRawSubjectToken middleware (see
+// internal/auth.RawSubjectTokenFromContext) and is extracted by the
+// per-broker Authenticator (T6) before the call to Exchange.
+type ExchangeInput struct {
+	// SubjectToken is the inbound JWT to exchange. Hashed into the
+	// singleflight key but never logged or otherwise echoed.
+	SubjectToken string
+	// BrokerAlias identifies which broker this exchange is for. Logging
+	// label only — does not appear in the IdP request body.
+	BrokerAlias string
+	// Audience is the per-broker audience value
+	// (brokers.<alias>.auth.oauth.audience). Sent to the IdP in the form
+	// field selected by Params.AudienceParam.
+	Audience string
+	// Scopes are the per-broker scopes
+	// (brokers.<alias>.auth.oauth.scopes). Sent to the IdP space-joined
+	// in the "scope" form field when non-empty; omitted otherwise.
+	Scopes []string
+}
+
+// Token is the result of a successful token exchange. Value is the
+// exchanged bearer token; ExpiresAt is computed from the IdP-reported
+// expires_in minus a 30-second skew so callers (and the future cache)
+// have a safe "use-by" instant rather than a fragile duration.
+type Token struct {
+	Value     string
+	ExpiresAt time.Time
+}
+
+// Sentinel errors the Exchanger returns. The per-call error is always one
+// of these three (possibly wrapped via fmt.Errorf with %w); upper layers
+// classify by errors.Is and map to broker-side HTTP status codes in T7b.
+var (
+	// ErrExchangeRejected — the IdP returned a 4xx with an OAuth-shaped
+	// JSON body. The exchange was refused; retrying without changing the
+	// inputs will not help. Mapped to broker-side 401.
+	ErrExchangeRejected = errors.New("token exchange rejected by IdP")
+
+	// ErrExchangeTransport — network failure, request timeout, or 5xx
+	// from the IdP. The exchange may succeed on retry. Mapped to
+	// broker-side 503.
+	ErrExchangeTransport = errors.New("token exchange transport failure")
+
+	// ErrInvalidResponse — the IdP returned 2xx but the response body
+	// could not be parsed as a token-exchange response. Either the IdP
+	// is misconfigured or the response shape has drifted; manual
+	// investigation required. Mapped to broker-side 502.
+	ErrInvalidResponse = errors.New("token exchange invalid response")
+)


### PR DESCRIPTION
## Summary

Implements the `internal/tokenexchange` package — the RFC 8693 token-exchange Exchanger that exchanges MCP client JWTs for broker-scoped access tokens via a configured IdP.

- **[SOL-150799](https://sol-jira.atlassian.net/browse/SOL-150799)** — T5: Exchanger: RFC 8693 + singleflight

## What's in this PR

### Package structure (14 files, ~4100 lines)

| File | Purpose |
|---|---|
| `types.go` | Params, ExchangeInput, Token, sentinel errors, typed enums (ClientAuthMethod, AudienceFormat, GrantType), RFC 8693 URN constants |
| `exchanger.go` | Exchanger struct (process singleton, immutable after construction), `New(Params)` constructor |
| `request.go` | `buildIdPRequest` — RFC 8693 POST body composition with per-concern setters (grant type, client auth, audience, scopes) |
| `response.go` | `parseIdPResponse` — response parser + three-way error classifier (rejected/transport/invalid) |
| `exchange.go` | Public `Exchange` method + singleflight wiring + `doExchange` glue + `logExchangeError` (error-path-only, secure) |
| `dedup_key.go` | `computeDeduplicationKey` — `sha256(subjectToken + NUL + brokerAlias)`, shared utility for singleflight and future cache |
| `from_config.go` | `FromConfig(*config.BrokerOAuthConfig, *http.Client)` — production adapter mapping YAML discriminated unions to typed enums |

### V1 runtime scope

- **Client auth methods:** `client_secret_basic`, `client_secret_post`
- **Grant type:** `urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693)
- **Audience parameter:** `audience` only; `scope` and `resource` are schema-accepted but rejected at runtime with a clear not-yet-implemented error

### Design decisions

1. **Two constructors:** `New(Params)` for tests (no YAML dependency), `FromConfig` for production wiring (only file importing `internal/config`)
2. **Singleflight deduplication:** concurrent identical exchanges (same subject token + broker alias) collapse into one IdP round-trip. Key is `sha256(subjectToken + \x00 + brokerAlias)` — audience and scopes are deployment-global from config, not per-call
3. **Three sentinel errors:** `ErrExchangeRejected` (4xx+OAuth → WARN → 401), `ErrExchangeTransport` (5xx/network → ERROR → 503), `ErrInvalidResponse` (2xx+garbage → ERROR → 502)
4. **Context cancellation:** returned raw (`ctx.Err()`), not wrapped in any sentinel, not logged at Exchange level — upper layer (tools/manager.go) handles it
5. **Immutability invariant:** all Exchanger fields written once in `New()`, never mutated. Race detector enforces at test time
6. **Error-path-only logging:** no success-path logs. Log attributes: `broker_alias`, `audience`, `token_endpoint`, `elapsed`, `error`
7. **`nowFunc` injection:** deterministic clock control in tests, `time.Now` in production, set once at construction

### Singleflight cancellation footgun (acknowledged, won't fix in T5)

singleflight passes the owner goroutine's context to the HTTP call. If the owner cancels, all waiters sharing that key get `context.Canceled`. This only affects the same user's concurrent requests to the same broker — different users have different subject tokens → different keys → fully isolated. Acceptable for V1.

### Secure logging compliance

**Never logged at any level:** `subject_token`, `access_token`, `client_secret`, `error_description`

## What is NOT in this PR

- **Token cache** — deferred to a follow-up story; every cold burst hits the IdP (modulo singleflight collapse)
- **T6:** `OAuthAuthenticator` ([SOL-150800](https://sol-jira.atlassian.net/browse/SOL-150800))
- **T7a:** wiring into `cmd/server/main.go`
- **T7b:** Sender 401 refactor
- **mTLS / private_key_jwt** — future auth methods
- **Configurable `token_expiry_fallback`** — ([SOL-151324](https://sol-jira.atlassian.net/browse/SOL-151324))

## For reviewers — focus areas

1. **SOL-150219 timeout invariant:** `FromConfig` accepts `*http.Client` (built via `idpclient.NewHTTPClient` which enforces the timeout bound). No timeout bypass path exists.
2. **Per-user isolation via SHA-256 key:** different subject tokens → different singleflight keys → fully isolated IdP calls. Verified by concurrent tests with request-body capture.
3. **Secure logging:** `/check-logs` clean. No sensitive fields in any log line.
4. **Singleflight concurrency matrix:** all four key-component combinations tested (same/same, diff/diff, same-token/diff-broker, diff-token/same-broker) + error sharing + cancellation scoping. Each test verifies three layers: IdP call count, what the IdP received, what each caller got back.

## Test plan

- [ ] `go test ./internal/tokenexchange/ -race -count=1` — all tests pass
- [ ] `make check` — build, vet, lint, race-enabled tests
- [ ] `/check-logs` — no CRITICAL/HIGH findings
- [ ] Review sentinel error classification against RFC 8693 response codes
- [ ] Review singleflight key composition (only subjectToken + brokerAlias, not audience/scopes)
- [ ] Verify no sensitive fields in log attributes

[SOL-150799]: https://sol-jira.atlassian.net/browse/SOL-150799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-150800]: https://sol-jira.atlassian.net/browse/SOL-150800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ