### PR TITLE
diag: reproduce PR #150 SA5011 lint failure with cache busted + issue caps removed

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,10 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
+          # TEMPORARY (debug/lint-sa5011-cache): bypass the analysis cache to
+          # test whether stale cached facts are the source of the SA5011
+          # errors on PR #150. Revert before merging.
+          skip-cache: true
 
   build:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,12 @@
 version: "2"
 
+# TEMPORARY (debug/lint-sa5011-cache): remove issue caps so CI reports every
+# SA5011 hit instead of the default 3-per-text / 50-per-linter truncation.
+# Revert before merging back to main.
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
   enable:
     - errcheck      # unchecked error return values

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -596,6 +596,7 @@ func main() {
 				slog.String("error", err.Error()))
 			os.Exit(1)
 		}
+		defer exchanger.Close()
 	}
 
 	// 4. Create broker pool

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess/handlers" // register handlers via init()
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 	"github.com/SolaceDev/solace-broker-mcp/internal/idpclient"
 	"github.com/SolaceDev/solace-broker-mcp/internal/middleware/recovery"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
@@ -459,7 +460,15 @@ func newTokenExchanger(oauthCfg *config.BrokerOAuthConfig) (*tokenexchange.Excha
 	if err != nil {
 		return nil, fmt.Errorf("creating IdP HTTP client: %w", err)
 	}
-	exchanger, err := tokenexchange.FromConfig(oauthCfg, httpClient)
+	tokenCache, err := cache.NewTokenCache(cache.CacheConfig{
+		MaxSize:   defaults.DefaultOAuthCacheMaxSize,
+		ClockSkew: defaults.DefaultTokenExpirySkew,
+		MaxTTL:    defaults.DefaultMaxOAuthTokenTTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating token cache: %w", err)
+	}
+	exchanger, err := tokenexchange.FromConfig(oauthCfg, httpClient, tokenCache)
 	if err != nil {
 		return nil, fmt.Errorf("creating token exchanger: %w", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -470,6 +470,14 @@ func newTokenExchanger(oauthCfg *config.BrokerOAuthConfig) (*tokenexchange.Excha
 	}
 	exchanger, err := tokenexchange.FromConfig(oauthCfg, httpClient, tokenCache)
 	if err != nil {
+		// Cache already started its Otter eviction goroutine on construction.
+		// Release it before returning so the failed-startup path doesn't leak
+		// resources (the eventual os.Exit(1) reaps them anyway, but a test
+		// that drives this path would leak per invocation).
+		if closeErr := tokenCache.Close(); closeErr != nil {
+			slog.Warn("closing token cache after exchanger construction failed",
+				slog.String("error", closeErr.Error()))
+		}
 		return nil, fmt.Errorf("creating token exchanger: %w", err)
 	}
 	slog.Info("token exchanger created for broker OAuth")
@@ -596,7 +604,12 @@ func main() {
 				slog.String("error", err.Error()))
 			os.Exit(1)
 		}
-		defer exchanger.Close()
+		defer func() {
+			if closeErr := exchanger.Close(); closeErr != nil {
+				slog.Warn("closing token exchanger on shutdown",
+					slog.String("error", closeErr.Error()))
+			}
+		}()
 	}
 
 	// 4. Create broker pool

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,12 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+require (
+	github.com/dolthub/maphash v0.1.0 // indirect
+	github.com/gammazero/deque v0.2.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/maypok86/otter v1.2.4 // indirect
+)
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,12 @@ github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
+github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
+github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/getkin/kin-openapi v0.134.0 h1:/L5+1+kfe6dXh8Ot/wqiTgUkjOIEJiC0bbYVziHB8rU=
 github.com/getkin/kin-openapi v0.134.0/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
@@ -39,6 +43,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/maypok86/otter v1.2.4 h1:HhW1Pq6VdJkmWwcZZq19BlEQkHtI8xgsQzBVXJU0nfc=
+github.com/maypok86/otter v1.2.4/go.mod h1:mKLfoI7v1HOmQMwFgX4QkRk23mX6ge3RDvjdHOWG4R4=
 github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
 github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -226,6 +226,27 @@ const DefaultRetryMaxInterval = 30 * time.Second
 // are an IdP misconfiguration for machine-to-machine flows.
 const DefaultTokenExpirySkew = 30 * time.Second
 
+// DefaultOAuthCacheMaxSize is the maximum number of entries in the in-memory
+// OAuth token cache. When full, Otter's adaptive W-TinyLFU eviction policy
+// removes the least valuable entries automatically.
+//
+// Decided: 10000 entries.
+// Reasoning: enterprise deployments typically have far fewer concurrent users
+// than 10000; this provides generous headroom while keeping memory bounded
+// (each entry is a short string + time.Time, O(100 bytes) → ~1 MB at max).
+const DefaultOAuthCacheMaxSize = 10000
+
+// DefaultMaxOAuthTokenTTL caps the maximum TTL of any entry in the OAuth token
+// cache. Handles two edge cases: IdPs that omit expires_in (RFC 8693 makes it
+// RECOMMENDED, not mandatory) and IdPs that return absurdly large expires_in
+// values (e.g., 100 years).
+//
+// Decided: 24 hours.
+// Reasoning: enterprise IdPs typically issue tokens valid for minutes to hours.
+// A 24h cap accepts any realistic expiry while bounding memory and ensuring
+// stale tokens are eventually evicted even if the background sweeper misfires.
+const DefaultMaxOAuthTokenTTL = 24 * time.Hour
+
 // DefaultSaturationThresholdMs is the latency above which a tool call is
 // considered slow enough to emit a saturation signal (a future observability
 // story consumes this). Expressed in milliseconds to match the YAML field

--- a/internal/oauth/cache/cache.go
+++ b/internal/oauth/cache/cache.go
@@ -32,27 +32,49 @@ func (c CachedCredential) GoString() string {
 	return c.String()
 }
 
+// GetStatus describes the outcome of a Get call.
+type GetStatus int
+
+const (
+	GetHit         GetStatus = iota // Entry found and fresh.
+	GetMissAbsent                   // No entry for this key.
+	GetMissExpired                  // Entry exists but failed the freshness check.
+)
+
+// GetResult is returned by Get. Callers inspect Status to distinguish
+// hit, clean miss, and expired miss — each has different diagnostic meaning.
+type GetResult struct {
+	Entry  CachedCredential
+	Status GetStatus
+}
+
+// PutStatus describes the outcome of a Put call.
+type PutStatus int
+
+const (
+	PutStored     PutStatus = iota // Entry accepted and stored.
+	PutDroppedTTL                  // TTL was zero or negative after clock-skew; not stored.
+	PutDroppedFull                 // Otter's admission policy rejected the entry (cache full).
+)
+
+// PutResult is returned by Put.
+type PutResult struct {
+	Status PutStatus
+}
+
+// DeleteResult is returned by Delete. Empty today; exists so a future backend
+// (e.g. Redis DEL returning a count) can surface info without changing the
+// interface signature.
+type DeleteResult struct{}
+
 // TokenCache is the boundary between the Exchanger and whatever storage
 // implementation backs the cache. The Exchanger depends on this interface only.
-//
-// Freshness contract: Get returns found=false for both "never stored" and
-// "stored but expired" — callers cannot distinguish the two cases, by design.
-// This keeps all freshness policy inside the cache implementation.
 //
 // Error contract: errors are for backend failures only (e.g., Redis down in a
 // future implementation). In-memory implementations should never return
 // non-nil errors.
 type TokenCache interface {
-	// Get returns a credential only if one is stored AND still fresh by the
-	// cache's policy. found=false means "no usable entry here".
-	Get(ctx context.Context, key string) (entry CachedCredential, found bool, err error)
-
-	// Put stores a credential. The cache uses entry.ExpiresAt to determine TTL.
-	// If the computed TTL is zero or negative (already expired or within the
-	// clock-skew window), the entry is not stored.
-	Put(ctx context.Context, key string, entry CachedCredential) error
-
-	// Delete forcibly evicts a key. Idempotent — deleting a non-existent key
-	// returns nil. Used for known-bad token paths (e.g., broker 401).
-	Delete(ctx context.Context, key string) error
+	Get(ctx context.Context, key string) (GetResult, error)
+	Put(ctx context.Context, key string, entry CachedCredential) (PutResult, error)
+	Delete(ctx context.Context, key string) (DeleteResult, error)
 }

--- a/internal/oauth/cache/cache.go
+++ b/internal/oauth/cache/cache.go
@@ -1,0 +1,44 @@
+// Package cache provides the TokenCache interface and its Otter v2-backed
+// implementation for the OAuth token exchange feature (SOL-150052).
+//
+// The cache is silent: it emits no logs and no metrics. Observability for
+// cache operations lives in the Exchanger (the caller), not here.
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+// CachedCredential is a cached OAuth access token with its expiry time as
+// reported by the identity provider. The Value field must never appear in
+// error messages, log lines, or metrics labels — it is a credential.
+type CachedCredential struct {
+	Value     string
+	ExpiresAt time.Time
+}
+
+// TokenCache is the boundary between the Exchanger and whatever storage
+// implementation backs the cache. The Exchanger depends on this interface only.
+//
+// Freshness contract: Get returns found=false for both "never stored" and
+// "stored but expired" — callers cannot distinguish the two cases, by design.
+// This keeps all freshness policy inside the cache implementation.
+//
+// Error contract: errors are for backend failures only (e.g., Redis down in a
+// future implementation). In-memory implementations should never return
+// non-nil errors.
+type TokenCache interface {
+	// Get returns a credential only if one is stored AND still fresh by the
+	// cache's policy. found=false means "no usable entry here".
+	Get(ctx context.Context, key string) (entry CachedCredential, found bool, err error)
+
+	// Put stores a credential. The cache uses entry.ExpiresAt to determine TTL.
+	// If the computed TTL is zero or negative (already expired or within the
+	// clock-skew window), the entry is not stored.
+	Put(ctx context.Context, key string, entry CachedCredential) error
+
+	// Delete forcibly evicts a key. Idempotent — deleting a non-existent key
+	// returns nil. Used for known-bad token paths (e.g., broker 401).
+	Delete(ctx context.Context, key string) error
+}

--- a/internal/oauth/cache/cache.go
+++ b/internal/oauth/cache/cache.go
@@ -128,4 +128,5 @@ type TokenCache interface {
 	Get(ctx context.Context, key string) (GetResult, error)
 	Put(ctx context.Context, key string, entry CachedCredential) (PutResult, error)
 	Delete(ctx context.Context, key string) (DeleteResult, error)
+	Close() error
 }

--- a/internal/oauth/cache/cache.go
+++ b/internal/oauth/cache/cache.go
@@ -12,6 +12,13 @@ import (
 	"time"
 )
 
+// CacheConfig holds the parameters for constructing a TokenCache.
+type CacheConfig struct {
+	MaxSize   int
+	ClockSkew time.Duration
+	MaxTTL    time.Duration
+}
+
 // CachedCredential is a cached OAuth access token with its expiry time as
 // reported by the identity provider. The Value field must never appear in
 // error messages, log lines, or metrics labels — it is a credential.

--- a/internal/oauth/cache/cache.go
+++ b/internal/oauth/cache/cache.go
@@ -41,6 +41,28 @@ const (
 	GetMissExpired                  // Entry exists but failed the freshness check.
 )
 
+func (s GetStatus) String() string {
+	switch s {
+	case GetHit:
+		return "hit"
+	case GetMissAbsent:
+		return "miss_absent"
+	case GetMissExpired:
+		return "miss_expired"
+	default:
+		return fmt.Sprintf("GetStatus(%d)", int(s))
+	}
+}
+
+func (s GetStatus) Level() slog.Level {
+	switch s {
+	case GetMissExpired:
+		return slog.LevelWarn
+	default:
+		return slog.LevelDebug
+	}
+}
+
 // GetResult is returned by Get. Callers inspect Status to distinguish
 // hit, clean miss, and expired miss — each has different diagnostic meaning.
 type GetResult struct {
@@ -56,6 +78,28 @@ const (
 	PutDroppedTTL                  // TTL was zero or negative after clock-skew; not stored.
 	PutDroppedFull                 // Otter's admission policy rejected the entry (cache full).
 )
+
+func (s PutStatus) String() string {
+	switch s {
+	case PutStored:
+		return "stored"
+	case PutDroppedTTL:
+		return "dropped_ttl"
+	case PutDroppedFull:
+		return "dropped_full"
+	default:
+		return fmt.Sprintf("PutStatus(%d)", int(s))
+	}
+}
+
+func (s PutStatus) Level() slog.Level {
+	switch s {
+	case PutDroppedTTL, PutDroppedFull:
+		return slog.LevelWarn
+	default:
+		return slog.LevelDebug
+	}
+}
 
 // PutResult is returned by Put.
 type PutResult struct {

--- a/internal/oauth/cache/cache.go
+++ b/internal/oauth/cache/cache.go
@@ -7,6 +7,8 @@ package cache
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -16,6 +18,18 @@ import (
 type CachedCredential struct {
 	Value     string
 	ExpiresAt time.Time
+}
+
+func (c CachedCredential) String() string {
+	return fmt.Sprintf("CachedCredential{ExpiresAt: %v}", c.ExpiresAt)
+}
+
+func (c CachedCredential) LogValue() slog.Value {
+	return slog.GroupValue(slog.Time("expires_at", c.ExpiresAt))
+}
+
+func (c CachedCredential) GoString() string {
+	return c.String()
 }
 
 // TokenCache is the boundary between the Exchanger and whatever storage

--- a/internal/oauth/cache/cache_test.go
+++ b/internal/oauth/cache/cache_test.go
@@ -342,17 +342,13 @@ func TestPut_OverwritesExistingKey(t *testing.T) {
 	}
 }
 
-// T12: MaxSize=0 panics at construction.
-// otter.MustBuilder panics on invalid MaxSize (panic-on-misuse contract).
-func TestNewTokenCache_PanicsOnMaxSizeZero(t *testing.T) {
+// T12: MaxSize=0 returns an error at construction.
+func TestNewTokenCache_ErrorOnMaxSizeZero(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for MaxSize=0, got none")
-		}
-	}()
-	//nolint:errcheck // return value unreachable — panic fires inside MustBuilder.
-	_, _ = NewTokenCache(CacheConfig{MaxSize: 0, ClockSkew: 0, MaxTTL: time.Hour})
+	_, err := NewTokenCache(CacheConfig{MaxSize: 0, ClockSkew: 0, MaxTTL: time.Hour})
+	if err == nil {
+		t.Fatal("expected error for MaxSize=0, got nil")
+	}
 }
 
 // T14: All Put/Get/Delete calls return nil error, including edge cases.

--- a/internal/oauth/cache/cache_test.go
+++ b/internal/oauth/cache/cache_test.go
@@ -331,6 +331,37 @@ func TestNewTokenCache_ErrorOnMaxSizeZero(t *testing.T) {
 	}
 }
 
+// T12a: MaxTTL<=0 returns an error at construction. A zero or negative MaxTTL
+// would clamp every safeTTL to <= 0 in Put, causing every entry to be silently
+// dropped as PutDroppedTTL — a valid-looking cache that never caches anything.
+// Fail loud at construction instead.
+func TestNewTokenCache_ErrorOnMaxTTLZero(t *testing.T) {
+	t.Parallel()
+	_, err := NewTokenCache(CacheConfig{MaxSize: 100, ClockSkew: 0, MaxTTL: 0})
+	if err == nil {
+		t.Fatal("expected error for MaxTTL=0, got nil")
+	}
+}
+
+func TestNewTokenCache_ErrorOnMaxTTLNegative(t *testing.T) {
+	t.Parallel()
+	_, err := NewTokenCache(CacheConfig{MaxSize: 100, ClockSkew: 0, MaxTTL: -time.Second})
+	if err == nil {
+		t.Fatal("expected error for negative MaxTTL, got nil")
+	}
+}
+
+// T12b: A negative ClockSkew is a wiring bug — it would extend the effective
+// TTL past the token's real ExpiresAt, serving already-expired credentials
+// after Otter's sweeper hasn't caught up yet.
+func TestNewTokenCache_ErrorOnClockSkewNegative(t *testing.T) {
+	t.Parallel()
+	_, err := NewTokenCache(CacheConfig{MaxSize: 100, ClockSkew: -time.Second, MaxTTL: time.Hour})
+	if err == nil {
+		t.Fatal("expected error for negative ClockSkew, got nil")
+	}
+}
+
 // T14: All Put/Get/Delete calls return nil error, including edge cases.
 func TestErrors_AlwaysNil(t *testing.T) {
 	t.Parallel()

--- a/internal/oauth/cache/cache_test.go
+++ b/internal/oauth/cache/cache_test.go
@@ -16,8 +16,6 @@ func newTestCache(t *testing.T, cfg CacheConfig) TokenCache {
 	if err != nil {
 		t.Fatalf("NewTokenCache: %v", err)
 	}
-	// otter.CacheWithVariableTTL embeds baseCache which exposes Close().
-	// We reach it through the concrete type returned by newOtterTokenCache.
 	t.Cleanup(func() {
 		c.(*otterTokenCache).cache.Close()
 	})
@@ -31,10 +29,6 @@ var defaultCfg = CacheConfig{
 }
 
 // T1: Get returns only fresh tokens.
-//
-// Sub-case 2 note: a token with ExpiresAt in the past produces a non-positive TTL
-// inside Put, so the entry is silently dropped before it ever reaches otter.
-// The token is therefore absent from Get, not evicted — Put short-circuits on ttl<=0.
 func TestGet_ReturnsFreshTokensOnly(t *testing.T) {
 	t.Parallel()
 
@@ -44,21 +38,21 @@ func TestGet_ReturnsFreshTokensOnly(t *testing.T) {
 		ctx := context.Background()
 		tok := CachedCredential{Value: "tok", ExpiresAt: time.Now().Add(5 * time.Minute)}
 
-		if err := c.Put(ctx, "k", tok); err != nil {
+		if _, err := c.Put(ctx, "k", tok); err != nil {
 			t.Fatalf("Put: %v", err)
 		}
-		got, found, err := c.Get(ctx, "k")
+		res, err := c.Get(ctx, "k")
 		if err != nil {
 			t.Fatalf("Get: %v", err)
 		}
-		if !found {
-			t.Fatal("expected found=true for fresh token")
+		if res.Status != GetHit {
+			t.Fatalf("expected GetHit, got %v", res.Status)
 		}
-		if got.Value != tok.Value {
-			t.Errorf("Value: got %q, want %q", got.Value, tok.Value)
+		if res.Entry.Value != tok.Value {
+			t.Errorf("Value: got %q, want %q", res.Entry.Value, tok.Value)
 		}
-		if !got.ExpiresAt.Equal(tok.ExpiresAt) {
-			t.Errorf("ExpiresAt: got %v, want %v", got.ExpiresAt, tok.ExpiresAt)
+		if !res.Entry.ExpiresAt.Equal(tok.ExpiresAt) {
+			t.Errorf("ExpiresAt: got %v, want %v", res.Entry.ExpiresAt, tok.ExpiresAt)
 		}
 	})
 
@@ -66,58 +60,54 @@ func TestGet_ReturnsFreshTokensOnly(t *testing.T) {
 		t.Parallel()
 		c := newTestCache(t, defaultCfg)
 		ctx := context.Background()
-		// ExpiresAt in the past → Put computes ttl<=0 and drops the entry silently.
 		tok := CachedCredential{Value: "old", ExpiresAt: time.Now().Add(-5 * time.Minute)}
 
-		if err := c.Put(ctx, "k2", tok); err != nil {
+		pr, err := c.Put(ctx, "k2", tok)
+		if err != nil {
 			t.Fatalf("Put: %v", err)
 		}
-		got, found, err := c.Get(ctx, "k2")
+		if pr.Status != PutDroppedTTL {
+			t.Errorf("expected PutDroppedTTL, got %v", pr.Status)
+		}
+		res, err := c.Get(ctx, "k2")
 		if err != nil {
 			t.Fatalf("Get: %v", err)
 		}
-		if found {
-			t.Errorf("expected found=false for expired token, got found=true with value %q", got.Value)
-		}
-		if got != (CachedCredential{}) {
-			t.Errorf("expected zero Token on miss, got %+v", got)
+		if res.Status != GetMissAbsent {
+			t.Errorf("expected GetMissAbsent, got %v", res.Status)
 		}
 	})
 }
 
-// T2: Put and Get round-trip across multiple keys.
-func TestPutGet_RoundTrip(t *testing.T) {
+// T2: Delete one key does not affect another key (key isolation).
+func TestDelete_KeyIsolation(t *testing.T) {
 	t.Parallel()
 	c := newTestCache(t, defaultCfg)
 	ctx := context.Background()
 
-	tok1 := CachedCredential{Value: "access-token-1", ExpiresAt: time.Now().Add(10 * time.Minute)}
-	tok2 := CachedCredential{Value: "stale", ExpiresAt: time.Now().Add(-1 * time.Minute)}
+	tok1 := CachedCredential{Value: "v1", ExpiresAt: time.Now().Add(10 * time.Minute)}
+	tok2 := CachedCredential{Value: "v2", ExpiresAt: time.Now().Add(10 * time.Minute)}
 
-	if err := c.Put(ctx, "k1", tok1); err != nil {
+	if _, err := c.Put(ctx, "k1", tok1); err != nil {
 		t.Fatalf("Put k1: %v", err)
 	}
-	if err := c.Put(ctx, "k2", tok2); err != nil {
+	if _, err := c.Put(ctx, "k2", tok2); err != nil {
 		t.Fatalf("Put k2: %v", err)
 	}
 
-	got1, found1, err := c.Get(ctx, "k1")
-	if err != nil {
-		t.Fatalf("Get k1: %v", err)
-	}
-	if !found1 {
-		t.Error("expected found=true for k1")
-	}
-	if got1.Value != "access-token-1" {
-		t.Errorf("k1 Value: got %q, want %q", got1.Value, "access-token-1")
+	if _, err := c.Delete(ctx, "k1"); err != nil {
+		t.Fatalf("Delete k1: %v", err)
 	}
 
-	_, found2, err := c.Get(ctx, "k2")
+	res, err := c.Get(ctx, "k2")
 	if err != nil {
 		t.Fatalf("Get k2: %v", err)
 	}
-	if found2 {
-		t.Error("expected found=false for stale k2")
+	if res.Status != GetHit {
+		t.Error("expected k2 still present after deleting k1")
+	}
+	if res.Entry.Value != "v2" {
+		t.Errorf("k2 Value: got %q, want %q", res.Entry.Value, "v2")
 	}
 }
 
@@ -128,25 +118,25 @@ func TestDelete_RemovesEntry(t *testing.T) {
 	ctx := context.Background()
 
 	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(10 * time.Minute)}
-	if err := c.Put(ctx, "k", tok); err != nil {
+	if _, err := c.Put(ctx, "k", tok); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
-	_, found, err := c.Get(ctx, "k")
-	if err != nil || !found {
-		t.Fatalf("pre-delete Get: found=%v err=%v", found, err)
+	res, err := c.Get(ctx, "k")
+	if err != nil || res.Status != GetHit {
+		t.Fatalf("pre-delete Get: status=%v err=%v", res.Status, err)
 	}
 
-	if err := c.Delete(ctx, "k"); err != nil {
+	if _, err := c.Delete(ctx, "k"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 
-	_, found, err = c.Get(ctx, "k")
+	res, err = c.Get(ctx, "k")
 	if err != nil {
 		t.Fatalf("post-delete Get: %v", err)
 	}
-	if found {
-		t.Error("expected found=false after Delete")
+	if res.Status != GetMissAbsent {
+		t.Error("expected GetMissAbsent after Delete")
 	}
 }
 
@@ -158,7 +148,7 @@ func TestDelete_Idempotent(t *testing.T) {
 		t.Parallel()
 		c := newTestCache(t, defaultCfg)
 		ctx := context.Background()
-		if err := c.Delete(ctx, "never-stored"); err != nil {
+		if _, err := c.Delete(ctx, "never-stored"); err != nil {
 			t.Errorf("Delete(never-stored): expected nil, got %v", err)
 		}
 	})
@@ -168,21 +158,19 @@ func TestDelete_Idempotent(t *testing.T) {
 		c := newTestCache(t, defaultCfg)
 		ctx := context.Background()
 		tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(10 * time.Minute)}
-		if err := c.Put(ctx, "k", tok); err != nil {
+		if _, err := c.Put(ctx, "k", tok); err != nil {
 			t.Fatalf("Put: %v", err)
 		}
-		if err := c.Delete(ctx, "k"); err != nil {
+		if _, err := c.Delete(ctx, "k"); err != nil {
 			t.Errorf("first Delete: %v", err)
 		}
-		if err := c.Delete(ctx, "k"); err != nil {
+		if _, err := c.Delete(ctx, "k"); err != nil {
 			t.Errorf("second Delete: %v", err)
 		}
 	})
 }
 
 // T5: Concurrent access under -race flag.
-// 50 goroutines Put, 50 goroutines Get — no data race allowed.
-// t.Errorf (not t.Fatal) is used inside goroutines per contract.
 func TestConcurrentAccess(t *testing.T) {
 	t.Parallel()
 	c := newTestCache(t, CacheConfig{MaxSize: 1000, ClockSkew: 0, MaxTTL: time.Hour})
@@ -194,32 +182,29 @@ func TestConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(n * 2)
 
-	// Writers
 	for i := 0; i < n; i++ {
 		i := i
 		go func() {
 			defer wg.Done()
 			key := fmt.Sprintf("key-%d", i)
 			tok := CachedCredential{Value: fmt.Sprintf("val-%d", i), ExpiresAt: expiresAt}
-			if err := c.Put(ctx, key, tok); err != nil {
+			if _, err := c.Put(ctx, key, tok); err != nil {
 				t.Errorf("Put(%s): %v", key, err)
 			}
 		}()
 	}
 
-	// Readers
 	for i := 0; i < n; i++ {
 		i := i
 		go func() {
 			defer wg.Done()
 			key := fmt.Sprintf("key-%d", i)
-			tok, found, err := c.Get(ctx, key)
+			res, err := c.Get(ctx, key)
 			if err != nil {
 				t.Errorf("Get(%s): %v", key, err)
 			}
-			// found may be false if Put hasn't run yet — that's a valid race outcome.
-			if found && tok.ExpiresAt.IsZero() {
-				t.Errorf("Get(%s): found=true but ExpiresAt is zero", key)
+			if res.Status == GetHit && res.Entry.ExpiresAt.IsZero() {
+				t.Errorf("Get(%s): GetHit but ExpiresAt is zero", key)
 			}
 		}()
 	}
@@ -234,86 +219,81 @@ func TestTTL_NormalCase(t *testing.T) {
 	ctx := context.Background()
 
 	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(2 * time.Minute)}
-	if err := c.Put(ctx, "k", tok); err != nil {
+	if _, err := c.Put(ctx, "k", tok); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
-	_, found, err := c.Get(ctx, "k")
+	res, err := c.Get(ctx, "k")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if !found {
-		t.Error("expected found=true for token well within TTL")
+	if res.Status != GetHit {
+		t.Error("expected GetHit for token well within TTL")
 	}
 }
 
 // T7: TTL MaxTTL cap — token with long ExpiresAt is capped to MaxTTL but still positive.
 func TestTTL_MaxTTLCap(t *testing.T) {
 	t.Parallel()
-	// MaxTTL=1m, ClockSkew=30s → effective TTL = min(rawTTL-30s, 1m).
-	// rawTTL ≈ 1h → safeTTL ≈ 59m30s → capped to 1m. Still positive → stored.
 	c := newTestCache(t, CacheConfig{MaxSize: 100, ClockSkew: 30 * time.Second, MaxTTL: time.Minute})
 	ctx := context.Background()
 
 	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(time.Hour)}
-	if err := c.Put(ctx, "k", tok); err != nil {
+	if _, err := c.Put(ctx, "k", tok); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
-	_, found, err := c.Get(ctx, "k")
+	res, err := c.Get(ctx, "k")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if !found {
-		t.Error("expected found=true after MaxTTL cap with positive remaining TTL")
+	if res.Status != GetHit {
+		t.Error("expected GetHit after MaxTTL cap with positive remaining TTL")
 	}
 }
 
 // T8: TTL within skew margin — token expiring within clockSkew window is not stored.
 func TestTTL_WithinSkewMargin(t *testing.T) {
 	t.Parallel()
-	// ClockSkew=30s, token expires in 20s → safeTTL = 20s-30s = -10s → ttl<=0 → not stored.
 	c := newTestCache(t, CacheConfig{MaxSize: 100, ClockSkew: 30 * time.Second, MaxTTL: 24 * time.Hour})
 	ctx := context.Background()
 
-	expiresAt := time.Now().Add(20 * time.Second)
-	tok := CachedCredential{Value: "v", ExpiresAt: expiresAt}
-	if err := c.Put(ctx, "k", tok); err != nil {
+	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(20 * time.Second)}
+	pr, err := c.Put(ctx, "k", tok)
+	if err != nil {
 		t.Fatalf("Put: %v", err)
 	}
+	if pr.Status != PutDroppedTTL {
+		t.Errorf("expected PutDroppedTTL, got %v", pr.Status)
+	}
 
-	_, found, err := c.Get(ctx, "k")
+	res, err := c.Get(ctx, "k")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if found {
-		t.Error("expected found=false for token within clock skew margin")
+	if res.Status != GetMissAbsent {
+		t.Error("expected GetMissAbsent for token within clock skew margin")
 	}
 }
 
-// T9: Freshness contract — cache miss and expired-token Put both return (CachedCredential{}, false, nil).
-func TestFreshnessContract_Indistinguishable(t *testing.T) {
+// T9: GetMissAbsent is returned for a never-stored key.
+// GetMissExpired exists for belt-and-suspenders (Otter sweeper lag) but is not
+// deterministically testable — Otter evicts before ExpiresAt is reached.
+func TestGetResult_AbsentStatus(t *testing.T) {
 	t.Parallel()
 	c := newTestCache(t, defaultCfg)
 	ctx := context.Background()
 
-	// Sub-case A: key never stored.
-	gotA, foundA, errA := c.Get(ctx, "never-stored")
-	if errA != nil || foundA || gotA != (CachedCredential{}) {
-		t.Errorf("sub-case A: got (%+v, %v, %v), want (CachedCredential{}, false, nil)", gotA, foundA, errA)
+	res, err := c.Get(ctx, "never-stored")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
 	}
-
-	// Sub-case B: expired token dropped by Put (ttl<=0), Get sees absence.
-	tokB := CachedCredential{Value: "old", ExpiresAt: time.Now().Add(-1 * time.Minute)}
-	if err := c.Put(ctx, "k", tokB); err != nil {
-		t.Fatalf("Put: %v", err)
+	if res.Status != GetMissAbsent {
+		t.Errorf("got %v, want GetMissAbsent", res.Status)
 	}
-	gotB, foundB, errB := c.Get(ctx, "k")
-	if errB != nil || foundB || gotB != (CachedCredential{}) {
-		t.Errorf("sub-case B: got (%+v, %v, %v), want (CachedCredential{}, false, nil)", gotB, foundB, errB)
+	if res.Entry != (CachedCredential{}) {
+		t.Errorf("expected zero CachedCredential on miss, got %+v", res.Entry)
 	}
-
-	// Both results are structurally identical — callers cannot distinguish the two cases.
 }
 
 // T11: Put overwrites an existing key with a new value.
@@ -323,22 +303,22 @@ func TestPut_OverwritesExistingKey(t *testing.T) {
 	ctx := context.Background()
 	exp := time.Now().Add(10 * time.Minute)
 
-	if err := c.Put(ctx, "k", CachedCredential{Value: "token1", ExpiresAt: exp}); err != nil {
+	if _, err := c.Put(ctx, "k", CachedCredential{Value: "token1", ExpiresAt: exp}); err != nil {
 		t.Fatalf("Put token1: %v", err)
 	}
-	if err := c.Put(ctx, "k", CachedCredential{Value: "token2", ExpiresAt: exp}); err != nil {
+	if _, err := c.Put(ctx, "k", CachedCredential{Value: "token2", ExpiresAt: exp}); err != nil {
 		t.Fatalf("Put token2: %v", err)
 	}
 
-	got, found, err := c.Get(ctx, "k")
+	res, err := c.Get(ctx, "k")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if !found {
-		t.Fatal("expected found=true after overwrite")
+	if res.Status != GetHit {
+		t.Fatal("expected GetHit after overwrite")
 	}
-	if got.Value != "token2" {
-		t.Errorf("Value: got %q, want %q", got.Value, "token2")
+	if res.Entry.Value != "token2" {
+		t.Errorf("Value: got %q, want %q", res.Entry.Value, "token2")
 	}
 }
 
@@ -357,33 +337,78 @@ func TestErrors_AlwaysNil(t *testing.T) {
 	c := newTestCache(t, defaultCfg)
 	ctx := context.Background()
 
-	// Put with future ExpiresAt.
-	if err := c.Put(ctx, "fresh", CachedCredential{Value: "v", ExpiresAt: time.Now().Add(time.Minute)}); err != nil {
+	if _, err := c.Put(ctx, "fresh", CachedCredential{Value: "v", ExpiresAt: time.Now().Add(time.Minute)}); err != nil {
 		t.Errorf("Put(fresh): %v", err)
 	}
 
-	// Put with past ExpiresAt (ttl<=0, silently dropped).
-	if err := c.Put(ctx, "expired", CachedCredential{Value: "v", ExpiresAt: time.Now().Add(-time.Minute)}); err != nil {
+	if _, err := c.Put(ctx, "expired", CachedCredential{Value: "v", ExpiresAt: time.Now().Add(-time.Minute)}); err != nil {
 		t.Errorf("Put(expired): %v", err)
 	}
 
-	// Get existing (fresh) key.
-	if _, _, err := c.Get(ctx, "fresh"); err != nil {
+	if _, err := c.Get(ctx, "fresh"); err != nil {
 		t.Errorf("Get(fresh): %v", err)
 	}
 
-	// Get nonexistent key.
-	if _, _, err := c.Get(ctx, "nonexistent"); err != nil {
+	if _, err := c.Get(ctx, "nonexistent"); err != nil {
 		t.Errorf("Get(nonexistent): %v", err)
 	}
 
-	// Delete existing key.
-	if err := c.Delete(ctx, "fresh"); err != nil {
+	if _, err := c.Delete(ctx, "fresh"); err != nil {
 		t.Errorf("Delete(fresh): %v", err)
 	}
 
-	// Delete nonexistent key.
-	if err := c.Delete(ctx, "nonexistent"); err != nil {
+	if _, err := c.Delete(ctx, "nonexistent"); err != nil {
 		t.Errorf("Delete(nonexistent): %v", err)
+	}
+}
+
+// Test B: Stale token is not served after natural expiry (belt-and-suspenders).
+func TestGet_StaleNotServedAfterExpiry(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, defaultCfg)
+	ctx := context.Background()
+
+	tok := CachedCredential{Value: "short", ExpiresAt: time.Now().Add(1 * time.Second)}
+	pr, err := c.Put(ctx, "k", tok)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if pr.Status != PutStored {
+		t.Fatalf("expected PutStored, got %v", pr.Status)
+	}
+
+	// Verify it's there.
+	res, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get before expiry: %v", err)
+	}
+	if res.Status != GetHit {
+		t.Fatalf("expected GetHit before expiry, got %v", res.Status)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	res, err = c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get after expiry: %v", err)
+	}
+	if res.Status == GetHit {
+		t.Error("stale token should not be served after expiry")
+	}
+}
+
+// Test C: PutResult reports PutStored for a successfully stored entry.
+func TestPutResult_ReportsStored(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, defaultCfg)
+	ctx := context.Background()
+
+	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(5 * time.Minute)}
+	pr, err := c.Put(ctx, "k", tok)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if pr.Status != PutStored {
+		t.Errorf("expected PutStored, got %v", pr.Status)
 	}
 }

--- a/internal/oauth/cache/cache_test.go
+++ b/internal/oauth/cache/cache_test.go
@@ -8,8 +8,14 @@ import (
 	"time"
 )
 
-// newTestCache constructs a TokenCache from cfg and registers t.Cleanup to call
-// Close() on the underlying otter cache, preventing goroutine leaks between tests.
+// newTestCache constructs a TokenCache from cfg and registers t.Cleanup to
+// call Close() on the interface, preventing goroutine leaks (Otter's sweeper)
+// and unpinning the cache from the GC between tests.
+//
+// External packages should not duplicate this helper — use
+// internal/oauth/cache/cachetest.Default(t) instead. This local copy exists
+// because the cache package's own tests cannot import cachetest without
+// creating an import cycle.
 func newTestCache(t *testing.T, cfg CacheConfig) TokenCache {
 	t.Helper()
 	c, err := NewTokenCache(cfg)
@@ -17,7 +23,9 @@ func newTestCache(t *testing.T, cfg CacheConfig) TokenCache {
 		t.Fatalf("NewTokenCache: %v", err)
 	}
 	t.Cleanup(func() {
-		c.(*otterTokenCache).cache.Close()
+		if err := c.Close(); err != nil {
+			t.Logf("cache.Close: %v", err)
+		}
 	})
 	return c
 }

--- a/internal/oauth/cache/cache_test.go
+++ b/internal/oauth/cache/cache_test.go
@@ -1,0 +1,393 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestCache constructs a TokenCache from cfg and registers t.Cleanup to call
+// Close() on the underlying otter cache, preventing goroutine leaks between tests.
+func newTestCache(t *testing.T, cfg CacheConfig) TokenCache {
+	t.Helper()
+	c, err := NewTokenCache(cfg)
+	if err != nil {
+		t.Fatalf("NewTokenCache: %v", err)
+	}
+	// otter.CacheWithVariableTTL embeds baseCache which exposes Close().
+	// We reach it through the concrete type returned by newOtterTokenCache.
+	t.Cleanup(func() {
+		c.(*otterTokenCache).cache.Close()
+	})
+	return c
+}
+
+var defaultCfg = CacheConfig{
+	MaxSize:   100,
+	ClockSkew: 0,
+	MaxTTL:    time.Hour,
+}
+
+// T1: Get returns only fresh tokens.
+//
+// Sub-case 2 note: a token with ExpiresAt in the past produces a non-positive TTL
+// inside Put, so the entry is silently dropped before it ever reaches otter.
+// The token is therefore absent from Get, not evicted — Put short-circuits on ttl<=0.
+func TestGet_ReturnsFreshTokensOnly(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fresh token is returned", func(t *testing.T) {
+		t.Parallel()
+		c := newTestCache(t, defaultCfg)
+		ctx := context.Background()
+		tok := CachedCredential{Value: "tok", ExpiresAt: time.Now().Add(5 * time.Minute)}
+
+		if err := c.Put(ctx, "k", tok); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		got, found, err := c.Get(ctx, "k")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if !found {
+			t.Fatal("expected found=true for fresh token")
+		}
+		if got.Value != tok.Value {
+			t.Errorf("Value: got %q, want %q", got.Value, tok.Value)
+		}
+		if !got.ExpiresAt.Equal(tok.ExpiresAt) {
+			t.Errorf("ExpiresAt: got %v, want %v", got.ExpiresAt, tok.ExpiresAt)
+		}
+	})
+
+	t.Run("expired token is not returned (Put short-circuits on ttl<=0)", func(t *testing.T) {
+		t.Parallel()
+		c := newTestCache(t, defaultCfg)
+		ctx := context.Background()
+		// ExpiresAt in the past → Put computes ttl<=0 and drops the entry silently.
+		tok := CachedCredential{Value: "old", ExpiresAt: time.Now().Add(-5 * time.Minute)}
+
+		if err := c.Put(ctx, "k2", tok); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		got, found, err := c.Get(ctx, "k2")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if found {
+			t.Errorf("expected found=false for expired token, got found=true with value %q", got.Value)
+		}
+		if got != (CachedCredential{}) {
+			t.Errorf("expected zero Token on miss, got %+v", got)
+		}
+	})
+}
+
+// T2: Put and Get round-trip across multiple keys.
+func TestPutGet_RoundTrip(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, defaultCfg)
+	ctx := context.Background()
+
+	tok1 := CachedCredential{Value: "access-token-1", ExpiresAt: time.Now().Add(10 * time.Minute)}
+	tok2 := CachedCredential{Value: "stale", ExpiresAt: time.Now().Add(-1 * time.Minute)}
+
+	if err := c.Put(ctx, "k1", tok1); err != nil {
+		t.Fatalf("Put k1: %v", err)
+	}
+	if err := c.Put(ctx, "k2", tok2); err != nil {
+		t.Fatalf("Put k2: %v", err)
+	}
+
+	got1, found1, err := c.Get(ctx, "k1")
+	if err != nil {
+		t.Fatalf("Get k1: %v", err)
+	}
+	if !found1 {
+		t.Error("expected found=true for k1")
+	}
+	if got1.Value != "access-token-1" {
+		t.Errorf("k1 Value: got %q, want %q", got1.Value, "access-token-1")
+	}
+
+	_, found2, err := c.Get(ctx, "k2")
+	if err != nil {
+		t.Fatalf("Get k2: %v", err)
+	}
+	if found2 {
+		t.Error("expected found=false for stale k2")
+	}
+}
+
+// T3: Delete removes an entry that was previously found.
+func TestDelete_RemovesEntry(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, defaultCfg)
+	ctx := context.Background()
+
+	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(10 * time.Minute)}
+	if err := c.Put(ctx, "k", tok); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, found, err := c.Get(ctx, "k")
+	if err != nil || !found {
+		t.Fatalf("pre-delete Get: found=%v err=%v", found, err)
+	}
+
+	if err := c.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, found, err = c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("post-delete Get: %v", err)
+	}
+	if found {
+		t.Error("expected found=false after Delete")
+	}
+}
+
+// T4: Delete is idempotent — both on a never-stored key and on double-delete.
+func TestDelete_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("never-stored key", func(t *testing.T) {
+		t.Parallel()
+		c := newTestCache(t, defaultCfg)
+		ctx := context.Background()
+		if err := c.Delete(ctx, "never-stored"); err != nil {
+			t.Errorf("Delete(never-stored): expected nil, got %v", err)
+		}
+	})
+
+	t.Run("double delete", func(t *testing.T) {
+		t.Parallel()
+		c := newTestCache(t, defaultCfg)
+		ctx := context.Background()
+		tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(10 * time.Minute)}
+		if err := c.Put(ctx, "k", tok); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		if err := c.Delete(ctx, "k"); err != nil {
+			t.Errorf("first Delete: %v", err)
+		}
+		if err := c.Delete(ctx, "k"); err != nil {
+			t.Errorf("second Delete: %v", err)
+		}
+	})
+}
+
+// T5: Concurrent access under -race flag.
+// 50 goroutines Put, 50 goroutines Get — no data race allowed.
+// t.Errorf (not t.Fatal) is used inside goroutines per contract.
+func TestConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, CacheConfig{MaxSize: 1000, ClockSkew: 0, MaxTTL: time.Hour})
+	ctx := context.Background()
+
+	const n = 50
+	expiresAt := time.Now().Add(10 * time.Minute)
+
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+
+	// Writers
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", i)
+			tok := CachedCredential{Value: fmt.Sprintf("val-%d", i), ExpiresAt: expiresAt}
+			if err := c.Put(ctx, key, tok); err != nil {
+				t.Errorf("Put(%s): %v", key, err)
+			}
+		}()
+	}
+
+	// Readers
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", i)
+			tok, found, err := c.Get(ctx, key)
+			if err != nil {
+				t.Errorf("Get(%s): %v", key, err)
+			}
+			// found may be false if Put hasn't run yet — that's a valid race outcome.
+			if found && tok.ExpiresAt.IsZero() {
+				t.Errorf("Get(%s): found=true but ExpiresAt is zero", key)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// T6: TTL normal case — token with ExpiresAt well beyond clockSkew is returned immediately.
+func TestTTL_NormalCase(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, CacheConfig{MaxSize: 100, ClockSkew: 30 * time.Second, MaxTTL: 24 * time.Hour})
+	ctx := context.Background()
+
+	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(2 * time.Minute)}
+	if err := c.Put(ctx, "k", tok); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, found, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !found {
+		t.Error("expected found=true for token well within TTL")
+	}
+}
+
+// T7: TTL MaxTTL cap — token with long ExpiresAt is capped to MaxTTL but still positive.
+func TestTTL_MaxTTLCap(t *testing.T) {
+	t.Parallel()
+	// MaxTTL=1m, ClockSkew=30s → effective TTL = min(rawTTL-30s, 1m).
+	// rawTTL ≈ 1h → safeTTL ≈ 59m30s → capped to 1m. Still positive → stored.
+	c := newTestCache(t, CacheConfig{MaxSize: 100, ClockSkew: 30 * time.Second, MaxTTL: time.Minute})
+	ctx := context.Background()
+
+	tok := CachedCredential{Value: "v", ExpiresAt: time.Now().Add(time.Hour)}
+	if err := c.Put(ctx, "k", tok); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, found, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !found {
+		t.Error("expected found=true after MaxTTL cap with positive remaining TTL")
+	}
+}
+
+// T8: TTL within skew margin — token expiring within clockSkew window is not stored.
+func TestTTL_WithinSkewMargin(t *testing.T) {
+	t.Parallel()
+	// ClockSkew=30s, token expires in 20s → safeTTL = 20s-30s = -10s → ttl<=0 → not stored.
+	c := newTestCache(t, CacheConfig{MaxSize: 100, ClockSkew: 30 * time.Second, MaxTTL: 24 * time.Hour})
+	ctx := context.Background()
+
+	expiresAt := time.Now().Add(20 * time.Second)
+	tok := CachedCredential{Value: "v", ExpiresAt: expiresAt}
+	if err := c.Put(ctx, "k", tok); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, found, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if found {
+		t.Error("expected found=false for token within clock skew margin")
+	}
+}
+
+// T9: Freshness contract — cache miss and expired-token Put both return (CachedCredential{}, false, nil).
+func TestFreshnessContract_Indistinguishable(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, defaultCfg)
+	ctx := context.Background()
+
+	// Sub-case A: key never stored.
+	gotA, foundA, errA := c.Get(ctx, "never-stored")
+	if errA != nil || foundA || gotA != (CachedCredential{}) {
+		t.Errorf("sub-case A: got (%+v, %v, %v), want (CachedCredential{}, false, nil)", gotA, foundA, errA)
+	}
+
+	// Sub-case B: expired token dropped by Put (ttl<=0), Get sees absence.
+	tokB := CachedCredential{Value: "old", ExpiresAt: time.Now().Add(-1 * time.Minute)}
+	if err := c.Put(ctx, "k", tokB); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	gotB, foundB, errB := c.Get(ctx, "k")
+	if errB != nil || foundB || gotB != (CachedCredential{}) {
+		t.Errorf("sub-case B: got (%+v, %v, %v), want (CachedCredential{}, false, nil)", gotB, foundB, errB)
+	}
+
+	// Both results are structurally identical — callers cannot distinguish the two cases.
+}
+
+// T11: Put overwrites an existing key with a new value.
+func TestPut_OverwritesExistingKey(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, defaultCfg)
+	ctx := context.Background()
+	exp := time.Now().Add(10 * time.Minute)
+
+	if err := c.Put(ctx, "k", CachedCredential{Value: "token1", ExpiresAt: exp}); err != nil {
+		t.Fatalf("Put token1: %v", err)
+	}
+	if err := c.Put(ctx, "k", CachedCredential{Value: "token2", ExpiresAt: exp}); err != nil {
+		t.Fatalf("Put token2: %v", err)
+	}
+
+	got, found, err := c.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true after overwrite")
+	}
+	if got.Value != "token2" {
+		t.Errorf("Value: got %q, want %q", got.Value, "token2")
+	}
+}
+
+// T12: MaxSize=0 panics at construction.
+// otter.MustBuilder panics on invalid MaxSize (panic-on-misuse contract).
+func TestNewTokenCache_PanicsOnMaxSizeZero(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for MaxSize=0, got none")
+		}
+	}()
+	//nolint:errcheck // return value unreachable — panic fires inside MustBuilder.
+	_, _ = NewTokenCache(CacheConfig{MaxSize: 0, ClockSkew: 0, MaxTTL: time.Hour})
+}
+
+// T14: All Put/Get/Delete calls return nil error, including edge cases.
+func TestErrors_AlwaysNil(t *testing.T) {
+	t.Parallel()
+	c := newTestCache(t, defaultCfg)
+	ctx := context.Background()
+
+	// Put with future ExpiresAt.
+	if err := c.Put(ctx, "fresh", CachedCredential{Value: "v", ExpiresAt: time.Now().Add(time.Minute)}); err != nil {
+		t.Errorf("Put(fresh): %v", err)
+	}
+
+	// Put with past ExpiresAt (ttl<=0, silently dropped).
+	if err := c.Put(ctx, "expired", CachedCredential{Value: "v", ExpiresAt: time.Now().Add(-time.Minute)}); err != nil {
+		t.Errorf("Put(expired): %v", err)
+	}
+
+	// Get existing (fresh) key.
+	if _, _, err := c.Get(ctx, "fresh"); err != nil {
+		t.Errorf("Get(fresh): %v", err)
+	}
+
+	// Get nonexistent key.
+	if _, _, err := c.Get(ctx, "nonexistent"); err != nil {
+		t.Errorf("Get(nonexistent): %v", err)
+	}
+
+	// Delete existing key.
+	if err := c.Delete(ctx, "fresh"); err != nil {
+		t.Errorf("Delete(fresh): %v", err)
+	}
+
+	// Delete nonexistent key.
+	if err := c.Delete(ctx, "nonexistent"); err != nil {
+		t.Errorf("Delete(nonexistent): %v", err)
+	}
+}

--- a/internal/oauth/cache/cachetest/cachetest.go
+++ b/internal/oauth/cache/cachetest/cachetest.go
@@ -1,0 +1,71 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cachetest provides *testing.T-aware constructors for TokenCache
+// so tests always get a fresh cache with automatic Close on cleanup, and
+// never leak Otter's background sweeper goroutine (which also pins the
+// cache in memory as a GC root).
+//
+// Prefer these over calling cache.NewTokenCache directly in tests. The
+// bare constructor allocates an Otter cache that will leak — a per-test
+// goroutine and its retained heap — unless the caller manually plumbs
+// Close through t.Cleanup.
+//
+// The cache package's own tests cannot import this sub-package (that
+// would be a cycle) and use a local newTestCache helper instead.
+package cachetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
+)
+
+// defaultTestConfig is the sensible starting point for most tokenexchange /
+// integration tests: small MaxSize so full-cache paths are cheap to exercise,
+// zero ClockSkew so tests do not need to reason about the safety margin, and
+// a 1-hour MaxTTL that covers any test-generated ExpiresAt.
+var defaultTestConfig = cache.CacheConfig{
+	MaxSize:   100,
+	ClockSkew: 0,
+	MaxTTL:    time.Hour,
+}
+
+// Default returns a fresh TokenCache with test-friendly defaults and
+// registers t.Cleanup to Close it, so the sweeper goroutine dies with the
+// test and the cache's heap becomes GC-eligible.
+//
+// Use this instead of building a cache.NewTokenCache directly in test code.
+func Default(t *testing.T) cache.TokenCache {
+	t.Helper()
+	return WithConfig(t, defaultTestConfig)
+}
+
+// WithConfig is like Default but exposes CacheConfig so tests can exercise
+// specific MaxSize / TTL / skew behavior. Prefer Default when the config
+// does not matter to the test's assertions.
+func WithConfig(t *testing.T, cfg cache.CacheConfig) cache.TokenCache {
+	t.Helper()
+	tc, err := cache.NewTokenCache(cfg)
+	if err != nil {
+		t.Fatalf("cache.NewTokenCache: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := tc.Close(); err != nil {
+			t.Logf("cache.Close: %v", err)
+		}
+	})
+	return tc
+}

--- a/internal/oauth/cache/factory.go
+++ b/internal/oauth/cache/factory.go
@@ -1,0 +1,13 @@
+package cache
+
+import "fmt"
+
+// NewTokenCache constructs a TokenCache backed by Otter v2 using the provided
+// configuration. This is the only public constructor — no other package in the
+// project instantiates the cache directly.
+func NewTokenCache(cfg CacheConfig) (TokenCache, error) {
+	if cfg.MaxSize <= 0 {
+		return nil, fmt.Errorf("cache: MaxSize must be > 0, got %d", cfg.MaxSize)
+	}
+	return newOtterTokenCache(cfg)
+}

--- a/internal/oauth/cache/factory.go
+++ b/internal/oauth/cache/factory.go
@@ -5,9 +5,21 @@ import "fmt"
 // NewTokenCache constructs a TokenCache backed by Otter v2 using the provided
 // configuration. This is the only public constructor — no other package in the
 // project instantiates the cache directly.
+//
+// All three CacheConfig fields are validated. MaxSize must be > 0; MaxTTL must
+// be > 0; ClockSkew must be >= 0. A misconfigured MaxTTL of 0 (or negative)
+// would silently make every Put drop as PutDroppedTTL, effectively disabling
+// the cache — failing loud here surfaces the misconfiguration at startup
+// rather than as a mysterious performance regression under load.
 func NewTokenCache(cfg CacheConfig) (TokenCache, error) {
 	if cfg.MaxSize <= 0 {
 		return nil, fmt.Errorf("cache: MaxSize must be > 0, got %d", cfg.MaxSize)
+	}
+	if cfg.MaxTTL <= 0 {
+		return nil, fmt.Errorf("cache: MaxTTL must be > 0, got %v", cfg.MaxTTL)
+	}
+	if cfg.ClockSkew < 0 {
+		return nil, fmt.Errorf("cache: ClockSkew must be >= 0, got %v", cfg.ClockSkew)
 	}
 	return newOtterTokenCache(cfg)
 }

--- a/internal/oauth/cache/otter.go
+++ b/internal/oauth/cache/otter.go
@@ -32,35 +32,31 @@ func newOtterTokenCache(cfg CacheConfig) (*otterTokenCache, error) {
 	}, nil
 }
 
-// Get returns a token only if it is stored and still fresh. Belt-and-suspenders
-// check against token.ExpiresAt guards against any Otter sweeper lag.
-func (o *otterTokenCache) Get(_ context.Context, key string) (CachedCredential, bool, error) {
+func (o *otterTokenCache) Get(_ context.Context, key string) (GetResult, error) {
 	entry, ok := o.cache.Get(key)
 	if !ok {
-		return CachedCredential{}, false, nil
+		return GetResult{Status: GetMissAbsent}, nil
 	}
-	// Belt-and-suspenders: Otter's TTL should have evicted this, but check anyway.
 	if !time.Now().Before(entry.ExpiresAt) {
-		return CachedCredential{}, false, nil
+		return GetResult{Status: GetMissExpired}, nil
 	}
-	return entry, true, nil
+	return GetResult{Entry: entry, Status: GetHit}, nil
 }
 
-// Put stores the token with a TTL derived from ExpiresAt minus ClockSkew,
-// capped at MaxTTL. Does not store if the computed TTL is zero or negative.
-func (o *otterTokenCache) Put(_ context.Context, key string, entry CachedCredential) error {
+func (o *otterTokenCache) Put(_ context.Context, key string, entry CachedCredential) (PutResult, error) {
 	rawTTL := time.Until(entry.ExpiresAt)
 	safeTTL := rawTTL - o.clockSkew
 	ttl := min(safeTTL, o.maxTTL)
 	if ttl <= 0 {
-		return nil
+		return PutResult{Status: PutDroppedTTL}, nil
 	}
-	o.cache.Set(key, entry, ttl)
-	return nil
+	if !o.cache.Set(key, entry, ttl) {
+		return PutResult{Status: PutDroppedFull}, nil
+	}
+	return PutResult{Status: PutStored}, nil
 }
 
-// Delete removes the key from the cache immediately. Idempotent.
-func (o *otterTokenCache) Delete(_ context.Context, key string) error {
+func (o *otterTokenCache) Delete(_ context.Context, key string) (DeleteResult, error) {
 	o.cache.Delete(key)
-	return nil
+	return DeleteResult{}, nil
 }

--- a/internal/oauth/cache/otter.go
+++ b/internal/oauth/cache/otter.go
@@ -60,3 +60,8 @@ func (o *otterTokenCache) Delete(_ context.Context, key string) (DeleteResult, e
 	o.cache.Delete(key)
 	return DeleteResult{}, nil
 }
+
+func (o *otterTokenCache) Close() error {
+	o.cache.Close()
+	return nil
+}

--- a/internal/oauth/cache/otter.go
+++ b/internal/oauth/cache/otter.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/maypok86/otter"
+)
+
+// otterTokenCache is the Otter v2-backed implementation of TokenCache.
+// It is unexported — callers must use NewTokenCache.
+type otterTokenCache struct {
+	cache     otter.CacheWithVariableTTL[string, CachedCredential]
+	clockSkew time.Duration
+	maxTTL    time.Duration
+}
+
+// newOtterTokenCache builds an Otter cache with cfg.MaxSize capacity and wraps
+// it in an otterTokenCache. Returns an error if Otter's builder fails.
+func newOtterTokenCache(cfg CacheConfig) (*otterTokenCache, error) {
+	c, err := otter.MustBuilder[string, CachedCredential](cfg.MaxSize).
+		WithVariableTTL().
+		Build()
+	if err != nil {
+		return nil, fmt.Errorf("cache: build otter: %w", err)
+	}
+	return &otterTokenCache{
+		cache:     c,
+		clockSkew: cfg.ClockSkew,
+		maxTTL:    cfg.MaxTTL,
+	}, nil
+}
+
+// Get returns a token only if it is stored and still fresh. Belt-and-suspenders
+// check against token.ExpiresAt guards against any Otter sweeper lag.
+func (o *otterTokenCache) Get(_ context.Context, key string) (CachedCredential, bool, error) {
+	entry, ok := o.cache.Get(key)
+	if !ok {
+		return CachedCredential{}, false, nil
+	}
+	// Belt-and-suspenders: Otter's TTL should have evicted this, but check anyway.
+	if !time.Now().Before(entry.ExpiresAt) {
+		return CachedCredential{}, false, nil
+	}
+	return entry, true, nil
+}
+
+// Put stores the token with a TTL derived from ExpiresAt minus ClockSkew,
+// capped at MaxTTL. Does not store if the computed TTL is zero or negative.
+func (o *otterTokenCache) Put(_ context.Context, key string, entry CachedCredential) error {
+	rawTTL := time.Until(entry.ExpiresAt)
+	safeTTL := rawTTL - o.clockSkew
+	ttl := min(safeTTL, o.maxTTL)
+	if ttl <= 0 {
+		return nil
+	}
+	o.cache.Set(key, entry, ttl)
+	return nil
+}
+
+// Delete removes the key from the cache immediately. Idempotent.
+func (o *otterTokenCache) Delete(_ context.Context, key string) error {
+	o.cache.Delete(key)
+	return nil
+}

--- a/internal/semp/auth/oauth.go
+++ b/internal/semp/auth/oauth.go
@@ -14,6 +14,7 @@ import (
 // implements it in production; the interface exists for test fakes.
 type tokenExchanger interface {
 	Exchange(ctx context.Context, input tokenexchange.ExchangeInput) (*tokenexchange.Token, error)
+	Invalidate(ctx context.Context, input tokenexchange.DeduplicationKeyInput)
 }
 
 // OAuthAuthenticator obtains a broker-bound access token by exchanging
@@ -71,9 +72,17 @@ func (a *OAuthAuthenticator) AddAuth(ctx context.Context, req *http.Request) err
 	return nil
 }
 
-// HandleAuthFailure returns false unconditionally — the Exchanger is
-// stateless (no cache to evict), so retrying after a broker 401 with
-// the same exchanged token is pointless.
-func (a *OAuthAuthenticator) HandleAuthFailure(_ context.Context, _ http.Header) bool {
-	return false
+// HandleAuthFailure evicts the cached token for this broker and subject
+// token, then returns true so the retry layer re-calls AddAuth — which
+// will miss the cache and fetch a fresh token from the IdP.
+func (a *OAuthAuthenticator) HandleAuthFailure(ctx context.Context, _ http.Header) bool {
+	subjectToken, ok := internalauth.RawSubjectTokenFromContext(ctx)
+	if !ok {
+		return false
+	}
+	a.exchanger.Invalidate(ctx, tokenexchange.DeduplicationKeyInput{
+		SubjectToken: subjectToken,
+		BrokerAlias:  a.brokerAlias,
+	})
+	return true
 }

--- a/internal/semp/auth/oauth.go
+++ b/internal/semp/auth/oauth.go
@@ -73,8 +73,18 @@ func (a *OAuthAuthenticator) AddAuth(ctx context.Context, req *http.Request) err
 }
 
 // HandleAuthFailure evicts the cached token for this broker and subject
-// token, then returns true so the retry layer re-calls AddAuth — which
-// will miss the cache and fetch a fresh token from the IdP.
+// token, then returns true to signal the retry layer to retry.
+//
+// Known limitation (SOL-151624): the retry layer does not yet re-invoke
+// AddAuth between attempts (resilience/sender.go has no PrepareRetry
+// hook), so retryablehttp replays the same *http.Request with the stale
+// Authorization header, and the in-flight retry fails against the same
+// 401. Eviction still helps the *next* request through this broker: it
+// will miss the cache and fetch a fresh token.
+//
+// Basic/Bearer are unaffected — their AddAuth sets a static header, so
+// replaying the request on retry carries the same (still-correct) value.
+// Only OAuth needs the PrepareRetry hook to make in-flight recovery work.
 func (a *OAuthAuthenticator) HandleAuthFailure(ctx context.Context, _ http.Header) bool {
 	subjectToken, ok := internalauth.RawSubjectTokenFromContext(ctx)
 	if !ok {

--- a/internal/semp/auth/oauth_test.go
+++ b/internal/semp/auth/oauth_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type fakeExchanger struct {
-	returnToken *tokenexchange.Token
-	returnErr   error
-	mu          sync.Mutex
-	calls       []tokenexchange.ExchangeInput
+	returnToken    *tokenexchange.Token
+	returnErr      error
+	mu             sync.Mutex
+	calls          []tokenexchange.ExchangeInput
+	invalidateCalls []tokenexchange.DeduplicationKeyInput
 }
 
 func (f *fakeExchanger) Exchange(_ context.Context, input tokenexchange.ExchangeInput) (*tokenexchange.Token, error) {
@@ -26,6 +27,12 @@ func (f *fakeExchanger) Exchange(_ context.Context, input tokenexchange.Exchange
 	f.calls = append(f.calls, input)
 	f.mu.Unlock()
 	return f.returnToken, f.returnErr
+}
+
+func (f *fakeExchanger) Invalidate(_ context.Context, input tokenexchange.DeduplicationKeyInput) {
+	f.mu.Lock()
+	f.invalidateCalls = append(f.invalidateCalls, input)
+	f.mu.Unlock()
 }
 
 // ctxWithSubjectToken runs the InjectRawSubjectToken middleware to place

--- a/internal/semp/auth/oauth_test.go
+++ b/internal/semp/auth/oauth_test.go
@@ -136,10 +136,29 @@ func TestOAuthAuthenticator_AddAuth_ExchangeError(t *testing.T) {
 	}
 }
 
-func TestOAuthAuthenticator_HandleAuthFailure(t *testing.T) {
+func TestOAuthAuthenticator_HandleAuthFailure_NoSubjectToken(t *testing.T) {
 	a := NewOAuthAuthenticator(&fakeExchanger{}, "aud", nil, "b")
-	if got := a.HandleAuthFailure(context.Background(), nil); got {
-		t.Error("HandleAuthFailure should return false for OAuth (stateless, no retry)")
+	if a.HandleAuthFailure(context.Background(), nil) {
+		t.Error("expected false when no subject token on context")
+	}
+}
+
+func TestOAuthAuthenticator_HandleAuthFailure_WithSubjectToken(t *testing.T) {
+	exchg := &fakeExchanger{}
+	a := NewOAuthAuthenticator(exchg, "aud", nil, "my-broker")
+
+	ctx := ctxWithSubjectToken(t, "agent-jwt")
+	if !a.HandleAuthFailure(ctx, nil) {
+		t.Error("expected true when subject token present")
+	}
+
+	exchg.mu.Lock()
+	defer exchg.mu.Unlock()
+	if len(exchg.invalidateCalls) != 1 {
+		t.Fatalf("expected 1 Invalidate call, got %d", len(exchg.invalidateCalls))
+	}
+	if exchg.invalidateCalls[0].BrokerAlias != "my-broker" {
+		t.Errorf("broker alias = %q, want %q", exchg.invalidateCalls[0].BrokerAlias, "my-broker")
 	}
 }
 

--- a/internal/semp/broker.go
+++ b/internal/semp/broker.go
@@ -44,6 +44,10 @@ type BrokerClient struct {
 // from brokerCfg.Auth and passes the same pointer to both protocol clients.
 // newAuthenticator is a pure dispatcher; each Authenticator constructor
 // owns its own precondition checks.
+//
+// exchanger is the process-wide token exchanger for OAuth brokers. Pass
+// nil when no broker uses OAuth; newAuthenticator returns an error if an
+// OAuth broker is configured without an exchanger.
 func NewBrokerClient(alias string, brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig, exchanger *tokenexchange.Exchanger) (*BrokerClient, error) {
 	jar, err := newCookieJar(alias, brokerCfg.Auth.Mode)
 	if err != nil {
@@ -115,6 +119,9 @@ func newAuthenticator(alias string, brokerCfg *config.BrokerConfig, jar *resilie
 	case config.AuthModeBearer:
 		return auth.NewBearerAuthenticator(cfg.Token), nil
 	case config.AuthModeOAuth:
+		if exchanger == nil {
+			return nil, fmt.Errorf("oauth auth requires a token exchanger for broker %q", alias)
+		}
 		return auth.NewOAuthAuthenticator(exchanger, cfg.Audience, cfg.Scopes, alias), nil
 	default:
 		return nil, fmt.Errorf("unsupported auth mode %q for broker %q", cfg.Mode, alias)

--- a/internal/tokenexchange/exchange.go
+++ b/internal/tokenexchange/exchange.go
@@ -19,17 +19,35 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 )
 
 // Exchange performs an RFC 8693 token exchange against the configured IdP.
-// Concurrent calls with the same (subjectToken, brokerAlias) pair are
-// collapsed into a single IdP round-trip via singleflight.
+// It checks the cache first; on a miss, concurrent calls with the same
+// (subjectToken, brokerAlias) pair are collapsed into a single IdP
+// round-trip via singleflight, and the result is cached for future calls.
 func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, error) {
 	key := computeDeduplicationKey(DeduplicationKeyInput{
 		SubjectToken: input.SubjectToken,
 		BrokerAlias:  input.BrokerAlias,
 	})
 
+	// Cross-time dedup: serve from cache if a fresh token exists.
+	gr, getErr := e.cache.Get(ctx, key)
+	if getErr != nil {
+		slog.Warn("token cache get failed", "broker", input.BrokerAlias, "error", getErr)
+	} else {
+		slog.Log(ctx, gr.Status.Level(), "token cache get", "broker", input.BrokerAlias, "status", gr.Status)
+		if gr.Status == cache.GetHit {
+			return &Token{
+				Value:     gr.Entry.Value,
+				ExpiresAt: gr.Entry.ExpiresAt,
+			}, nil
+		}
+	}
+
+	// In-flight dedup: collapse concurrent misses into one IdP call.
 	start := e.nowFunc()
 	v, err, _ := e.group.Do(key, func() (interface{}, error) {
 		// Detach from the caller's context so one caller's cancellation
@@ -57,10 +75,38 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 		return nil, err
 	}
 
+	tok := v.(*Token)
+
 	slog.Debug("token exchange succeeded",
 		slog.String("broker", input.BrokerAlias),
 		slog.Duration("exchange_elapsed", elapsed))
-	return v.(*Token), nil
+
+	// Store the exchanged token for future requests.
+	pr, putErr := e.cache.Put(ctx, key, cache.CachedCredential{
+		Value:     tok.Value,
+		ExpiresAt: tok.ExpiresAt,
+	})
+	if putErr != nil {
+		slog.Warn("token cache put failed", "broker", input.BrokerAlias, "error", putErr)
+	} else {
+		slog.Log(ctx, pr.Status.Level(), "token cache put", "broker", input.BrokerAlias, "status", pr.Status)
+	}
+
+	return tok, nil
+}
+
+// Invalidate evicts a cached token for the given (subjectToken, brokerAlias)
+// pair. Called by OAuthAuthenticator.HandleAuthFailure when the broker
+// rejects the token with a 401 — the next Exchange call will miss the
+// cache and fetch a fresh token from the IdP.
+func (e *Exchanger) Invalidate(ctx context.Context, input DeduplicationKeyInput) {
+	key := computeDeduplicationKey(input)
+	_, err := e.cache.Delete(ctx, key)
+	if err != nil {
+		slog.Warn("token cache delete failed", "broker", input.BrokerAlias, "error", err)
+	} else {
+		slog.Debug("token cache invalidated", "broker", input.BrokerAlias)
+	}
 }
 
 func (e *Exchanger) doExchange(ctx context.Context, input ExchangeInput) (*Token, error) {

--- a/internal/tokenexchange/exchange.go
+++ b/internal/tokenexchange/exchange.go
@@ -47,7 +47,16 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 		}
 	}
 
-	// In-flight dedup: collapse concurrent misses into one IdP call.
+	// In-flight dedup: collapse concurrent misses into one IdP call. The
+	// cache Put runs INSIDE the singleflight func so it executes exactly
+	// once per burst (only the winner runs the func; all waiters share its
+	// return value). Doing Put outside would run it N times for N concurrent
+	// callers, producing N redundant writes and log lines.
+	//
+	// The success log stays OUTSIDE the func because it's per-caller
+	// observability: a caller that cancelled mid-exchange should not
+	// see "exchange succeeded" attributed to their request. The Put log
+	// is per-exchange and stays inside with the Put.
 	start := e.nowFunc()
 	v, err, _ := e.group.Do(key, func() (interface{}, error) {
 		// Detach from the caller's context so one caller's cancellation
@@ -55,7 +64,23 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 		// The explicit timeout bounds the detached call independently.
 		exchCtx, cancel := context.WithTimeout(context.Background(), e.exchangeTimeout)
 		defer cancel()
-		return e.doExchange(exchCtx, input)
+
+		tok, err := e.doExchange(exchCtx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		pr, putErr := e.cache.Put(exchCtx, key, cache.CachedCredential{
+			Value:     tok.Value,
+			ExpiresAt: tok.ExpiresAt,
+		})
+		if putErr != nil {
+			slog.WarnContext(exchCtx, "token cache put failed", "broker", input.BrokerAlias, "error", putErr)
+		} else {
+			slog.Log(exchCtx, pr.Status.Level(), "token cache put", "broker", input.BrokerAlias, "status", pr.Status)
+		}
+
+		return tok, nil
 	})
 	elapsed := e.nowFunc().Sub(start)
 
@@ -80,17 +105,6 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 	slog.DebugContext(ctx, "token exchange succeeded",
 		slog.String("broker", input.BrokerAlias),
 		slog.Duration("exchange_elapsed", elapsed))
-
-	// Store the exchanged token for future requests.
-	pr, putErr := e.cache.Put(ctx, key, cache.CachedCredential{
-		Value:     tok.Value,
-		ExpiresAt: tok.ExpiresAt,
-	})
-	if putErr != nil {
-		slog.WarnContext(ctx, "token cache put failed", "broker", input.BrokerAlias, "error", putErr)
-	} else {
-		slog.Log(ctx, pr.Status.Level(), "token cache put", "broker", input.BrokerAlias, "status", pr.Status)
-	}
 
 	return tok, nil
 }

--- a/internal/tokenexchange/exchange.go
+++ b/internal/tokenexchange/exchange.go
@@ -36,7 +36,7 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 	// Cross-time dedup: serve from cache if a fresh token exists.
 	gr, getErr := e.cache.Get(ctx, key)
 	if getErr != nil {
-		slog.Warn("token cache get failed", "broker", input.BrokerAlias, "error", getErr)
+		slog.WarnContext(ctx, "token cache get failed", "broker", input.BrokerAlias, "error", getErr)
 	} else {
 		slog.Log(ctx, gr.Status.Level(), "token cache get", "broker", input.BrokerAlias, "status", gr.Status)
 		if gr.Status == cache.GetHit {
@@ -77,7 +77,7 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 
 	tok := v.(*Token)
 
-	slog.Debug("token exchange succeeded",
+	slog.DebugContext(ctx, "token exchange succeeded",
 		slog.String("broker", input.BrokerAlias),
 		slog.Duration("exchange_elapsed", elapsed))
 
@@ -87,7 +87,7 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 		ExpiresAt: tok.ExpiresAt,
 	})
 	if putErr != nil {
-		slog.Warn("token cache put failed", "broker", input.BrokerAlias, "error", putErr)
+		slog.WarnContext(ctx, "token cache put failed", "broker", input.BrokerAlias, "error", putErr)
 	} else {
 		slog.Log(ctx, pr.Status.Level(), "token cache put", "broker", input.BrokerAlias, "status", pr.Status)
 	}
@@ -103,9 +103,9 @@ func (e *Exchanger) Invalidate(ctx context.Context, input DeduplicationKeyInput)
 	key := computeDeduplicationKey(input)
 	_, err := e.cache.Delete(ctx, key)
 	if err != nil {
-		slog.Warn("token cache delete failed", "broker", input.BrokerAlias, "error", err)
+		slog.WarnContext(ctx, "token cache delete failed", "broker", input.BrokerAlias, "error", err)
 	} else {
-		slog.Debug("token cache invalidated", "broker", input.BrokerAlias)
+		slog.DebugContext(ctx, "token cache invalidated", "broker", input.BrokerAlias)
 	}
 }
 

--- a/internal/tokenexchange/exchange.go
+++ b/internal/tokenexchange/exchange.go
@@ -95,6 +95,13 @@ func (e *Exchanger) Exchange(ctx context.Context, input ExchangeInput) (*Token, 
 	return tok, nil
 }
 
+// Close releases resources held by the cache backend (e.g. Otter's
+// background eviction goroutines). Must be called after all in-flight
+// Exchange calls have completed.
+func (e *Exchanger) Close() error {
+	return e.cache.Close()
+}
+
 // Invalidate evicts a cached token for the given (subjectToken, brokerAlias)
 // pair. Called by OAuthAuthenticator.HandleAuthFailure when the broker
 // rejects the token with a 401 — the next Exchange call will miss the

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -573,6 +573,7 @@ func TestDoExchange_BuildRequestFailureWrapsAsTransport(t *testing.T) {
 		grantType:        GrantTypeTokenExchange,
 		audienceParam:    AudienceParamAudience,
 		httpClient:       &http.Client{},
+		cache:            mustTestCache(),
 		nowFunc:          func() time.Time { return pinnedNow() },
 	}
 
@@ -941,6 +942,7 @@ func TestExchange_UnknownGrantTypeReturnsTransportError(t *testing.T) {
 		grantType:        GrantType(99),
 		audienceParam:    AudienceParamAudience,
 		httpClient:       &http.Client{},
+		cache:            mustTestCache(),
 		nowFunc:          func() time.Time { return pinnedNow() },
 	}
 

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 )
 
 // newTestExchanger builds an Exchanger pointing at the given httptest server
@@ -1103,3 +1104,194 @@ func TestExchange_FourxxWithOAuthError(t *testing.T) {
 	}
 }
 
+// ---------- cache integration: Exchanger-cache contract ----------
+
+// countingIdP returns an httptest server that increments callCount on each
+// request and hands out a distinct access token per call ("tok-1", "tok-2", …).
+// Distinct tokens per call make it trivial to prove which response a caller
+// received without threading assertions through the handler.
+func countingIdP(callCount *atomic.Int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON(fmt.Sprintf("tok-%d", n), 3600))
+	}))
+}
+
+// TestExchange_CacheHitShortCircuitsIdP pins the core cache-hit contract:
+// once a token has been exchanged for a given (subjectToken, brokerAlias),
+// the next call with the same key returns from cache without touching the IdP.
+// Silent regression here means every request hits the IdP — cache is a no-op.
+func TestExchange_CacheHitShortCircuitsIdP(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	srv := countingIdP(&callCount)
+	defer srv.Close()
+
+	// Use the real clock: Otter compares CachedCredential.ExpiresAt against
+	// time.Now(), not e.nowFunc. Pinning nowFunc to a past instant would make
+	// every Put appear expired and be silently dropped as PutDroppedTTL.
+	e := newTestExchanger(t, srv.URL)
+
+	first, err := e.Exchange(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("first Exchange: %v", err)
+	}
+	second, err := e.Exchange(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("second Exchange: %v", err)
+	}
+
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("IdP called %d times, want 1 (second call must be served from cache)", got)
+	}
+	if first.Value != second.Value {
+		t.Errorf("token values differ: first=%q second=%q; cache hit must return the stored token", first.Value, second.Value)
+	}
+	if !first.ExpiresAt.Equal(second.ExpiresAt) {
+		t.Errorf("ExpiresAt differs: first=%v second=%v", first.ExpiresAt, second.ExpiresAt)
+	}
+}
+
+// TestExchange_CacheMissStoresResult verifies the write half of the cache
+// contract: a successful IdP exchange lands in the cache under the same key
+// the next Get will use. If Put breaks silently, the cache is a no-op and
+// every request re-hits the IdP.
+func TestExchange_CacheMissStoresResult(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	srv := countingIdP(&callCount)
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+
+	input := validInput()
+	tok, err := e.Exchange(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+
+	key := computeDeduplicationKey(DeduplicationKeyInput{
+		SubjectToken: input.SubjectToken,
+		BrokerAlias:  input.BrokerAlias,
+	})
+	gr, err := e.cache.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("cache.Get: %v", err)
+	}
+	if gr.Status != cache.GetHit {
+		t.Fatalf("cache status = %v, want GetHit (Exchange should have stored the result)", gr.Status)
+	}
+	if gr.Entry.Value != tok.Value {
+		t.Errorf("cached value = %q, want %q (must match returned token bytes)", gr.Entry.Value, tok.Value)
+	}
+	if !gr.Entry.ExpiresAt.Equal(tok.ExpiresAt) {
+		t.Errorf("cached ExpiresAt = %v, want %v", gr.Entry.ExpiresAt, tok.ExpiresAt)
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("IdP called %d times during setup, want 1", got)
+	}
+}
+
+// TestExchange_InvalidateForcesRefetch pins the invalidation contract used
+// by OAuthAuthenticator.HandleAuthFailure. After Invalidate for a key, the
+// next Exchange must miss the cache and re-fetch from the IdP. If this
+// regresses, the broker's 401-retry loop keeps re-serving the stale token.
+func TestExchange_InvalidateForcesRefetch(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	srv := countingIdP(&callCount)
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+
+	input := validInput()
+	first, err := e.Exchange(context.Background(), input)
+	if err != nil {
+		t.Fatalf("first Exchange: %v", err)
+	}
+
+	e.Invalidate(context.Background(), DeduplicationKeyInput{
+		SubjectToken: input.SubjectToken,
+		BrokerAlias:  input.BrokerAlias,
+	})
+
+	second, err := e.Exchange(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second Exchange: %v", err)
+	}
+
+	if got := callCount.Load(); got != 2 {
+		t.Errorf("IdP called %d times, want 2 (Invalidate should have forced a re-fetch)", got)
+	}
+	if first.Value == second.Value {
+		t.Errorf("token values equal (%q) — second Exchange should have fetched a fresh token, not returned a cached one", first.Value)
+	}
+}
+
+// TestExchange_ConcurrentMissesCollapse verifies the interplay between
+// singleflight and the cache: many concurrent misses for the same key must
+// collapse into ONE IdP call and ONE cache write. Without this guarantee,
+// a burst of first-time requests would hammer the IdP and race the cache.
+func TestExchange_ConcurrentMissesCollapse(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	gate := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		<-gate
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("burst-tok", 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+
+	input := validInput()
+	const n = 100
+	var wg sync.WaitGroup
+	tokens := make([]*Token, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tokens[idx], errs[idx] = e.Exchange(context.Background(), input)
+		}(i)
+	}
+	// Let goroutines queue up on singleflight before releasing the IdP.
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Errorf("goroutine %d: error = %v", i, errs[i])
+			continue
+		}
+		if tokens[i] == nil || tokens[i].Value != "burst-tok" {
+			t.Errorf("goroutine %d: token = %+v, want burst-tok", i, tokens[i])
+		}
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("IdP called %d times, want 1 (singleflight must collapse concurrent misses)", got)
+	}
+
+	// The winning singleflight caller must have written the result to the
+	// cache; a follow-up lookup for the same key must be a hit.
+	key := computeDeduplicationKey(DeduplicationKeyInput{
+		SubjectToken: input.SubjectToken,
+		BrokerAlias:  input.BrokerAlias,
+	})
+	gr, err := e.cache.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("post-burst cache.Get: %v", err)
+	}
+	if gr.Status != cache.GetHit {
+		t.Errorf("cache status after burst = %v, want GetHit (singleflight winner should have stored the token)", gr.Status)
+	}
+}

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -30,13 +30,14 @@ import (
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache/cachetest"
 )
 
 // newTestExchanger builds an Exchanger pointing at the given httptest server
 // with a pinned clock. The returned nowFunc can be swapped to advance time.
 func newTestExchanger(t *testing.T, serverURL string) *Exchanger {
 	t.Helper()
-	p := validParams()
+	p := validParams(t)
 	p.TokenURL = serverURL
 	e, err := New(p)
 	if err != nil {
@@ -574,7 +575,7 @@ func TestDoExchange_BuildRequestFailureWrapsAsTransport(t *testing.T) {
 		grantType:        GrantTypeTokenExchange,
 		audienceParam:    AudienceParamAudience,
 		httpClient:       &http.Client{},
-		cache:            mustTestCache(),
+		cache:            cachetest.Default(t),
 		nowFunc:          func() time.Time { return pinnedNow() },
 	}
 
@@ -943,7 +944,7 @@ func TestExchange_UnknownGrantTypeReturnsTransportError(t *testing.T) {
 		grantType:        GrantType(99),
 		audienceParam:    AudienceParamAudience,
 		httpClient:       &http.Client{},
-		cache:            mustTestCache(),
+		cache:            cachetest.Default(t),
 		nowFunc:          func() time.Time { return pinnedNow() },
 	}
 

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -1295,3 +1295,70 @@ func TestExchange_ConcurrentMissesCollapse(t *testing.T) {
 		t.Errorf("cache status after burst = %v, want GetHit (singleflight winner should have stored the token)", gr.Status)
 	}
 }
+
+// countingCache wraps a real TokenCache and counts Put calls. Used to prove
+// that the singleflight-winner gating actually collapses N concurrent Put
+// attempts into 1, not just N Puts that Otter happens to deduplicate.
+type countingCache struct {
+	inner cache.TokenCache
+	puts  atomic.Int32
+}
+
+func (c *countingCache) Get(ctx context.Context, key string) (cache.GetResult, error) {
+	return c.inner.Get(ctx, key)
+}
+func (c *countingCache) Put(ctx context.Context, key string, entry cache.CachedCredential) (cache.PutResult, error) {
+	c.puts.Add(1)
+	return c.inner.Put(ctx, key, entry)
+}
+func (c *countingCache) Delete(ctx context.Context, key string) (cache.DeleteResult, error) {
+	return c.inner.Delete(ctx, key)
+}
+func (c *countingCache) Close() error {
+	return c.inner.Close()
+}
+
+// TestExchange_SingleflightWinnerOnlyWritesCache pins the C1/C2 contract:
+// when N goroutines burst-miss the same key, only the singleflight winner
+// runs cache.Put. Waiters that received a shared result must NOT re-Put
+// (that would produce N redundant writes and N log lines per burst).
+func TestExchange_SingleflightWinnerOnlyWritesCache(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	gate := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		<-gate
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, successJSON("winner-tok", 3600))
+	}))
+	defer srv.Close()
+
+	e := newTestExchanger(t, srv.URL)
+	// Wrap the real cache with a counter so we can observe the number of
+	// Put calls the exchanger actually makes.
+	counter := &countingCache{inner: e.cache}
+	e.cache = counter
+
+	input := validInput()
+	const n = 100
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = e.Exchange(context.Background(), input)
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	if got := callCount.Load(); got != 1 {
+		t.Errorf("IdP called %d times, want 1 (singleflight collapses concurrent misses)", got)
+	}
+	if got := counter.puts.Load(); got != 1 {
+		t.Errorf("cache.Put called %d times, want 1 (only the singleflight winner should Put)", got)
+	}
+}

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -87,6 +87,7 @@ func TestExchange_HappyPath(t *testing.T) {
 	}
 	if tok == nil {
 		t.Fatal("tok = nil, want non-nil")
+		return
 	}
 	if tok.Value != "exchanged-tok" {
 		t.Errorf("tok.Value = %q, want %q", tok.Value, "exchanged-tok")

--- a/internal/tokenexchange/exchanger.go
+++ b/internal/tokenexchange/exchanger.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/defaults"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -39,6 +40,7 @@ type Exchanger struct {
 	audienceParam    AudienceFormat
 	httpClient       *http.Client
 	exchangeTimeout  time.Duration
+	cache            cache.TokenCache
 	group            singleflight.Group
 	nowFunc          func() time.Time
 }
@@ -57,6 +59,9 @@ func New(p Params) (*Exchanger, error) {
 	if p.HTTPClient == nil {
 		return nil, errors.New("tokenexchange: HTTPClient is required")
 	}
+	if p.Cache == nil {
+		return nil, errors.New("tokenexchange: Cache is required")
+	}
 	return &Exchanger{
 		tokenURL:         p.TokenURL,
 		clientID:         p.ClientID,
@@ -66,6 +71,7 @@ func New(p Params) (*Exchanger, error) {
 		audienceParam:    p.AudienceParam,
 		httpClient:       p.HTTPClient,
 		exchangeTimeout:  defaults.DefaultOIDCHTTPTimeout,
+		cache:            p.Cache,
 		nowFunc:          time.Now,
 	}, nil
 }

--- a/internal/tokenexchange/exchanger_test.go
+++ b/internal/tokenexchange/exchanger_test.go
@@ -23,20 +23,6 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 )
 
-// newTestCache builds a small TokenCache for tests. The caller must call
-// Close on the returned closer when done. Use via validParamsWithCache.
-func newTestCache(t *testing.T) cache.TokenCache {
-	t.Helper()
-	tc, err := cache.NewTokenCache(cache.CacheConfig{
-		MaxSize:   100,
-		ClockSkew: 0,
-		MaxTTL:    time.Hour,
-	})
-	if err != nil {
-		t.Fatalf("NewTokenCache: %v", err)
-	}
-	return tc
-}
 
 // validParams returns a Params struct with every field set to a value
 // that would survive every layer of validation. Tests start from this

--- a/internal/tokenexchange/exchanger_test.go
+++ b/internal/tokenexchange/exchanger_test.go
@@ -56,6 +56,7 @@ func TestNew_HTTPClientNilRejected(t *testing.T) {
 	ex, err := New(p)
 	if err == nil {
 		t.Fatal("expected error for nil HTTPClient")
+		return
 	}
 	if ex != nil {
 		t.Errorf("expected nil Exchanger on error, got %#v", ex)
@@ -73,6 +74,7 @@ func TestNew_CacheNilRejected(t *testing.T) {
 	ex, err := New(p)
 	if err == nil {
 		t.Fatal("expected error for nil Cache")
+		return
 	}
 	if ex != nil {
 		t.Errorf("expected nil Exchanger on error, got %#v", ex)

--- a/internal/tokenexchange/exchanger_test.go
+++ b/internal/tokenexchange/exchanger_test.go
@@ -18,7 +18,25 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 )
+
+// newTestCache builds a small TokenCache for tests. The caller must call
+// Close on the returned closer when done. Use via validParamsWithCache.
+func newTestCache(t *testing.T) cache.TokenCache {
+	t.Helper()
+	tc, err := cache.NewTokenCache(cache.CacheConfig{
+		MaxSize:   100,
+		ClockSkew: 0,
+		MaxTTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewTokenCache: %v", err)
+	}
+	return tc
+}
 
 // validParams returns a Params struct with every field set to a value
 // that would survive every layer of validation. Tests start from this
@@ -32,7 +50,20 @@ func validParams() Params {
 		GrantType:        GrantTypeTokenExchange,
 		AudienceParam:    AudienceParamAudience,
 		HTTPClient:       &http.Client{},
+		Cache:            mustTestCache(),
 	}
+}
+
+func mustTestCache() cache.TokenCache {
+	tc, err := cache.NewTokenCache(cache.CacheConfig{
+		MaxSize:   100,
+		ClockSkew: 0,
+		MaxTTL:    time.Hour,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return tc
 }
 
 // TestNew_HTTPClientNilRejected pins the only runtime check New performs.
@@ -53,6 +84,23 @@ func TestNew_HTTPClientNilRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HTTPClient") {
 		t.Errorf("error message should mention HTTPClient, got: %v", err)
+	}
+}
+
+// TestNew_CacheNilRejected pins the runtime check that Cache must be non-nil.
+func TestNew_CacheNilRejected(t *testing.T) {
+	p := validParams()
+	p.Cache = nil
+
+	ex, err := New(p)
+	if err == nil {
+		t.Fatal("expected error for nil Cache")
+	}
+	if ex != nil {
+		t.Errorf("expected nil Exchanger on error, got %#v", ex)
+	}
+	if !strings.Contains(err.Error(), "Cache") {
+		t.Errorf("error message should mention Cache, got: %v", err)
 	}
 }
 

--- a/internal/tokenexchange/exchanger_test.go
+++ b/internal/tokenexchange/exchanger_test.go
@@ -18,16 +18,20 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache/cachetest"
 )
-
 
 // validParams returns a Params struct with every field set to a value
 // that would survive every layer of validation. Tests start from this
 // and mutate one field at a time to exercise specific cases.
-func validParams() Params {
+//
+// Takes *testing.T so the cache built into Cache is closed via t.Cleanup
+// when the test finishes — leaving that off (as the earlier mustTestCache
+// helper did) leaked Otter's sweeper goroutine per test and pinned the
+// cache's heap for the whole `go test` run.
+func validParams(t *testing.T) Params {
+	t.Helper()
 	return Params{
 		TokenURL:         "https://idp.example.com/token",
 		ClientID:         "solace-mcp-server",
@@ -36,20 +40,8 @@ func validParams() Params {
 		GrantType:        GrantTypeTokenExchange,
 		AudienceParam:    AudienceParamAudience,
 		HTTPClient:       &http.Client{},
-		Cache:            mustTestCache(),
+		Cache:            cachetest.Default(t),
 	}
-}
-
-func mustTestCache() cache.TokenCache {
-	tc, err := cache.NewTokenCache(cache.CacheConfig{
-		MaxSize:   100,
-		ClockSkew: 0,
-		MaxTTL:    time.Hour,
-	})
-	if err != nil {
-		panic(err)
-	}
-	return tc
 }
 
 // TestNew_HTTPClientNilRejected pins the only runtime check New performs.
@@ -58,7 +50,7 @@ func mustTestCache() cache.TokenCache {
 // non-nil for the Exchanger to function. A nil here is a programming
 // error in main's wiring — fail fast, do not ship a half-built Exchanger.
 func TestNew_HTTPClientNilRejected(t *testing.T) {
-	p := validParams()
+	p := validParams(t)
 	p.HTTPClient = nil
 
 	ex, err := New(p)
@@ -75,7 +67,7 @@ func TestNew_HTTPClientNilRejected(t *testing.T) {
 
 // TestNew_CacheNilRejected pins the runtime check that Cache must be non-nil.
 func TestNew_CacheNilRejected(t *testing.T) {
-	p := validParams()
+	p := validParams(t)
 	p.Cache = nil
 
 	ex, err := New(p)
@@ -93,7 +85,7 @@ func TestNew_CacheNilRejected(t *testing.T) {
 // TestNew_HappyPath verifies that a fully-populated Params yields a
 // non-nil Exchanger with no error.
 func TestNew_HappyPath(t *testing.T) {
-	ex, err := New(validParams())
+	ex, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -107,7 +99,7 @@ func TestNew_HappyPath(t *testing.T) {
 // not affect the constructed Exchanger. Effectively-immutable state is
 // the foundation of the concurrency safety story (Decision 8).
 func TestNew_FieldsAreCopied(t *testing.T) {
-	p := validParams()
+	p := validParams(t)
 	ex, err := New(p)
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/tokenexchange/from_config.go
+++ b/internal/tokenexchange/from_config.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 )
 
 // FromConfig constructs an Exchanger from the validated broker_oauth
@@ -32,7 +33,7 @@ import (
 // in their respective allowlists. FromConfig translates the validated
 // YAML-level types (strings, discriminated unions) into the typed Params
 // enums the Exchanger expects.
-func FromConfig(cfg *config.BrokerOAuthConfig, httpClient *http.Client) (*Exchanger, error) {
+func FromConfig(cfg *config.BrokerOAuthConfig, httpClient *http.Client, tokenCache cache.TokenCache) (*Exchanger, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("tokenexchange: broker_oauth config is nil")
 	}
@@ -60,6 +61,7 @@ func FromConfig(cfg *config.BrokerOAuthConfig, httpClient *http.Client) (*Exchan
 		GrantType:        grantType,
 		AudienceParam:    audienceParam,
 		HTTPClient:       httpClient,
+		Cache:            tokenCache,
 	})
 }
 

--- a/internal/tokenexchange/from_config_test.go
+++ b/internal/tokenexchange/from_config_test.go
@@ -85,6 +85,7 @@ func TestFromConfig_NilConfigReturnsError(t *testing.T) {
 	_, err := FromConfig(nil, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig(nil) = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "nil") {
 		t.Errorf("error = %q, want it to mention nil", err.Error())
@@ -97,6 +98,7 @@ func TestFromConfig_NilHTTPClientReturnsError(t *testing.T) {
 	_, err := FromConfig(validBrokerOAuthConfig(), nil, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with nil HTTPClient = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "HTTPClient") {
 		t.Errorf("error = %q, want it to mention HTTPClient", err.Error())
@@ -112,6 +114,7 @@ func TestFromConfig_NoClientAuthMethodReturnsError(t *testing.T) {
 	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with no client auth = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "no client auth") {
 		t.Errorf("error = %q, want it to mention no client auth method", err.Error())
@@ -130,6 +133,7 @@ func TestFromConfig_BothClientAuthMethodsReturnsError(t *testing.T) {
 	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with both client auth methods = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "both") {
 		t.Errorf("error = %q, want it to mention both methods", err.Error())
@@ -145,6 +149,7 @@ func TestFromConfig_UnknownGrantTypeReturnsError(t *testing.T) {
 	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with unknown grant type = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "jwt-bearer") {
 		t.Errorf("error = %q, want it to mention the unsupported grant type", err.Error())
@@ -160,6 +165,7 @@ func TestFromConfig_AudienceParamScopeNotYetImplemented(t *testing.T) {
 	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with audience_parameter_name=scope = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "not yet implemented") {
 		t.Errorf("error = %q, want it to mention not yet implemented", err.Error())
@@ -175,6 +181,7 @@ func TestFromConfig_AudienceParamResourceNotYetImplemented(t *testing.T) {
 	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with audience_parameter_name=resource = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "not yet implemented") {
 		t.Errorf("error = %q, want it to mention not yet implemented", err.Error())
@@ -190,6 +197,7 @@ func TestFromConfig_UnknownAudienceParamReturnsError(t *testing.T) {
 	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with unknown audience param = nil error, want error")
+		return
 	}
 	if !strings.Contains(err.Error(), "custom_param") {
 		t.Errorf("error = %q, want it to mention the unsupported param name", err.Error())

--- a/internal/tokenexchange/from_config_test.go
+++ b/internal/tokenexchange/from_config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache/cachetest"
 )
 
 func validBrokerOAuthConfig() *config.BrokerOAuthConfig {
@@ -38,7 +39,7 @@ func TestFromConfig_ClientSecretPostResolvesCorrectly(t *testing.T) {
 	t.Parallel()
 
 	cfg := validBrokerOAuthConfig()
-	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	e, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -65,7 +66,7 @@ func TestFromConfig_ClientSecretBasicResolvesCorrectly(t *testing.T) {
 		ClientSecretBasic: &config.ClientSecretAuth{Secret: "basic-secret"},
 	}
 
-	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	e, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestFromConfig_ClientSecretBasicResolvesCorrectly(t *testing.T) {
 func TestFromConfig_NilConfigReturnsError(t *testing.T) {
 	t.Parallel()
 
-	_, err := FromConfig(nil, &http.Client{}, mustTestCache())
+	_, err := FromConfig(nil, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig(nil) = nil error, want error")
 	}
@@ -93,7 +94,7 @@ func TestFromConfig_NilConfigReturnsError(t *testing.T) {
 func TestFromConfig_NilHTTPClientReturnsError(t *testing.T) {
 	t.Parallel()
 
-	_, err := FromConfig(validBrokerOAuthConfig(), nil, mustTestCache())
+	_, err := FromConfig(validBrokerOAuthConfig(), nil, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with nil HTTPClient = nil error, want error")
 	}
@@ -108,7 +109,7 @@ func TestFromConfig_NoClientAuthMethodReturnsError(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.ClientAuth = config.BrokerClientAuth{}
 
-	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with no client auth = nil error, want error")
 	}
@@ -126,7 +127,7 @@ func TestFromConfig_BothClientAuthMethodsReturnsError(t *testing.T) {
 		ClientSecretPost:  &config.ClientSecretAuth{Secret: "b"},
 	}
 
-	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with both client auth methods = nil error, want error")
 	}
@@ -141,7 +142,7 @@ func TestFromConfig_UnknownGrantTypeReturnsError(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
-	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with unknown grant type = nil error, want error")
 	}
@@ -156,7 +157,7 @@ func TestFromConfig_AudienceParamScopeNotYetImplemented(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.AudienceParam = config.AudienceParamScope
 
-	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with audience_parameter_name=scope = nil error, want error")
 	}
@@ -171,7 +172,7 @@ func TestFromConfig_AudienceParamResourceNotYetImplemented(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.AudienceParam = config.AudienceParamResource
 
-	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with audience_parameter_name=resource = nil error, want error")
 	}
@@ -186,7 +187,7 @@ func TestFromConfig_UnknownAudienceParamReturnsError(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.AudienceParam = "custom_param"
 
-	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	_, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err == nil {
 		t.Fatal("FromConfig with unknown audience param = nil error, want error")
 	}
@@ -199,7 +200,7 @@ func TestFromConfig_GrantTypeAndAudienceParamMapToCorrectEnums(t *testing.T) {
 	t.Parallel()
 
 	cfg := validBrokerOAuthConfig()
-	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	e, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -216,7 +217,7 @@ func TestFromConfig_NowFuncIsSet(t *testing.T) {
 	t.Parallel()
 
 	cfg := validBrokerOAuthConfig()
-	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
+	e, err := FromConfig(cfg, &http.Client{}, cachetest.Default(t))
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}

--- a/internal/tokenexchange/from_config_test.go
+++ b/internal/tokenexchange/from_config_test.go
@@ -38,7 +38,7 @@ func TestFromConfig_ClientSecretPostResolvesCorrectly(t *testing.T) {
 	t.Parallel()
 
 	cfg := validBrokerOAuthConfig()
-	e, err := FromConfig(cfg, &http.Client{})
+	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestFromConfig_ClientSecretBasicResolvesCorrectly(t *testing.T) {
 		ClientSecretBasic: &config.ClientSecretAuth{Secret: "basic-secret"},
 	}
 
-	e, err := FromConfig(cfg, &http.Client{})
+	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestFromConfig_ClientSecretBasicResolvesCorrectly(t *testing.T) {
 func TestFromConfig_NilConfigReturnsError(t *testing.T) {
 	t.Parallel()
 
-	_, err := FromConfig(nil, &http.Client{})
+	_, err := FromConfig(nil, &http.Client{}, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig(nil) = nil error, want error")
 	}
@@ -93,7 +93,7 @@ func TestFromConfig_NilConfigReturnsError(t *testing.T) {
 func TestFromConfig_NilHTTPClientReturnsError(t *testing.T) {
 	t.Parallel()
 
-	_, err := FromConfig(validBrokerOAuthConfig(), nil)
+	_, err := FromConfig(validBrokerOAuthConfig(), nil, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig with nil HTTPClient = nil error, want error")
 	}
@@ -108,7 +108,7 @@ func TestFromConfig_NoClientAuthMethodReturnsError(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.ClientAuth = config.BrokerClientAuth{}
 
-	_, err := FromConfig(cfg, &http.Client{})
+	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig with no client auth = nil error, want error")
 	}
@@ -126,7 +126,7 @@ func TestFromConfig_BothClientAuthMethodsReturnsError(t *testing.T) {
 		ClientSecretPost:  &config.ClientSecretAuth{Secret: "b"},
 	}
 
-	_, err := FromConfig(cfg, &http.Client{})
+	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig with both client auth methods = nil error, want error")
 	}
@@ -141,7 +141,7 @@ func TestFromConfig_UnknownGrantTypeReturnsError(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
-	_, err := FromConfig(cfg, &http.Client{})
+	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig with unknown grant type = nil error, want error")
 	}
@@ -156,7 +156,7 @@ func TestFromConfig_AudienceParamScopeNotYetImplemented(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.AudienceParam = config.AudienceParamScope
 
-	_, err := FromConfig(cfg, &http.Client{})
+	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig with audience_parameter_name=scope = nil error, want error")
 	}
@@ -171,7 +171,7 @@ func TestFromConfig_AudienceParamResourceNotYetImplemented(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.AudienceParam = config.AudienceParamResource
 
-	_, err := FromConfig(cfg, &http.Client{})
+	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig with audience_parameter_name=resource = nil error, want error")
 	}
@@ -186,7 +186,7 @@ func TestFromConfig_UnknownAudienceParamReturnsError(t *testing.T) {
 	cfg := validBrokerOAuthConfig()
 	cfg.AudienceParam = "custom_param"
 
-	_, err := FromConfig(cfg, &http.Client{})
+	_, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err == nil {
 		t.Fatal("FromConfig with unknown audience param = nil error, want error")
 	}
@@ -199,7 +199,7 @@ func TestFromConfig_GrantTypeAndAudienceParamMapToCorrectEnums(t *testing.T) {
 	t.Parallel()
 
 	cfg := validBrokerOAuthConfig()
-	e, err := FromConfig(cfg, &http.Client{})
+	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestFromConfig_NowFuncIsSet(t *testing.T) {
 	t.Parallel()
 
 	cfg := validBrokerOAuthConfig()
-	e, err := FromConfig(cfg, &http.Client{})
+	e, err := FromConfig(cfg, &http.Client{}, mustTestCache())
 	if err != nil {
 		t.Fatalf("FromConfig: %v", err)
 	}

--- a/internal/tokenexchange/request_test.go
+++ b/internal/tokenexchange/request_test.go
@@ -46,7 +46,7 @@ func readFormBody(t *testing.T, req *http.Request) url.Values {
 func TestBuildIdPRequest_MandatoryRFCFields(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestBuildIdPRequest_MandatoryRFCFields(t *testing.T) {
 func TestBuildIdPRequest_ClientSecretPost(t *testing.T) {
 	t.Parallel()
 
-	p := validParams()
+	p := validParams(t)
 	p.ClientAuthMethod = ClientSecretPost
 	p.ClientID = "my-client"
 	p.ClientSecret = "my-secret"
@@ -115,7 +115,7 @@ func TestBuildIdPRequest_ClientSecretPost(t *testing.T) {
 func TestBuildIdPRequest_ClientSecretBasic(t *testing.T) {
 	t.Parallel()
 
-	p := validParams()
+	p := validParams(t)
 	p.ClientAuthMethod = ClientSecretBasic
 	p.ClientID = "my-client"
 	p.ClientSecret = "my-secret"
@@ -174,7 +174,7 @@ func TestBuildIdPRequest_NeverBothCredentials(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			p := validParams()
+			p := validParams(t)
 			p.ClientAuthMethod = tc.method
 			p.ClientID = "cid"
 			p.ClientSecret = "csec"
@@ -366,7 +366,7 @@ func TestBuildIdPRequest_AudienceConditional(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			e, err := New(validParams())
+			e, err := New(validParams(t))
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -414,7 +414,7 @@ func TestBuildIdPRequest_ScopeConditional(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			e, err := New(validParams())
+			e, err := New(validParams(t))
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -456,7 +456,7 @@ func TestBuildIdPRequest_ContentTypeAlwaysSet(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			p := validParams()
+			p := validParams(t)
 			p.ClientAuthMethod = tc.method
 			e, err := New(p)
 			if err != nil {
@@ -483,7 +483,7 @@ func TestBuildIdPRequest_ContentTypeAlwaysSet(t *testing.T) {
 func TestBuildIdPRequest_ContextPropagation(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -545,7 +545,7 @@ func TestBuildIdPRequest_MalformedTokenURL(t *testing.T) {
 func TestBuildIdPRequest_MethodIsPOST(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -569,7 +569,7 @@ func TestBuildIdPRequest_MethodIsPOST(t *testing.T) {
 func TestBuildIdPRequest_URLEqualsTokenURL(t *testing.T) {
 	t.Parallel()
 
-	p := validParams()
+	p := validParams(t)
 	p.TokenURL = "https://idp.example.com/v2/token"
 	e, err := New(p)
 	if err != nil {
@@ -595,7 +595,7 @@ func TestBuildIdPRequest_URLEqualsTokenURL(t *testing.T) {
 func TestBuildIdPRequest_BrokerAliasExcluded(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -625,7 +625,7 @@ func TestBuildIdPRequest_BrokerAliasExcluded(t *testing.T) {
 func TestBuildIdPRequest_EmptySubjectTokenPassThrough(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -660,7 +660,7 @@ func TestBuildIdPRequest_EmptySubjectTokenPassThrough(t *testing.T) {
 func TestBuildIdPRequest_ScopeDuplicatesPreserved(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -690,7 +690,7 @@ func TestBuildIdPRequest_ScopeDuplicatesPreserved(t *testing.T) {
 func TestBuildIdPRequest_BlankScopeElementProducesEmptyValue(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/internal/tokenexchange/request_test.go
+++ b/internal/tokenexchange/request_test.go
@@ -240,6 +240,7 @@ func TestBuildIdPRequest_UnknownGrantType(t *testing.T) {
 
 			if err == nil {
 				t.Fatal("expected error for unknown GrantType, got nil")
+				return
 			}
 			if req != nil {
 				t.Errorf("expected nil request on error, got non-nil")
@@ -287,6 +288,7 @@ func TestBuildIdPRequest_UnknownClientAuthMethod(t *testing.T) {
 
 			if err == nil {
 				t.Fatal("expected error for unknown ClientAuthMethod, got nil")
+				return
 			}
 			if req != nil {
 				t.Errorf("expected nil request on error, got non-nil")
@@ -335,6 +337,7 @@ func TestBuildIdPRequest_UnknownAudienceFormat(t *testing.T) {
 
 			if err == nil {
 				t.Fatal("expected error for unknown AudienceFormat, got nil")
+				return
 			}
 			if req != nil {
 				t.Errorf("expected nil request on error, got non-nil")
@@ -526,6 +529,7 @@ func TestBuildIdPRequest_MalformedTokenURL(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("expected error for malformed tokenURL, got nil")
+		return
 	}
 	if req != nil {
 		t.Errorf("expected nil request on error, got non-nil")

--- a/internal/tokenexchange/response_test.go
+++ b/internal/tokenexchange/response_test.go
@@ -63,7 +63,7 @@ func (b *trackingBodyOK) Close() error {
 func TestParseIdPResponse_BodyAlwaysClosedOnError(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestParseIdPResponse_BodyAlwaysClosedOnError(t *testing.T) {
 func TestParseIdPResponse_BodyAlwaysClosedOnSuccess(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestParseIdPResponse_BodyAlwaysClosedOnSuccess(t *testing.T) {
 func TestParseIdPResponse_BodySizeCappedAt1MiB(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestParseIdPResponse_BodySizeCappedAt1MiB(t *testing.T) {
 func TestParseIdPResponse_NonJSONContentTypeReturnsInvalidResponse(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestParseIdPResponse_NonJSONContentTypeReturnsInvalidResponse(t *testing.T)
 func TestParseIdPResponse_MissingContentTypeBypassesGuard(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestParseIdPResponse_MissingContentTypeBypassesGuard(t *testing.T) {
 func TestParseIdPResponse_MalformedContentTypeBypassesGuard(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestResponseMediaType_CaseInsensitive(t *testing.T) {
 func TestParseSuccessBody_InvalidJSONReturnsInvalidResponse(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestParseSuccessBody_MissingAccessTokenReturnsInvalidResponse(t *testing.T)
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			e, err := New(validParams())
+			e, err := New(validParams(t))
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -374,7 +374,7 @@ func TestParseSuccessBody_TokenTypeCaseInsensitiveBearer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			e, err := New(validParams())
+			e, err := New(validParams(t))
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -423,7 +423,7 @@ func TestParseSuccessBody_IssuedTokenTypeExactMatchRequired(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			e, err := New(validParams()) // sets GrantTypeTokenExchange
+			e, err := New(validParams(t)) // sets GrantTypeTokenExchange
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -500,7 +500,7 @@ func TestParseSuccessBody_ExpiresInNonPositiveReturnsInvalidResponse(t *testing.
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			e, err := New(validParams())
+			e, err := New(validParams(t))
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -526,7 +526,7 @@ func TestParseSuccessBody_ExpiresInNonPositiveReturnsInvalidResponse(t *testing.
 func TestParseSuccessBody_ExpiresInOverflowGuard(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -562,7 +562,7 @@ func TestParseSuccessBody_ExpiresInOverflowGuard(t *testing.T) {
 func TestParseSuccessBody_TokenConstructionAndExpiresAt(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -594,7 +594,7 @@ func TestParseSuccessBody_TokenConstructionAndExpiresAt(t *testing.T) {
 func TestParseIdPResponse_FourxxOAuthErrorReturnsExchangeRejected(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -627,7 +627,7 @@ func TestParseIdPResponse_FourxxOAuthErrorReturnsExchangeRejected(t *testing.T) 
 func TestParseIdPResponse_FourxxNonOAuthBodyReturnsExchangeTransport(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -672,7 +672,7 @@ func TestParseIdPResponse_ThreexxAndFivexxReturnExchangeTransport(t *testing.T) 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			e, err := New(validParams())
+			e, err := New(validParams(t))
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -764,7 +764,7 @@ func TestClassifyClientError_ErrorDescriptionNotInMessage(t *testing.T) {
 func TestParseIdPResponse_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -815,7 +815,7 @@ func TestParseSuccessBody_ShortLivedTokenReturnsNonErrorTokenWithPastExpiresAt(t
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			e, err := New(validParams())
+			e, err := New(validParams(t))
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
@@ -861,7 +861,7 @@ func TestParseSuccessBody_ShortLivedTokenReturnsNonErrorTokenWithPastExpiresAt(t
 func TestParseIdPResponse_OversizedBodySurfacesAsInvalidResponseNotTransport(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -896,7 +896,7 @@ func TestParseIdPResponse_OversizedBodySurfacesAsInvalidResponseNotTransport(t *
 func TestParseSuccessBody_NullBodyTriggersAccessTokenMissingError(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -939,7 +939,7 @@ func TestClassifyClientError_ExplicitEmptyErrorFieldRoutesToTransport(t *testing
 func TestParseSuccessBody_UnknownFieldsSilentlyIgnored(t *testing.T) {
 	t.Parallel()
 
-	e, err := New(validParams())
+	e, err := New(validParams(t))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/internal/tokenexchange/response_test.go
+++ b/internal/tokenexchange/response_test.go
@@ -578,6 +578,7 @@ func TestParseSuccessBody_TokenConstructionAndExpiresAt(t *testing.T) {
 	}
 	if tok == nil {
 		t.Fatal("tok = nil, want non-nil")
+		return
 	}
 	if tok.Value != "my-token" {
 		t.Errorf("tok.Value = %q, want %q", tok.Value, "my-token")
@@ -784,6 +785,7 @@ func TestParseIdPResponse_HappyPath(t *testing.T) {
 	}
 	if tok == nil {
 		t.Fatal("tok = nil, want non-nil")
+		return
 	}
 	if tok.Value != "exchanged-token" {
 		t.Errorf("tok.Value = %q, want %q", tok.Value, "exchanged-token")
@@ -829,6 +831,7 @@ func TestParseSuccessBody_ShortLivedTokenReturnsNonErrorTokenWithPastExpiresAt(t
 			}
 			if tok == nil {
 				t.Fatal("tok = nil, want non-nil")
+				return
 			}
 
 			wantExpiresAt := now.Add(time.Duration(tc.expiresIn)*time.Second - 30*time.Second)
@@ -962,6 +965,7 @@ func TestParseSuccessBody_UnknownFieldsSilentlyIgnored(t *testing.T) {
 	}
 	if tok == nil {
 		t.Fatal("tok = nil, want non-nil")
+		return
 	}
 	if tok.Value != "tok" {
 		t.Errorf("tok.Value = %q, want %q", tok.Value, "tok")

--- a/internal/tokenexchange/types.go
+++ b/internal/tokenexchange/types.go
@@ -36,6 +36,8 @@ import (
 	"errors"
 	"net/http"
 	"time"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 )
 
 // ClientAuthMethod identifies the OAuth client-authentication method the
@@ -115,6 +117,10 @@ type Params struct {
 	// HTTPClient is the IdP-bound HTTP client; typically built via
 	// idpclient.NewHTTPClient so the SOL-150219 timeout bound applies.
 	HTTPClient *http.Client
+	// Cache is the token cache for cross-time deduplication. The exchanger
+	// checks the cache before hitting the IdP and stores successful
+	// exchange results. Required — a nil cache is a wiring bug.
+	Cache cache.TokenCache
 }
 
 // ExchangeInput are the per-call inputs to Exchange. Subject token comes

--- a/test/integration/oauth_cache_wiring_test.go
+++ b/test/integration/oauth_cache_wiring_test.go
@@ -37,6 +37,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache/cachetest"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tokenexchange"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
 )
@@ -86,7 +87,7 @@ func TestOAuthCache_TwoRequestsSameBearerHitIdPOnce(t *testing.T) {
 	}))
 	defer fakeBroker.Close()
 
-	tc := newIntegrationTestCache(t)
+	tc := cachetest.Default(t)
 	exchanger, err := tokenexchange.New(tokenexchange.Params{
 		TokenURL:         fakeIdP.URL,
 		ClientID:         "mcp-server",

--- a/test/integration/oauth_cache_wiring_test.go
+++ b/test/integration/oauth_cache_wiring_test.go
@@ -1,0 +1,138 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end coverage for the OAuth token-exchange cache wiring introduced
+// in SOL-151442. These tests drive tool calls through the top of the stack
+// (mgr.CallTool) so any regression in the interplay between OAuthAuthenticator,
+// Exchanger, and cache Get/Put surfaces here.
+//
+// Companion unit tests in internal/tokenexchange/exchange_test.go pin the
+// direct Exchanger↔cache contract (hit, miss+store, invalidate, singleflight
+// under concurrency); these tests add the wiring proof for the cache-hit path.
+//
+// Not covered here: 401-retry-refresh. resilience/sender.go calls
+// authenticator.AddAuth exactly once before entering retryablehttp's retry
+// loop, so on 401 the retry re-sends the stale token even though
+// Exchanger.Invalidate has evicted the cache entry. Requires a PrepareRetry
+// hook to re-invoke AddAuth on retry; tracked separately as followup.
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/tokenexchange"
+	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
+)
+
+// idpHitCounter installs a JSON handler that increments callCount on each
+// request and hands out a distinct access token per call ("cache-tok-1",
+// "cache-tok-2", …) with a real 1-hour TTL. The distinct-per-call value
+// makes it trivial to prove which response a broker request carried.
+func idpHitCounter(callCount *atomic.Int32) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		n := callCount.Add(1)
+		body := map[string]any{
+			"access_token":      fmt.Sprintf("cache-tok-%d", n),
+			"token_type":        "Bearer",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+			"expires_in":        3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+// sempV1OKReply is the minimal successful SEMPv1 envelope: an <rpc-reply>
+// carrying an inner <rpc> element and a code="ok" <execute-result>.
+const sempV1OKReply = `<rpc-reply><rpc><show><version/></show></rpc><execute-result code="ok"/></rpc-reply>`
+
+// TestOAuthCache_TwoRequestsSameBearerHitIdPOnce is the read-side wiring proof:
+// two tool invocations under the same subject-token context must exchange with
+// the IdP exactly once. The second call must be served from the exchanger's
+// cache without touching the IdP.
+//
+// If the cache is a no-op (regression: Put silently fails, Get always returns
+// miss, or the deduplication key differs between Put and Get), the IdP counter
+// climbs to 2 and this test fails.
+func TestOAuthCache_TwoRequestsSameBearerHitIdPOnce(t *testing.T) {
+	var idpHits atomic.Int32
+	fakeIdP := httptest.NewTLSServer(idpHitCounter(&idpHits))
+	defer fakeIdP.Close()
+
+	var brokerHits atomic.Int32
+	var seenBrokerTokens sync.Map // downstream Authorization header values
+	fakeBroker := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		brokerHits.Add(1)
+		seenBrokerTokens.Store(r.Header.Get("Authorization"), true)
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(sempV1OKReply))
+	}))
+	defer fakeBroker.Close()
+
+	tc := newIntegrationTestCache(t)
+	exchanger, err := tokenexchange.New(tokenexchange.Params{
+		TokenURL:         fakeIdP.URL,
+		ClientID:         "mcp-server",
+		ClientAuthMethod: tokenexchange.ClientSecretBasic,
+		ClientSecret:     "fake-secret",
+		GrantType:        tokenexchange.GrantTypeTokenExchange,
+		AudienceParam:    tokenexchange.AudienceParamAudience,
+		HTTPClient:       fakeIdP.Client(),
+		Cache:            tc,
+	})
+	if err != nil {
+		t.Fatalf("tokenexchange.New: %v", err)
+	}
+
+	pool, mgr := buildOAuthPoolAndManager(t, fakeIdP.URL, fakeBroker.URL, exchanger)
+	defer pool.Close()
+
+	// One subject-token context reused across both invocations — the
+	// (subject, broker) key is stable, so the second call must be a cache hit.
+	ctx := oauthInjectSubjectToken(t, "shared-jwt-cache-wiring")
+
+	for i := 1; i <= 2; i++ {
+		res, err := mgr.CallTool(ctx, "test-oauth-tool", map[string]any{"broker": "oauth-broker"}, tools.Identity{})
+		if err != nil {
+			t.Fatalf("mgr.CallTool #%d: unexpected error: %v", i, err)
+		}
+		if res == nil || res.IsError {
+			t.Fatalf("mgr.CallTool #%d: got error result: %+v", i, res)
+		}
+	}
+
+	if got := idpHits.Load(); got != 1 {
+		t.Errorf("IdP hits = %d, want 1 (second tool call must be served from the exchanger's cache)", got)
+	}
+	if got := brokerHits.Load(); got != 2 {
+		t.Errorf("broker hits = %d, want 2 (both tool calls should reach the broker)", got)
+	}
+
+	// Both broker requests must have carried the SAME downstream Bearer —
+	// the value the exchanger stored on the first call.
+	var distinct int
+	seenBrokerTokens.Range(func(_, _ any) bool {
+		distinct++
+		return true
+	})
+	if distinct != 1 {
+		t.Errorf("broker saw %d distinct Authorization values, want 1 (cached token should be reused verbatim)", distinct)
+	}
+}

--- a/test/integration/oauth_error_visibility_test.go
+++ b/test/integration/oauth_error_visibility_test.go
@@ -31,9 +31,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	internalauth "github.com/SolaceDev/solace-broker-mcp/internal/auth"
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tokenexchange"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
@@ -95,6 +97,7 @@ func runOAuthVisibilityTest(t *testing.T, label string, idpHandler http.HandlerF
 	}))
 	defer fakeBroker.Close()
 
+	tc := newIntegrationTestCache(t)
 	exchanger, err := tokenexchange.New(tokenexchange.Params{
 		TokenURL:         fakeIdP.URL,
 		ClientID:         "mcp-server",
@@ -103,6 +106,7 @@ func runOAuthVisibilityTest(t *testing.T, label string, idpHandler http.HandlerF
 		GrantType:        tokenexchange.GrantTypeTokenExchange,
 		AudienceParam:    tokenexchange.AudienceParamAudience,
 		HTTPClient:       fakeIdP.Client(),
+		Cache:            tc,
 	})
 	if err != nil {
 		t.Fatalf("tokenexchange.New: %v", err)
@@ -135,6 +139,7 @@ func runOAuthVisibilityTestNoSubjectToken(t *testing.T) {
 	}))
 	defer fakeBroker.Close()
 
+	tc := newIntegrationTestCache(t)
 	exchanger, err := tokenexchange.New(tokenexchange.Params{
 		TokenURL:         fakeIdP.URL,
 		ClientID:         "mcp-server",
@@ -143,6 +148,7 @@ func runOAuthVisibilityTestNoSubjectToken(t *testing.T) {
 		GrantType:        tokenexchange.GrantTypeTokenExchange,
 		AudienceParam:    tokenexchange.AudienceParamAudience,
 		HTTPClient:       fakeIdP.Client(),
+		Cache:            tc,
 	})
 	if err != nil {
 		t.Fatalf("tokenexchange.New: %v", err)
@@ -287,4 +293,18 @@ func oauthCallToolAndCaptureDetail(t *testing.T, mgr *tools.ToolManager, ctx con
 	}
 
 	return detail
+}
+
+func newIntegrationTestCache(t *testing.T) cache.TokenCache {
+	t.Helper()
+	tc, err := cache.NewTokenCache(cache.CacheConfig{
+		MaxSize:   100,
+		ClockSkew: 0,
+		MaxTTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewTokenCache: %v", err)
+	}
+	t.Cleanup(func() { tc.Close() })
+	return tc
 }

--- a/test/integration/oauth_error_visibility_test.go
+++ b/test/integration/oauth_error_visibility_test.go
@@ -31,11 +31,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	internalauth "github.com/SolaceDev/solace-broker-mcp/internal/auth"
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
-	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache"
+	"github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache/cachetest"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tokenexchange"
 	"github.com/SolaceDev/solace-broker-mcp/internal/tools"
@@ -97,7 +96,7 @@ func runOAuthVisibilityTest(t *testing.T, label string, idpHandler http.HandlerF
 	}))
 	defer fakeBroker.Close()
 
-	tc := newIntegrationTestCache(t)
+	tc := cachetest.Default(t)
 	exchanger, err := tokenexchange.New(tokenexchange.Params{
 		TokenURL:         fakeIdP.URL,
 		ClientID:         "mcp-server",
@@ -139,7 +138,7 @@ func runOAuthVisibilityTestNoSubjectToken(t *testing.T) {
 	}))
 	defer fakeBroker.Close()
 
-	tc := newIntegrationTestCache(t)
+	tc := cachetest.Default(t)
 	exchanger, err := tokenexchange.New(tokenexchange.Params{
 		TokenURL:         fakeIdP.URL,
 		ClientID:         "mcp-server",
@@ -293,18 +292,4 @@ func oauthCallToolAndCaptureDetail(t *testing.T, mgr *tools.ToolManager, ctx con
 	}
 
 	return detail
-}
-
-func newIntegrationTestCache(t *testing.T) cache.TokenCache {
-	t.Helper()
-	tc, err := cache.NewTokenCache(cache.CacheConfig{
-		MaxSize:   100,
-		ClockSkew: 0,
-		MaxTTL:    time.Hour,
-	})
-	if err != nil {
-		t.Fatalf("NewTokenCache: %v", err)
-	}
-	t.Cleanup(func() { tc.Close() })
-	return tc
 }


### PR DESCRIPTION
**Do not merge.** Diagnostic-only PR to isolate the SA5011 lint failure on #150.

## Context
PR #150 fails CI lint with 6 SA5011 errors in `internal/tools/composite_handler_test.go` and `internal/tools/register_test.go`. Cannot reproduce locally after:
- Wiping `~/Library/Caches/golangci-lint` and `go clean -cache`
- Stashing all untracked scratch dirs so the working tree matches CI
- Running with Go 1.25.0 (matching CI's `setup-go@v5` resolution from `go.mod`)
- Both scoped (`./internal/tools/...`) and repo-root runs

All local runs report `0 issues`.

## What this PR changes
Off `cache-exchange-wiring-cleanup` HEAD, adds two diagnostic knobs:

1. `.golangci.yml`: `issues.max-issues-per-linter: 0` and `max-same-issues: 0`. The 6-error CI output splits exactly 3+3 across two message texts, matching the default `max-same-issues=3`. Removing the caps reveals whether more hits exist that CI is currently truncating.
2. `.github/workflows/build-and-test.yml`: `skip-cache: true` on `golangci-lint-action`. Forces a from-scratch lint analysis, bypassing any restored cache from prior main runs.

## What we expect from CI

| Outcome | Interpretation |
|---|---|
| 0 issues | Stale cached staticcheck facts were the cause. Long-term fix: add `.golangci.yml` hash or `git rev-parse HEAD:internal/tools` to the cache key. |
| Same 6 errors | Cache ruled out. Delta is elsewhere — narrow further. |
| >6 errors | Cap was hiding scope. Follow-up fix commit needed to make more test sites SA5011-clean (in addition to whatever else). |

## After CI runs
Close this PR without merging; roll the actual fix into #150 based on the answer.