### PR TITLE
SOL-151315: list-slow-subscribers aggregations

### DIFF
--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -375,9 +375,21 @@ tools:
           msgVpnName: "{{.Params.msgVpnName}}"
           count: "100"
           where: "slowSubscriber==true"
-          select: "clientAddress, clientName, clientUsername, msgVpnName, platform, rxMsgRate, slowSubscriber, txDiscardedMsgCount, txMsgRate, uptime"
+        select:
+          - clientAddress
+          - clientName
+          - clientProfileName
+          - clientUsername
+          - msgVpnName
+          - platform
+          - rxMsgRate
+          - slowSubscriber
+          - txDiscardedMsgCount
+          - txMsgRate
+          - uptime
     result:
-      strategy: collect
+      strategy: postProcess
+      postProcess: listSlowSubscribers
 
   - name: list-queue-discards
     description: >

--- a/internal/composite/postprocess/handlers/list_slow_subscribers.go
+++ b/internal/composite/postprocess/handlers/list_slow_subscribers.go
@@ -1,0 +1,100 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
+)
+
+// listSlowSubscribersStepID is the step ID this handler keys into. Declared as
+// a const so the init-time RequiredSteps registration and the runtime lookup
+// cannot drift out of sync — and so the boot-time check in ValidateTool
+// catches a YAML rename of the step.
+const listSlowSubscribersStepID = "slowSubscribers"
+
+func init() {
+	postprocess.Register("listSlowSubscribers", postprocess.Handler{
+		Fn:            ListSlowSubscribers,
+		RequiredSteps: []string{listSlowSubscribersStepID},
+		RequiredFields: []string{
+			"clientProfileName",
+			"platform",
+			"txDiscardedMsgCount",
+		},
+	})
+}
+
+// ListSlowSubscribers aggregates the slow-subscriber list into triage signals:
+//   - byClientProfile: count grouped by clientProfileName — surfaces whether
+//     offenders share a QoS/policy bucket.
+//   - byPlatform:      count grouped by platform — surfaces SDK/version
+//     regressions.
+//   - totalTxDiscardedMsgCount: sum of txDiscardedMsgCount — severity signal;
+//     distinguishes minor TCP blips from a flood of dropped messages.
+//
+// Aggregations are over what the paginator actually returned. Under truncation
+// the summary also includes scanned (items observed) and truncated: true so
+// the LLM sees the partial-scan reality next to the counts.
+//
+// A row whose required fields are missing or the wrong type is skipped from
+// every aggregation and tallied into skipped (surfaced only when non-zero).
+// One odd row must not drop the raw list — that would be a robustness step
+// down from the collect strategy. Structural errors (step missing, data not a
+// list, item not an object) still hard-fail since the whole result is unusable.
+func ListSlowSubscribers(stepResults map[string]map[string]any) (map[string]any, error) {
+	step, ok := stepResults[listSlowSubscribersStepID]
+	if !ok {
+		return nil, fmt.Errorf("step %q not in results", listSlowSubscribersStepID)
+	}
+	items, ok := step["data"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("slowSubscribers.data: want []any, got %T", step["data"])
+	}
+	byClientProfile := map[string]int{}
+	byPlatform := map[string]int{}
+	var totalDiscarded float64
+	var skipped int
+	for i, raw := range items {
+		c, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("slowSubscribers.data[%d]: want object, got %T", i, raw)
+		}
+		profile, ok1 := stringField(c, "clientProfileName")
+		platform, ok2 := stringField(c, "platform")
+		discarded, ok3 := numField(c, "txDiscardedMsgCount")
+		if !ok1 || !ok2 || !ok3 {
+			skipped++
+			continue
+		}
+		byClientProfile[profile]++
+		byPlatform[platform]++
+		totalDiscarded += discarded
+	}
+	out := map[string]any{
+		"byClientProfile":          byClientProfile,
+		"byPlatform":               byPlatform,
+		"totalTxDiscardedMsgCount": totalDiscarded,
+		"scanned":                  len(items),
+	}
+	if skipped > 0 {
+		out["skipped"] = skipped
+	}
+	if t, _ := step["truncated"].(bool); t {
+		out["truncated"] = true
+	}
+	return out, nil
+}

--- a/internal/composite/postprocess/handlers/list_slow_subscribers_test.go
+++ b/internal/composite/postprocess/handlers/list_slow_subscribers_test.go
@@ -1,0 +1,304 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+)
+
+// sub builds a slow-subscriber item with the three required fields.
+func sub(profile, platform string, discarded any) map[string]any {
+	return map[string]any{
+		"clientProfileName":   profile,
+		"platform":            platform,
+		"txDiscardedMsgCount": discarded,
+	}
+}
+
+func TestListSlowSubscribers_Empty(t *testing.T) {
+	got, err := ListSlowSubscribers(map[string]map[string]any{
+		"slowSubscribers": {"data": []any{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["scanned"] != 0 {
+		t.Errorf("scanned: got %v, want 0", got["scanned"])
+	}
+	if got["totalTxDiscardedMsgCount"] != float64(0) {
+		t.Errorf("totalTxDiscardedMsgCount: got %v, want 0", got["totalTxDiscardedMsgCount"])
+	}
+	profiles, ok := got["byClientProfile"].(map[string]int)
+	if !ok || len(profiles) != 0 {
+		t.Errorf("byClientProfile: got %v, want empty map", got["byClientProfile"])
+	}
+	platforms, ok := got["byPlatform"].(map[string]int)
+	if !ok || len(platforms) != 0 {
+		t.Errorf("byPlatform: got %v, want empty map", got["byPlatform"])
+	}
+	for _, k := range []string{"skipped", "truncated"} {
+		if _, present := got[k]; present {
+			t.Errorf("%s should be omitted, got %v", k, got[k])
+		}
+	}
+}
+
+func TestListSlowSubscribers_AllSameProfile(t *testing.T) {
+	items := []any{
+		sub("default", "linux", float64(5)),
+		sub("default", "linux", float64(10)),
+		sub("default", "windows", float64(0)),
+	}
+	got, err := ListSlowSubscribers(map[string]map[string]any{
+		"slowSubscribers": {"data": items},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profiles := got["byClientProfile"].(map[string]int)
+	if len(profiles) != 1 || profiles["default"] != 3 {
+		t.Errorf("byClientProfile: got %v, want {default:3}", profiles)
+	}
+	platforms := got["byPlatform"].(map[string]int)
+	if platforms["linux"] != 2 || platforms["windows"] != 1 {
+		t.Errorf("byPlatform: got %v, want {linux:2, windows:1}", platforms)
+	}
+	if got["totalTxDiscardedMsgCount"] != float64(15) {
+		t.Errorf("totalTxDiscardedMsgCount: got %v, want 15", got["totalTxDiscardedMsgCount"])
+	}
+	if got["scanned"] != 3 {
+		t.Errorf("scanned: got %v, want 3", got["scanned"])
+	}
+}
+
+func TestListSlowSubscribers_MixedProfiles(t *testing.T) {
+	items := []any{
+		sub("default", "linux", float64(1)),
+		sub("high-throughput", "linux", float64(2)),
+		sub("default", "macos", float64(4)),
+		sub("high-throughput", "windows", float64(8)),
+	}
+	got, err := ListSlowSubscribers(map[string]map[string]any{
+		"slowSubscribers": {"data": items},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profiles := got["byClientProfile"].(map[string]int)
+	if profiles["default"] != 2 || profiles["high-throughput"] != 2 {
+		t.Errorf("byClientProfile: got %v", profiles)
+	}
+	platforms := got["byPlatform"].(map[string]int)
+	if platforms["linux"] != 2 || platforms["macos"] != 1 || platforms["windows"] != 1 {
+		t.Errorf("byPlatform: got %v", platforms)
+	}
+	if got["totalTxDiscardedMsgCount"] != float64(15) {
+		t.Errorf("totalTxDiscardedMsgCount: got %v, want 15", got["totalTxDiscardedMsgCount"])
+	}
+}
+
+// TestListSlowSubscribers_NumericShapes asserts that totalTxDiscardedMsgCount
+// sums across the numeric shapes JSON decoders produce — float64 (default),
+// json.Number (UseNumber decoder), int/int64 (custom unmarshalers). This is
+// the same insulation numField provides for listQueues; a future SEMP-client
+// decode-mode change must not silently drop discard counts.
+func TestListSlowSubscribers_NumericShapes(t *testing.T) {
+	items := []any{
+		sub("p", "linux", float64(1.5)),
+		sub("p", "linux", json.Number("2")),
+		sub("p", "linux", int(3)),
+		sub("p", "linux", int64(4)),
+	}
+	got, err := ListSlowSubscribers(map[string]map[string]any{
+		"slowSubscribers": {"data": items},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["totalTxDiscardedMsgCount"] != float64(10.5) {
+		t.Errorf("totalTxDiscardedMsgCount: got %v, want 10.5", got["totalTxDiscardedMsgCount"])
+	}
+	if got["scanned"] != 4 {
+		t.Errorf("scanned: got %v, want 4", got["scanned"])
+	}
+}
+
+// TestListSlowSubscribers_LargeSum guards against silent overflow at counts a
+// production broker can plausibly report: txDiscardedMsgCount is a 64-bit
+// counter, and 100 slow clients each with 2^53 discards would already exceed
+// float64's exact-integer range. The handler documents float64 accumulation;
+// this test freezes that behavior so a switch to int64 accumulation later is
+// a deliberate change, not an accidental one.
+func TestListSlowSubscribers_LargeSum(t *testing.T) {
+	big := float64(1 << 53) // largest exact-integer float64
+	items := []any{
+		sub("p", "linux", big),
+		sub("p", "linux", big),
+	}
+	got, err := ListSlowSubscribers(map[string]map[string]any{
+		"slowSubscribers": {"data": items},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := big * 2
+	if got["totalTxDiscardedMsgCount"] != want {
+		t.Errorf("totalTxDiscardedMsgCount: got %v, want %v", got["totalTxDiscardedMsgCount"], want)
+	}
+	if math.IsInf(want, 0) {
+		t.Fatal("test assumption failed: 2*2^53 should be finite")
+	}
+}
+
+// TestListSlowSubscribers_MissingField asserts that omitting any one required
+// field skips that row rather than aborting. Table-driven over each field so
+// reordering the handler's reads doesn't break the test for the wrong reason.
+func TestListSlowSubscribers_MissingField(t *testing.T) {
+	full := sub("default", "linux", float64(7))
+	if _, err := ListSlowSubscribers(map[string]map[string]any{"slowSubscribers": {"data": []any{full}}}); err != nil {
+		t.Fatalf("baseline full input should pass, got %v", err)
+	}
+	for field := range full {
+		t.Run(field, func(t *testing.T) {
+			item := map[string]any{}
+			for k, v := range full {
+				if k != field {
+					item[k] = v
+				}
+			}
+			// Pair the broken row with a healthy one so we can also assert the
+			// healthy row's signal still lands.
+			healthy := sub("high-throughput", "windows", float64(3))
+			got, err := ListSlowSubscribers(map[string]map[string]any{"slowSubscribers": {"data": []any{item, healthy}}})
+			if err != nil {
+				t.Fatalf("expected skip on missing %q, got error %v", field, err)
+			}
+			if got["skipped"] != 1 {
+				t.Errorf("skipped: got %v, want 1", got["skipped"])
+			}
+			if got["scanned"] != 2 {
+				t.Errorf("scanned: got %v, want 2", got["scanned"])
+			}
+			profiles := got["byClientProfile"].(map[string]int)
+			if profiles["high-throughput"] != 1 {
+				t.Errorf("healthy row lost from byClientProfile: %v", profiles)
+			}
+			platforms := got["byPlatform"].(map[string]int)
+			if platforms["windows"] != 1 {
+				t.Errorf("healthy row lost from byPlatform: %v", platforms)
+			}
+			if got["totalTxDiscardedMsgCount"] != float64(3) {
+				t.Errorf("totalTxDiscardedMsgCount: got %v, want 3", got["totalTxDiscardedMsgCount"])
+			}
+		})
+	}
+}
+
+// TestListSlowSubscribers_WrongType asserts a wrong-typed field skips the row
+// rather than aborting — same rationale as MissingField.
+func TestListSlowSubscribers_WrongType(t *testing.T) {
+	bad := sub("default", "linux", "not-a-number")
+	healthy := sub("high-throughput", "windows", float64(9))
+	got, err := ListSlowSubscribers(map[string]map[string]any{"slowSubscribers": {"data": []any{bad, healthy}}})
+	if err != nil {
+		t.Fatalf("wrong-type field should skip, got %v", err)
+	}
+	if got["skipped"] != 1 {
+		t.Errorf("skipped: got %v, want 1", got["skipped"])
+	}
+	if got["totalTxDiscardedMsgCount"] != float64(9) {
+		t.Errorf("totalTxDiscardedMsgCount: got %v, want 9", got["totalTxDiscardedMsgCount"])
+	}
+}
+
+// TestListSlowSubscribers_TruncationSurfaced asserts that when the paginator
+// marks the step truncated, the summary exposes scanned and truncated: true.
+func TestListSlowSubscribers_TruncationSurfaced(t *testing.T) {
+	items := []any{sub("default", "linux", float64(1)), sub("default", "linux", float64(2))}
+	t.Run("truncated", func(t *testing.T) {
+		got, err := ListSlowSubscribers(map[string]map[string]any{
+			"slowSubscribers": {"data": items, "truncated": true},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got["scanned"] != 2 {
+			t.Errorf("scanned: got %v, want 2", got["scanned"])
+		}
+		if got["truncated"] != true {
+			t.Errorf("truncated: got %v, want true", got["truncated"])
+		}
+	})
+	t.Run("not truncated omits flag", func(t *testing.T) {
+		got, err := ListSlowSubscribers(map[string]map[string]any{
+			"slowSubscribers": {"data": items, "truncated": false},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, present := got["truncated"]; present {
+			t.Errorf("truncated key should be omitted when false, got %v", got["truncated"])
+		}
+	})
+}
+
+// TestListSlowSubscribers_SkippedOmittedWhenZero keeps the summary key set
+// minimal in the common case — skipped is noise when nothing was skipped.
+func TestListSlowSubscribers_SkippedOmittedWhenZero(t *testing.T) {
+	got, err := ListSlowSubscribers(map[string]map[string]any{
+		"slowSubscribers": {"data": []any{sub("default", "linux", float64(1))}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := got["skipped"]; present {
+		t.Errorf("skipped key should be omitted when 0, got %v", got["skipped"])
+	}
+}
+
+func TestListSlowSubscribers_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   map[string]map[string]any
+		wantSub string
+	}{
+		{
+			name:    "missing step",
+			input:   map[string]map[string]any{},
+			wantSub: `step "slowSubscribers" not in results`,
+		},
+		{
+			name:    "data wrong type",
+			input:   map[string]map[string]any{"slowSubscribers": {"data": "oops"}},
+			wantSub: "slowSubscribers.data: want []any",
+		},
+		{
+			name:    "item wrong type",
+			input:   map[string]map[string]any{"slowSubscribers": {"data": []any{"not-an-object"}}},
+			wantSub: "slowSubscribers.data[0]: want object",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListSlowSubscribers(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("got %v, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `listSlowSubscribers` postprocess aggregation to `list-slow-subscribers` so LLMs can triage slow-subscriber sprawl without walking the raw list. Mirrors the `listQueues` (SOL-151312) pattern.

Fixes SOL-151315

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

When a VPN has many slow subscribers, the raw list gives the LLM no way to tell "10 clients on the same misconfigured client-profile" from "10 clients each dropping millions of messages." The three aggregations surface the triage-critical signals directly in `summary`:

- `byClientProfile` — do all offenders share a QoS/policy bucket?
- `byPlatform` — is this a specific SDK/version regressing?
- `totalTxDiscardedMsgCount` — severity signal; distinguishes minor TCP blips from a message flood.

## Changes Made

- New handler `internal/composite/postprocess/handlers/list_slow_subscribers.go` registered as `listSlowSubscribers`. Aggregates the three signals above; adds `scanned`; conditionally emits `truncated` and `skipped`. Skip-don't-abort on missing/wrong-typed fields; hard-fail only on structural errors — matches `listQueues` robustness.
- Unit tests in `internal/composite/postprocess/handlers/list_slow_subscribers_test.go`: empty, all-same-profile, mixed, numeric shapes (float64/json.Number/int/int64), large-sum overflow guard at 2·2^53, per-required-field missing (table-driven), wrong-type skip, truncation surfacing, `skipped` omitted when zero, structural errors.
- `internal/composite/definitions/tools.yaml` `list-slow-subscribers`: `strategy: postProcess`, `postProcess: listSlowSubscribers`. Moved `select` from an `args.select` string to a structured list (postProcess strategy requires it — see `loader.go:123`) and added `clientProfileName`.

Envelope stays backward-compatible: `.slowSubscribers.data` / `.slowSubscribers.truncated` unchanged; `summary` is a new sibling.

## Testing

**Test Environment:**
- Go version: 1.24
- OS: Linux (Fedora 43)
- Broker version: e2e-monitoring Docker image (broker-a + broker-b)

**Tests Performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — existing Tool 10 e2e coverage still passes; no new e2e assertions added on summary fields (see Follow-ups)
- [x] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker (via `make e2e-monitoring-all`, 46/46 pass)

**Test Coverage:**
- All 15 subtests in `list_slow_subscribers_test.go` pass with `-race`.
- Full repo `go test -race ./...` clean.
- `make e2e-monitoring-all`: 46/46 pass, including all 4 Tool 10 `list-slow-subscribers` cases (broker-a, broker-b, pagination × 2) against the F6 slow-subscriber fixture.
- `make lint` shows two gosec findings (`internal/idpclient/client.go:91`, `internal/observability/correlation/middleware.go:227`) — both pre-existing on `main`, unrelated to this change (verified with `git stash`).

## Breaking Changes

None. Existing consumers reading `.slowSubscribers.data` are unaffected.

**Impact:** N/A

**Migration Guide:** N/A

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (checked all files, commits, and logs)
- [x] Followed secure logging rules — new handler has no log calls; `/check-logs` clean
- [x] Credential-carrying types implement `slog.LogValuer` — N/A, this change touches none
- [x] No security vulnerabilities introduced (pre-existing gosec findings only)

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests (empty, missing/nil/wrong-type fields, numeric-shape variance, near-overflow accumulation, truncation)
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (if user-facing changes) — N/A
- [ ] docs/ updated (if architecture/design changes) — N/A, pattern already documented under `listQueues` / SOL-151312
- [x] godoc comments added/updated for exported functions
- [ ] CHANGELOG.md updated (if applicable) — N/A
- [ ] Examples updated (if applicable) — N/A

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

### Breaking Changes (if applicable)
- [ ] Breaking changes documented in commit message — N/A
- [ ] Breaking changes documented in PR description — N/A
- [ ] Migration guide provided — N/A
- [ ] Deprecated functionality marked with comments and deprecation notices — N/A

## Screenshots (if applicable)

```json
"summary": {
  "byClientProfile":          { "default": 1 },
  "byPlatform":               { "solace-messaging-go-client / Linux26-x86_64_opt - C SDK": 1 },
  "scanned":                  1,
  "totalTxDiscardedMsgCount": 11717
}

```
## Additional Notes

**Design decisions worth flagging on review:**

- No per-handler validator cross-check test. The generic `RequiredFields ⊄ select` boot-time failure is already covered by `TestValidateTool` (`postprocess_test.go:65`) and by `loader_test.go:1203` via a stub handler. A `listSlowSubscribers`-anchored version would test the framework twice, not this handler. Happy to add one if reviewers want the belt-and-braces.
- `totalTxDiscardedMsgCount` accumulates as `float64` (matches what `numField` returns). Added `TestListSlowSubscribers_LargeSum` at 2·2^53 to freeze that behavior — a future switch to `int64` accumulation should then be a deliberate change, not a silent one, since a 64-bit SEMP counter can plausibly exceed float64's exact-integer range at scale.

---

**For Reviewers:**

**Focus Areas**:
- `listSlowSubscribers` behavior vs `listQueues` — they should be shape-identical (`scanned` always, `truncated`/`skipped` only when non-zero/true, aggregations keyed on required fields).
- The yaml `select` list conversion — I dropped the comma-separated `args.select` form because postProcess strategy rejects it (`loader.go:123`); double-check no downstream consumer depended on that specific string.
