### PR TITLE
fix(safego): recover panics in errgroup worker goroutines [SOL-151514]

### DIFF
--- a/internal/composite/executor.go
+++ b/internal/composite/executor.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
+	"github.com/SolaceDev/solace-broker-mcp/internal/safego"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 )
 
@@ -394,7 +395,7 @@ func (ce *CompositeExecutor) executeBatch(ctx context.Context, batch ExecutionBa
 
 	for _, step := range batch.Steps {
 		step := step // capture loop variable
-		g.Go(func() error {
+		safego.Go(g, func() error {
 			args, err := ResolveArgs(step.Args, execCtx)
 			if err != nil {
 				return fmt.Errorf("tool step %s: failed to resolve args: %w", step.ID, err)

--- a/internal/safego/safego.go
+++ b/internal/safego/safego.go
@@ -1,0 +1,59 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package safego runs work on new goroutines with panic recovery.
+//
+// errgroup does not recover panics in the goroutines it starts, and the
+// request-path recovery nets — recovery.HTTPMiddleware (internal/middleware/
+// recovery) and withRecovery (internal/tools) — trap panics only on their OWN
+// goroutine. A panic on a goroutine that a handler SPAWNS is therefore caught
+// nowhere and crashes the whole multi-session process. safego.Go is that
+// missing net, applied at the point of goroutine creation (SOL-151514).
+package safego
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Go runs fn on a new goroutine managed by g, recovering any panic in fn and
+// converting it into the goroutine's returned error. Use it in place of
+// g.Go(fn) wherever a worker goroutine runs code that could panic: without the
+// recover, a panic escapes the errgroup goroutine and crashes the process,
+// because errgroup does not recover the goroutines it starts.
+//
+// On a recovered panic it logs at ERROR with event="panic_recovered", the panic
+// value's Go TYPE (panic_type) and a stack trace, and returns a generic error
+// carrying only that type. It never logs or returns the panic value's text:
+// panic values are unaudited and can carry arbitrary strings, the same
+// secure-logging rule recovery.HTTPMiddleware and withRecovery apply
+// (docs/internal/secure-logging-rules.md). The stack pinpoints the panic site
+// without echoing the value.
+func Go(g *errgroup.Group, fn func() error) {
+	g.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("recovered panic in worker goroutine",
+					slog.String("event", "panic_recovered"),
+					slog.String("panic_type", fmt.Sprintf("%T", r)),
+					slog.String("stack", string(debug.Stack())))
+				err = fmt.Errorf("worker goroutine panicked (%T)", r)
+			}
+		}()
+		return fn()
+	})
+}

--- a/internal/safego/safego_test.go
+++ b/internal/safego/safego_test.go
@@ -1,0 +1,90 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package safego_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/safego"
+)
+
+// TestGo_ConvertsPanicToError is the core guarantee: a panic in a worker
+// goroutine must not escape to crash the process; it must surface as the
+// group's error. Without the recover in safego.Go this panic escapes the
+// errgroup goroutine and crashes the test binary (errgroup does not recover).
+func TestGo_ConvertsPanicToError(t *testing.T) {
+	var g errgroup.Group
+	safego.Go(&g, func() error {
+		panic("boom")
+	})
+
+	if err := g.Wait(); err == nil {
+		t.Fatal("expected an error from a panicking goroutine, got nil")
+	}
+}
+
+// TestGo_PanicErrorOmitsValueText guards the secure-logging contract: the panic
+// value's text must never reach the returned error (only its Go type may).
+func TestGo_PanicErrorOmitsValueText(t *testing.T) {
+	var g errgroup.Group
+	safego.Go(&g, func() error {
+		panic("super-secret-token-value")
+	})
+
+	err := g.Wait()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if strings.Contains(err.Error(), "super-secret-token-value") {
+		t.Fatalf("panic value text leaked into error: %q", err.Error())
+	}
+}
+
+// TestGo_PassesThroughNormalError confirms the helper is transparent on the
+// non-panic error path — the fn's own error flows through unchanged.
+func TestGo_PassesThroughNormalError(t *testing.T) {
+	sentinel := errors.New("normal failure")
+
+	var g errgroup.Group
+	safego.Go(&g, func() error {
+		return sentinel
+	})
+
+	if err := g.Wait(); !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error to pass through, got %v", err)
+	}
+}
+
+// TestGo_SuccessReturnsNil confirms the happy path is unaffected: fn runs and
+// a nil return stays nil.
+func TestGo_SuccessReturnsNil(t *testing.T) {
+	var g errgroup.Group
+	ran := false
+	safego.Go(&g, func() error {
+		ran = true
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		t.Fatalf("expected nil error on success, got %v", err)
+	}
+	if !ran {
+		t.Fatal("fn was never executed")
+	}
+}

--- a/internal/tools/queuemetrics/handler.go
+++ b/internal/tools/queuemetrics/handler.go
@@ -41,6 +41,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/safego"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
 )
@@ -173,7 +174,7 @@ func (h *Handler) Handle(ctx context.Context, tc *tools.ToolContext, params map[
 
 	g, gCtx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		op := buildSEMPv2Operation()
 		args := map[string]any{
 			"msgVpnName": msgVpnName,
@@ -188,7 +189,7 @@ func (h *Handler) Handle(ctx context.Context, tc *tools.ToolContext, params map[
 		return nil
 	})
 
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		reqXML, err := sempv1DetailXML(msgVpnName, queueName)
 		if err != nil {
 			return fmt.Errorf("%s: building SEMPv1 request: %w", toolName, err)

--- a/internal/tools/sempv1/brokerstatus/handler.go
+++ b/internal/tools/sempv1/brokerstatus/handler.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/safego"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv1"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
 	"golang.org/x/sync/errgroup"
@@ -128,16 +129,16 @@ func (h *Handler) Handle(
 
 	g, gCtx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		return executeAndDecode(gCtx, tc.SEMPv1Client, versionXML, "version", &versionResp)
 	})
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		return executeAndDecode(gCtx, tc.SEMPv1Client, systemXML, "system", &systemResp)
 	})
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		return executeAndDecode(gCtx, tc.SEMPv1Client, memoryXML, "memory", &memoryResp)
 	})
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		return executeAndDecode(gCtx, tc.SEMPv1Client, spoolXML, "message-spool", &spoolResp)
 	})
 

--- a/internal/tools/sempv1/discardstats/handler.go
+++ b/internal/tools/sempv1/discardstats/handler.go
@@ -38,6 +38,7 @@ import (
 	"encoding/xml"
 	"fmt"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/safego"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv1"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
 	"golang.org/x/sync/errgroup"
@@ -160,10 +161,10 @@ func (h *Handler) handleBrokerWide(ctx context.Context, client sempv1.Client) (*
 	)
 
 	g, gCtx := errgroup.WithContext(ctx)
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		return executeAndDecode(gCtx, client, statsClientXML, "client", &clientResp)
 	})
-	g.Go(func() error {
+	safego.Go(g, func() error {
 		return executeAndDecode(gCtx, client, spoolStatsXML, "spool", &spoolResp)
 	})
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
## What was wrong
`errgroup` does not recover panics in the goroutines it starts, and the request-path recovery nets (`recovery.HTTPMiddleware`, `tools.withRecovery` in `internal/tools/register.go`) only trap panics on their own goroutine. A panic in any `g.Go` closure — e.g. `structToMap` in `queuemetrics`, or `applySelect`/`constructRequestBody` on user args in the composite executor — escaped both nets and crashed the entire multi-session server process. This is the spawned-goroutine gap the `recovery` package doc explicitly calls out (`internal/middleware/recovery/middleware.go:65-70`).

## What the fix does
Adds `internal/safego.Go(g, fn)`, which runs `fn` under `g.Go` inside a deferred `recover()` that converts a panic into the goroutine's returned error — logging the panic's Go type and stack only, never its value text (matching the secure-logging rule the other two nets follow). A worker panic now fails that one request instead of the whole process. Applied to all four `errgroup` call sites: `queuemetrics`, `discardstats`, `brokerstatus`, and the composite executor. The happy path is unchanged. A neutral leaf package was required because `internal/composite` cannot import `internal/tools` (import cycle).

## Tests
- Added `TestGo_ConvertsPanicToError`: a panic in a worker goroutine surfaces as `g.Wait()`'s error instead of escaping.
- Added `TestGo_PanicErrorOmitsValueText`: the panic value's text never reaches the returned error.
- Added `TestGo_PassesThroughNormalError`: a normal `fn` error flows through unchanged.
- Added `TestGo_SuccessReturnsNil`: the success path is unaffected.
- Revert-verify: with the recover removed, `TestGo_ConvertsPanicToError` fails (panic escapes and crashes the runner); with it restored, all pass. Full race-enabled suite green.

## Jira
[SOL-151514](https://sol-jira.atlassian.net/browse/SOL-151514)

🤖 Generated with [good:fix](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-151514]: https://sol-jira.atlassian.net/browse/SOL-151514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ