### PR TITLE
feat(cmd/server): second signal forces immediate shutdown [SOL-151437]

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -295,15 +295,44 @@ func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error 
 // the full shutdownTimeout to drain in-flight requests, exactly as the K8s
 // terminationGracePeriodSeconds calculation in deploy/kubernetes/deployment.yaml
 // assumes (grace = drainDelay + shutdownTimeout + buffer).
-func drainAndShutdown(srv shutdowner, readiness *health.ReadinessState, drainDelay, shutdownTimeout time.Duration) error {
+//
+// forceSig carries a SECOND shutdown signal (SOL-151437). A second SIGINT/SIGTERM
+// arriving while the drain window is sleeping short-circuits the rest of the
+// sequence: forceClose drops in-flight connections and we return immediately,
+// skipping the graceful wait. Readiness has already flipped to 503 above, so a
+// forced exit still leaves /readyz correct. A nil forceSig (the startup-error
+// path, which never drains) simply never fires that select case.
+func drainAndShutdown(srv shutdowner, readiness *health.ReadinessState, drainDelay, shutdownTimeout time.Duration, forceSig <-chan os.Signal) error {
 	readiness.SetShuttingDown()
 	slog.Info("draining before shutdown",
 		slog.String("reason", "signal"),
 		slog.Duration("drain_delay", drainDelay))
 	if drainDelay > 0 {
-		time.Sleep(drainDelay)
+		timer := time.NewTimer(drainDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			// Drain window elapsed normally; fall through to the graceful wait.
+		case sig := <-forceSig:
+			forceClose(srv, sig)
+			return nil
+		}
 	}
-	return gracefulShutdown(srv, shutdownTimeout)
+	return gracefulShutdown(srv, shutdownTimeout, forceSig)
+}
+
+// forceClose is the shared "second signal" reaction (SOL-151437): a single WARN
+// line naming the triggering signal, then srv.Close() to drop in-flight
+// connections immediately. Close is the only way to actually drop connections —
+// cancelling Shutdown's context would merely stop the wait and leave them open.
+// http.Server.Close is safe to call even if Shutdown is concurrently running or
+// has already returned, so this never double-closes.
+func forceClose(srv shutdowner, sig os.Signal) {
+	slog.Warn("second signal received, forcing immediate shutdown; in-flight connections dropped without draining",
+		slog.String("signal", sig.String()))
+	if err := srv.Close(); err != nil {
+		slog.Error("forced close failed", slog.String("error", err.Error()))
+	}
 }
 
 // drainDelayForSignal returns the drain delay to apply for the received
@@ -342,17 +371,35 @@ type shutdowner interface {
 // moment Shutdown begins. On the signal path this happens AFTER drainAndShutdown
 // has already slept the drain delay, so the drain delay never consumes any of
 // the shutdown budget.
-func gracefulShutdown(srv shutdowner, timeout time.Duration) error {
+//
+// forceSig carries a SECOND shutdown signal (SOL-151437). Shutdown runs in a
+// goroutine so we can select between it completing and a second signal arriving:
+// on a second signal forceClose drops in-flight connections (which also unblocks
+// the in-flight Shutdown) and we return immediately. The result channel is
+// buffered so that goroutine can always send and exit even after we have
+// returned via the force path — no goroutine leak. A nil forceSig (the
+// startup-error path) never fires that case, so that path keeps its exact
+// prior behavior, including the Shutdown-timed-out forced-close fallback.
+func gracefulShutdown(srv shutdowner, timeout time.Duration, forceSig <-chan os.Signal) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	err := srv.Shutdown(ctx)
-	if err != nil {
-		slog.Error("shutdown timed out, forcing close", slog.String("error", err.Error()))
-		if closeErr := srv.Close(); closeErr != nil {
-			slog.Error("forced close failed", slog.String("error", closeErr.Error()))
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- srv.Shutdown(ctx) }()
+
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			slog.Error("shutdown timed out, forcing close", slog.String("error", err.Error()))
+			if closeErr := srv.Close(); closeErr != nil {
+				slog.Error("forced close failed", slog.String("error", closeErr.Error()))
+			}
 		}
+		return err
+	case sig := <-forceSig:
+		forceClose(srv, sig)
+		return nil
 	}
-	return err
 }
 
 // registerSEMPv1Tools attaches every Go-native SEMPv1 tool handler to mgr.
@@ -664,7 +711,12 @@ func main() {
 	addr := cfg.BindAddress()
 	httpServer := newHTTPServer(addr, rootHandler)
 
-	done := make(chan os.Signal, 1)
+	// Buffered at 2 (SOL-151437) so a rapidly delivered SECOND signal is not
+	// dropped in the window between main()'s first receive and the shutdown
+	// path arming its own select on this channel. signal.Notify does a
+	// non-blocking send, so a full buffer would silently discard the "I mean
+	// it, exit now" signal.
+	done := make(chan os.Signal, 2)
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
 
 	serverErr := startServer(httpServer, cfg.TLSCertFile, cfg.TLSKeyFile)
@@ -712,9 +764,13 @@ func main() {
 
 	if fromSignal {
 		drainDelay := drainDelayForSignal(receivedSignal, time.Duration(cfg.Observability.ShutdownDrainDelayS)*time.Second)
-		_ = drainAndShutdown(httpServer, readiness, drainDelay, shutdownTimeout)
+		// Pass the still-registered signal channel so a second SIGINT/SIGTERM
+		// during the drain or graceful wait forces an immediate close (SOL-151437).
+		_ = drainAndShutdown(httpServer, readiness, drainDelay, shutdownTimeout, done)
 	} else {
-		_ = gracefulShutdown(httpServer, shutdownTimeout)
+		// Startup-error path never began serving, so there is nothing to drain
+		// and no second-signal semantics: pass a nil force channel.
+		_ = gracefulShutdown(httpServer, shutdownTimeout, nil)
 	}
 
 	slog.Info("server stopped")

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -16,9 +16,12 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -101,7 +104,7 @@ func TestDrainAndShutdown_FlipsReadyzBeforeDelay(t *testing.T) {
 	}()
 
 	start := time.Now()
-	if err := drainAndShutdown(srv, readiness, drainDelay, 5*time.Second); err != nil {
+	if err := drainAndShutdown(srv, readiness, drainDelay, 5*time.Second, nil); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 	elapsed := time.Since(start)
@@ -132,7 +135,7 @@ func TestDrainAndShutdown_SetsShuttingDownEvenWithZeroDelay(t *testing.T) {
 	readiness := health.NewReadinessState()
 	readiness.SetInitialized()
 
-	if err := drainAndShutdown(srv, readiness, 0, 5*time.Second); err != nil {
+	if err := drainAndShutdown(srv, readiness, 0, 5*time.Second, nil); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 	if !readiness.IsShuttingDown() {
@@ -191,7 +194,7 @@ func TestDrainAndShutdown_ShutdownGetsFullBudgetAfterDrain(t *testing.T) {
 	readiness.SetInitialized()
 
 	start := time.Now()
-	if err := drainAndShutdown(cs, readiness, drainDelay, shutdownTimeout); err != nil {
+	if err := drainAndShutdown(cs, readiness, drainDelay, shutdownTimeout, nil); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 
@@ -235,12 +238,195 @@ func TestGracefulShutdown_ForcedCloseFallback(t *testing.T) {
 	wantErr := context.DeadlineExceeded
 	cs := &captureShutdowner{shutdownErr: wantErr}
 
-	err := gracefulShutdown(cs, 50*time.Millisecond)
+	err := gracefulShutdown(cs, 50*time.Millisecond, nil)
 	if err != wantErr {
 		t.Errorf("gracefulShutdown returned %v, want the original Shutdown error %v", err, wantErr)
 	}
 	if !cs.closeCalled {
 		t.Error("forced Close was not called after Shutdown failed; the fallback is missing")
+	}
+}
+
+// blockingShutdowner is a shutdowner whose Shutdown blocks until Close is
+// called (SOL-151437), so the "second signal forces close" paths can be driven
+// deterministically without any real drain or shutdown sleeps. Shutdown also
+// returns if its context is cancelled, so a broken force path fails the test via
+// the timeout budget rather than hanging forever.
+//
+//   - closeCount records EVERY Close call (not just the first), so a test can
+//     assert Close ran exactly once and would catch a production double-close —
+//     a sync.Once guard would instead silently swallow the second call. The
+//     channel close itself is still guarded by closeOnce so the fake cannot
+//     panic on a double close while we measure it.
+//   - shutdownReturned is closed when Shutdown actually returns, letting a test
+//     prove the Shutdown goroutine unblocked and exited after a forced Close
+//     (AC #5, "no goroutine leak") rather than trusting a comment.
+type blockingShutdowner struct {
+	closed           chan struct{}
+	shutdownReturned chan struct{}
+	closeOnce        sync.Once
+	closeCount       atomic.Int64
+}
+
+func newBlockingShutdowner() *blockingShutdowner {
+	return &blockingShutdowner{
+		closed:           make(chan struct{}),
+		shutdownReturned: make(chan struct{}),
+	}
+}
+
+func (b *blockingShutdowner) Shutdown(ctx context.Context) error {
+	defer close(b.shutdownReturned)
+	select {
+	case <-b.closed:
+		return http.ErrServerClosed
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *blockingShutdowner) Close() error {
+	b.closeCount.Add(1)
+	b.closeOnce.Do(func() { close(b.closed) })
+	return nil
+}
+
+// TestDrainAndShutdown_SecondSignalDuringDrainForcesClose proves AC #1
+// (SOL-151437): a second signal arriving while the drain window is sleeping
+// short-circuits it — forced Close, and the graceful step is skipped — instead
+// of waiting the window out. We use a long drain window the test must NOT wait
+// out; the second signal is pre-armed so the drain select picks it immediately.
+func TestDrainAndShutdown_SecondSignalDuringDrainForcesClose(t *testing.T) {
+	srv := newBlockingShutdowner()
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+
+	// A drain window far longer than this test should ever run. If the second
+	// signal is honored we return in microseconds; if it is dropped we would
+	// block here for 30s and the -timeout guard would fail the run.
+	const drainDelay = 30 * time.Second
+	forceSig := make(chan os.Signal, 1)
+	forceSig <- syscall.SIGTERM
+
+	start := time.Now()
+	if err := drainAndShutdown(srv, readiness, drainDelay, 30*time.Second, forceSig); err != nil {
+		t.Fatalf("drainAndShutdown returned error on forced close: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if got := srv.closeCount.Load(); got != 1 {
+		t.Errorf("forced Close called %d times for a second signal during the drain window, want exactly 1", got)
+	}
+	if elapsed >= drainDelay {
+		t.Errorf("drainAndShutdown waited out the %v drain window (took %v); the second signal must short-circuit it", drainDelay, elapsed)
+	}
+	// Readiness must still have flipped before the forced exit (AC #5 / #2).
+	if !readiness.IsShuttingDown() {
+		t.Error("readiness did not flip to shutting-down before the forced exit")
+	}
+}
+
+// TestDrainAndShutdown_SecondSignalDuringGracefulForcesClose proves AC #2
+// (SOL-151437) through the real production call path: with a zero drain delay
+// (the SIGINT case) drainAndShutdown goes straight to the graceful wait, and a
+// second signal there forces an immediate Close that unblocks the in-flight
+// Shutdown. blockingShutdowner.Shutdown blocks until Close, so the graceful wait
+// is genuinely in progress when the signal arrives.
+func TestDrainAndShutdown_SecondSignalDuringGracefulForcesClose(t *testing.T) {
+	srv := newBlockingShutdowner()
+	readiness := health.NewReadinessState()
+	readiness.SetInitialized()
+
+	forceSig := make(chan os.Signal, 1)
+	forceSig <- syscall.SIGINT
+
+	done := make(chan error, 1)
+	go func() {
+		done <- drainAndShutdown(srv, readiness, 0, 30*time.Second, forceSig)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("drainAndShutdown returned %v on forced close, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainAndShutdown did not return after a second signal during the graceful wait; force path is broken")
+	}
+	if got := srv.closeCount.Load(); got != 1 {
+		t.Errorf("forced Close called %d times for a second signal during the graceful wait, want exactly 1", got)
+	}
+	// AC #5 (no goroutine leak): the Shutdown goroutine spawned by
+	// gracefulShutdown must actually unblock and exit after the forced Close,
+	// not linger. Close (and the deferred context cancel) should release it.
+	select {
+	case <-srv.shutdownReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown goroutine did not return after forced Close; goroutine leak on the force path")
+	}
+}
+
+// recordingHandler is a minimal slog.Handler that captures every record so a
+// test can assert exactly what was logged. It records all levels; the test
+// filters. Guarded by a mutex because slog handlers must be safe for concurrent
+// Handle calls, though these tests log from a single goroutine.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+// TestForceClose_LogsSingleWarnNamingSignal proves AC #4 (SOL-151437): a forced
+// exit emits exactly ONE WARN line, it describes the forced shutdown, and it
+// names the triggering signal. forceClose is the shared reaction for both the
+// drain-window and graceful-wait force paths, so testing it once covers both.
+// It swaps the process-global slog default, so it must not run in parallel with
+// other tests in this package (none here call t.Parallel).
+func TestForceClose_LogsSingleWarnNamingSignal(t *testing.T) {
+	rec := &recordingHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(rec))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	srv := newBlockingShutdowner()
+	forceClose(srv, syscall.SIGTERM)
+
+	var warns []slog.Record
+	for _, r := range rec.records {
+		if r.Level == slog.LevelWarn {
+			warns = append(warns, r)
+		}
+	}
+	if len(warns) != 1 {
+		t.Fatalf("forceClose emitted %d WARN lines, want exactly 1", len(warns))
+	}
+	w := warns[0]
+	if !strings.Contains(w.Message, "forcing immediate shutdown") {
+		t.Errorf("WARN message %q does not describe the forced shutdown", w.Message)
+	}
+	var sigAttr string
+	w.Attrs(func(a slog.Attr) bool {
+		if a.Key == "signal" {
+			sigAttr = a.Value.String()
+		}
+		return true
+	})
+	if sigAttr != syscall.SIGTERM.String() {
+		t.Errorf("WARN signal attr = %q, want the triggering signal %q", sigAttr, syscall.SIGTERM.String())
+	}
+	if got := srv.closeCount.Load(); got != 1 {
+		t.Errorf("forceClose invoked Close %d times, want exactly 1", got)
 	}
 }
 

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -302,9 +302,10 @@ func TestDrainAndShutdown_SecondSignalDuringDrainForcesClose(t *testing.T) {
 	readiness.SetInitialized()
 
 	// A drain window far longer than this test should ever run. If the second
-	// signal is honored we return in microseconds; if it is dropped we would
-	// block here for 30s and the -timeout guard would fail the run.
-	const drainDelay = 30 * time.Second
+	// signal is honored we return in microseconds; if it is dropped we fail
+	// fast on the elapsed-time assertion below rather than waiting out the
+	// full window and relying on the -timeout guard to catch the regression.
+	const drainDelay = 3 * time.Second
 	forceSig := make(chan os.Signal, 1)
 	forceSig <- syscall.SIGTERM
 


### PR DESCRIPTION
## What

Once graceful shutdown begins, a **second** SIGINT/SIGTERM now forces an immediate exit instead of being buffered and ignored until the drain window and shutdown timeout elapse.

Resolves [SOL-151437](https://sol-jira.atlassian.net/browse/SOL-151437). Follow-up to the graceful-shutdown work in SOL-151288.

## Why

On shutdown the server flips `/readyz` to 503, waits the drain window (SIGTERM only), then drains in-flight requests up to the shutdown timeout. A second signal was previously dropped, so an impatient second Ctrl-C in local dev appeared to do nothing until the timeout elapsed. In Kubernetes this is bounded by the grace-period SIGKILL, so it is primarily a **local-dev ergonomics** improvement, not a correctness fix.

## How

- Thread a receive-only force-signal channel through `drainAndShutdown` and `gracefulShutdown`. The startup-error path passes `nil`; a nil channel case in a `select` never fires, so that path keeps its exact prior behavior (including the Shutdown-timed-out forced-close fallback).
- **Drain window:** `select` on (timer, second signal); a second signal forces close and returns, skipping the rest of the sequence.
- **Graceful wait:** run `srv.Shutdown` in a goroutine with a buffered result channel (no goroutine leak); `select` on (completion, second signal); a second signal calls `srv.Close`, which unblocks the in-flight `Shutdown`, and we return.
- Shared `forceClose` helper logs one WARN line naming the signal and stating that in-flight connections are dropped, then calls `srv.Close`.
- Bump the `done` signal channel buffer 1→2 so a rapidly delivered second signal is not dropped before the shutdown path arms its `select`.

## Scope

`cmd/server` only. No config, deployment, or API changes. Single-signal path unchanged: SIGTERM still honors the full drain window then drains gracefully; SIGINT still skips the drain. Readiness still flips to 503 before any forced exit.

## Acceptance criteria

- [x] Second signal during the drain window → immediate forced close, rest of drain skipped
- [x] Second signal during the graceful wait → immediate forced close and return
- [x] Single-signal path unchanged (SIGTERM drains, SIGINT skips)
- [x] Forced exit logs a single clear WARN line naming the signal
- [x] No goroutine leak, no double-close panic on any path

## Testing

`make check` passes (build, vet, golangci-lint, race-enabled tests). New tests are deterministic via a `blockingShutdowner` fake whose `Shutdown` blocks until `Close` — no real multi-second sleeps:

- Second signal during drain → immediate `Close`, drain not completed
- Second signal during graceful wait → immediate `Close`, and the `Shutdown` goroutine is asserted to exit (guards the no-leak AC)
- `forceClose` emits exactly one WARN naming the signal (guards the WARN-line AC)
- `Close` called exactly once on every force path (guards the no-double-close AC)

## Review

Reviewed pre-merge through a five-lens principal pass (architect, QA, security, support, SRE). Security clean. Applied the confirmed findings: the WARN line now states connections are dropped (converged support + SRE), and the three missing acceptance-criteria tests were added. Two forward-looking items were considered and deliberately deferred (a distinct return sentinel for forced vs clean shutdown; a deployment.yaml note on duplicate-SIGTERM) as out of scope / YAGNI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOL-151437]: https://sol-jira.atlassian.net/browse/SOL-151437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ