### PR TITLE
SOL-151506: harden BasicAuthenticator with nil-jar panic

### DIFF
--- a/internal/semp/auth/authenticator_test.go
+++ b/internal/semp/auth/authenticator_test.go
@@ -18,12 +18,20 @@ func newReq(t *testing.T) *http.Request {
 	return req
 }
 
+// stubJar is a no-op CookieJarClearer for tests that construct a
+// BasicAuthenticator but don't exercise the jar-clearing path. Tests
+// that need to observe Clear() calls or error paths should use their
+// own recording stub.
+type stubJar struct{}
+
+func (stubJar) Clear() error { return nil }
+
 func TestBasicAuthenticator_AddAuth(t *testing.T) {
 	const (
 		user = "admin"
 		pass = "s3cret"
 	)
-	a := NewBasicAuthenticator(user, pass, nil)
+	a := NewBasicAuthenticator(user, pass, stubJar{})
 	req := newReq(t)
 
 	if err := a.AddAuth(context.Background(), req); err != nil {
@@ -63,7 +71,7 @@ func TestAuthenticator_ConcurrentAddAuth_NoFieldMutation(t *testing.T) {
 	const goroutines = 16
 
 	t.Run("basic", func(t *testing.T) {
-		a := NewBasicAuthenticator("admin", "s3cret", nil)
+		a := NewBasicAuthenticator("admin", "s3cret", stubJar{})
 		wantUser, wantPass := a.username, a.password
 		wantCreds := wantUser + ":" + wantPass
 

--- a/internal/semp/auth/basic.go
+++ b/internal/semp/auth/basic.go
@@ -17,10 +17,15 @@ type BasicAuthenticator struct {
 }
 
 // NewBasicAuthenticator returns a BasicAuthenticator that will attach the
-// given credentials to every request via http.Request.SetBasicAuth.
-// jar may be nil — HandleAuthFailure will return retry=false when no jar
-// is available.
+// given credentials to every request via http.Request.SetBasicAuth. The
+// jar is required — HandleAuthFailure clears it to force fresh Basic
+// credentials on the retry, so an authenticator without a jar cannot
+// recover from a 401. Panics if jar is nil — a nil jar is a wiring bug,
+// not a runtime condition.
 func NewBasicAuthenticator(username, password string, jar CookieJarClearer) *BasicAuthenticator {
+	if jar == nil {
+		panic("NewBasicAuthenticator: jar must be non-nil")
+	}
 	return &BasicAuthenticator{username: username, password: password, jar: jar}
 }
 
@@ -34,12 +39,8 @@ func (a *BasicAuthenticator) AddAuth(_ context.Context, req *http.Request) error
 
 // HandleAuthFailure clears stale session cookies so the next request
 // re-sends raw Basic credentials. Returns retry=true on success so the
-// Sender retries the request. Returns retry=false when no jar is
-// available or the clear fails.
+// Sender retries the request. Returns retry=false when the clear fails.
 func (a *BasicAuthenticator) HandleAuthFailure(_ context.Context, _ http.Header) bool {
-	if a.jar == nil {
-		return false
-	}
 	if err := a.jar.Clear(); err != nil {
 		slog.Warn("basic auth: 401 received but failed to clear cookie jar",
 			slog.String("error", err.Error()))

--- a/internal/semp/auth/basic_test.go
+++ b/internal/semp/auth/basic_test.go
@@ -41,6 +41,29 @@ func TestNewBasicAuthenticator_PanicsOnNilJar(t *testing.T) {
 	NewBasicAuthenticator("admin", "s3cret", nil)
 }
 
+// TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic pins the accepted
+// limit of the nil-jar guard: a typed-nil implementation (Go's classic
+// "nil interface vs. nil concrete" gotcha — see
+// https://go.dev/doc/faq#nil_error) produces a non-nil interface value
+// and slips past the == nil check.
+//
+// This is intentional and matches the ecosystem convention: defend at
+// the producer, not the consumer. Production wiring (newCookieJar →
+// newAuthenticator) never emits a typed-nil, so the case is unreachable
+// in production. If we ever adopt reflect-based detection or a linter
+// that upgrades this to a compile-time error, this test will fail — and
+// that failure is the intended signal that we're deliberately changing
+// the contract.
+func TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic(t *testing.T) {
+	var typedNil *recordingJar // nil pointer, but wrapping it in the interface produces a non-nil header
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewBasicAuthenticator with typed-nil jar panicked unexpectedly: %v", r)
+		}
+	}()
+	_ = NewBasicAuthenticator("admin", "s3cret", typedNil)
+}
+
 // TestBasicAuthenticator_HandleAuthFailure_ClearsJarAndReturnsTrue pins
 // the happy-path contract: on a 401, HandleAuthFailure calls jar.Clear()
 // exactly once and returns retry=true so the Sender re-sends with fresh

--- a/internal/semp/auth/basic_test.go
+++ b/internal/semp/auth/basic_test.go
@@ -22,11 +22,20 @@ func (r *recordingJar) Clear() error {
 // a nil jar is a wiring bug and must fail fast at construction, not later
 // at first 401 recovery attempt. Same rationale as
 // NewOAuthAuthenticator's nil-exchanger panic.
+//
+// The panic message is part of the assertion so a future refactor that
+// panics for a different reason (bad username, etc.) can't quietly pass
+// this test while dropping the nil-jar guard.
 func TestNewBasicAuthenticator_PanicsOnNilJar(t *testing.T) {
+	const wantMsg = "NewBasicAuthenticator: jar must be non-nil"
 	defer func() {
 		r := recover()
 		if r == nil {
 			t.Fatal("NewBasicAuthenticator(_, _, nil) did not panic")
+		}
+		got, ok := r.(string)
+		if !ok || got != wantMsg {
+			t.Fatalf("panic value = %#v, want string %q", r, wantMsg)
 		}
 	}()
 	NewBasicAuthenticator("admin", "s3cret", nil)

--- a/internal/semp/auth/basic_test.go
+++ b/internal/semp/auth/basic_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// recordingJar records Clear() invocations and can be configured to return
+// an error from Clear() to exercise the failure branch of HandleAuthFailure.
+type recordingJar struct {
+	clearErr   error
+	clearCalls int
+}
+
+func (r *recordingJar) Clear() error {
+	r.clearCalls++
+	return r.clearErr
+}
+
+// TestNewBasicAuthenticator_PanicsOnNilJar pins the constructor contract:
+// a nil jar is a wiring bug and must fail fast at construction, not later
+// at first 401 recovery attempt. Same rationale as
+// NewOAuthAuthenticator's nil-exchanger panic.
+func TestNewBasicAuthenticator_PanicsOnNilJar(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("NewBasicAuthenticator(_, _, nil) did not panic")
+		}
+	}()
+	NewBasicAuthenticator("admin", "s3cret", nil)
+}
+
+// TestBasicAuthenticator_HandleAuthFailure_ClearsJarAndReturnsTrue pins
+// the happy-path contract: on a 401, HandleAuthFailure calls jar.Clear()
+// exactly once and returns retry=true so the Sender re-sends with fresh
+// Basic credentials. Covered transitively by resilience.Sender tests, but
+// isolating it here defends the auth-side contract against refactors of
+// the retry loop that might silently drop the Clear() call.
+func TestBasicAuthenticator_HandleAuthFailure_ClearsJarAndReturnsTrue(t *testing.T) {
+	jar := &recordingJar{}
+	a := NewBasicAuthenticator("admin", "s3cret", jar)
+
+	if !a.HandleAuthFailure(context.Background(), nil) {
+		t.Error("HandleAuthFailure returned false, want true on successful clear")
+	}
+	if jar.clearCalls != 1 {
+		t.Errorf("jar.Clear() called %d times, want 1", jar.clearCalls)
+	}
+}
+
+// TestBasicAuthenticator_HandleAuthFailure_JarClearError pins the failure
+// branch: if jar.Clear() fails, HandleAuthFailure returns retry=false so
+// the Sender does not retry with a possibly-inconsistent jar. This branch
+// was previously untested at any level.
+func TestBasicAuthenticator_HandleAuthFailure_JarClearError(t *testing.T) {
+	sentinel := errors.New("clear failed")
+	jar := &recordingJar{clearErr: sentinel}
+	a := NewBasicAuthenticator("admin", "s3cret", jar)
+
+	if a.HandleAuthFailure(context.Background(), nil) {
+		t.Error("HandleAuthFailure returned true, want false when jar.Clear() fails")
+	}
+	if jar.clearCalls != 1 {
+		t.Errorf("jar.Clear() called %d times, want 1", jar.clearCalls)
+	}
+}

--- a/internal/semp/broker.go
+++ b/internal/semp/broker.go
@@ -111,9 +111,6 @@ func newAuthenticator(alias string, brokerCfg *config.BrokerConfig, jar *resilie
 	cfg := brokerCfg.Auth
 	switch cfg.Mode {
 	case config.AuthModeBasic:
-		if jar == nil {
-			return nil, fmt.Errorf("basic auth requires a cookie jar for broker %q", alias)
-		}
 		return auth.NewBasicAuthenticator(cfg.Username, cfg.Password, jar), nil
 	case config.AuthModeBearer:
 		return auth.NewBearerAuthenticator(cfg.Token), nil

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -366,9 +366,9 @@ func TestSender_RateLimiter_PerBrokerIndependence(t *testing.T) {
 	}))
 	defer serverB.Close()
 
-	senderA := newTestSender(t, serverA.Client(), auth.NewBasicAuthenticator("admin", "secret", nil), 0)
+	senderA := newTestSender(t, serverA.Client(), auth.NewBasicAuthenticator("admin", "secret", mustNewSafeCookieJar(t)), 0)
 	senderA.brokerURL = serverA.URL
-	senderB := newTestSender(t, serverB.Client(), auth.NewBasicAuthenticator("admin", "secret", nil), 0)
+	senderB := newTestSender(t, serverB.Client(), auth.NewBasicAuthenticator("admin", "secret", mustNewSafeCookieJar(t)), 0)
 	senderB.brokerURL = serverB.URL
 
 	// Block sender A's rate limiter.

--- a/internal/semp/sempv1/client_test.go
+++ b/internal/semp/sempv1/client_test.go
@@ -446,6 +446,10 @@ func TestHTTPClient_LogValue_ExcludesCredentials(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer srv.Close()
 
+	basicJar, err := resilience.NewSafeCookieJar()
+	if err != nil {
+		t.Fatalf("NewSafeCookieJar: %v", err)
+	}
 	cases := []struct {
 		name    string
 		authn   auth.Authenticator
@@ -454,7 +458,8 @@ func TestHTTPClient_LogValue_ExcludesCredentials(t *testing.T) {
 	}{
 		{
 			name:    "basic auth credentials are not logged",
-			authn:   auth.NewBasicAuthenticator("SECRET_USERNAME_VAL", "SECRET_PASSWORD_VAL", nil),
+			authn:   auth.NewBasicAuthenticator("SECRET_USERNAME_VAL", "SECRET_PASSWORD_VAL", basicJar),
+			jar:     basicJar,
 			secrets: []string{"SECRET_USERNAME_VAL", "SECRET_PASSWORD_VAL"},
 		},
 		{


### PR DESCRIPTION
## Summary

Move the `jar != nil` invariant from `HandleAuthFailure` and the `newAuthenticator` dispatcher into `NewBasicAuthenticator` itself — panic at construction, delete the two now-dead defensive checks. Same pattern as `NewOAuthAuthenticator` in SOL-150800.

Fixes [SOL-151506](https://sol-jira.atlassian.net/browse/SOL-151506)

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Bug fix (non-breaking change which fixes an issue) — the old nil-jar branch masked wiring bugs; the new panic surfaces them

## Motivation and Context

The cookie jar is a **core dependency** of `BasicAuthenticator` — without it, `HandleAuthFailure` cannot clear stale session cookies after a 401, so the retry-on-auth-failure path is broken. A `BasicAuthenticator` constructed with a nil jar is an object that cannot function correctly in production.

Despite that, `NewBasicAuthenticator` accepted `nil` silently and `HandleAuthFailure` returned `retry=false` in that case, hiding the wiring bug instead of surfacing it. The dispatcher `newAuthenticator` in `broker.go` had a duplicate `if jar == nil` check for the same invariant.

In production, `newCookieJar` always creates a real jar for basic auth mode, so the nil path is unreachable — but that's a wiring guarantee, not a type-system one. Centralizing the check in the constructor makes the invariant explicit and lets us remove two now-dead defensive branches.

Rationale for `panic` vs `error`: the jar is built once at startup and set at construction — it can't become nil at runtime. `NewBasicAuthenticator` is internal wiring, never called by external users. Nil jar is a programmer error, so fail-fast is correct. Same reasoning as `NewOAuthAuthenticator`.

## Changes Made

- `internal/semp/auth/basic.go`: `NewBasicAuthenticator` panics on nil jar; `HandleAuthFailure`'s nil guard removed; doc comment updated to describe the new contract.
- `internal/semp/broker.go`: `newAuthenticator` no longer pre-checks `jar == nil` for basic auth — the constructor owns that invariant now.
- **Tests: fixed 4 brittle setups.** Four existing tests passed nil jar as a setup shortcut even though the jar was irrelevant to what they verified. They now pass a real jar / stub, testing what they actually meant to test:
  - `internal/semp/auth/authenticator_test.go`: `TestBasicAuthenticator_AddAuth`, `TestAuthenticator_ConcurrentAddAuth_NoFieldMutation/basic`
  - `internal/semp/resilience/sender_test.go`: `TestSender_RateLimiter_PerBrokerIndependence`
  - `internal/semp/sempv1/client_test.go`: `TestHTTPClient_LogValue_ExcludesCredentials` (basic-auth table row)
- **Tests: added 3 direct unit tests** in a new `internal/semp/auth/basic_test.go`:
  - `TestNewBasicAuthenticator_PanicsOnNilJar` — defends the new panic contract
  - `TestBasicAuthenticator_HandleAuthFailure_ClearsJarAndReturnsTrue` — defends the happy path directly (was only covered transitively via `resilience.Sender`)
  - `TestBasicAuthenticator_HandleAuthFailure_JarClearError` — defends the `jar.Clear()`-fails branch (previously **zero** coverage at any level)

## Testing

**Test Environment:**
- Go version: go1.26.0 darwin/arm64
- OS: macOS (Darwin 24.6.0)
- Broker version: N/A (unit + integration only; no wire-level behavior change)

**Tests Performed:**
- [x] Unit tests added/updated (3 new, 4 fixed)
- [x] Integration tests added/updated (N/A — existing integration tests unchanged and still pass)
- [ ] E2E tests added/updated (N/A — no wire behavior change)
- [x] Tested locally with `go test -race ./...`
- [ ] Tested with real Solace broker (N/A)

**Test Coverage:**
- New panic contract is defended directly by a `defer/recover` test.
- Both branches of `HandleAuthFailure` (success + `jar.Clear()` error) now have direct unit tests with a `recordingJar` fake, in addition to the pre-existing end-to-end resilience-layer coverage.
- `make check` (build + vet + lint + race unit + integration tests) all green.
- Critical existing tests confirmed intact:
  - `TestBrokerClient_SharedJar_401ClearVisibleAcrossProtocols` (cross-protocol jar sharing)
  - `TestSender_Retry_401_BasicAuth_ClearsCookiesAndRetries` (401 → clear → retry)
  - `TestSenderRetryStateIsolatedUnderConcurrency` (50 goroutines, `-race`: 100/100 hits)

## Breaking Changes

**Impact:** None user-visible. Production wiring goes through `newAuthenticator`, which always supplies a jar for basic auth. Any code that direct-constructed a `BasicAuthenticator` with `nil` jar was already broken (couldn't handle a 401) — such code will now fail fast at construction instead of silently at first 401.

**Migration Guide:** N/A.

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed
- [x] Code is well-commented (WHY, not WHAT)
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code
- [x] Followed secure logging rules (only pre-existing `slog.Warn` retained verbatim; no new logging introduced)
- [x] No security vulnerabilities introduced

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests (both success and jar.Clear-error branches)
- [x] Error paths tested (jar.Clear() error path was previously untested; now covered)
- [x] Test names clearly describe what is being tested

### Documentation
- [x] godoc comments updated on `NewBasicAuthenticator` and `HandleAuthFailure` to describe the new contract
- [ ] README.md updated — N/A (internal wiring change)
- [ ] docs/ updated — N/A (no architecture change)

### Git & CI
- [x] Commits have clear, descriptive messages (split into production change + test change for reviewer clarity)
- [x] Branch is up to date with main
- [x] No merge conflicts

## Additional Notes

While auditing this surface I noticed `NewOAuthAuthenticator` panics on nil exchanger but has **no test** defending that contract. Filed as follow-up [SOL-151601](https://sol-jira.atlassian.net/browse/SOL-151601) — out of scope here.

## Related Issues/PRs

- Related to SOL-150800 (same encapsulation pattern applied to `NewOAuthAuthenticator`)
- Parent epic: SOL-148417 (Enterprise-Ready Broker MCP: Multi-User Auth & Performance at Scale)
- Follow-up: [SOL-151601](https://sol-jira.atlassian.net/browse/SOL-151601)

---

**For Reviewers:**

**Focus Areas:**
- Whether the panic contract is the right choice vs. returning an error (see rationale under "Motivation and Context")
- Whether the `stubJar` in `authenticator_test.go` and `recordingJar` in `basic_test.go` should be unified or whether the split (no-op stub vs. recording fake) is worth keeping. I kept them separate because they serve different intents.

**Questions:**
- The `jar.Clear()` error branch currently logs `WARN` and returns `retry=false`. That's the pre-existing behavior; I added the test to pin it. If we ever want jar-clear failures to be louder (return an error, surface a metric), that should be a separate ticket — happy to file if desired.

[SOL-151506]: https://sol-jira.atlassian.net/browse/SOL-151506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151601]: https://sol-jira.atlassian.net/browse/SOL-151601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ