### PR TITLE
fix(sempv1): bound broker error text at capture [SOL-151516]

### DIFF
--- a/internal/semp/sempv1/envelope.go
+++ b/internal/semp/sempv1/envelope.go
@@ -49,7 +49,7 @@ func parseReply(body []byte) ([]byte, *Error) {
 		return nil, &Error{
 			Kind:       ErrorKindParse,
 			StatusCode: 200,
-			Message:    *r.ParseError,
+			Message:    truncateErrorText(*r.ParseError),
 			Body:       body,
 		}
 	}
@@ -57,7 +57,7 @@ func parseReply(body []byte) ([]byte, *Error) {
 		return nil, &Error{
 			Kind:       ErrorKindPermission,
 			StatusCode: 200,
-			Message:    *r.PermissionError,
+			Message:    truncateErrorText(*r.PermissionError),
 			Body:       body,
 		}
 	}
@@ -65,7 +65,7 @@ func parseReply(body []byte) ([]byte, *Error) {
 		return nil, &Error{
 			Kind:       ErrorKindLimit,
 			StatusCode: 200,
-			Message:    *r.LimitError,
+			Message:    truncateErrorText(*r.LimitError),
 			Body:       body,
 		}
 	}
@@ -75,7 +75,7 @@ func parseReply(body []byte) ([]byte, *Error) {
 		return nil, &Error{
 			Kind:       ErrorKindExecuteFail,
 			StatusCode: 200,
-			Message:    r.ExecuteResult.Reason,
+			Message:    truncateErrorText(r.ExecuteResult.Reason),
 			ReasonCode: r.ExecuteResult.ReasonCode,
 			Body:       body,
 		}

--- a/internal/semp/sempv1/errors.go
+++ b/internal/semp/sempv1/errors.go
@@ -6,7 +6,40 @@
 // sempv2.SEMPError.
 package sempv1
 
-import "fmt"
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// maxErrorTextLen bounds broker-controlled error text (Error.Message) captured
+// from an <rpc-reply>. The response body is capped at 16 MiB
+// (defaults.MaxSEMPResponseBytes), so without this bound a misbehaving broker
+// or intermediary can push a multi-MiB string into every sink that renders the
+// message: Error.Error() (logged as the tool-result "detail" field) and the
+// agent-facing message built by the tools layer (which also runs it through
+// regex sanitization). Truncating at capture bounds all of them at once. This
+// mirrors sempv2's maxErrorTextLen; 4 KiB comfortably holds any real SEMP error
+// text. (Error.Body is deliberately not truncated here — it is a debug-only
+// field that no sink renders.)
+const maxErrorTextLen = 4096
+
+// truncationMarker is appended to error text cut at maxErrorTextLen.
+const truncationMarker = "... [truncated]"
+
+// truncateErrorText caps s at maxErrorTextLen bytes, backing up to a rune
+// boundary so the result stays valid UTF-8, and appends truncationMarker. The
+// cut path concatenates, which allocates a fresh string, so an oversized
+// input's backing array is never retained.
+func truncateErrorText(s string) string {
+	if len(s) <= maxErrorTextLen {
+		return s
+	}
+	cut := maxErrorTextLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + truncationMarker
+}
 
 // ErrorKind classifies a SEMPv1 failure so callers can branch without parsing
 // the raw response body. A zero-valued Kind (ErrorKindUnknown) indicates a

--- a/internal/semp/sempv1/truncate_test.go
+++ b/internal/semp/sempv1/truncate_test.go
@@ -1,0 +1,78 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sempv1
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTruncateErrorText covers the helper directly: short input is returned
+// unchanged; oversized input is cut to the cap plus marker and stays valid
+// UTF-8 (no rune split).
+func TestTruncateErrorText(t *testing.T) {
+	t.Run("short input unchanged", func(t *testing.T) {
+		in := "a normal broker error"
+		if got := truncateErrorText(in); got != in {
+			t.Errorf("short input changed: got %q want %q", got, in)
+		}
+	})
+
+	t.Run("oversized input truncated with marker", func(t *testing.T) {
+		in := strings.Repeat("A", maxErrorTextLen*4)
+		got := truncateErrorText(in)
+		if len(got) > maxErrorTextLen+len(truncationMarker) {
+			t.Errorf("not truncated: len=%d, cap=%d", len(got), maxErrorTextLen+len(truncationMarker))
+		}
+		if !strings.HasSuffix(got, truncationMarker) {
+			t.Errorf("missing truncation marker; tail=%q", got[len(got)-len(truncationMarker):])
+		}
+	})
+
+	t.Run("multibyte input stays valid UTF-8", func(t *testing.T) {
+		// '€' is 3 bytes; a run of them crosses the cap mid-rune, exercising
+		// the rune-boundary backup.
+		got := truncateErrorText(strings.Repeat("€", maxErrorTextLen))
+		if !strings.HasSuffix(got, truncationMarker) {
+			t.Fatalf("expected truncation, got tail %q", got[len(got)-len(truncationMarker):])
+		}
+		body := strings.TrimSuffix(got, truncationMarker)
+		if !strings.ContainsRune(body, '€') || strings.ContainsRune(body, '�') {
+			t.Errorf("truncation split a rune: %q", body[len(body)-6:])
+		}
+	})
+}
+
+// TestParseReply_TruncatesOversizedMessage proves the capture-site fix: a
+// broker <parse-error> larger than the cap yields a bounded Error.Message,
+// so Error(), the tool log detail, and the agent message are all bounded.
+func TestParseReply_TruncatesOversizedMessage(t *testing.T) {
+	huge := strings.Repeat("A", maxErrorTextLen*4)
+	body := "<rpc-reply><parse-error>" + huge + "</parse-error></rpc-reply>"
+
+	_, err := parseReply([]byte(body))
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if err.Kind != ErrorKindParse {
+		t.Fatalf("kind mismatch: got %v want %v", err.Kind, ErrorKindParse)
+	}
+	if len(err.Message) > maxErrorTextLen+len(truncationMarker) {
+		t.Errorf("Message not truncated: len=%d", len(err.Message))
+	}
+	if !strings.HasSuffix(err.Message, truncationMarker) {
+		t.Errorf("expected truncation marker on Message")
+	}
+}


### PR DESCRIPTION
## What was wrong
`sempv1.Error.Message` was stored untruncated from the `<parse-error>`, `<permission-error>`, `<limit-error>`, and `<execute-result reason=...>` elements in `parseReply` (`internal/semp/sempv1/envelope.go`). Because the response body is only capped at 16 MiB, a misbehaving or compromised broker could put a multi-MiB string in that text, which then flowed verbatim into `Error.Error()` (logged as the tool-result `detail` field at `manager.go:313`) and through the tool layer's three regex-pass `sanitizeBrokerText` into the agent-facing message (`tools/errors.go:222`). SEMPv2 already truncates the equivalent text at capture (`maxErrorTextLen = 4096`); SEMPv1 did not.

## What the fix does
Adds `truncateErrorText` to `internal/semp/sempv1/errors.go` (rune-safe, 4 KiB cap + `... [truncated]` marker, mirroring the SEMPv2 client) and applies it to the four `Message` capture sites in `parseReply`. Truncating at capture bounds every downstream sink at once.

`Error.Body` is deliberately left untouched: a grep confirms no sink renders it (`Error()` ignores it; the HTTP-error agent message is generic), so it is debug-only transient memory. This is a documented, intentional divergence from SEMPv2, whose `Body` *is* a rendered fallback.

## Tests
- Added `TestTruncateErrorText`: short input unchanged; oversized input cut to cap + marker; multibyte (`€`) input stays valid UTF-8 (rune-boundary backup).
- Added `TestParseReply_TruncatesOversizedMessage`: an oversized `<parse-error>` yields a bounded `Error.Message` ending in the marker.
- Revert-verify: un-wrapping the ParseError assignment made `TestParseReply_TruncatesOversizedMessage` fail (Message = full 16384 bytes); restoring passed. Full sempv1 race suite green.

## Jira
[SOL-151516](https://sol-jira.atlassian.net/browse/SOL-151516)

🤖 Generated with [good:fix](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-151516]: https://sol-jira.atlassian.net/browse/SOL-151516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ