### PR TITLE
ci(lint): disable stale analysis cache and uncap issue reporting

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,17 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
+          # Disable the analysis cache. Its key is
+          # os + cwd + interval + go.mod hash, so it does not invalidate on
+          # source or .golangci.yml changes and can restore stale staticcheck
+          # facts that produce phantom diagnostics against current sources
+          # (seen as flaky SA5011 on PR #150). Trading ~30s per run for
+          # honest, reproducible lint results.
+          skip-cache: true
+          # --verbose surfaces per-linter timing, active-linter list, and
+          # package-load stats so a "0 issues" result can be verified as
+          # full analysis rather than a silent skip.
+          args: --verbose
 
   build:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,13 @@
 version: "2"
 
+# Report every issue found. golangci-lint defaults to max-issues-per-linter=50
+# and max-same-issues=3, silently truncating the rest — which produces false
+# confidence ("I fixed the 3 things it reported") when more instances of the
+# same problem exist elsewhere. Uncap so CI output reflects the full picture.
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
   enable:
     - errcheck      # unchecked error return values


### PR DESCRIPTION
## Summary

Two related changes to make the lint job on CI honest and reproducible.

### 1. Disable the golangci-lint analysis cache

The [`golangci-lint-action`](https://github.com/golangci/golangci-lint-action) cache key is `os + cwd + interval + go.mod hash`. It **does not include source file content or `.golangci.yml`**, so any change to Go source or lint config does not invalidate the cache — cached staticcheck facts get restored against modified sources and produce phantom diagnostics.

Observed on #150: 6 SA5011 errors reported by CI at test-file line numbers untouched by that branch, unreproducible locally under any combination of cold caches, Go 1.25 toolchain matching CI, or clean working tree. Disabling the cache on the same commit made CI produce 0 issues, matching local. Re-enabling reproduced the failure.

Verbose lint output confirms **full type checking + analysis still runs every time**:

```
Go packages loading at mode 8767 (imports|exports_file|files|name|types_sizes|compiled_files|deps) took 5.115981807s
Active 9 linters: [bodyclose errcheck gosec govet ineffassign noctx revive staticcheck unused]
analyzers took 24.34s with top 10 stages: buildir: 12.79s, gosec: 3.73s, revive: 2.58s, ...
Issues before processing: 301, after processing: 0
```

Cost: ~30-40s extra per CI run. Value: results that can be trusted.

### 2. Uncap issue reporting

`golangci-lint` defaults `max-issues-per-linter=50` and `max-same-issues=3` — silent truncation. If staticcheck finds 20 hits of the same pattern, CI shows 3 and drops the other 17 with no message. That produces false confidence when scoping a fix. Uncap so a "clean" build actually means clean, and a failing one shows the full scope.

## Test plan

- [x] Verified via draft PR #155 and #150 that `skip-cache: true` produces `0 issues` on the same source that fails with cache enabled.
- [x] Confirmed via `--verbose` output that all 9 configured linters run, `go/packages` loads types + deps, and staticcheck's `buildir` executes full SSA construction.
- [ ] After merge: rebase #150 on main and confirm its lint job passes without any test-file changes.

## Follow-ups

- The 6 SA5011 sites on #150 (`if got == nil { t.Fatal(...) }; deref`) are a false-positive-prone pattern regardless of cache. Consider adding an explicit `return` after each `t.Fatal` in a separate PR to make those tests robust to any future staticcheck version.
- If cache-off proves too slow long-term, a smarter cache key (hash of `.golangci.yml` + source tree) can be threaded in via `restore-keys` on the action.