### PR TITLE
SOL-150260: report accurate live queue depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The server exposes read-only tools grouped by what they inspect, plus a small se
 | Broker status | `get-broker-status`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA and mate-link state |
 | Replication | `get-replication-status` | Replication role, sync eligibility, bridge status, transaction mode, and queued-message counts |
 | Message VPN | `list-vpns`, `get-vpn-health`, `get-message-rates` | List VPNs, check per-VPN service health, read message and byte rates |
-| Queues | `list-queues`, `get-queue-metrics` | List queues with depth and throughput; drill into spool, bindings, consumers |
+| Queues | `list-queues`, `get-queue-metrics` | List queues with cumulative spooled count and throughput; drill into spool, bindings, consumers |
 | Clients | `list-clients`, `get-client-details`, `list-client-subscriptions`, `list-slow-subscribers` | List connections, inspect per-client rates and discards, list subscriptions, filter for slow-subscriber-flagged clients |
 | REST Delivery Points | `list-rdps`, `get-rdp-status` | List RDPs; inspect bindings, REST consumers, and last failure reason |
 | Discards | `get-discard-stats`, `list-queue-discards` | Broker-wide and per-VPN discard aggregates; per-queue discard counters |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The server exposes read-only tools grouped by what they inspect, plus a small se
 | Broker status | `get-broker-status`, `get-redundancy-status` | Snapshot of version, uptime, resources, spool, and HA and mate-link state |
 | Replication | `get-replication-status` | Replication role, sync eligibility, bridge status, transaction mode, and queued-message counts |
 | Message VPN | `list-vpns`, `get-vpn-health`, `get-message-rates` | List VPNs, check per-VPN service health, read message and byte rates |
-| Queues | `list-queues`, `get-queue-metrics` | List queues with cumulative spooled count and throughput; drill into spool, bindings, consumers |
+| Queues | `list-queues`, `get-queue-metrics` | List queues with cumulative spooled count and throughput; drill into a single queue for authoritative current depth, spool, and rates |
 | Clients | `list-clients`, `get-client-details`, `list-client-subscriptions`, `list-slow-subscribers` | List connections, inspect per-client rates and discards, list subscriptions, filter for slow-subscriber-flagged clients |
 | REST Delivery Points | `list-rdps`, `get-rdp-status` | List RDPs; inspect bindings, REST consumers, and last failure reason |
 | Discards | `get-discard-stats`, `list-queue-discards` | Broker-wide and per-VPN discard aggregates; per-queue discard counters |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2/specs"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
+	"github.com/SolaceDev/solace-broker-mcp/internal/tools/queuemetrics"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools/sempv1/brokerstatus"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools/sempv1/discardstats"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools/sempv1/redundancy"
@@ -473,6 +474,14 @@ func registerSEMPv2Tools(mgr *tools.ToolManager) {
 	mgr.Register(clientactions.NewClearStatsHandler())
 }
 
+// registerMixedTools attaches native Go tool handlers that use BOTH the SEMPv2
+// and SEMPv1 clients in one call. get-queue-metrics merges the SEMPv2 monitor
+// snapshot with the authoritative SEMPv1 live-depth block; it is read-only and
+// registers regardless of enable_write_tools.
+func registerMixedTools(mgr *tools.ToolManager) {
+	mgr.Register(queuemetrics.NewHandler())
+}
+
 func main() {
 	if len(os.Args) == 2 && (os.Args[1] == "-version" || os.Args[1] == "--version") {
 		fmt.Println(version.Version())
@@ -625,6 +634,7 @@ func main() {
 	mgr := tools.NewToolManagerFromComposite(pool, compositeTools, executor)
 	registerSEMPv1Tools(mgr)
 	registerSEMPv2Tools(mgr)
+	registerMixedTools(mgr)
 	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools)
 	slog.Info("tool registration complete",
 		slog.Bool("enable_write_tools", cfg.EnableWriteTools))

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,7 +4,7 @@ The Solace Event Broker MCP Server is an [MCP (Model Context Protocol)](https://
 
 Application scenarios:
 
-- **Incident triage** — Query event broker status, queue backlogs, and slow consumers using natural language queries instead of direct SEMP API calls.
+- **Incident triage** — Query event broker status, queue activity, and slow consumers using natural language queries instead of direct SEMP API calls.
 - **Operational monitoring** — Monitor VPN health, client connections, and message rates across multiple brokers through a conversational interface.
 - **Multi-broker management** — Configure multiple event broker connections and address them by alias in queries.
 
@@ -124,8 +124,8 @@ The server exposes 17 read-only tools plus 4 action tools (21 total when action 
 
 | Tool | Description |
 |---|---|
-| `list-queues` | List queues in a VPN with depth, bind count, and throughput rates. Default 100 results, max 500. |
-| `get-queue-metrics` | Detailed metrics for a specific queue: message depth, throughput rates, spool usage, and configuration. Use to diagnose backlogs. |
+| `list-queues` | List queues in a VPN with cumulative spooled count (`spooledMsgCount`, lifetime — not live depth), bind count, and throughput rates. Default 100 results, max 500. |
+| `get-queue-metrics` | Detailed metrics for a specific queue: cumulative spooled count (`spooledMsgCount`, lifetime — not live depth), throughput rates, spool usage, and configuration. SEMPv2 does not expose live queue depth as a scalar. |
 
 ### Clients
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -125,7 +125,7 @@ The server exposes 17 read-only tools plus 4 action tools (21 total when action 
 | Tool | Description |
 |---|---|
 | `list-queues` | List queues in a VPN with cumulative spooled count (`spooledMsgCount`, lifetime — not live depth), bind count, and throughput rates. Default 100 results, max 500. |
-| `get-queue-metrics` | Detailed metrics for a specific queue: cumulative spooled count (`spooledMsgCount`, lifetime — not live depth), throughput rates, spool usage, and configuration. SEMPv2 does not expose live queue depth as a scalar. |
+| `get-queue-metrics` | Detailed metrics for a specific queue. Returns `liveDepth.currentMsgCount` — the **authoritative current queue depth** (messages in the queue right now, decreases as they are consumed; sourced from SEMPv1) — plus a `queueMetrics` block with throughput rates, spool usage, configuration, and cumulative counters. Note `queueMetrics.spooledMsgCount` is a lifetime counter (messages ever spooled), not the current depth. |
 
 ### Clients
 

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -66,43 +66,10 @@ tools:
     result:
       strategy: collect
 
-  - name: get-queue-metrics
-    description: >
-      Get detailed metrics for a queue: spooledMsgCount, txUnackedMsgCount,
-      bindCount, rxMsgRate, txMsgRate, redelivery counts, congestion state, and
-      spool usage. IMPORTANT: spooledMsgCount is the cumulative lifetime count
-      of messages ever spooled to the queue (a counter that only increases since
-      queue creation / last stats clear) — it is NOT the current number of
-      messages in the queue and does NOT decrease as messages are consumed.
-      Current/live queue depth is not exposed as a scalar via SEMPv2; do not
-      report spooledMsgCount as the current backlog. Primary signal for
-      detecting a slow guaranteed-message consumer: spooledMsgCount rising
-      across successive calls AND bindCount > 0 AND rxMsgRate > txMsgRate AND
-      txUnackedMsgCount near the per-flow unacked limit. Note that msgSpoolUsage
-      is in bytes while maxMsgSpoolUsage is in megabytes — convert before
-      computing a utilization percentage. The per-client slowSubscriber field
-      does not flip for slow ACKs, so this tool — not get-client-details — is
-      the right starting point.
-    annotations:
-      readOnly: true
-    parameters:
-      - name: msgVpnName
-        type: string
-        required: true
-        description: "The Message VPN containing the queue"
-      - name: queueName
-        type: string
-        required: true
-        description: "The name of the queue"
-    steps:
-      - id: queueMetrics
-        operation: monitor/getMsgVpnQueue
-        args:
-          msgVpnName: "{{.Params.msgVpnName}}"
-          queueName: "{{.Params.queueName}}"
-          select: "accessType, averageRxMsgRate, averageTxMsgRate, bindCount, durable, egressEnabled, ingressEnabled, lowPriorityMsgCongestionState, maxBindCount, maxDeliveredUnackedMsgsPerFlow, maxMsgSize, maxMsgSpoolUsage, maxMsgSpoolUsageExceededDiscardedMsgCount, maxRedeliveryCount, maxRedeliveryExceededDiscardedMsgCount, maxTtl, maxTtlExceededDiscardedMsgCount, msgSpoolUsage, msgVpnName, noLocalDeliveryDiscardedMsgCount, owner, queueName, redeliveredMsgCount, rxByteRate, rxMsgRate, spooledMsgCount, txByteRate, txMsgRate, txUnackedMsgCount"
-    result:
-      strategy: collect
+  # get-queue-metrics is implemented as a native mixed-protocol Go handler
+  # (internal/tools/queuemetrics) rather than a composite tool: it merges the
+  # SEMPv2 monitor snapshot with an authoritative SEMPv1 "show queue detail"
+  # live-depth block, which the SEMPv2-only composite engine cannot express.
 
   - name: get-client-details
     description: >

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -14,6 +14,12 @@
 #   (e.g., "For per-queue metrics, use get-queue-metrics instead")
 # - Keep it concise: Aim for 2-4 sentences
 # - Avoid jargon where possible: Prefer "message backlog" over "spool utilization"
+#   BUT never label a cumulative lifetime counter as "depth" or "backlog".
+#   spooledMsgCount (MsgVpnQueue) is the total messages ever spooled since queue
+#   creation / last stats clear — it only increases and is NOT the current number
+#   of messages in the queue. SEMPv2 does not expose live queue depth as a
+#   scalar; say so rather than implying spooledMsgCount is it. Also note
+#   msgSpoolUsage is in bytes but maxMsgSpoolUsage is in megabytes.
 # - Pagination limits: For list tools with maxResults, state the default and cap
 #   in the description (e.g., "Returns up to 100 by default (max 500 via maxResults)").
 #   These values are defined as constants in executor.go (defaultMax, capMax) —
@@ -64,12 +70,19 @@ tools:
     description: >
       Get detailed metrics for a queue: spooledMsgCount, txUnackedMsgCount,
       bindCount, rxMsgRate, txMsgRate, redelivery counts, congestion state, and
-      spool usage. Use this to diagnose queue backlogs. Primary signal for
-      detecting a slow guaranteed-message consumer: spooledMsgCount growing AND
-      bindCount > 0 AND rxMsgRate > txMsgRate AND txUnackedMsgCount near the
-      per-flow unacked limit. The per-client slowSubscriber field does not flip
-      for slow ACKs, so this tool — not get-client-details — is the right
-      starting point.
+      spool usage. IMPORTANT: spooledMsgCount is the cumulative lifetime count
+      of messages ever spooled to the queue (a counter that only increases since
+      queue creation / last stats clear) — it is NOT the current number of
+      messages in the queue and does NOT decrease as messages are consumed.
+      Current/live queue depth is not exposed as a scalar via SEMPv2; do not
+      report spooledMsgCount as the current backlog. Primary signal for
+      detecting a slow guaranteed-message consumer: spooledMsgCount rising
+      across successive calls AND bindCount > 0 AND rxMsgRate > txMsgRate AND
+      txUnackedMsgCount near the per-flow unacked limit. Note that msgSpoolUsage
+      is in bytes while maxMsgSpoolUsage is in megabytes — convert before
+      computing a utilization percentage. The per-client slowSubscriber field
+      does not flip for slow ACKs, so this tool — not get-client-details — is
+      the right starting point.
     annotations:
       readOnly: true
     parameters:
@@ -200,13 +213,21 @@ tools:
 
   - name: list-queues
     description: >
-      List queues in a VPN with depth (spooledMsgCount), unacked count
+      List queues in a VPN with spooledMsgCount, unacked count
       (txUnackedMsgCount), bindCount, congestion state, and rates. Returns up to
-      100 by default (max 500 via maxResults). Primary VPN-wide scan for slow
-      guaranteed-message consumers: queues with spooledMsgCount growing,
-      txUnackedMsgCount high, rxMsgRate > txMsgRate, and bindCount > 0 indicate
-      consumer-side slowness even when slowSubscriber is false on the bound
-      client.
+      100 by default (max 500 via maxResults). IMPORTANT: spooledMsgCount is the
+      cumulative lifetime count of messages ever spooled to each queue (it only
+      increases since queue creation / last stats clear) — it is NOT the current
+      number of messages in the queue and does NOT decrease as messages are
+      consumed. SEMPv2 does not expose live queue depth as a scalar; do not
+      report spooledMsgCount as the current backlog. The response summary counts
+      queues with no consumers, congestion, and near-full spool (>=80% of
+      quota); it deliberately omits a live-backlog count because that is not
+      derivable from these fields. Primary VPN-wide scan for slow
+      guaranteed-message consumers: queues with spooledMsgCount rising across
+      successive calls, txUnackedMsgCount high, rxMsgRate > txMsgRate, and
+      bindCount > 0 indicate consumer-side slowness even when slowSubscriber is
+      false on the bound client.
     annotations:
       readOnly: true
     parameters:

--- a/internal/composite/postprocess/handlers/list_queues.go
+++ b/internal/composite/postprocess/handlers/list_queues.go
@@ -24,11 +24,17 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
 )
 
-// nearFullThreshold is the msgSpoolUsage / maxMsgSpoolUsage ratio at or above
-// which a queue is counted as "near full". 0.8 is the conventional warning
-// threshold for guaranteed-message storage; queues at this fill level are at
-// risk of taking SPOOL_OVER_QUOTA discards if their consumers don't catch up.
+// nearFullThreshold is the spool-usage fill ratio at or above which a queue is
+// counted as "near full". 0.8 is the conventional warning threshold for
+// guaranteed-message storage; queues at this fill level are at risk of taking
+// SPOOL_OVER_QUOTA discards if their consumers don't catch up.
 const nearFullThreshold = 0.8
+
+// bytesPerMB converts maxMsgSpoolUsage (megabytes, per the SEMPv2 monitor spec)
+// to bytes so it can be compared against msgSpoolUsage (bytes). Without this
+// conversion the fill ratio is off by a factor of ~1e6 and flags essentially
+// every non-empty queue as near full (SOL-150260).
+const bytesPerMB = 1024 * 1024
 
 // listQueuesStepID is the step ID this handler keys into. Declared as a const
 // so the init-time RequiredSteps registration and the runtime lookup cannot
@@ -42,7 +48,6 @@ func init() {
 		RequiredSteps: []string{listQueuesStepID},
 		RequiredFields: []string{
 			"bindCount",
-			"spooledMsgCount",
 			"lowPriorityMsgCongestionState",
 			"msgSpoolUsage",
 			"maxMsgSpoolUsage",
@@ -50,12 +55,21 @@ func init() {
 	})
 }
 
-// ListQueues aggregates the queue list into four counts:
+// ListQueues aggregates the queue list into three counts:
 //   - noConsumerCount: queues with bindCount == 0 (nothing reading)
 //   - congestedCount:  queues whose lowPriorityMsgCongestionState == "congested"
-//   - backloggedCount: queues with spooledMsgCount > 0 (any backlog at all)
-//   - nearFullCount:   queues with msgSpoolUsage/maxMsgSpoolUsage >= 0.8
+//   - nearFullCount:   queues whose spool usage is >= 80% of their quota, i.e.
+//     msgSpoolUsage (bytes) / (maxMsgSpoolUsage MB * bytesPerMB) >= 0.8
 //     (skips queues with maxMsgSpoolUsage == 0 — unbounded or unset)
+//
+// Note there is intentionally no "backlog"/"depth" count here: spooledMsgCount
+// is a cumulative lifetime counter (messages ever spooled), not the current
+// number of messages in a queue, so counting queues with spooledMsgCount > 0
+// would report every queue that has ever received a message — not queues with a
+// live backlog (SOL-150260). A current-depth-based count requires either
+// deriving currentMsgCount = spooledMsgCount - deletedMsgCount or an
+// authoritative SEMPv1 num-messages-spooled read; both are deferred to the
+// follow-up capability work.
 //
 // The counts are over what the paginator actually returned. Under truncation
 // (followPages stopped at maxResults / capMax / maxPages), the summary also
@@ -77,7 +91,7 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 	if !ok {
 		return nil, fmt.Errorf("queues.data: want []any, got %T", step["data"])
 	}
-	var noConsumer, congested, backlogged, nearFull, skipped int
+	var noConsumer, congested, nearFull, skipped int
 	for i, raw := range items {
 		q, ok := raw.(map[string]any)
 		if !ok {
@@ -85,10 +99,9 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 		}
 		bindCount, ok1 := numField(q, "bindCount")
 		state, ok2 := stringField(q, "lowPriorityMsgCongestionState")
-		spooled, ok3 := numField(q, "spooledMsgCount")
-		usage, ok4 := numField(q, "msgSpoolUsage")
-		maxUsage, ok5 := numField(q, "maxMsgSpoolUsage")
-		if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 {
+		usage, ok3 := numField(q, "msgSpoolUsage")
+		maxUsage, ok4 := numField(q, "maxMsgSpoolUsage")
+		if !ok1 || !ok2 || !ok3 || !ok4 {
 			skipped++
 			continue
 		}
@@ -98,17 +111,13 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 		if state == "congested" {
 			congested++
 		}
-		if spooled > 0 {
-			backlogged++
-		}
-		if maxUsage > 0 && usage/maxUsage >= nearFullThreshold {
+		if maxUsage > 0 && usage/(maxUsage*bytesPerMB) >= nearFullThreshold {
 			nearFull++
 		}
 	}
 	out := map[string]any{
 		"noConsumerCount": noConsumer,
 		"congestedCount":  congested,
-		"backloggedCount": backlogged,
 		"nearFullCount":   nearFull,
 		"scanned":         len(items),
 	}

--- a/internal/composite/postprocess/handlers/list_queues_test.go
+++ b/internal/composite/postprocess/handlers/list_queues_test.go
@@ -19,24 +19,26 @@ import (
 	"testing"
 )
 
-// queue is a tiny helper to build a queue item with the five required fields.
-func queue(bindCount, spooled, usage, maxUsage float64, state string) map[string]any {
+// queue is a tiny helper to build a queue item with the four required fields.
+// usageBytes is msgSpoolUsage in bytes; maxUsageMB is maxMsgSpoolUsage in
+// megabytes — the same unit split the broker uses, so tests exercise the
+// MB→bytes conversion in the near-full computation rather than papering over it.
+func queue(bindCount, usageBytes, maxUsageMB float64, state string) map[string]any {
 	return map[string]any{
 		"bindCount":                     bindCount,
-		"spooledMsgCount":               spooled,
-		"msgSpoolUsage":                 usage,
-		"maxMsgSpoolUsage":              maxUsage,
+		"msgSpoolUsage":                 usageBytes,
+		"maxMsgSpoolUsage":              maxUsageMB,
 		"lowPriorityMsgCongestionState": state,
 	}
 }
 
 func TestListQueues_Counts(t *testing.T) {
 	items := []any{
-		queue(0, 0, 0, 100, "not-congested"),     // noConsumer
-		queue(0, 50, 80, 100, "congested"), // noConsumer + congested + backlogged + nearFull (0.8)
-		queue(2, 10, 99, 100, "not-congested"),   // backlogged + nearFull (0.99)
-		queue(2, 0, 50, 100, "not-congested"),    // nothing
-		queue(1, 5, 0, 0, "not-congested"),       // backlogged only (unbounded — skip nearFull)
+		queue(0, 0, 100, "not-congested"),             // noConsumer
+		queue(0, 90*bytesPerMB, 100, "congested"),     // noConsumer + congested + nearFull (0.90)
+		queue(2, 99*bytesPerMB, 100, "not-congested"), // nearFull (0.99)
+		queue(2, 50*bytesPerMB, 100, "not-congested"), // nothing (0.50)
+		queue(1, 0, 0, "not-congested"),               // unbounded — skip nearFull
 	}
 	got, err := ListQueues(map[string]map[string]any{
 		"queues": {"data": items},
@@ -47,13 +49,35 @@ func TestListQueues_Counts(t *testing.T) {
 	checks := map[string]int{
 		"noConsumerCount": 2,
 		"congestedCount":  1,
-		"backloggedCount": 3,
 		"nearFullCount":   2,
 	}
 	for k, want := range checks {
 		if got[k] != want {
 			t.Errorf("%s: got %v, want %d", k, got[k], want)
 		}
+	}
+	// backloggedCount was removed (it counted queues with cumulative
+	// spooledMsgCount > 0, which is not a live backlog — SOL-150260).
+	if _, present := got["backloggedCount"]; present {
+		t.Errorf("backloggedCount should no longer be emitted, got %v", got["backloggedCount"])
+	}
+}
+
+// TestListQueues_NearFullUnits is the regression guard for the bytes-vs-MB unit
+// bug (SOL-150260). msgSpoolUsage is bytes; maxMsgSpoolUsage is MB. A queue
+// using 0.8 MB (838860 bytes) of a 100 MB quota is at 0.8% — NOT near full. The
+// pre-fix code compared 838860 / 100 = 8388 >= 0.8 and wrongly counted it.
+func TestListQueues_NearFullUnits(t *testing.T) {
+	items := []any{
+		queue(1, 0.8*bytesPerMB, 100, "not-congested"), // 0.8% full — not near full
+		queue(1, 80*bytesPerMB, 100, "not-congested"),  // 80% full — near full
+	}
+	got, err := ListQueues(map[string]map[string]any{"queues": {"data": items}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["nearFullCount"] != 1 {
+		t.Errorf("nearFullCount: got %v, want 1 (only the 80%% queue is near full)", got["nearFullCount"])
 	}
 }
 
@@ -64,8 +88,8 @@ func TestListQueues_Counts(t *testing.T) {
 // treat the counts as global rather than over the visible page.
 func TestListQueues_TruncationSurfaced(t *testing.T) {
 	items := []any{
-		queue(0, 0, 0, 100, "not-congested"),
-		queue(2, 10, 50, 100, "not-congested"),
+		queue(0, 0, 100, "not-congested"),
+		queue(2, 50*bytesPerMB, 100, "not-congested"),
 	}
 	t.Run("truncated", func(t *testing.T) {
 		got, err := ListQueues(map[string]map[string]any{
@@ -104,7 +128,7 @@ func TestListQueues_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, k := range []string{"noConsumerCount", "congestedCount", "backloggedCount", "nearFullCount"} {
+	for _, k := range []string{"noConsumerCount", "congestedCount", "nearFullCount"} {
 		if got[k] != 0 {
 			t.Errorf("%s: got %v, want 0", k, got[k])
 		}
@@ -149,7 +173,7 @@ func TestListQueues_Errors(t *testing.T) {
 // wrong reason. Hard-failing on one bad row would drop the raw list too —
 // a step down from the collect strategy.
 func TestListQueues_MissingField(t *testing.T) {
-	full := queue(0, 0, 0, 100, "not-congested")
+	full := queue(0, 0, 100, "not-congested")
 	// Sanity: full input must succeed, otherwise the omission cases prove nothing.
 	if _, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{full}}}); err != nil {
 		t.Fatalf("baseline full input should pass, got %v", err)
@@ -165,7 +189,7 @@ func TestListQueues_MissingField(t *testing.T) {
 			// Pair the broken row with a healthy one so we can also assert the
 			// healthy row's signal still lands (the broken row in the baseline
 			// is a noConsumer, so use a row that ISN'T to disambiguate).
-			healthy := queue(2, 10, 99, 100, "congested") // congested + backlogged + nearFull
+			healthy := queue(2, 90*bytesPerMB, 100, "congested") // congested + nearFull
 			got, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{item, healthy}}})
 			if err != nil {
 				t.Fatalf("expected skip on missing %q, got error %v", field, err)
@@ -177,7 +201,7 @@ func TestListQueues_MissingField(t *testing.T) {
 				t.Errorf("scanned: got %v, want 2", got["scanned"])
 			}
 			// Healthy row should still contribute.
-			for _, k := range []string{"congestedCount", "backloggedCount", "nearFullCount"} {
+			for _, k := range []string{"congestedCount", "nearFullCount"} {
 				if got[k] != 1 {
 					t.Errorf("%s: got %v, want 1 (healthy row should still count)", k, got[k])
 				}
@@ -191,9 +215,9 @@ func TestListQueues_MissingField(t *testing.T) {
 // motivating case for the skip-don't-abort behavior: one queue with a nil
 // msgSpoolUsage shouldn't lose the raw list of every other queue.
 func TestListQueues_NilField(t *testing.T) {
-	bad := queue(0, 0, 0, 100, "not-congested")
+	bad := queue(0, 0, 100, "not-congested")
 	bad["msgSpoolUsage"] = nil
-	healthy := queue(2, 10, 99, 100, "not-congested")
+	healthy := queue(2, 90*bytesPerMB, 100, "not-congested")
 	got, err := ListQueues(map[string]map[string]any{"queues": {"data": []any{bad, healthy}}})
 	if err != nil {
 		t.Fatalf("nil field should skip, got %v", err)
@@ -201,7 +225,7 @@ func TestListQueues_NilField(t *testing.T) {
 	if got["skipped"] != 1 {
 		t.Errorf("skipped: got %v, want 1", got["skipped"])
 	}
-	if got["backloggedCount"] != 1 || got["nearFullCount"] != 1 {
+	if got["nearFullCount"] != 1 {
 		t.Errorf("healthy row signals lost: %+v", got)
 	}
 }
@@ -210,7 +234,7 @@ func TestListQueues_NilField(t *testing.T) {
 // the common case — skipped is noise when nothing was skipped.
 func TestListQueues_SkippedOmittedWhenZero(t *testing.T) {
 	got, err := ListQueues(map[string]map[string]any{
-		"queues": {"data": []any{queue(0, 0, 0, 100, "not-congested")}},
+		"queues": {"data": []any{queue(0, 0, 100, "not-congested")}},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tools/queuemetrics/handler.go
+++ b/internal/tools/queuemetrics/handler.go
@@ -1,0 +1,250 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package queuemetrics implements the get-queue-metrics MCP tool.
+//
+// It is a mixed-protocol tool: it issues a SEMPv2 monitor query and a SEMPv1
+// "show queue detail" command against the same queue in parallel and merges
+// them into one response:
+//
+//	SEMPv2 monitor/getMsgVpnQueue → "queueMetrics" (rates, config, congestion,
+//	    and cumulative lifetime counters such as spooledMsgCount)
+//	SEMPv1 show queue ... detail  → "liveDepth" (authoritative CURRENT depth)
+//
+// The reason for the split: SEMPv2 MsgVpnQueue exposes no scalar for the
+// current number of messages in a queue — spooledMsgCount is a cumulative
+// lifetime counter that only increases, and spooledMsgCount - deletedMsgCount
+// does not track consumption (deletedMsgCount does not increment on normal
+// consume+ack). SEMPv1 num-messages-spooled is the authoritative live depth
+// and decreases as messages are consumed (SOL-150260). This tool was
+// previously a SEMPv2-only composite tool; it is native so it can merge the
+// two protocols in a single call.
+package queuemetrics
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
+	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
+)
+
+// toolName is the on-the-wire MCP tool name and the prefix used for tool-side
+// error wrapping. Kept in one place so the two cannot drift.
+const toolName = "get-queue-metrics"
+
+// sempv2Select is the SEMPv2 monitor field set surfaced under "queueMetrics".
+// It matches the field list this tool used when it was a composite tool, so
+// the queueMetrics block's shape is unchanged for existing consumers.
+// spooledMsgCount is retained deliberately (it is a useful cumulative signal
+// when read as "messages ever spooled", not current depth).
+const sempv2Select = "accessType, averageRxMsgRate, averageTxMsgRate, bindCount, " +
+	"durable, egressEnabled, ingressEnabled, lowPriorityMsgCongestionState, " +
+	"maxBindCount, maxDeliveredUnackedMsgsPerFlow, maxMsgSize, maxMsgSpoolUsage, " +
+	"maxMsgSpoolUsageExceededDiscardedMsgCount, maxRedeliveryCount, " +
+	"maxRedeliveryExceededDiscardedMsgCount, maxTtl, maxTtlExceededDiscardedMsgCount, " +
+	"msgSpoolUsage, msgVpnName, noLocalDeliveryDiscardedMsgCount, owner, queueName, " +
+	"redeliveredMsgCount, rxByteRate, rxMsgRate, spooledMsgCount, txByteRate, " +
+	"txMsgRate, txUnackedMsgCount"
+
+// Compile-time check that Handler satisfies tools.ToolHandler.
+var _ tools.ToolHandler = (*Handler)(nil)
+
+// Handler implements the get-queue-metrics MCP tool. Stateless; one instance
+// is sufficient per server.
+type Handler struct{}
+
+// NewHandler returns a get-queue-metrics tool handler ready to register with a
+// ToolManager.
+func NewHandler() *Handler { return &Handler{} }
+
+// Metadata describes the tool to the MCP layer. Returns a freshly allocated
+// value per call so callers cannot mutate shared state.
+func (h *Handler) Metadata() tools.Metadata {
+	return tools.Metadata{
+		Name: toolName,
+		Description: "Get detailed metrics for a queue. Returns two blocks: " +
+			"'liveDepth' (from SEMPv1) with the AUTHORITATIVE current queue depth — " +
+			"liveDepth.currentMsgCount is the number of messages sitting in the queue " +
+			"right now and decreases as they are consumed; use this for backlog/depth " +
+			"questions. 'queueMetrics' (from SEMPv2) with rates, congestion state, " +
+			"spool usage, redelivery counts, and configuration. IMPORTANT: the " +
+			"queueMetrics.spooledMsgCount field is a cumulative lifetime counter " +
+			"(messages ever spooled since creation / last stats clear) — it only " +
+			"increases and is NOT the current depth; do not report it as the current " +
+			"backlog. Note queueMetrics.msgSpoolUsage is in bytes while " +
+			"maxMsgSpoolUsage is in megabytes. Primary signal for a slow " +
+			"guaranteed-message consumer: liveDepth.currentMsgCount rising across " +
+			"successive calls AND bindCount > 0 AND rxMsgRate > txMsgRate AND " +
+			"txUnackedMsgCount near the per-flow unacked limit. The per-client " +
+			"slowSubscriber field does not flip for slow ACKs, so this tool — not " +
+			"get-client-details — is the right starting point.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"msgVpnName": map[string]any{
+					"type":        "string",
+					"minLength":   1,
+					"description": "The Message VPN containing the queue",
+				},
+				"queueName": map[string]any{
+					"type":        "string",
+					"minLength":   1,
+					"description": "The name of the queue",
+				},
+			},
+			"required": []string{"msgVpnName", "queueName"},
+		},
+		OutputSchema: tools.StepKeyedEnvelopeSchema(),
+		Annotations:  tools.ReadOnlyAnnotations(),
+	}
+}
+
+// buildSEMPv2Operation returns the monitor/getMsgVpnQueue operation. Native
+// handlers do not receive the parsed OpenAPI catalog, so the operation is
+// declared inline (same pattern as the queueactions handlers). The path is the
+// private monitor endpoint because fields like bindCount are not available on
+// the public monitor endpoint.
+func buildSEMPv2Operation() *sempv2.Operation {
+	return &sempv2.Operation{
+		ID:     "getMsgVpnQueue",
+		Method: "GET",
+		Path:   "/SEMP/v2/__private_monitor__/msgVpns/{msgVpnName}/queues/{queueName}",
+		Parameters: []sempv2.Parameter{
+			{Name: "msgVpnName", In: "path", Type: "string", Required: true},
+			{Name: "queueName", In: "path", Type: "string", Required: true},
+			{Name: "select", In: "query", Type: "array"},
+		},
+	}
+}
+
+// sempv1DetailXML builds the SEMPv1 request for a single queue's detail. The
+// queue and VPN names are XML-escaped defensively; the schema's minLength:1
+// already rejects empty values upstream.
+func sempv1DetailXML(msgVpnName, queueName string) (string, error) {
+	qb, err := xmlEscape(queueName)
+	if err != nil {
+		return "", err
+	}
+	vb, err := xmlEscape(msgVpnName)
+	if err != nil {
+		return "", err
+	}
+	return "<rpc><show><queue><name>" + qb + "</name><vpn-name>" +
+		vb + "</vpn-name><detail/></queue></show></rpc>", nil
+}
+
+// Handle issues the SEMPv2 monitor query and the SEMPv1 detail command in
+// parallel and merges them. Partial-failure policy mirrors get-broker-status:
+// if either call fails, the whole tool fails, because a metrics snapshot that
+// silently drops the live depth (or vice versa) would mislead the caller.
+// errgroup's first-error-cancels semantics give us this for free.
+func (h *Handler) Handle(ctx context.Context, tc *tools.ToolContext, params map[string]any) (*tools.ToolResult, error) {
+	msgVpnName, _ := params["msgVpnName"].(string)
+	queueName, _ := params["queueName"].(string)
+	if msgVpnName == "" {
+		return nil, fmt.Errorf("%s: msgVpnName is required", toolName)
+	}
+	if queueName == "" {
+		return nil, fmt.Errorf("%s: queueName is required", toolName)
+	}
+
+	// Pre-allocated slots — each goroutine writes its own, so no lock needed.
+	var (
+		queueMetrics map[string]any
+		liveDepth    map[string]any
+	)
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		op := buildSEMPv2Operation()
+		args := map[string]any{
+			"msgVpnName": msgVpnName,
+			"queueName":  queueName,
+			"select":     sempv2Select,
+		}
+		result, err := tc.SEMPv2Client.Execute(gCtx, op, args)
+		if err != nil {
+			return err
+		}
+		queueMetrics = result.Data
+		return nil
+	})
+
+	g.Go(func() error {
+		reqXML, err := sempv1DetailXML(msgVpnName, queueName)
+		if err != nil {
+			return fmt.Errorf("%s: building SEMPv1 request: %w", toolName, err)
+		}
+		result, err := tc.SEMPv1Client.Execute(gCtx, reqXML)
+		if err != nil {
+			return err
+		}
+		var resp queueDetailResponse
+		if err := xml.Unmarshal(result.InnerXML, &resp); err != nil {
+			return fmt.Errorf("%s: parsing queue detail response: %w", toolName, err)
+		}
+		liveDepth, err = structToMap(resp.Info)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return &tools.ToolResult{
+		StructuredContent: map[string]any{
+			"queueMetrics": queueMetrics,
+			"liveDepth":    liveDepth,
+		},
+	}, nil
+}
+
+// structToMap round-trips v through json.Marshal / json.Unmarshal so the
+// resulting map honors json: tags and ,omitempty (mirrors the brokerstatus
+// helper). A nil *queueInfo yields an empty map rather than a JSON null, so
+// the liveDepth key is always a well-formed object.
+func structToMap(v *queueInfo) (map[string]any, error) {
+	out := map[string]any{}
+	if v == nil {
+		return out, nil
+	}
+	asJSON, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshalling live depth to JSON: %w", toolName, err)
+	}
+	if err := json.Unmarshal(asJSON, &out); err != nil {
+		return nil, fmt.Errorf("%s: parsing live depth JSON: %w", toolName, err)
+	}
+	return out, nil
+}
+
+// xmlEscape returns the XML-escaped form of s for safe interpolation into the
+// SEMPv1 request body.
+func xmlEscape(s string) (string, error) {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/internal/tools/queuemetrics/handler_test.go
+++ b/internal/tools/queuemetrics/handler_test.go
@@ -1,0 +1,219 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queuemetrics
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv1"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
+	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
+)
+
+// mockV1 is a stub sempv1.Client. It returns the configured InnerXML (or err)
+// and records the request XML so tests can assert the built command.
+type mockV1 struct {
+	inner   []byte
+	err     error
+	lastXML string
+}
+
+func (m *mockV1) Execute(_ context.Context, x string) (*sempv1.Result, error) {
+	m.lastXML = x
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &sempv1.Result{InnerXML: m.inner}, nil
+}
+
+// mockV2 is a stub sempv2.Client. It returns the configured Data (or err) and
+// records the operation and args so tests can assert path/select.
+type mockV2 struct {
+	data     map[string]any
+	err      error
+	lastOp   *sempv2.Operation
+	lastArgs map[string]any
+}
+
+func (m *mockV2) Execute(_ context.Context, op *sempv2.Operation, args map[string]any) (*sempv2.Result, error) {
+	m.lastOp = op
+	m.lastArgs = args
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &sempv2.Result{Data: m.data, StatusCode: 200}, nil
+}
+
+// sempv2Envelope is a representative SEMPv2 monitor response body: the queue
+// fields nested under "data", plus a "meta" block — the shape get-queue-metrics
+// preserves under the "queueMetrics" key.
+func sempv2Envelope() map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"queueName":         "sol150260-test",
+			"msgVpnName":        "vpn_1",
+			"spooledMsgCount":   float64(10), // cumulative lifetime, not current depth
+			"bindCount":         float64(1),
+			"txUnackedMsgCount": float64(0),
+			"rxMsgRate":         float64(5),
+			"txMsgRate":         float64(5),
+		},
+		"meta": map[string]any{"responseCode": float64(200)},
+	}
+}
+
+func fixtureXML(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile("testdata/show_queue_detail.xml")
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+	return b
+}
+
+func callHandle(t *testing.T, v1 *mockV1, v2 *mockV2, params map[string]any) (*tools.ToolResult, error) {
+	t.Helper()
+	tc := &tools.ToolContext{SEMPv1Client: v1, SEMPv2Client: v2}
+	return NewHandler().Handle(context.Background(), tc, params)
+}
+
+func defaultParams() map[string]any {
+	return map[string]any{"msgVpnName": "vpn_1", "queueName": "sol150260-test"}
+}
+
+func TestHandle_MergesBothProtocols(t *testing.T) {
+	v1 := &mockV1{inner: fixtureXML(t)}
+	v2 := &mockV2{data: sempv2Envelope()}
+
+	res, err := callHandle(t, v1, v2, defaultParams())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	// queueMetrics is the SEMPv2 envelope verbatim.
+	qm, ok := res.StructuredContent["queueMetrics"].(map[string]any)
+	if !ok {
+		t.Fatalf("queueMetrics missing/wrong type: %T", res.StructuredContent["queueMetrics"])
+	}
+	data, ok := qm["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("queueMetrics.data missing/wrong type: %T", qm["data"])
+	}
+	if data["spooledMsgCount"] != float64(10) {
+		t.Errorf("queueMetrics.data.spooledMsgCount = %v, want 10 (cumulative preserved)", data["spooledMsgCount"])
+	}
+
+	// liveDepth is the authoritative current depth from SEMPv1.
+	ld, ok := res.StructuredContent["liveDepth"].(map[string]any)
+	if !ok {
+		t.Fatalf("liveDepth missing/wrong type: %T", res.StructuredContent["liveDepth"])
+	}
+	if ld["currentMsgCount"] != float64(10) {
+		t.Errorf("liveDepth.currentMsgCount = %v, want 10", ld["currentMsgCount"])
+	}
+	if ld["currentSpoolUsageBytes"] != float64(340) {
+		t.Errorf("liveDepth.currentSpoolUsageBytes = %v, want 340", ld["currentSpoolUsageBytes"])
+	}
+	if ld["oldestMsgId"] != float64(12794319) || ld["newestMsgId"] != float64(12794328) {
+		t.Errorf("oldest/newest msg id = %v/%v, want 12794319/12794328", ld["oldestMsgId"], ld["newestMsgId"])
+	}
+
+	// SEMPv2 call used the private monitor path and passed the select.
+	if !strings.Contains(v2.lastOp.Path, "__private_monitor__") {
+		t.Errorf("SEMPv2 path = %q, want private monitor endpoint", v2.lastOp.Path)
+	}
+	if sel, _ := v2.lastArgs["select"].(string); !strings.Contains(sel, "spooledMsgCount") || !strings.Contains(sel, "bindCount") {
+		t.Errorf("select missing expected fields: %q", sel)
+	}
+	// SEMPv1 request targets the right queue/vpn with detail.
+	if !strings.Contains(v1.lastXML, "<name>sol150260-test</name>") ||
+		!strings.Contains(v1.lastXML, "<vpn-name>vpn_1</vpn-name>") ||
+		!strings.Contains(v1.lastXML, "<detail/>") {
+		t.Errorf("SEMPv1 request malformed: %q", v1.lastXML)
+	}
+}
+
+func TestHandle_EmptyQueueReturnsZeroDepth(t *testing.T) {
+	// Empty queue: num-messages-spooled 0, no oldest/newest msg id.
+	inner := []byte(`<show><queue><queues><queue><info>` +
+		`<message-vpn>vpn_1</message-vpn>` +
+		`<num-messages-spooled>0</num-messages-spooled>` +
+		`<current-spool-usage-in-bytes>0</current-spool-usage-in-bytes>` +
+		`<total-delivered-unacked-msgs>0</total-delivered-unacked-msgs>` +
+		`</info></queue></queues></queue></show>`)
+	v1 := &mockV1{inner: inner}
+	v2 := &mockV2{data: sempv2Envelope()}
+
+	res, err := callHandle(t, v1, v2, defaultParams())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	ld := res.StructuredContent["liveDepth"].(map[string]any)
+	// currentMsgCount is present and zero (explicit 0, not omitted).
+	if ld["currentMsgCount"] != float64(0) {
+		t.Errorf("currentMsgCount = %v, want 0", ld["currentMsgCount"])
+	}
+	// oldest/newest are omitted when the broker does not report them.
+	if _, present := ld["oldestMsgId"]; present {
+		t.Errorf("oldestMsgId should be omitted on an empty queue, got %v", ld["oldestMsgId"])
+	}
+}
+
+func TestHandle_SEMPv1ErrorFailsWhole(t *testing.T) {
+	v1 := &mockV1{err: &sempv1.Error{Kind: sempv1.ErrorKindHTTP, StatusCode: 401}}
+	v2 := &mockV2{data: sempv2Envelope()}
+	if _, err := callHandle(t, v1, v2, defaultParams()); err == nil {
+		t.Fatal("expected error when SEMPv1 fails")
+	}
+}
+
+func TestHandle_SEMPv2ErrorFailsWhole(t *testing.T) {
+	v1 := &mockV1{inner: fixtureXML(t)}
+	v2 := &mockV2{err: errors.New("boom")}
+	if _, err := callHandle(t, v1, v2, defaultParams()); err == nil {
+		t.Fatal("expected error when SEMPv2 fails")
+	}
+}
+
+func TestHandle_MissingParams(t *testing.T) {
+	v1 := &mockV1{inner: fixtureXML(t)}
+	v2 := &mockV2{data: sempv2Envelope()}
+	for _, p := range []map[string]any{
+		{"queueName": "q"},  // no msgVpnName
+		{"msgVpnName": "v"}, // no queueName
+		{"msgVpnName": "", "queueName": ""},
+	} {
+		if _, err := callHandle(t, v1, v2, p); err == nil {
+			t.Errorf("expected error for params %v", p)
+		}
+	}
+}
+
+func TestMetadata(t *testing.T) {
+	m := NewHandler().Metadata()
+	if m.Name != toolName {
+		t.Errorf("Name = %q, want %q", m.Name, toolName)
+	}
+	if !m.Annotations.ReadOnly {
+		t.Error("expected ReadOnly annotation")
+	}
+	if !strings.Contains(m.Description, "currentMsgCount") {
+		t.Error("description should mention currentMsgCount as the authoritative depth")
+	}
+}

--- a/internal/tools/queuemetrics/queue_response.go
+++ b/internal/tools/queuemetrics/queue_response.go
@@ -1,0 +1,54 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queuemetrics
+
+import "encoding/xml"
+
+// queueDetailResponse decodes the fields we need from a SEMPv1
+// <rpc><show><queue><name>..</name><vpn-name>..</vpn-name><detail/></queue></show></rpc>
+// response. The client strips the <rpc>...</rpc> envelope, so the InnerXML we
+// unmarshal starts at <show>; the Go xml path tag walks down to the single
+// <info> block.
+//
+// Unlike SEMPv2 MsgVpnQueue (whose *MsgCount fields are all cumulative), this
+// SEMPv1 block carries the AUTHORITATIVE live state: num-messages-spooled is
+// the current number of messages sitting in the queue, and it decreases as
+// messages are consumed (SOL-150260). Only the live-state fields are decoded;
+// everything else (config, redelivery policy, event thresholds) is already
+// covered by the SEMPv2 half of get-queue-metrics.
+type queueDetailResponse struct {
+	XMLName xml.Name   `xml:"show"`
+	Info    *queueInfo `xml:"queue>queues>queue>info"`
+}
+
+// queueInfo holds the curated live-state fields from the SEMPv1 queue <info>
+// block. Pointer fields with json ",omitempty" so a field the broker omits
+// (e.g. oldest/newest msg id on an empty queue) drops out of the output after
+// the JSON round-trip rather than surfacing as a misleading zero.
+type queueInfo struct {
+	// CurrentMsgCount is the authoritative current queue depth — the number of
+	// messages currently spooled in the queue right now. This is the field the
+	// tool exists to surface; contrast SEMPv2 spooledMsgCount (cumulative).
+	CurrentMsgCount *int64 `xml:"num-messages-spooled" json:"currentMsgCount,omitempty"`
+	// CurrentSpoolUsageBytes is the live spool usage in bytes.
+	CurrentSpoolUsageBytes *int64 `xml:"current-spool-usage-in-bytes" json:"currentSpoolUsageBytes,omitempty"`
+	// DeliveredUnackedMsgCount is the SEMPv1 analogue of SEMPv2 txUnackedMsgCount.
+	DeliveredUnackedMsgCount *int64 `xml:"total-delivered-unacked-msgs" json:"deliveredUnackedMsgCount,omitempty"`
+	// HighWaterMarkBytes is the peak spool usage in bytes.
+	HighWaterMarkBytes *int64 `xml:"high-water-mark-in-bytes" json:"highWaterMarkBytes,omitempty"`
+	// OldestMsgID / NewestMsgID are present only when the queue holds messages.
+	OldestMsgID *int64 `xml:"oldest-msg-id" json:"oldestMsgId,omitempty"`
+	NewestMsgID *int64 `xml:"newest-msg-id" json:"newestMsgId,omitempty"`
+}

--- a/internal/tools/queuemetrics/testdata/show_queue_detail.xml
+++ b/internal/tools/queuemetrics/testdata/show_queue_detail.xml
@@ -1,0 +1,24 @@
+<show>
+  <queue>
+    <queues>
+      <queue>
+        <name>sol150260-test</name>
+        <info>
+          <message-vpn>vpn_1</message-vpn>
+          <durable>true</durable>
+          <access-type>exclusive</access-type>
+          <num-messages-spooled>10</num-messages-spooled>
+          <current-spool-usage-in-mb>0</current-spool-usage-in-mb>
+          <current-spool-usage-in-bytes>340</current-spool-usage-in-bytes>
+          <high-water-mark-in-mb>0</high-water-mark-in-mb>
+          <high-water-mark-in-bytes>340</high-water-mark-in-bytes>
+          <total-delivered-unacked-msgs>0</total-delivered-unacked-msgs>
+          <oldest-msg-id>12794319</oldest-msg-id>
+          <newest-msg-id>12794328</newest-msg-id>
+          <bind-count>0</bind-count>
+          <topic-subscription-count>1</topic-subscription-count>
+        </info>
+      </queue>
+    </queues>
+  </queue>
+</show>

--- a/test/e2e-monitoring/tool-tests.sh
+++ b/test/e2e-monitoring/tool-tests.sh
@@ -402,7 +402,7 @@ test_list_rdps_pagination_b() { test_list_rdps_pagination "broker-b"; }
 
 test_get_queue_metrics_slow_consumer() {
     local broker="$1"
-    local response content bind unacked rx tx spooled1 spooled2
+    local response content bind unacked rx tx spooled1 spooled2 live
 
     response=$(mcp_call_tool "get-queue-metrics" \
         "$(jq -nc --arg b "$broker" --arg q "$F5_QUEUE" \
@@ -415,6 +415,18 @@ test_get_queue_metrics_slow_consumer() {
     tx=$(echo "$content" | jq -r '.queueMetrics.data.txMsgRate')
     spooled1=$(echo "$content" | jq -r '.queueMetrics.data.spooledMsgCount')
     log_info "get-queue-metrics [$broker]: bindCount=$bind txUnackedMsgCount=$unacked (ceiling $F5_MAX_UNACKED) rxMsgRate=$rx txMsgRate=$tx spooledMsgCount=$spooled1"
+
+    # SOL-150260: liveDepth.currentMsgCount (SEMPv1 num-messages-spooled) is the
+    # AUTHORITATIVE current depth. On the backlogged slow-consumer queue it must
+    # be > 0 (messages are sitting there now), and it must be <= the cumulative
+    # spooledMsgCount — the two are different quantities (live vs lifetime), which
+    # is the whole point of this ticket.
+    live=$(echo "$content" | jq -r '.liveDepth.currentMsgCount')
+    log_info "get-queue-metrics [$broker]: liveDepth.currentMsgCount=$live (authoritative current) vs spooledMsgCount=$spooled1 (cumulative)"
+    assert_json_field "$content" '.liveDepth.currentMsgCount > 0' "true" \
+        "get-queue-metrics [$broker]: liveDepth.currentMsgCount must be > 0 on a backlogged queue (got $live)" || return 1
+    assert_json_field "$content" '.liveDepth.currentMsgCount <= .queueMetrics.data.spooledMsgCount' "true" \
+        "get-queue-metrics [$broker]: currentMsgCount ($live) must be <= cumulative spooledMsgCount ($spooled1)" || return 1
 
     # A consumer is bound to the slow-consumer queue.
     assert_json_field "$content" '.queueMetrics.data.bindCount > 0' "true" \


### PR DESCRIPTION
## Summary

`get-queue-metrics` and `list-queues` were surfacing the broker's cumulative
`spooledMsgCount` as if it were live queue depth. This PR reports accurate
current depth instead.

Fixes SOL-150260

## Changes

- **list-queues** (`06cd984`): stop presenting cumulative `spooledMsgCount` as
  live depth in the post-process handler.
- **get-queue-metrics** (`e43fb1f`): reimplemented as a native mixed-protocol Go
  handler (`internal/tools/queuemetrics`) instead of a composite YAML tool — it
  merges the SEMPv2 monitor response with the SEMPv1 show-queue-detail
  `num-messages-spooled` count to report accurate live queue depth.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all green (Go 1.25).
- Native handler unit tests drive the merge with a SEMPv1 `show queue detail`
  XML fixture (`internal/tools/queuemetrics/testdata`), including the
  live-vs-cumulative distinction.
- Verified live against `lab-129-78`: `get-queue-metrics` returns 200 from both
  the SEMPv2 monitor and SEMPv1 detail calls and merges `liveDepth` (SEMPv1
  `num-messages-spooled`) with `queueMetrics` (SEMPv2, incl. cumulative
  `spooledMsgCount`). A nonzero-depth scenario wasn't exercisable on the test
  host (messaging ports closed — no way to publish/spool), so the nonzero
  live-vs-cumulative gap is covered by the unit tests, not live.
- Rebased onto latest `main` (includes #88); 0 behind.
**- Still I'd like to confirm the behaviour against United's setup with more realistic queue/traffic patterns**

## Breaking Changes

None, same tool name and output shape; the depth value is now correct.
