### PR TITLE
SOL-151500: Extract shared field-coercion helpers into one file for postprocess aggregation handlers

### DIFF
--- a/internal/composite/postprocess/handlers/fields.go
+++ b/internal/composite/postprocess/handlers/fields.go
@@ -40,6 +40,8 @@ func numField(item map[string]any, name string) (float64, bool) {
 	}
 }
 
+// stringField returns the named string from item. Returns ok=false for missing,
+// nil, or unexpected types so the caller can skip the row rather than abort.
 func stringField(item map[string]any, name string) (string, bool) {
 	v, ok := item[name].(string)
 	return v, ok

--- a/internal/composite/postprocess/handlers/fields.go
+++ b/internal/composite/postprocess/handlers/fields.go
@@ -1,0 +1,53 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import "encoding/json"
+
+// numField accepts any of the numeric shapes JSON decoders produce: float64
+// (encoding/json default for map[string]any), json.Number (decoder with
+// UseNumber), int / int64 (custom unmarshalers). Keeps the handler insulated
+// from future SEMP-client decode-mode changes. Returns ok=false for missing,
+// nil, or unexpected types so the caller can skip the row rather than abort.
+func numField(item map[string]any, name string) (float64, bool) {
+	switch v := item[name].(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
+}
+
+func stringField(item map[string]any, name string) (string, bool) {
+	v, ok := item[name].(string)
+	return v, ok
+}
+
+// boolField returns the named bool from item. Returns ok=false for missing,
+// nil, or unexpected types so the caller can skip the row rather than abort.
+func boolField(item map[string]any, name string) (bool, bool) {
+	v, ok := item[name].(bool)
+	return v, ok
+}

--- a/internal/composite/postprocess/handlers/list_queues.go
+++ b/internal/composite/postprocess/handlers/list_queues.go
@@ -18,7 +18,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess"
@@ -128,33 +127,4 @@ func ListQueues(stepResults map[string]map[string]any) (map[string]any, error) {
 		out["truncated"] = true
 	}
 	return out, nil
-}
-
-// numField accepts any of the numeric shapes JSON decoders produce: float64
-// (encoding/json default for map[string]any), json.Number (decoder with
-// UseNumber), int / int64 (custom unmarshalers). Keeps the handler insulated
-// from future SEMP-client decode-mode changes. Returns ok=false for missing,
-// nil, or unexpected types so the caller can skip the row rather than abort.
-func numField(item map[string]any, name string) (float64, bool) {
-	switch v := item[name].(type) {
-	case float64:
-		return v, true
-	case int:
-		return float64(v), true
-	case int64:
-		return float64(v), true
-	case json.Number:
-		f, err := v.Float64()
-		if err != nil {
-			return 0, false
-		}
-		return f, true
-	default:
-		return 0, false
-	}
-}
-
-func stringField(item map[string]any, name string) (string, bool) {
-	v, ok := item[name].(string)
-	return v, ok
 }

--- a/internal/composite/postprocess/handlers/list_vpns.go
+++ b/internal/composite/postprocess/handlers/list_vpns.go
@@ -113,10 +113,3 @@ func ListVpns(stepResults map[string]map[string]any) (map[string]any, error) {
 	}
 	return out, nil
 }
-
-// boolField returns the named bool from item. Returns ok=false for missing,
-// nil, or unexpected types so the caller can skip the row rather than abort.
-func boolField(item map[string]any, name string) (bool, bool) {
-	v, ok := item[name].(bool)
-	return v, ok
-}


### PR DESCRIPTION
  ## Summary

Consolidate the shared field-coercion helpers (`numField`, `stringField`, `boolField`) into a single `fields.go` in the postprocess handlers package so parallel handler PRs can't re-declare them and break `main`.

Fixes [SOL-151500](https://sol-jira.atlassian.net/browse/SOL-151500)

## Type of Change
- [x] Refactoring (no functional changes)

## Motivation and Context

The aggregation rollout under SOL-151311 adds one postprocess handler per list tool, authored in parallel off `main`. The tiny row-decoding helpers were copy-declared in individual handler files, and `boolField` was independently added in PR #128 (`list_rdps.go`) and PR #132 (`list_vpns.go`). Each branch compiled on its own, but `main` broke with a duplicate-declaration error once both landed. No single-PR review or Copilot check catches this, since the collision only appears after merge. Giving the helpers one canonical home makes the collision structurally impossible.

## Changes Made

- Add `internal/composite/postprocess/handlers/fields.go` holding `numField`, `stringField`, and `boolField` with their existing godoc.
- Remove `numField` and `stringField` from `list_queues.go`; drop the now-unused `encoding/json` import.
- Remove `boolField` from `list_vpns.go`.
- No call-site changes; all existing usages resolve to the same package-level identifiers.

## Testing

**Test Environment:**
- Go version: go1.23 (repo `go.mod`)
- OS: Linux (Fedora 43)
- Broker version (if applicable): latest docker image 

**Tests Performed:**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**
- Pure refactor — no new behavior to test. All existing handler `*_test.go` files exercise the helpers via their callers and pass unchanged: `go test -race ./internal/composite/postprocess/handlers/...` is green.
- `make check` build + vet + race tests pass; the two pre-existing gosec findings in `internal/idpclient/` and `internal/observability/correlation/` are unrelated to this diff.
- tested against live broker and tool calls work as expected 

## Breaking Changes

n/a — helpers are package-private; signatures and semantics are identical.

**Impact:** None.

**Migration Guide:** None.

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code**
- [x] Followed secure logging rules (no logging touched)
- [x] Credential-carrying types implement `slog.LogValuer` (n/a — no such types added)
- [x] No security vulnerabilities introduced (no new gosec findings from this diff)

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests (existing handler tests cover the helpers)
- [x] Error paths tested (existing tests)
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (no user-facing change)
- [ ] docs/ updated (no architecture change)
- [x] godoc comments added/updated for exported functions (helpers are unexported; existing godoc preserved)
- [ ] CHANGELOG.md updated (n/a)
- [ ] Examples updated (n/a)

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

## Additional Notes

Sequencing note from the ticket: whichever of #128/#132 merged first was expected to carry `boolField`; this PR makes that consolidation the permanent home so the collision cannot recur.

## Related Issues/PRs

- Related to SOL-151311 (parent aggregation rollout), PRs #128, #132, #134, #135


[SOL-151500]: https://sol-jira.atlassian.net/browse/SOL-151500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ