### PR TITLE
fix(resilience): bound the overall SEMP retry chain with a deadline [SOL-151518]

### DIFF
--- a/internal/semp/resilience/sender.go
+++ b/internal/semp/resilience/sender.go
@@ -43,9 +43,10 @@ type Sender struct {
 	retryClient   *retryablehttp.Client
 	authenticator auth.Authenticator // for 401 re-auth: delegates recovery to the auth mode
 	rateLimiter   <-chan time.Time
-	rateTicker    *time.Ticker // non-nil when rate limiting enabled; stopped by Close()
-	sem           Semaphore    // bounds in-flight requests; shared per-broker across SEMPv1+v2
-	brokerURL     string       // for logging context
+	rateTicker    *time.Ticker  // non-nil when rate limiting enabled; stopped by Close()
+	sem           Semaphore     // bounds in-flight requests; shared per-broker across SEMPv1+v2
+	brokerURL     string        // for logging context
+	retryBudget   time.Duration // overall deadline for the whole retry chain; 0 disables
 }
 
 // New creates a Sender configured for a specific broker. It sets up retryablehttp
@@ -87,6 +88,20 @@ func New(httpClient *http.Client, sempCfg *config.SEMPConfig, authn auth.Authent
 	retryClient.ErrorHandler = d.errorHandler
 	retryClient.Logger = nil // manual logging in checkRetry
 	d.retryClient = retryClient
+
+	// Overall retry-chain deadline. httpClient.Timeout bounds a single attempt,
+	// but retryablehttp issues up to RetryMax+1 attempts with backoff between
+	// them, and the per-broker semaphore slot (see Do) is held for that entire
+	// span. Without an overall deadline a slow or degraded broker keeps a slot
+	// for the full chain, stalling every other call to that broker. Bound it at
+	// the retry policy's own configured worst case — every attempt at its full
+	// timeout plus every backoff at its cap — so the slot is released once that
+	// budget is spent even if a per-attempt guard is missing or misbehaves. It
+	// never cuts a chain that stays within its configured budget. Zero when
+	// RequestTimeoutDuration is unset (e.g. some tests); Do then skips it.
+	retryMax := *sempCfg.Retries
+	d.retryBudget = time.Duration(retryMax+1)*sempCfg.RequestTimeoutDuration +
+		time.Duration(retryMax)*sempCfg.RetryMaxInterval
 
 	// Per-broker rate limiter: ticker-based interval enforcement.
 	// When interval > 0, each Do() blocks until the ticker fires.
@@ -137,6 +152,19 @@ func (d *Sender) Do(ctx context.Context, req *http.Request) (*http.Response, err
 	}
 	defer func() { <-d.sem }()
 
+	// Bound the whole retry chain (all attempts + backoffs), not just each
+	// attempt, so a slow or degraded broker cannot pin resources for its full
+	// chain. WithTimeout composes with any earlier caller deadline (it takes the
+	// sooner of the two), and retryablehttp honors ctx cancellation during
+	// backoff. cancel must not run while the caller is still reading the
+	// response body, so on success it is transferred to Body.Close (below)
+	// rather than deferred here — a premature cancel would abort the connection
+	// instead of returning it to the idle pool and could truncate the body.
+	var cancel context.CancelFunc
+	if d.retryBudget > 0 {
+		ctx, cancel = context.WithTimeout(ctx, d.retryBudget)
+	}
+
 	// Attach per-request retry state for checkRetry, including the HTTP method
 	// so the non-idempotent method guard can fire even on connection errors
 	// (where resp is nil and resp.Request.Method is unavailable), and the
@@ -149,10 +177,42 @@ func (d *Sender) Do(ctx context.Context, req *http.Request) (*http.Response, err
 
 	retryReq, err := retryablehttp.FromRequest(req)
 	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
 		return nil, fmt.Errorf("wrapping request: %w", err)
 	}
 
-	return d.retryClient.Do(retryReq)
+	resp, err := d.retryClient.Do(retryReq)
+	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
+		return nil, err
+	}
+
+	// Success: the body is returned open for the caller to read. Release the
+	// deadline's timer when the caller closes the body, so the deadline still
+	// bounds the read but the connection is pooled normally.
+	if cancel != nil {
+		resp.Body = &cancelOnCloseReadCloser{ReadCloser: resp.Body, cancel: cancel}
+	}
+	return resp, nil
+}
+
+// cancelOnCloseReadCloser wraps a response body so closing it also cancels the
+// retry-chain deadline's context. This defers the cancel from Do's return (when
+// the body is still open for the caller to read) to Body.Close, so the deadline
+// covers the read without a premature cancel aborting the pooled connection.
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseReadCloser) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
 }
 
 // Close releases resources held by the Sender. Stops the rate limiter ticker

--- a/internal/semp/resilience/sender.go
+++ b/internal/semp/resilience/sender.go
@@ -97,7 +97,15 @@ func New(httpClient *http.Client, sempCfg *config.SEMPConfig, authn auth.Authent
 	// the retry policy's own configured worst case — every attempt at its full
 	// timeout plus every backoff at its cap — so the slot is released once that
 	// budget is spent even if a per-attempt guard is missing or misbehaves. It
-	// never cuts a chain that stays within its configured budget.
+	// never cuts a chain whose backoffs stay within RetryMaxInterval.
+	//
+	// Exception: RateLimitLinearJitterBackoff (below) honors a broker's
+	// Retry-After header verbatim, uncapped by RetryMaxInterval. A broker that
+	// returns a long Retry-After can make this deadline fire mid-chain, cutting
+	// the retry short. That is intentional, not a bug: without this deadline, a
+	// degraded broker returning e.g. Retry-After: 300 would park the slot (and
+	// every other call to that broker) for the full 300s per attempt regardless
+	// of the configured budget. This deadline is what caps that exposure.
 	//
 	// The RetryMax+1 term counts the successful attempt too, so after up to
 	// RetryMax failed attempts (each ≤ RequestTimeoutDuration) plus their

--- a/internal/semp/resilience/sender.go
+++ b/internal/semp/resilience/sender.go
@@ -106,13 +106,17 @@ func New(httpClient *http.Client, sempCfg *config.SEMPConfig, authn auth.Authent
 	// body read, which the deadline also covers. That matches the per-attempt
 	// http.Client.Timeout, so the read is never bounded more tightly than before.
 	//
-	// Production always sets RequestTimeoutDuration > 0 (validate() enforces it),
-	// so the budget is applied. It is only zero — and Do skips the deadline — when
-	// a config is built with RequestTimeoutDuration == 0 AND either no retries or
-	// RetryMaxInterval == 0 (some direct-construction tests).
-	retryMax := *sempCfg.Retries
-	d.retryBudget = time.Duration(retryMax+1)*sempCfg.RequestTimeoutDuration +
-		time.Duration(retryMax)*sempCfg.RetryMaxInterval
+	// The budget is anchored on the per-attempt timeout, so it is only computed
+	// when RequestTimeoutDuration > 0. Production always sets it (validate()
+	// enforces it), so the deadline is always applied there. When it is unset
+	// (a direct-construction test), retryBudget stays 0 and Do skips the
+	// deadline — a backoff-only budget would allot no time to the attempts
+	// themselves and fire spuriously under load.
+	if sempCfg.RequestTimeoutDuration > 0 {
+		retryMax := *sempCfg.Retries
+		d.retryBudget = time.Duration(retryMax+1)*sempCfg.RequestTimeoutDuration +
+			time.Duration(retryMax)*sempCfg.RetryMaxInterval
+	}
 
 	// Per-broker rate limiter: ticker-based interval enforcement.
 	// When interval > 0, each Do() blocks until the ticker fires.

--- a/internal/semp/resilience/sender.go
+++ b/internal/semp/resilience/sender.go
@@ -97,8 +97,19 @@ func New(httpClient *http.Client, sempCfg *config.SEMPConfig, authn auth.Authent
 	// the retry policy's own configured worst case — every attempt at its full
 	// timeout plus every backoff at its cap — so the slot is released once that
 	// budget is spent even if a per-attempt guard is missing or misbehaves. It
-	// never cuts a chain that stays within its configured budget. Zero when
-	// RequestTimeoutDuration is unset (e.g. some tests); Do then skips it.
+	// never cuts a chain that stays within its configured budget.
+	//
+	// The RetryMax+1 term counts the successful attempt too, so after up to
+	// RetryMax failed attempts (each ≤ RequestTimeoutDuration) plus their
+	// backoffs (each ≤ RetryMaxInterval) at least one full RequestTimeoutDuration
+	// of budget always remains for the final attempt — including its response
+	// body read, which the deadline also covers. That matches the per-attempt
+	// http.Client.Timeout, so the read is never bounded more tightly than before.
+	//
+	// Production always sets RequestTimeoutDuration > 0 (validate() enforces it),
+	// so the budget is applied. It is only zero — and Do skips the deadline — when
+	// a config is built with RequestTimeoutDuration == 0 AND either no retries or
+	// RetryMaxInterval == 0 (some direct-construction tests).
 	retryMax := *sempCfg.Retries
 	d.retryBudget = time.Duration(retryMax+1)*sempCfg.RequestTimeoutDuration +
 		time.Duration(retryMax)*sempCfg.RetryMaxInterval

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -120,8 +120,13 @@ func jsonOK(w http.ResponseWriter) {
 // the deadline fires and the slot is released.
 func TestSender_Do_BoundsOverallRetryChainDeadline(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(3 * time.Second)
-		jsonOK(w)
+		// Observe cancellation so the handler returns as soon as the client's
+		// deadline fires; otherwise server.Close() blocks on the full sleep.
+		select {
+		case <-time.After(3 * time.Second):
+			jsonOK(w)
+		case <-r.Context().Done():
+		}
 	}))
 	defer server.Close()
 

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -170,6 +170,74 @@ func TestSender_Do_BoundsOverallRetryChainDeadline(t *testing.T) {
 	}
 }
 
+// TestSender_Do_RetryBudgetBoundsMultiAttemptChain proves the retryBudget
+// formula holds across a genuine multi-attempt chain, not just the single
+// attempt / zero backoff case above. httpClient.Timeout is set to
+// RequestTimeoutDuration (mirroring production wiring in sempv2/client.go and
+// sempv1/client.go), so a hung broker times out and is retried on every
+// attempt rather than being cut once by the overall deadline. With RetryMax=2
+// the chain runs 3 attempts with backoff between them; elapsed must clear the
+// deterministic 3-attempt floor (proving the chain actually ran to
+// completion, not a short-circuit) and stay within the computed budget plus
+// scheduling slack (proving the deadline is still the ceiling).
+func TestSender_Do_RetryBudgetBoundsMultiAttemptChain(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Never respond inside the per-attempt timeout; observe cancellation so
+		// the handler returns as soon as httpClient.Timeout fires instead of
+		// leaking a goroutine per attempt.
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	retries := 2
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 40 * time.Millisecond,
+		RetryMinInterval:       5 * time.Millisecond,
+		RetryMaxInterval:       15 * time.Millisecond,
+	}
+	httpClient := &http.Client{
+		Timeout:   sempCfg.RequestTimeoutDuration,
+		Transport: server.Client().Transport,
+	}
+	d := New(httpClient, sempCfg, bearerAuth(t), server.URL, NewSemaphore(1))
+
+	wantBudget := time.Duration(retries+1)*sempCfg.RequestTimeoutDuration + time.Duration(retries)*sempCfg.RetryMaxInterval
+	attemptFloor := time.Duration(retries+1) * sempCfg.RequestTimeoutDuration
+
+	start := time.Now()
+	resp, err := d.Do(context.Background(), newGetRequest(t, server.URL))
+	elapsed := time.Since(start)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	if err == nil {
+		t.Fatal("expected an error: every attempt times out and the broker never recovers")
+	}
+	if elapsed < attemptFloor {
+		t.Errorf("elapsed %s is under the %d-attempt floor %s; the chain was short-circuited instead of retrying", elapsed, retries+1, attemptFloor)
+	}
+	if elapsed > wantBudget+100*time.Millisecond {
+		t.Errorf("elapsed %s exceeded the retry budget %s by more than scheduling slack", elapsed, wantBudget)
+	}
+	var exhausted *RetriesExhaustedError
+	if errors.As(err, &exhausted) && exhausted.Attempts != retries+1 {
+		t.Errorf("expected %d attempts (RetryMax+1) on natural exhaustion, got %d", retries+1, exhausted.Attempts)
+	}
+
+	// The semaphore slot must be released once the chain ends, whether it ended
+	// via natural exhaustion or the overall deadline.
+	select {
+	case d.sem <- struct{}{}:
+		<-d.sem
+	default:
+		t.Error("semaphore slot was not released after the chain ended")
+	}
+}
+
 // TestSender_Do_NoOverallDeadlineWhenPerAttemptTimeoutUnset proves the overall
 // retry-chain deadline is disabled (retryBudget == 0) when RequestTimeoutDuration
 // is unset, even with RetryMaxInterval set. The budget is anchored on the

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -170,6 +170,52 @@ func TestSender_Do_BoundsOverallRetryChainDeadline(t *testing.T) {
 	}
 }
 
+// TestSender_Do_NoOverallDeadlineWhenPerAttemptTimeoutUnset proves the overall
+// retry-chain deadline is disabled (retryBudget == 0) when RequestTimeoutDuration
+// is unset, even with RetryMaxInterval set. The budget is anchored on the
+// per-attempt timeout; a backoff-only budget would allot no time to the attempts
+// themselves and fire spuriously. This guards against the earlier math that
+// computed retryMax*RetryMaxInterval regardless of the per-attempt timeout.
+func TestSender_Do_NoOverallDeadlineWhenPerAttemptTimeoutUnset(t *testing.T) {
+	// Server responds only after 100ms — longer than the (hypothetical)
+	// backoff-only budget of retryMax*RetryMaxInterval = 3*10ms = 30ms. If that
+	// budget were applied, the call would be cut with DeadlineExceeded.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(100 * time.Millisecond):
+			jsonOK(w)
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+
+	retries := 3
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 0, // unset per-attempt timeout: overall deadline disabled
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
+	}
+	httpClient := &http.Client{Transport: server.Client().Transport}
+	d := New(httpClient, sempCfg, bearerAuth(t), server.URL, NewSemaphore(1))
+
+	// Directly falsify the finding: no per-attempt timeout means no budget. The
+	// earlier math produced retryMax*RetryMaxInterval (30ms) here.
+	if d.retryBudget != 0 {
+		t.Fatalf("retryBudget = %s, want 0 when RequestTimeoutDuration is unset", d.retryBudget)
+	}
+
+	// Behavioral confirmation: Do applies no context.WithTimeout, so the slow
+	// request completes normally rather than being cut by an overall deadline.
+	resp, err := d.Do(context.Background(), newGetRequest(t, server.URL))
+	if err != nil {
+		t.Fatalf("Do returned error, expected success with no overall deadline: %v", err)
+	}
+	resp.Body.Close()
+}
+
 func TestSender_RateLimiter_BlocksUntilChannelReady(t *testing.T) {
 	var requestCount atomic.Int32
 	sender, server := newTestSenderWithServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -46,10 +46,11 @@ func newTestSender(t *testing.T, httpClient *http.Client, authn auth.Authenticat
 	t.Helper()
 	minInterval := time.Duration(0)
 	sempCfg := &config.SEMPConfig{
-		Retries:            &retries,
-		RequestMinInterval: &minInterval,
-		RetryMinInterval:   1 * time.Millisecond,
-		RetryMaxInterval:   10 * time.Millisecond,
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 30 * time.Second, // generous per-attempt + overall budget for tests
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
 	}
 	return New(httpClient, sempCfg, authn, "http://test-broker", NewSemaphore(10))
 }
@@ -60,10 +61,11 @@ func newTestSenderBasic(t *testing.T, httpClient *http.Client, retries int) *Sen
 	t.Helper()
 	minInterval := time.Duration(0)
 	sempCfg := &config.SEMPConfig{
-		Retries:            &retries,
-		RequestMinInterval: &minInterval,
-		RetryMinInterval:   1 * time.Millisecond,
-		RetryMaxInterval:   10 * time.Millisecond,
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 30 * time.Second, // generous per-attempt + overall budget for tests
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
 	}
 	jar := mustNewSafeCookieJar(t)
 	httpClient.Jar = jar
@@ -111,6 +113,57 @@ func jsonOK(w http.ResponseWriter) {
 }
 
 // --- Rate Limiter Tests ---
+
+// TestSender_Do_BoundsOverallRetryChainDeadline proves the overall retry-chain
+// deadline bounds a call even when the per-attempt httpClient.Timeout is absent
+// (0). A slow broker must not pin the semaphore slot for the full server delay:
+// the deadline fires and the slot is released.
+func TestSender_Do_BoundsOverallRetryChainDeadline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		jsonOK(w)
+	}))
+	defer server.Close()
+
+	retries := 0
+	minInterval := time.Duration(0)
+	sempCfg := &config.SEMPConfig{
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 100 * time.Millisecond, // retryBudget = 1*100ms = 100ms
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
+	}
+	// No per-attempt Timeout, so only the overall retry-chain deadline can bound
+	// the call.
+	httpClient := &http.Client{Transport: server.Client().Transport}
+	d := New(httpClient, sempCfg, bearerAuth(t), server.URL, NewSemaphore(1))
+
+	start := time.Now()
+	resp, err := d.Do(context.Background(), newGetRequest(t, server.URL))
+	elapsed := time.Since(start)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	if err == nil {
+		t.Fatal("expected an error from the overall retry-chain deadline, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded in the chain, got %v", err)
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("Do did not honor the overall deadline: took %s (budget ~100ms)", elapsed)
+	}
+	// The semaphore slot must be released: a fresh acquire on the size-1
+	// semaphore must succeed immediately rather than block.
+	select {
+	case d.sem <- struct{}{}:
+		<-d.sem
+	default:
+		t.Error("semaphore slot was not released after the deadline fired")
+	}
+}
 
 func TestSender_RateLimiter_BlocksUntilChannelReady(t *testing.T) {
 	var requestCount atomic.Int32
@@ -568,10 +621,11 @@ func TestSender_ErrorHandler_NetworkError_ProducesRetriesExhaustedError(t *testi
 	retries := 2
 	minInterval := time.Duration(0)
 	sempCfg := &config.SEMPConfig{
-		Retries:            &retries,
-		RequestMinInterval: &minInterval,
-		RetryMinInterval:   1 * time.Millisecond,
-		RetryMaxInterval:   10 * time.Millisecond,
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 30 * time.Second, // generous per-attempt + overall budget for tests
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
 	}
 	jar := mustNewSafeCookieJar(t)
 	sender := New(&http.Client{Jar: jar}, sempCfg, basicAuth(t, jar), serverURL, NewSemaphore(10))
@@ -713,10 +767,11 @@ func TestSender_NoRetry_POST_ConnectionError(t *testing.T) {
 	retries := 5
 	minInterval := time.Duration(0)
 	sempCfg := &config.SEMPConfig{
-		Retries:            &retries,
-		RequestMinInterval: &minInterval,
-		RetryMinInterval:   1 * time.Millisecond,
-		RetryMaxInterval:   10 * time.Millisecond,
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 30 * time.Second, // generous per-attempt + overall budget for tests
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
 	}
 	jar := mustNewSafeCookieJar(t)
 	sender := New(&http.Client{Jar: jar}, sempCfg, basicAuth(t, jar), serverURL, NewSemaphore(10))
@@ -752,10 +807,11 @@ func TestSender_NoRetry_PATCH_ConnectionError(t *testing.T) {
 	retries := 5
 	minInterval := time.Duration(0)
 	sempCfg := &config.SEMPConfig{
-		Retries:            &retries,
-		RequestMinInterval: &minInterval,
-		RetryMinInterval:   1 * time.Millisecond,
-		RetryMaxInterval:   10 * time.Millisecond,
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 30 * time.Second, // generous per-attempt + overall budget for tests
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
 	}
 	jar := mustNewSafeCookieJar(t)
 	sender := New(&http.Client{Jar: jar}, sempCfg, basicAuth(t, jar), serverURL, NewSemaphore(10))
@@ -809,10 +865,11 @@ func newTestSenderWithSem(t *testing.T, httpClient *http.Client, serverURL strin
 	retries := 0
 	minInterval := time.Duration(0)
 	sempCfg := &config.SEMPConfig{
-		Retries:            &retries,
-		RequestMinInterval: &minInterval,
-		RetryMinInterval:   1 * time.Millisecond,
-		RetryMaxInterval:   10 * time.Millisecond,
+		Retries:                &retries,
+		RequestMinInterval:     &minInterval,
+		RequestTimeoutDuration: 30 * time.Second, // generous per-attempt + overall budget for tests
+		RetryMinInterval:       1 * time.Millisecond,
+		RetryMaxInterval:       10 * time.Millisecond,
 	}
 	jar := mustNewSafeCookieJar(t)
 	httpClient.Jar = jar


### PR DESCRIPTION
## What was wrong
`Sender.Do` (`internal/semp/resilience/sender.go`) holds the per-broker semaphore slot across `retryablehttp`'s entire retry chain, but there was no explicit overall deadline on that chain. On the correctly-configured path (`httpClient.Timeout == RequestTimeoutDuration`, as both `sempv1` and `sempv2` clients wire it), the total wall-clock was already bounded — but only *emergently*, by three settings lining up (`Retries+1) × RequestTimeoutDuration + Retries × RetryMaxInterval`) rather than by one explicit, tested invariant.

There's one case where those three settings do **not** bound the chain: `RateLimitLinearJitterBackoff` honors a broker's `Retry-After` header verbatim, uncapped by `RetryMaxInterval`. A broker returning a long `Retry-After` (minutes) could hold a slot for that long per attempt, stalling every other call to that broker once all slots are pinned — that gap is real, not emergent.

## What the fix does
`New()` derives `retryBudget = (RetryMax+1)*RequestTimeout + RetryMax*RetryMaxInterval` — the retry policy's own configured worst case, from existing config (no new knob). `Do` applies it via `context.WithTimeout`. `retryablehttp` honors ctx cancellation during backoff (`client.go:785`), so the slot is released once the budget is spent even if a per-attempt guard is missing or misbehaves.

On the correctly-configured path this is hardening, not a behavior change: it makes an already-implied bound explicit and covered by a test, so it stops depending on three settings staying in sync. On the `Retry-After` path it's a real fix: it caps exposure to a broker announcing an arbitrarily long `Retry-After` instead of letting it park the slot for however long the broker asks.

On success the `cancel` is transferred to `Body.Close` (via a small `cancelOnCloseReadCloser` wrapper) rather than deferred at `Do`'s return — deferring would cancel the request context while the caller is still reading the open response body, aborting the connection instead of pooling it and potentially truncating the body. A zero budget (`RequestTimeout` unset, e.g. some tests) skips the deadline.

## Tests
- Added `TestSender_Do_BoundsOverallRetryChainDeadline`: with **no** per-attempt `httpClient.Timeout` and a slow broker, `Do` returns at ~budget with `context.DeadlineExceeded` and the semaphore slot is released (proves the overall deadline is the effective bound).
- Added `TestSender_Do_RetryBudgetBoundsMultiAttemptChain`: a real `RetryMax=2` chain (3 attempts + backoff, `httpClient.Timeout` wired like production) rather than the single-attempt/zero-backoff case above — elapsed is checked against both the deterministic attempt floor and the budget ceiling.
- Existing `TestClient_TransportPool_ReusesConnections` guards the success-path body/connection behavior — it caught an early `defer cancel()` version and passes with the cancel-on-close design.
- Test helpers now set a realistic `RequestTimeoutDuration` so their budgets are generous.
- Revert-verify: disabling the `WithTimeout` made the new test block ~3s and return no deadline error; restoring passed. Full `internal/semp` race suite green; `go vet` clean.

## Jira
[SOL-151518](https://sol-jira.atlassian.net/browse/SOL-151518)

🤖 Generated with [good:fix](https://github.com/SolaceDev/solly-marketplace) (Claude Code)

[SOL-151518]: https://sol-jira.atlassian.net/browse/SOL-151518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
