### PR TITLE
SOL-148461: Adding RDP Write Tools

### DIFF
--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -749,3 +749,111 @@ tools:
           topicEndpointName: "{{.Params.topicEndpointName}}"
     result:
       strategy: collect
+
+  - name: create-rdp
+    description: >
+      CONFIRMATION REQUIRED: before calling this tool you MUST first state the
+      target (broker, VPN, RDP name) and that a new RDP will be created, then wait
+      for the user to confirm in a separate reply. Do not treat the user's original
+      request as pre-confirmation, even if it implies intent.
+      Create a REST Delivery Point (RDP) in a Message VPN. Requires msgVpnName to
+      identify the VPN and restDeliveryPointName to name the new RDP; any attribute
+      omitted from rdpConfig is set to its broker default. Creates only the RDP
+      itself — REST consumers and queue bindings are separate resources not managed
+      by this tool, so a new RDP is created disabled by default and delivers nothing
+      until those are added. Fails if an RDP with the same name already exists.
+    annotations:
+      readOnly: false
+      destructive: false
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to create the RDP in"
+      - name: restDeliveryPointName
+        type: string
+        required: true
+        description: "The name of the REST Delivery Point to create"
+      - name: rdpConfig
+        type: object
+        required: false
+        description: "Optional RestDeliveryPoint attributes (enabled, clientProfileName, service, vendor). Omitted attributes use broker defaults. Do not include msgVpnName or restDeliveryPointName here. See the SEMP RestDeliveryPoint schema for the full list."
+    steps:
+      - id: createRdp
+        operation: config/createMsgVpnRestDeliveryPoint
+        # Only msgVpnName is a path param of POST .../restDeliveryPoints.
+        # restDeliveryPointName is deliberately omitted from args so
+        # constructRequestBody spreads it into the request body, where SEMP
+        # expects it for create.
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+    result:
+      strategy: collect
+
+  - name: update-rdp
+    description: >
+      CONFIRMATION REQUIRED: before calling this tool you MUST first state the
+      target (broker, VPN, RDP name) and the attributes that will change, then wait
+      for the user to confirm in a separate reply. Do not treat the user's original
+      request as pre-confirmation, even if it implies intent.
+      Update an existing REST Delivery Point. Requires msgVpnName and
+      restDeliveryPointName to identify the RDP; provide only the attributes you
+      want to change in rdpConfig. Omitted attributes are left unchanged. Use this
+      to update RDP settings such as enabled state or client profile — commonly to
+      enable an RDP that was created disabled.
+    annotations:
+      readOnly: false
+      destructive: true
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN containing the RDP"
+      - name: restDeliveryPointName
+        type: string
+        required: true
+        description: "The name of the REST Delivery Point to modify"
+      - name: rdpConfig
+        type: object
+        required: true
+        description: "RestDeliveryPoint attributes to update (enabled, clientProfileName, service, vendor). Only provided attributes are changed. Do not include msgVpnName or restDeliveryPointName here. See the SEMP RestDeliveryPoint schema for the full list."
+    steps:
+      - id: updateRdp
+        operation: config/updateMsgVpnRestDeliveryPoint
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          restDeliveryPointName: "{{.Params.restDeliveryPointName}}"
+    result:
+      strategy: collect
+
+  - name: delete-rdp
+    description: >
+      CONFIRMATION REQUIRED: before calling this tool you MUST first state the
+      target (broker, VPN, RDP name) and that the RDP and its REST consumers and
+      queue bindings will be permanently removed, then wait for the user to confirm
+      in a separate reply. Do not treat the user's original request as
+      pre-confirmation, even if it implies intent.
+      Delete a REST Delivery Point from a Message VPN. Requires msgVpnName and
+      restDeliveryPointName to identify the RDP to delete. This is a destructive
+      operation that permanently removes the RDP along with its REST consumers and
+      queue bindings.
+    annotations:
+      readOnly: false
+      destructive: true
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN containing the RDP"
+      - name: restDeliveryPointName
+        type: string
+        required: true
+        description: "The name of the REST Delivery Point to delete"
+    steps:
+      - id: deleteRdp
+        operation: config/deleteMsgVpnRestDeliveryPoint
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          restDeliveryPointName: "{{.Params.restDeliveryPointName}}"
+    result:
+      strategy: collect

--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -752,10 +752,11 @@ tools:
 
   - name: create-rdp
     description: >
-      CONFIRMATION REQUIRED: before calling this tool you MUST first state the
-      target (broker, VPN, RDP name) and that a new RDP will be created, then wait
-      for the user to confirm in a separate reply. Do not treat the user's original
-      request as pre-confirmation, even if it implies intent.
+      BEFORE INVOKING THIS TOOL, obtain explicit user confirmation, restating the
+      target (broker, VPN, RDP name) and that a new RDP will be created. The
+      confirmation MUST come as a separate user reply received AFTER you state the
+      target and effect — do not treat the user's original request as a
+      pre-confirmation, even if it implies intent.
       Create a REST Delivery Point (RDP) in a Message VPN. Requires msgVpnName to
       identify the VPN and restDeliveryPointName to name the new RDP; any attribute
       omitted from rdpConfig is set to its broker default. Creates only the RDP
@@ -792,10 +793,11 @@ tools:
 
   - name: update-rdp
     description: >
-      CONFIRMATION REQUIRED: before calling this tool you MUST first state the
-      target (broker, VPN, RDP name) and the attributes that will change, then wait
-      for the user to confirm in a separate reply. Do not treat the user's original
-      request as pre-confirmation, even if it implies intent.
+      BEFORE INVOKING THIS TOOL, obtain explicit user confirmation, restating the
+      target (broker, VPN, RDP name) and the attributes that will change. The
+      confirmation MUST come as a separate user reply received AFTER you state the
+      target and effect — do not treat the user's original request as a
+      pre-confirmation, even if it implies intent.
       Update an existing REST Delivery Point. Requires msgVpnName and
       restDeliveryPointName to identify the RDP; provide only the attributes you
       want to change in rdpConfig. Omitted attributes are left unchanged. Use this
@@ -828,11 +830,12 @@ tools:
 
   - name: delete-rdp
     description: >
-      CONFIRMATION REQUIRED: before calling this tool you MUST first state the
+      BEFORE INVOKING THIS TOOL, obtain explicit user confirmation, restating the
       target (broker, VPN, RDP name) and that the RDP and its REST consumers and
-      queue bindings will be permanently removed, then wait for the user to confirm
-      in a separate reply. Do not treat the user's original request as
-      pre-confirmation, even if it implies intent.
+      queue bindings will be permanently removed. The confirmation MUST come as a
+      separate user reply received AFTER you state the target and effect — do not
+      treat the user's original request as a pre-confirmation, even if it implies
+      intent.
       Delete a REST Delivery Point from a Message VPN. Requires msgVpnName and
       restDeliveryPointName to identify the RDP to delete. This is a destructive
       operation that permanently removes the RDP along with its REST consumers and

--- a/internal/composite/executor_test.go
+++ b/internal/composite/executor_test.go
@@ -191,6 +191,34 @@ func testOperations() map[string]*sempv2.Operation {
 				{Name: "topicEndpointName", In: "path", Type: "string", Required: true},
 			},
 		},
+		"config/createMsgVpnRestDeliveryPoint": {
+			ID:     "createMsgVpnRestDeliveryPoint",
+			Method: "POST",
+			Path:   "/SEMP/v2/__private_config__/msgVpns/{msgVpnName}/restDeliveryPoints",
+			Parameters: []sempv2.Parameter{
+				{Name: "msgVpnName", In: "path", Type: "string", Required: true},
+				{Name: "body", In: "body", Type: "object", Required: true},
+			},
+		},
+		"config/updateMsgVpnRestDeliveryPoint": {
+			ID:     "updateMsgVpnRestDeliveryPoint",
+			Method: "PATCH",
+			Path:   "/SEMP/v2/__private_config__/msgVpns/{msgVpnName}/restDeliveryPoints/{restDeliveryPointName}",
+			Parameters: []sempv2.Parameter{
+				{Name: "msgVpnName", In: "path", Type: "string", Required: true},
+				{Name: "restDeliveryPointName", In: "path", Type: "string", Required: true},
+				{Name: "body", In: "body", Type: "object", Required: true},
+			},
+		},
+		"config/deleteMsgVpnRestDeliveryPoint": {
+			ID:     "deleteMsgVpnRestDeliveryPoint",
+			Method: "DELETE",
+			Path:   "/SEMP/v2/__private_config__/msgVpns/{msgVpnName}/restDeliveryPoints/{restDeliveryPointName}",
+			Parameters: []sempv2.Parameter{
+				{Name: "msgVpnName", In: "path", Type: "string", Required: true},
+				{Name: "restDeliveryPointName", In: "path", Type: "string", Required: true},
+			},
+		},
 	}
 }
 
@@ -2835,5 +2863,240 @@ func TestExecute_DeleteTopicEndpoint_NoBodyConstructed(t *testing.T) {
 	}
 	if _, hasBody := recorded[0].args["body"]; hasBody {
 		t.Error("delete operation has no body param; no body should be constructed")
+	}
+}
+
+// createRDPTool returns the create-rdp tool definition for tests. Like
+// create-queue, msgVpnName is the only path param; restDeliveryPointName and
+// rdpConfig are assembled into the body by constructRequestBody.
+func createRDPTool() CompositeTool {
+	return CompositeTool{
+		Name:        "create-rdp",
+		Description: "Create a REST Delivery Point in a Message VPN",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+			{Name: "restDeliveryPointName", Type: "string", Required: true},
+			{Name: "rdpConfig", Type: "object", Required: false},
+		},
+		Steps: []Step{
+			{
+				ID:        "createRdp",
+				Operation: "config/createMsgVpnRestDeliveryPoint",
+				Args: map[string]string{
+					"msgVpnName": "{{.Params.msgVpnName}}",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+}
+
+// updateRDPTool returns the update-rdp tool definition for tests. Both
+// msgVpnName and restDeliveryPointName are path params (passed as step args);
+// only rdpConfig is spread into the PATCH body.
+func updateRDPTool() CompositeTool {
+	return CompositeTool{
+		Name:        "update-rdp",
+		Description: "Update an existing REST Delivery Point",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+			{Name: "restDeliveryPointName", Type: "string", Required: true},
+			{Name: "rdpConfig", Type: "object", Required: true},
+		},
+		Steps: []Step{
+			{
+				ID:        "updateRdp",
+				Operation: "config/updateMsgVpnRestDeliveryPoint",
+				Args: map[string]string{
+					"msgVpnName":            "{{.Params.msgVpnName}}",
+					"restDeliveryPointName": "{{.Params.restDeliveryPointName}}",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+}
+
+// deleteRDPTool returns the delete-rdp tool definition for tests. Both names are
+// path args and the operation carries no request body.
+func deleteRDPTool() CompositeTool {
+	return CompositeTool{
+		Name:        "delete-rdp",
+		Description: "Delete a REST Delivery Point from a Message VPN",
+		Parameters: []ParameterDef{
+			{Name: "msgVpnName", Type: "string", Required: true},
+			{Name: "restDeliveryPointName", Type: "string", Required: true},
+		},
+		Steps: []Step{
+			{
+				ID:        "deleteRdp",
+				Operation: "config/deleteMsgVpnRestDeliveryPoint",
+				Args: map[string]string{
+					"msgVpnName":            "{{.Params.msgVpnName}}",
+					"restDeliveryPointName": "{{.Params.restDeliveryPointName}}",
+				},
+			},
+		},
+		Result: ResultStrategy{Strategy: "collect"},
+	}
+}
+
+func TestExecute_CreateRDP_ConstructsBody(t *testing.T) {
+	var recorded []callRecord
+	var mu sync.Mutex
+	capture := &argCapturingClient{inner: newMockClient(), recorded: &recorded, mu: &mu}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), createRDPTool(), capture, map[string]any{
+		"msgVpnName":            "vpn-a",
+		"restDeliveryPointName": "rdp-1",
+		"rdpConfig": map[string]any{
+			"enabled":           true,
+			"clientProfileName": "default",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if recorded[0].opID != "createMsgVpnRestDeliveryPoint" {
+		t.Errorf("opID = %q, want createMsgVpnRestDeliveryPoint", recorded[0].opID)
+	}
+	// msgVpnName identifies the VPN via the URL path, so it stays in args.
+	if recorded[0].args["msgVpnName"] != "vpn-a" {
+		t.Errorf("args[msgVpnName] = %v, want vpn-a", recorded[0].args["msgVpnName"])
+	}
+
+	body, ok := recorded[0].args["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected body to be a map, got %T", recorded[0].args["body"])
+	}
+	// createMsgVpnRestDeliveryPoint declares no restDeliveryPointName path param,
+	// so the RDP name rides in the body as a scalar.
+	if body["restDeliveryPointName"] != "rdp-1" {
+		t.Errorf("body[restDeliveryPointName] = %v, want rdp-1", body["restDeliveryPointName"])
+	}
+	// rdpConfig fields are spread into the body as siblings of restDeliveryPointName.
+	if body["enabled"] != true {
+		t.Errorf("body[enabled] = %v, want true", body["enabled"])
+	}
+	if body["clientProfileName"] != "default" {
+		t.Errorf("body[clientProfileName] = %v, want default", body["clientProfileName"])
+	}
+	// msgVpnName is a path param and must not leak into the create body.
+	if _, leaked := body["msgVpnName"]; leaked {
+		t.Error("msgVpnName is a path param and must not appear in the create body")
+	}
+	if _, nested := body["rdpConfig"]; nested {
+		t.Error("rdpConfig should be spread into the body, not nested under rdpConfig")
+	}
+
+	if result["createRdp"] == nil {
+		t.Error("expected createRdp result to be collected")
+	}
+}
+
+func TestExecute_CreateRDP_AlreadyExists(t *testing.T) {
+	client := newMockClient()
+	client.errors["createMsgVpnRestDeliveryPoint"] = &sempv2.SEMPError{
+		Operation:   "createMsgVpnRestDeliveryPoint",
+		StatusCode:  400,
+		SEMPCode:    10,
+		SEMPStatus:  "ALREADY_EXISTS",
+		Description: "REST Delivery Point already exists",
+		Body:        `{"meta":{"error":{"code":10,"description":"REST Delivery Point already exists","status":"ALREADY_EXISTS"}}}`,
+	}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	_, err := executor.Execute(context.Background(), createRDPTool(), client, map[string]any{
+		"msgVpnName":            "vpn-a",
+		"restDeliveryPointName": "rdp-1",
+	})
+	if err == nil {
+		t.Fatal("expected error when RDP already exists, got nil")
+	}
+
+	var sempErr *sempv2.SEMPError
+	if !errors.As(err, &sempErr) {
+		t.Errorf("expected SEMPError in error chain, got: %v", err)
+	} else if sempErr.SEMPCode != 10 {
+		t.Errorf("SEMPCode = %d, want 10 (already exists)", sempErr.SEMPCode)
+	}
+}
+
+func TestExecute_UpdateRDP_BodyExcludesPathParams(t *testing.T) {
+	var recorded []callRecord
+	var mu sync.Mutex
+	capture := &argCapturingClient{inner: newMockClient(), recorded: &recorded, mu: &mu}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	_, err := executor.Execute(context.Background(), updateRDPTool(), capture, map[string]any{
+		"msgVpnName":            "vpn-a",
+		"restDeliveryPointName": "rdp-1",
+		"rdpConfig": map[string]any{
+			"enabled": false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if recorded[0].opID != "updateMsgVpnRestDeliveryPoint" {
+		t.Errorf("opID = %q, want updateMsgVpnRestDeliveryPoint", recorded[0].opID)
+	}
+	if recorded[0].args["msgVpnName"] != "vpn-a" {
+		t.Errorf("args[msgVpnName] = %v, want vpn-a", recorded[0].args["msgVpnName"])
+	}
+	if recorded[0].args["restDeliveryPointName"] != "rdp-1" {
+		t.Errorf("args[restDeliveryPointName] = %v, want rdp-1", recorded[0].args["restDeliveryPointName"])
+	}
+
+	body, ok := recorded[0].args["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected body to be a map, got %T", recorded[0].args["body"])
+	}
+	// Both names are path params; neither may be duplicated into the PATCH body.
+	if _, leaked := body["msgVpnName"]; leaked {
+		t.Error("msgVpnName is a path param and must not appear in the PATCH body")
+	}
+	if _, leaked := body["restDeliveryPointName"]; leaked {
+		t.Error("restDeliveryPointName is a path param and must not appear in the PATCH body")
+	}
+	if body["enabled"] != false {
+		t.Errorf("body[enabled] = %v, want false", body["enabled"])
+	}
+}
+
+func TestExecute_DeleteRDP_NoBodyConstructed(t *testing.T) {
+	var recorded []callRecord
+	var mu sync.Mutex
+	capture := &argCapturingClient{inner: newMockClient(), recorded: &recorded, mu: &mu}
+
+	executor := NewCompositeExecutor(testOperations())
+
+	result, err := executor.Execute(context.Background(), deleteRDPTool(), capture, map[string]any{
+		"msgVpnName":            "vpn-a",
+		"restDeliveryPointName": "rdp-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if recorded[0].opID != "deleteMsgVpnRestDeliveryPoint" {
+		t.Errorf("opID = %q, want deleteMsgVpnRestDeliveryPoint", recorded[0].opID)
+	}
+	if recorded[0].args["restDeliveryPointName"] != "rdp-1" {
+		t.Errorf("args[restDeliveryPointName] = %v, want rdp-1", recorded[0].args["restDeliveryPointName"])
+	}
+	// deleteMsgVpnRestDeliveryPoint declares no body parameter, so no body should be built.
+	if _, hasBody := recorded[0].args["body"]; hasBody {
+		t.Error("delete operation has no body param; no body should be constructed")
+	}
+
+	if result["deleteRdp"] == nil {
+		t.Error("expected deleteRdp result to be collected")
 	}
 }

--- a/internal/composite/loader_test.go
+++ b/internal/composite/loader_test.go
@@ -1963,3 +1963,237 @@ tools:
 		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
 	}
 }
+
+func TestLoadTools_CreateRDP(t *testing.T) {
+	yaml := `
+tools:
+  - name: create-rdp
+    description: Create a REST Delivery Point in a Message VPN.
+    annotations:
+      readOnly: false
+      destructive: false
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN to create the RDP in"
+      - name: restDeliveryPointName
+        type: string
+        required: true
+        description: "The name of the REST Delivery Point to create"
+      - name: rdpConfig
+        type: object
+        required: false
+        description: "Optional RestDeliveryPoint attributes"
+    steps:
+      - id: createRdp
+        operation: config/createMsgVpnRestDeliveryPoint
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+    result:
+      strategy: collect
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "create-rdp" {
+		t.Errorf("expected name %q, got %q", "create-rdp", tool.Name)
+	}
+
+	if tool.Annotations.ReadOnly == nil || *tool.Annotations.ReadOnly {
+		t.Error("expected ReadOnly = false")
+	}
+	if tool.Annotations.Destructive == nil || *tool.Annotations.Destructive {
+		t.Error("expected Destructive = false")
+	}
+
+	if len(tool.Parameters) != 3 {
+		t.Fatalf("expected 3 parameters, got %d", len(tool.Parameters))
+	}
+	if tool.Parameters[1].Name != "restDeliveryPointName" || tool.Parameters[1].Type != "string" || !tool.Parameters[1].Required {
+		t.Errorf("expected required string restDeliveryPointName parameter, got %+v", tool.Parameters[1])
+	}
+	if tool.Parameters[2].Name != "rdpConfig" || tool.Parameters[2].Type != "object" || tool.Parameters[2].Required {
+		t.Errorf("expected optional object rdpConfig parameter, got %+v", tool.Parameters[2])
+	}
+
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if tool.Steps[0].Operation != "config/createMsgVpnRestDeliveryPoint" {
+		t.Errorf("expected operation %q, got %q", "config/createMsgVpnRestDeliveryPoint", tool.Steps[0].Operation)
+	}
+	// Only msgVpnName is a path arg; restDeliveryPointName belongs in the body.
+	if tool.Steps[0].Args["msgVpnName"] != "{{.Params.msgVpnName}}" {
+		t.Errorf("expected msgVpnName path arg, got %q", tool.Steps[0].Args["msgVpnName"])
+	}
+	if _, ok := tool.Steps[0].Args["restDeliveryPointName"]; ok {
+		t.Error("restDeliveryPointName must not be a step arg on create — it belongs in the body")
+	}
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
+	}
+}
+
+func TestLoadTools_UpdateRDP(t *testing.T) {
+	yaml := `
+tools:
+  - name: update-rdp
+    description: Update an existing REST Delivery Point.
+    annotations:
+      readOnly: false
+      destructive: true
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN containing the RDP"
+      - name: restDeliveryPointName
+        type: string
+        required: true
+        description: "The name of the REST Delivery Point to modify"
+      - name: rdpConfig
+        type: object
+        required: true
+        description: "RestDeliveryPoint attributes to update"
+    steps:
+      - id: updateRdp
+        operation: config/updateMsgVpnRestDeliveryPoint
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          restDeliveryPointName: "{{.Params.restDeliveryPointName}}"
+    result:
+      strategy: collect
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "update-rdp" {
+		t.Errorf("expected name %q, got %q", "update-rdp", tool.Name)
+	}
+
+	if tool.Annotations.ReadOnly == nil || *tool.Annotations.ReadOnly {
+		t.Error("expected ReadOnly = false")
+	}
+	if tool.Annotations.Destructive == nil || !*tool.Annotations.Destructive {
+		t.Error("expected Destructive = true")
+	}
+
+	if len(tool.Parameters) != 3 {
+		t.Fatalf("expected 3 parameters, got %d", len(tool.Parameters))
+	}
+	if tool.Parameters[2].Name != "rdpConfig" || tool.Parameters[2].Type != "object" || !tool.Parameters[2].Required {
+		t.Errorf("expected required object rdpConfig parameter, got %+v", tool.Parameters[2])
+	}
+
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if tool.Steps[0].Operation != "config/updateMsgVpnRestDeliveryPoint" {
+		t.Errorf("expected operation %q, got %q", "config/updateMsgVpnRestDeliveryPoint", tool.Steps[0].Operation)
+	}
+	// Both names are path params, so both are wired as step args.
+	if tool.Steps[0].Args["msgVpnName"] != "{{.Params.msgVpnName}}" {
+		t.Errorf("expected msgVpnName path arg, got %q", tool.Steps[0].Args["msgVpnName"])
+	}
+	if tool.Steps[0].Args["restDeliveryPointName"] != "{{.Params.restDeliveryPointName}}" {
+		t.Errorf("expected restDeliveryPointName path arg, got %q", tool.Steps[0].Args["restDeliveryPointName"])
+	}
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
+	}
+}
+
+func TestLoadTools_DeleteRDP(t *testing.T) {
+	yaml := `
+tools:
+  - name: delete-rdp
+    description: Delete a REST Delivery Point from a Message VPN.
+    annotations:
+      readOnly: false
+      destructive: true
+    parameters:
+      - name: msgVpnName
+        type: string
+        required: true
+        description: "The Message VPN containing the RDP"
+      - name: restDeliveryPointName
+        type: string
+        required: true
+        description: "The name of the REST Delivery Point to delete"
+    steps:
+      - id: deleteRdp
+        operation: config/deleteMsgVpnRestDeliveryPoint
+        args:
+          msgVpnName: "{{.Params.msgVpnName}}"
+          restDeliveryPointName: "{{.Params.restDeliveryPointName}}"
+    result:
+      strategy: collect
+`
+	fsys := fstest.MapFS{
+		"tools.yaml": &fstest.MapFile{Data: []byte(yaml)},
+	}
+
+	tools, err := LoadTools(fsys, "tools.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0]
+	if tool.Name != "delete-rdp" {
+		t.Errorf("expected name %q, got %q", "delete-rdp", tool.Name)
+	}
+
+	if tool.Annotations.ReadOnly == nil || *tool.Annotations.ReadOnly {
+		t.Error("expected ReadOnly = false")
+	}
+	if tool.Annotations.Destructive == nil || !*tool.Annotations.Destructive {
+		t.Error("expected Destructive = true")
+	}
+
+	if len(tool.Parameters) != 2 {
+		t.Fatalf("expected 2 parameters, got %d", len(tool.Parameters))
+	}
+
+	if len(tool.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tool.Steps))
+	}
+	if tool.Steps[0].Operation != "config/deleteMsgVpnRestDeliveryPoint" {
+		t.Errorf("expected operation %q, got %q", "config/deleteMsgVpnRestDeliveryPoint", tool.Steps[0].Operation)
+	}
+	if tool.Steps[0].Args["msgVpnName"] != "{{.Params.msgVpnName}}" {
+		t.Errorf("expected msgVpnName path arg, got %q", tool.Steps[0].Args["msgVpnName"])
+	}
+	if tool.Steps[0].Args["restDeliveryPointName"] != "{{.Params.restDeliveryPointName}}" {
+		t.Errorf("expected restDeliveryPointName path arg, got %q", tool.Steps[0].Args["restDeliveryPointName"])
+	}
+	if tool.Result.Strategy != "collect" {
+		t.Errorf("expected strategy %q, got %q", "collect", tool.Result.Strategy)
+	}
+}


### PR DESCRIPTION
## Summary

Adding `create-rdp`, `update-rdp`, and `delete-rdp` composite tools so the MCP server can provision and manage REST Delivery Points over SEMPv2. 

Fixes # SOL-148461

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

Completing the set of Write RDP Tools. 

## Changes Made

- Adding three composite tools in tools.yaml
- Split up tools so that they are one tool per action, create RDP initially had more that it could do but have decided to drop that
- Front-loading the Confirmation in the RDP description (Hoping this will hit more often than having it in the middle / end) 
- Adding Unit Tests 

## Testing

**Test Environment:**
- Go version: 1.26.1
- OS: macOS 
- Broker version (if applicable):

**Tests Performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**
  - Create assembles the request body correctly (`restDeliveryPointName` + `rdpConfig` spread
    into body; `msgVpnName` stays a path param and does not leak into the body).
  - Update/delete keep both identifiers as path params and exclude them from the body; delete
    builds no body.
  - Create surfaces a SEMP `ALREADY_EXISTS` error (the behavior the description promises).
  - Loader validates names, annotations, parameters, operations, and args for all three tools.
  - Manually verified against a live broker: `delete-rdp` cascades to the RDP's REST consumers
    and queue bindings (the durable queues those bindings reference are unaffected).

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

**Impact:**

**Migration Guide:**

## Checklist

<!-- Ensure all items are completed before requesting review -->

### Code Quality
- [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (checked all files, commits, and logs)
- [x] Followed [secure logging rules](../docs/secure-logging-rules.md)
- [x] Credential-carrying types implement `slog.LogValuer`
- [x] No security vulnerabilities introduced (checked with golangci-lint/gosec)

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [x] Error paths tested
- [x ] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (if user-facing changes)
- [ ] docs/ updated (if architecture/design changes)
- [ ] godoc comments added/updated for exported functions
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Examples updated (if applicable)

### Git & CI
- [ ] All commits are signed off (DCO: `git commit -s`)
- [ ] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [ ] CI checks passing (lint, build, test, E2E)

### Breaking Changes (if applicable)
- [ ] Breaking changes documented in commit message
- [ ] Breaking changes documented in PR description
- [ ] Migration guide provided
- [ ] Deprecated functionality marked with comments and deprecation notices

## Screenshots (if applicable)

<!-- Add screenshots for UI changes, CLI output, etc. -->

## Additional Notes

<!-- Any other context, concerns, or follow-up work needed -->

## Related Issues/PRs

<!-- Link to related issues, PRs, or discussions -->

- Related to #
- Depends on #
- Blocks #

---

**For Reviewers:**

**Focus Areas**: <!-- What should reviewers pay special attention to? -->

**Questions**: <!-- Any specific questions for reviewers? -->
