### PR TITLE
SOL-151627: fix latent SA5011 nil-deref warnings in test files

### DIFF
--- a/internal/semp/sempv1/envelope_test.go
+++ b/internal/semp/sempv1/envelope_test.go
@@ -80,6 +80,7 @@ func TestParseReply_Errors(t *testing.T) {
 			}
 			if err == nil {
 				t.Fatalf("expected an error, got nil")
+				return
 			}
 			if err.Kind != tc.wantKind {
 				t.Errorf("error kind mismatch got: %v want: %v", err.Kind, tc.wantKind)

--- a/internal/semp/sempv1/truncate_test.go
+++ b/internal/semp/sempv1/truncate_test.go
@@ -65,6 +65,7 @@ func TestParseReply_TruncatesOversizedMessage(t *testing.T) {
 	_, err := parseReply([]byte(body))
 	if err == nil {
 		t.Fatal("expected an error, got nil")
+		return
 	}
 	if err.Kind != ErrorKindParse {
 		t.Fatalf("kind mismatch: got %v want %v", err.Kind, ErrorKindParse)

--- a/internal/tools/composite_handler_test.go
+++ b/internal/tools/composite_handler_test.go
@@ -107,9 +107,11 @@ func TestCompositeToolHandler_Handle(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 	if result.StructuredContent == nil {
 		t.Fatal("expected non-nil StructuredContent")
+		return
 	}
 
 	// Collect strategy: result keyed by step ID.


### PR DESCRIPTION
Tracked under [SOL-151627](https://sol-jira.atlassian.net/browse/SOL-151627), parent epic [SOL-148417](https://sol-jira.atlassian.net/browse/SOL-148417).

## Summary

Fix 6 latent SA5011 findings that golangci-lint (v2.11.4, Linux) reports on the current main. The warnings only surface when the golangci-lint cache misses — main's most recent CI run had a cache hit, so these findings hadn't been caught. PR #150 tripped a cache miss (`go.mod` / `go.sum` hashes changed) and hit them.

## The warning

staticcheck's `SA5011` complains about "possible nil pointer dereference" when it sees code like:

```go
if err == nil {
    t.Fatalf("expected an error, got nil")
}
if err.Kind != tc.wantKind {  // <-- SA5011 flags this line
```

`t.Fatalf` does terminate the goroutine via `runtime.Goexit`, but staticcheck can't statically prove that through the `testing.TB` interface. Adding an explicit `return` after each `t.Fatal` resolves the finding without weakening the assertion — and is safer against a future refactor that swaps `t.Fatal` for `t.Errorf`.

## Files changed

- `internal/semp/sempv1/envelope_test.go` — 1 spot
- `internal/semp/sempv1/truncate_test.go` — 1 spot
- `internal/tools/composite_handler_test.go` — 2 spots

Total: 4 added lines, all `return`s after existing `t.Fatal` calls in `_test.go` files. No production code touched. No test behavior changes.

## Why here

Discovered by CI on PR #150 (OAuth token cache). PR #150 doesn't touch these files — the findings are latent on main. Fixing them here keeps PR #150's diff focused on SOL-151442; once this merges, PR #150 gets rebased onto a lint-clean main.

## Testing

- `golangci-lint run` (with `test-artifacts/` scratch hidden to match CI shape): 0 issues
- `go test ./internal/semp/sempv1/... ./internal/tools/`: pass

## Type of Change

- [x] Chore / lint hygiene

No behavior change.

[SOL-151627]: https://sol-jira.atlassian.net/browse/SOL-151627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-148417]: https://sol-jira.atlassian.net/browse/SOL-148417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ