### PR TITLE
SOL-151601: Diagnosable constructor-panic contracts for Basic and OAuth authenticators

### DIFF
--- a/internal/middleware/recovery/middleware.go
+++ b/internal/middleware/recovery/middleware.go
@@ -56,8 +56,10 @@ const internalErrorBody = `{"error":"internal_error","error_description":"the se
 // On a recovered panic it logs at ERROR with event="panic_recovered", the panic
 // value's Go TYPE (panic_type) and a structured stack trace. It logs only the
 // type, never the panic value's text: panic values are unaudited and can carry
-// arbitrary strings, the same secure-logging rule withRecovery applies in
-// internal/tools (see docs/internal/secure-logging-rules.md).
+// arbitrary strings (see docs/internal/secure-logging-rules.md). The sibling
+// tool-handler recovery layer in internal/tools follows the same base rule but
+// extracts pre-vetted fields from auth.WiringError panics; this HTTP-mux-level
+// middleware does not, because auth-wiring panics do not surface here.
 //
 // Recovery is unconditional: buildRootHandler always wraps the mux with this
 // middleware. There is no flag to disable it.

--- a/internal/semp/auth/authenticator_test.go
+++ b/internal/semp/auth/authenticator_test.go
@@ -31,7 +31,7 @@ func TestBasicAuthenticator_AddAuth(t *testing.T) {
 		user = "admin"
 		pass = "s3cret"
 	)
-	a := NewBasicAuthenticator(user, pass, stubJar{})
+	a := NewBasicAuthenticator(user, pass, "test-broker", stubJar{})
 	req := newReq(t)
 
 	if err := a.AddAuth(context.Background(), req); err != nil {
@@ -71,7 +71,7 @@ func TestAuthenticator_ConcurrentAddAuth_NoFieldMutation(t *testing.T) {
 	const goroutines = 16
 
 	t.Run("basic", func(t *testing.T) {
-		a := NewBasicAuthenticator("admin", "s3cret", stubJar{})
+		a := NewBasicAuthenticator("admin", "s3cret", "test-broker", stubJar{})
 		wantUser, wantPass := a.username, a.password
 		wantCreds := wantUser + ":" + wantPass
 

--- a/internal/semp/auth/basic.go
+++ b/internal/semp/auth/basic.go
@@ -11,10 +11,9 @@ import (
 // so AddAuth and HandleAuthFailure are safe to call concurrently from
 // any number of goroutines.
 type BasicAuthenticator struct {
-	username    string
-	password    string
-	brokerAlias string
-	jar         CookieJarClearer
+	username string
+	password string
+	jar      CookieJarClearer
 }
 
 // NewBasicAuthenticator returns a BasicAuthenticator that will attach the
@@ -22,14 +21,15 @@ type BasicAuthenticator struct {
 // jar is required — HandleAuthFailure clears it to force fresh Basic
 // credentials on the retry, so an authenticator without a jar cannot
 // recover from a 401. Panics with a WiringError if jar is nil — a nil
-// jar is a wiring bug, not a runtime condition. The brokerAlias flows
-// into the panic payload so the tool-handler recovery layer can log
-// which broker tripped the invariant.
+// jar is a wiring bug, not a runtime condition. brokerAlias flows into
+// the panic payload so the tool-handler recovery layer can log which
+// broker tripped the invariant; it is not stored on the successful path
+// because no runtime code path reads it.
 func NewBasicAuthenticator(username, password, brokerAlias string, jar CookieJarClearer) *BasicAuthenticator {
 	if jar == nil {
 		panic(WiringError{BrokerAlias: brokerAlias, Reason: "NewBasicAuthenticator: jar must be non-nil"})
 	}
-	return &BasicAuthenticator{username: username, password: password, brokerAlias: brokerAlias, jar: jar}
+	return &BasicAuthenticator{username: username, password: password, jar: jar}
 }
 
 // AddAuth attaches an Authorization: Basic header to req. The ctx is

--- a/internal/semp/auth/basic.go
+++ b/internal/semp/auth/basic.go
@@ -11,9 +11,10 @@ import (
 // so AddAuth and HandleAuthFailure are safe to call concurrently from
 // any number of goroutines.
 type BasicAuthenticator struct {
-	username string
-	password string
-	jar      CookieJarClearer
+	username    string
+	password    string
+	brokerAlias string
+	jar         CookieJarClearer
 }
 
 // NewBasicAuthenticator returns a BasicAuthenticator that will attach the
@@ -21,12 +22,13 @@ type BasicAuthenticator struct {
 // jar is required — HandleAuthFailure clears it to force fresh Basic
 // credentials on the retry, so an authenticator without a jar cannot
 // recover from a 401. Panics if jar is nil — a nil jar is a wiring bug,
-// not a runtime condition.
-func NewBasicAuthenticator(username, password string, jar CookieJarClearer) *BasicAuthenticator {
+// not a runtime condition. The brokerAlias is retained for diagnostic
+// use by the wiring-panic payload (see WiringError).
+func NewBasicAuthenticator(username, password, brokerAlias string, jar CookieJarClearer) *BasicAuthenticator {
 	if jar == nil {
 		panic("NewBasicAuthenticator: jar must be non-nil")
 	}
-	return &BasicAuthenticator{username: username, password: password, jar: jar}
+	return &BasicAuthenticator{username: username, password: password, brokerAlias: brokerAlias, jar: jar}
 }
 
 // AddAuth attaches an Authorization: Basic header to req. The ctx is

--- a/internal/semp/auth/basic.go
+++ b/internal/semp/auth/basic.go
@@ -21,12 +21,13 @@ type BasicAuthenticator struct {
 // given credentials to every request via http.Request.SetBasicAuth. The
 // jar is required — HandleAuthFailure clears it to force fresh Basic
 // credentials on the retry, so an authenticator without a jar cannot
-// recover from a 401. Panics if jar is nil — a nil jar is a wiring bug,
-// not a runtime condition. The brokerAlias is retained for diagnostic
-// use by the wiring-panic payload (see WiringError).
+// recover from a 401. Panics with a WiringError if jar is nil — a nil
+// jar is a wiring bug, not a runtime condition. The brokerAlias flows
+// into the panic payload so the tool-handler recovery layer can log
+// which broker tripped the invariant.
 func NewBasicAuthenticator(username, password, brokerAlias string, jar CookieJarClearer) *BasicAuthenticator {
 	if jar == nil {
-		panic("NewBasicAuthenticator: jar must be non-nil")
+		panic(WiringError{BrokerAlias: brokerAlias, Reason: "NewBasicAuthenticator: jar must be non-nil"})
 	}
 	return &BasicAuthenticator{username: username, password: password, brokerAlias: brokerAlias, jar: jar}
 }

--- a/internal/semp/auth/basic_test.go
+++ b/internal/semp/auth/basic_test.go
@@ -23,22 +23,33 @@ func (r *recordingJar) Clear() error {
 // at first 401 recovery attempt. Same rationale as
 // NewOAuthAuthenticator's nil-exchanger panic.
 //
-// The panic message is part of the assertion so a future refactor that
-// panics for a different reason (bad username, etc.) can't quietly pass
-// this test while dropping the nil-jar guard.
+// The panic value's type AND reason string are both asserted so a future
+// refactor that panics for a different reason (bad username, etc.) can't
+// quietly pass this test while dropping the nil-jar guard. The
+// broker-alias field is asserted separately so the diagnostic contract
+// the tool-handler recovery layer relies on stays pinned.
 func TestNewBasicAuthenticator_PanicsOnNilJar(t *testing.T) {
-	const wantMsg = "NewBasicAuthenticator: jar must be non-nil"
+	const (
+		wantAlias  = "test-broker"
+		wantReason = "NewBasicAuthenticator: jar must be non-nil"
+	)
 	defer func() {
 		r := recover()
 		if r == nil {
 			t.Fatal("NewBasicAuthenticator(_, _, _, nil) did not panic")
 		}
-		got, ok := r.(string)
-		if !ok || got != wantMsg {
-			t.Fatalf("panic value = %#v, want string %q", r, wantMsg)
+		we, ok := r.(WiringError)
+		if !ok {
+			t.Fatalf("panic value = %#v, want WiringError", r)
+		}
+		if we.BrokerAlias != wantAlias {
+			t.Errorf("WiringError.BrokerAlias = %q, want %q", we.BrokerAlias, wantAlias)
+		}
+		if we.Reason != wantReason {
+			t.Errorf("WiringError.Reason = %q, want %q", we.Reason, wantReason)
 		}
 	}()
-	NewBasicAuthenticator("admin", "s3cret", "test-broker", nil)
+	NewBasicAuthenticator("admin", "s3cret", wantAlias, nil)
 }
 
 // TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic pins the accepted

--- a/internal/semp/auth/basic_test.go
+++ b/internal/semp/auth/basic_test.go
@@ -31,14 +31,14 @@ func TestNewBasicAuthenticator_PanicsOnNilJar(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Fatal("NewBasicAuthenticator(_, _, nil) did not panic")
+			t.Fatal("NewBasicAuthenticator(_, _, _, nil) did not panic")
 		}
 		got, ok := r.(string)
 		if !ok || got != wantMsg {
 			t.Fatalf("panic value = %#v, want string %q", r, wantMsg)
 		}
 	}()
-	NewBasicAuthenticator("admin", "s3cret", nil)
+	NewBasicAuthenticator("admin", "s3cret", "test-broker", nil)
 }
 
 // TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic pins the accepted
@@ -61,7 +61,7 @@ func TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic(t *testing.T) {
 			t.Fatalf("NewBasicAuthenticator with typed-nil jar panicked unexpectedly: %v", r)
 		}
 	}()
-	_ = NewBasicAuthenticator("admin", "s3cret", typedNil)
+	_ = NewBasicAuthenticator("admin", "s3cret", "test-broker", typedNil)
 }
 
 // TestBasicAuthenticator_HandleAuthFailure_ClearsJarAndReturnsTrue pins
@@ -72,7 +72,7 @@ func TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic(t *testing.T) {
 // the retry loop that might silently drop the Clear() call.
 func TestBasicAuthenticator_HandleAuthFailure_ClearsJarAndReturnsTrue(t *testing.T) {
 	jar := &recordingJar{}
-	a := NewBasicAuthenticator("admin", "s3cret", jar)
+	a := NewBasicAuthenticator("admin", "s3cret", "test-broker", jar)
 
 	if !a.HandleAuthFailure(context.Background(), nil) {
 		t.Error("HandleAuthFailure returned false, want true on successful clear")
@@ -89,7 +89,7 @@ func TestBasicAuthenticator_HandleAuthFailure_ClearsJarAndReturnsTrue(t *testing
 func TestBasicAuthenticator_HandleAuthFailure_JarClearError(t *testing.T) {
 	sentinel := errors.New("clear failed")
 	jar := &recordingJar{clearErr: sentinel}
-	a := NewBasicAuthenticator("admin", "s3cret", jar)
+	a := NewBasicAuthenticator("admin", "s3cret", "test-broker", jar)
 
 	if a.HandleAuthFailure(context.Background(), nil) {
 		t.Error("HandleAuthFailure returned true, want false when jar.Clear() fails")

--- a/internal/semp/auth/oauth.go
+++ b/internal/semp/auth/oauth.go
@@ -31,11 +31,13 @@ type OAuthAuthenticator struct {
 
 // NewOAuthAuthenticator returns an OAuthAuthenticator that will exchange
 // the agent's inbound token for a broker-scoped token on every SEMP
-// request. Panics if exchanger is nil — a nil exchanger is a wiring
-// bug, not a runtime condition.
+// request. Panics with a WiringError if exchanger is nil — a nil
+// exchanger is a wiring bug, not a runtime condition. The brokerAlias
+// flows into the panic payload so the tool-handler recovery layer can
+// log which broker tripped the invariant.
 func NewOAuthAuthenticator(exchanger tokenExchanger, audience string, scopes []string, brokerAlias string) *OAuthAuthenticator {
 	if exchanger == nil {
-		panic("NewOAuthAuthenticator: exchanger must be non-nil")
+		panic(WiringError{BrokerAlias: brokerAlias, Reason: "NewOAuthAuthenticator: exchanger must be non-nil"})
 	}
 	return &OAuthAuthenticator{
 		exchanger:   exchanger,

--- a/internal/semp/auth/oauth_test.go
+++ b/internal/semp/auth/oauth_test.go
@@ -53,6 +53,53 @@ func ctxWithSubjectToken(t *testing.T, token string) context.Context {
 	return captured
 }
 
+// TestNewOAuthAuthenticator_PanicsOnNilExchanger pins the constructor
+// contract: a nil exchanger is a wiring bug and must fail fast at
+// construction, not later on the first AddAuth call. Symmetric to
+// TestNewBasicAuthenticator_PanicsOnNilJar.
+//
+// The panic message is part of the assertion so a future refactor that
+// panics for a different reason (bad audience, empty alias, etc.) can't
+// quietly pass this test while dropping the nil-exchanger guard.
+func TestNewOAuthAuthenticator_PanicsOnNilExchanger(t *testing.T) {
+	const wantMsg = "NewOAuthAuthenticator: exchanger must be non-nil"
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("NewOAuthAuthenticator(nil, ...) did not panic")
+		}
+		got, ok := r.(string)
+		if !ok || got != wantMsg {
+			t.Fatalf("panic value = %#v, want string %q", r, wantMsg)
+		}
+	}()
+	NewOAuthAuthenticator(nil, "aud", nil, "b")
+}
+
+// TestNewOAuthAuthenticator_TypedNilExchanger_DoesNotPanic pins the
+// accepted limit of the nil-exchanger guard: a typed-nil implementation
+// (Go's classic "nil interface vs. nil concrete" gotcha — see
+// https://go.dev/doc/faq#nil_error) produces a non-nil interface value
+// and slips past the == nil check.
+//
+// This is intentional and matches the ecosystem convention: defend at
+// the producer, not the consumer. Production wiring (newAuthenticator in
+// internal/semp/broker.go) never emits a typed-nil, so the case is
+// unreachable in production. Symmetric to
+// TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic. If we ever adopt
+// reflect-based detection or a linter that upgrades this to a
+// compile-time error, this test will fail — and that failure is the
+// intended signal that we're deliberately changing the contract.
+func TestNewOAuthAuthenticator_TypedNilExchanger_DoesNotPanic(t *testing.T) {
+	var typedNil *fakeExchanger // nil pointer, but wrapping it in the interface produces a non-nil header
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewOAuthAuthenticator with typed-nil exchanger panicked unexpectedly: %v", r)
+		}
+	}()
+	_ = NewOAuthAuthenticator(typedNil, "aud", nil, "b")
+}
+
 func TestOAuthAuthenticator_AddAuth(t *testing.T) {
 	exchg := &fakeExchanger{
 		returnToken: &tokenexchange.Token{

--- a/internal/semp/auth/oauth_test.go
+++ b/internal/semp/auth/oauth_test.go
@@ -58,22 +58,34 @@ func ctxWithSubjectToken(t *testing.T, token string) context.Context {
 // construction, not later on the first AddAuth call. Symmetric to
 // TestNewBasicAuthenticator_PanicsOnNilJar.
 //
-// The panic message is part of the assertion so a future refactor that
-// panics for a different reason (bad audience, empty alias, etc.) can't
-// quietly pass this test while dropping the nil-exchanger guard.
+// The panic value's type AND reason string are both asserted so a future
+// refactor that panics for a different reason (bad audience, empty
+// alias, etc.) can't quietly pass this test while dropping the
+// nil-exchanger guard. The broker-alias field is asserted separately
+// so the diagnostic contract the tool-handler recovery layer relies on
+// stays pinned.
 func TestNewOAuthAuthenticator_PanicsOnNilExchanger(t *testing.T) {
-	const wantMsg = "NewOAuthAuthenticator: exchanger must be non-nil"
+	const (
+		wantAlias  = "test-broker"
+		wantReason = "NewOAuthAuthenticator: exchanger must be non-nil"
+	)
 	defer func() {
 		r := recover()
 		if r == nil {
 			t.Fatal("NewOAuthAuthenticator(nil, ...) did not panic")
 		}
-		got, ok := r.(string)
-		if !ok || got != wantMsg {
-			t.Fatalf("panic value = %#v, want string %q", r, wantMsg)
+		we, ok := r.(WiringError)
+		if !ok {
+			t.Fatalf("panic value = %#v, want WiringError", r)
+		}
+		if we.BrokerAlias != wantAlias {
+			t.Errorf("WiringError.BrokerAlias = %q, want %q", we.BrokerAlias, wantAlias)
+		}
+		if we.Reason != wantReason {
+			t.Errorf("WiringError.Reason = %q, want %q", we.Reason, wantReason)
 		}
 	}()
-	NewOAuthAuthenticator(nil, "aud", nil, "b")
+	NewOAuthAuthenticator(nil, "aud", nil, wantAlias)
 }
 
 // TestNewOAuthAuthenticator_TypedNilExchanger_DoesNotPanic pins the

--- a/internal/semp/auth/wiring.go
+++ b/internal/semp/auth/wiring.go
@@ -1,0 +1,28 @@
+package auth
+
+// WiringError is the panic value authenticator constructors use when a
+// required dependency is nil. It carries the broker alias so the
+// tool-handler recovery layer (internal/tools.withRecovery) can log it
+// as a pre-vetted structured field.
+//
+// Raw panic strings cannot be logged under the secure-logging rules
+// (docs/internal/secure-logging-rules.md): panic values are unaudited
+// and may carry arbitrary data. A typed panic value with explicitly
+// declared fields is the safe way to route a diagnostic string through
+// recovery — each field's contract makes it safe to log.
+//
+// Kept local to internal/semp/auth: the only callers are the
+// authenticator constructors in this package. If a third package needs
+// the same shape, lift this to a shared location — the compiler will
+// drive the rename.
+type WiringError struct {
+	// BrokerAlias identifies which broker's wiring tripped the panic.
+	// Sourced from the broker config alias, safe to log.
+	BrokerAlias string
+
+	// Reason is the constructor-authored message describing what
+	// invariant was violated (e.g. "NewOAuthAuthenticator: exchanger
+	// must be non-nil"). Authored by trusted code in this package;
+	// safe to log.
+	Reason string
+}

--- a/internal/semp/broker.go
+++ b/internal/semp/broker.go
@@ -117,6 +117,15 @@ func newCookieJar(alias string, mode string) (*resilience.SafeCookieJar, error) 
 // exchanger) live inside each constructor and fail fast via
 // auth.WiringError panics. The dispatcher does not re-validate them;
 // its only error path is an unknown auth mode.
+//
+// The nil-exchanger case for OAuth requires one bit of conversion
+// hygiene: passing a concrete nil *tokenexchange.Exchanger into
+// NewOAuthAuthenticator's tokenExchanger interface parameter would
+// produce a typed-nil interface header ({type: *Exchanger, value: nil})
+// that silently bypasses the constructor's `exchanger == nil` guard
+// (Go's classic nil-interface gotcha — see go.dev/doc/faq#nil_error).
+// Check the concrete pointer here and pass untyped nil so the guard
+// fires and the WiringError panic carries the broker alias.
 func newAuthenticator(alias string, brokerCfg *config.BrokerConfig, jar *resilience.SafeCookieJar, exchanger *tokenexchange.Exchanger) (auth.Authenticator, error) {
 	cfg := brokerCfg.Auth
 	switch cfg.Mode {
@@ -125,6 +134,9 @@ func newAuthenticator(alias string, brokerCfg *config.BrokerConfig, jar *resilie
 	case config.AuthModeBearer:
 		return auth.NewBearerAuthenticator(cfg.Token), nil
 	case config.AuthModeOAuth:
+		if exchanger == nil {
+			return auth.NewOAuthAuthenticator(nil, cfg.Audience, cfg.Scopes, alias), nil
+		}
 		return auth.NewOAuthAuthenticator(exchanger, cfg.Audience, cfg.Scopes, alias), nil
 	default:
 		return nil, fmt.Errorf("unsupported auth mode %q for broker %q", cfg.Mode, alias)

--- a/internal/semp/broker.go
+++ b/internal/semp/broker.go
@@ -46,8 +46,9 @@ type BrokerClient struct {
 // owns its own precondition checks.
 //
 // exchanger is the process-wide token exchanger for OAuth brokers. Pass
-// nil when no broker uses OAuth; newAuthenticator returns an error if an
-// OAuth broker is configured without an exchanger.
+// nil when no broker uses OAuth; NewOAuthAuthenticator panics with an
+// auth.WiringError if an OAuth broker is configured without an exchanger,
+// carrying the broker alias for operator diagnostics.
 func NewBrokerClient(alias string, brokerCfg *config.BrokerConfig, sempCfg *config.SEMPConfig, exchanger *tokenexchange.Exchanger) (*BrokerClient, error) {
 	jar, err := newCookieJar(alias, brokerCfg.Auth.Mode)
 	if err != nil {

--- a/internal/semp/broker.go
+++ b/internal/semp/broker.go
@@ -111,6 +111,11 @@ func newCookieJar(alias string, mode string) (*resilience.SafeCookieJar, error) 
 // auth config. Each mode has its own constructor with mode-specific deps;
 // this switch is the single dispatch point so NewBrokerClient stays
 // focused on wiring clients.
+//
+// Per-mode wiring invariants (e.g. non-nil cookie jar, non-nil token
+// exchanger) live inside each constructor and fail fast via
+// auth.WiringError panics. The dispatcher does not re-validate them;
+// its only error path is an unknown auth mode.
 func newAuthenticator(alias string, brokerCfg *config.BrokerConfig, jar *resilience.SafeCookieJar, exchanger *tokenexchange.Exchanger) (auth.Authenticator, error) {
 	cfg := brokerCfg.Auth
 	switch cfg.Mode {
@@ -119,9 +124,6 @@ func newAuthenticator(alias string, brokerCfg *config.BrokerConfig, jar *resilie
 	case config.AuthModeBearer:
 		return auth.NewBearerAuthenticator(cfg.Token), nil
 	case config.AuthModeOAuth:
-		if exchanger == nil {
-			return nil, fmt.Errorf("oauth auth requires a token exchanger for broker %q", alias)
-		}
 		return auth.NewOAuthAuthenticator(exchanger, cfg.Audience, cfg.Scopes, alias), nil
 	default:
 		return nil, fmt.Errorf("unsupported auth mode %q for broker %q", cfg.Mode, alias)

--- a/internal/semp/broker.go
+++ b/internal/semp/broker.go
@@ -115,7 +115,7 @@ func newAuthenticator(alias string, brokerCfg *config.BrokerConfig, jar *resilie
 	cfg := brokerCfg.Auth
 	switch cfg.Mode {
 	case config.AuthModeBasic:
-		return auth.NewBasicAuthenticator(cfg.Username, cfg.Password, jar), nil
+		return auth.NewBasicAuthenticator(cfg.Username, cfg.Password, alias, jar), nil
 	case config.AuthModeBearer:
 		return auth.NewBearerAuthenticator(cfg.Token), nil
 	case config.AuthModeOAuth:

--- a/internal/semp/broker_test.go
+++ b/internal/semp/broker_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp/sempv2"
 )
 
@@ -235,4 +236,52 @@ func TestBrokerClient_SharedJar_401ClearVisibleAcrossProtocols(t *testing.T) {
 	if got, _ := v1Cookie.Load().(string); got != "" {
 		t.Errorf("V1 request carried cookie %q — jar is not shared across protocols", got)
 	}
+}
+
+// TestNewBrokerClient_OAuth_NilExchanger_PanicsWithWiringError pins the
+// dispatcher-boundary contract for the nil-exchanger case: when an OAuth
+// broker is wired with a nil *tokenexchange.Exchanger, newAuthenticator
+// must produce a panic that carries the broker alias via auth.WiringError.
+//
+// The trap this defends against: passing the concrete nil pointer directly
+// into NewOAuthAuthenticator's tokenExchanger interface parameter produces
+// a typed-nil interface header ({type: *Exchanger, value: nil}) that
+// silently bypasses the constructor's `exchanger == nil` guard — a later
+// runtime nil-pointer panic then reaches withRecovery with panic_type
+// *runtime.PanicNilError and no broker context, losing the WiringError
+// diagnostic contract this ticket added. A future refactor that "cleans
+// up" the pre-conversion nil check in newAuthenticator as redundant would
+// silently re-introduce that regression; this test fails loudly when it
+// does.
+func TestNewBrokerClient_OAuth_NilExchanger_PanicsWithWiringError(t *testing.T) {
+	brokerCfg := &config.BrokerConfig{
+		URL: "http://example.test",
+		Auth: config.AuthConfig{
+			Mode:     config.AuthModeOAuth,
+			Audience: "broker-audience",
+			Scopes:   []string{"read"},
+		},
+	}
+	const wantAlias = "test-broker"
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("NewBrokerClient with nil exchanger did not panic")
+		}
+		we, ok := r.(auth.WiringError)
+		if !ok {
+			t.Fatalf("panic value = %#v, want auth.WiringError", r)
+		}
+		if we.BrokerAlias != wantAlias {
+			t.Errorf("BrokerAlias = %q, want %q", we.BrokerAlias, wantAlias)
+		}
+		const wantReason = "NewOAuthAuthenticator: exchanger must be non-nil"
+		if we.Reason != wantReason {
+			t.Errorf("Reason = %q, want %q", we.Reason, wantReason)
+		}
+	}()
+
+	_, _ = semp.NewBrokerClient(wantAlias, brokerCfg, testSEMPConfig(), nil)
+	t.Fatal("expected panic before this point")
 }

--- a/internal/semp/resilience/body_close_test.go
+++ b/internal/semp/resilience/body_close_test.go
@@ -60,7 +60,7 @@ func newErrorHandlerTestSender(t *testing.T) *Sender {
 		RetryMaxInterval:   10 * time.Millisecond,
 	}
 	jar := mustNewSafeCookieJar(t)
-	authn := auth.NewBasicAuthenticator("admin", "secret", jar)
+	authn := auth.NewBasicAuthenticator("admin", "secret", "test-broker", jar)
 	return New(&http.Client{Jar: jar}, sempCfg, authn, "http://broker.example:8080", NewSemaphore(10))
 }
 

--- a/internal/semp/resilience/sender_test.go
+++ b/internal/semp/resilience/sender_test.go
@@ -30,7 +30,7 @@ func mustNewSafeCookieJar(t *testing.T) *SafeCookieJar {
 // cookie-clearing works end-to-end in tests.
 func basicAuth(t *testing.T, jar *SafeCookieJar) auth.Authenticator {
 	t.Helper()
-	return auth.NewBasicAuthenticator("admin", "secret", jar)
+	return auth.NewBasicAuthenticator("admin", "secret", "test-broker", jar)
 }
 
 // bearerAuth creates a BearerAuthenticator (static token, no jar needed).
@@ -366,9 +366,9 @@ func TestSender_RateLimiter_PerBrokerIndependence(t *testing.T) {
 	}))
 	defer serverB.Close()
 
-	senderA := newTestSender(t, serverA.Client(), auth.NewBasicAuthenticator("admin", "secret", mustNewSafeCookieJar(t)), 0)
+	senderA := newTestSender(t, serverA.Client(), auth.NewBasicAuthenticator("admin", "secret", "broker-a", mustNewSafeCookieJar(t)), 0)
 	senderA.brokerURL = serverA.URL
-	senderB := newTestSender(t, serverB.Client(), auth.NewBasicAuthenticator("admin", "secret", mustNewSafeCookieJar(t)), 0)
+	senderB := newTestSender(t, serverB.Client(), auth.NewBasicAuthenticator("admin", "secret", "broker-b", mustNewSafeCookieJar(t)), 0)
 	senderB.brokerURL = serverB.URL
 
 	// Block sender A's rate limiter.

--- a/internal/semp/sempv1/client_test.go
+++ b/internal/semp/sempv1/client_test.go
@@ -54,7 +54,7 @@ func newTestClient(t *testing.T, srv *httptest.Server) *HTTPClient {
 	if err != nil {
 		t.Fatalf("NewSafeCookieJar: %v", err)
 	}
-	return newTestClientWith(t, srv, auth.NewBasicAuthenticator("user", "pass", jar), jar)
+	return newTestClientWith(t, srv, auth.NewBasicAuthenticator("user", "pass", "test-broker", jar), jar)
 }
 
 const successEnvelope = `<rpc-reply><rpc><show><version/></show></rpc><execute-result code="ok"/></rpc-reply>`
@@ -106,7 +106,7 @@ func TestExecute_RequestConstruction(t *testing.T) {
 		if jarErr != nil {
 			t.Fatalf("NewSafeCookieJar: %v", jarErr)
 		}
-		client := newTestClientWith(t, srv, auth.NewBasicAuthenticator("user", "pass", jar), jar)
+		client := newTestClientWith(t, srv, auth.NewBasicAuthenticator("user", "pass", "test-broker", jar), jar)
 
 		_, err := client.Execute(context.Background(), `<rpc><show/></rpc>`)
 		if err != nil {
@@ -458,7 +458,7 @@ func TestHTTPClient_LogValue_ExcludesCredentials(t *testing.T) {
 	}{
 		{
 			name:    "basic auth credentials are not logged",
-			authn:   auth.NewBasicAuthenticator("SECRET_USERNAME_VAL", "SECRET_PASSWORD_VAL", basicJar),
+			authn:   auth.NewBasicAuthenticator("SECRET_USERNAME_VAL", "SECRET_PASSWORD_VAL", "test-broker", basicJar),
 			jar:     basicJar,
 			secrets: []string{"SECRET_USERNAME_VAL", "SECRET_PASSWORD_VAL"},
 		},

--- a/internal/semp/sempv1/correlation_test.go
+++ b/internal/semp/sempv1/correlation_test.go
@@ -35,7 +35,7 @@ func newTestClientWithRetries(t *testing.T, srv *httptest.Server, maxRetries int
 	if jarErr != nil {
 		t.Fatalf("NewSafeCookieJar: %v", jarErr)
 	}
-	client, err := NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("user", "pass", jar), jar)
+	client, err := NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("user", "pass", "test-broker", jar), jar)
 	if err != nil {
 		t.Fatalf("NewHTTPClient: %v", err)
 	}

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -41,7 +41,7 @@ func newTestClient(t *testing.T, handler http.HandlerFunc) (*sempv2.HTTPClient, 
 	if jarErr != nil {
 		t.Fatalf("NewSafeCookieJar: %v", jarErr)
 	}
-	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", jar), jar)
+	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", "test-broker", jar), jar)
 	if err != nil {
 		t.Fatalf("NewHTTPClient() error: %v", err)
 	}
@@ -917,7 +917,7 @@ func TestClient_Execute_Timeout(t *testing.T) {
 	if jarErr != nil {
 		t.Fatalf("NewSafeCookieJar: %v", jarErr)
 	}
-	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", jar), jar)
+	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", "test-broker", jar), jar)
 	if err != nil {
 		t.Fatalf("NewHTTPClient() error: %v", err)
 	}
@@ -992,7 +992,7 @@ func TestClient_TransportPool_ReusesConnections(t *testing.T) {
 	if jarErr != nil {
 		t.Fatalf("NewSafeCookieJar: %v", jarErr)
 	}
-	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", jar), jar)
+	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", "test-broker", jar), jar)
 	if err != nil {
 		t.Fatalf("NewHTTPClient: %v", err)
 	}

--- a/internal/semp/sempv2/correlation_test.go
+++ b/internal/semp/sempv2/correlation_test.go
@@ -40,7 +40,7 @@ func newTestClientRetries(t *testing.T, maxRetries int, handler http.HandlerFunc
 	if jarErr != nil {
 		t.Fatalf("NewSafeCookieJar: %v", jarErr)
 	}
-	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", jar), jar)
+	client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", "test-broker", jar), jar)
 	if err != nil {
 		t.Fatalf("NewHTTPClient: %v", err)
 	}

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -68,10 +69,24 @@ func withRecovery(toolName string, h mcp.ToolHandler) mcp.ToolHandler {
 				// stack trace pinpoints the panic site without echoing the
 				// value, and the agent sees only the generic message below,
 				// matching the unknown-error branch of buildErrorMessage.
-				slog.Error("tool handler panicked",
+				//
+				// auth.WiringError is the one typed exception: its fields
+				// are explicitly declared as safe-to-log (broker alias from
+				// config, reason string authored in-package), so they are
+				// extracted here to give operators broker-context on
+				// constructor-panic invariants. All other panic types stay
+				// redacted per the secure-logging rule.
+				attrs := []any{
 					slog.String("tool", toolName),
 					slog.String("panic_type", fmt.Sprintf("%T", r)),
-					slog.String("stack", string(debug.Stack())))
+					slog.String("stack", string(debug.Stack())),
+				}
+				if we, ok := r.(auth.WiringError); ok {
+					attrs = append(attrs,
+						slog.String("broker_alias", we.BrokerAlias),
+						slog.String("wiring_reason", we.Reason))
+				}
+				slog.Error("tool handler panicked", attrs...)
 				result = &mcp.CallToolResult{
 					StructuredContent: map[string]any{
 						"error":     serverInternalErrorMessage,

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
+	"github.com/SolaceDev/solace-broker-mcp/internal/semp/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -258,6 +259,76 @@ func TestPanicAuditedAsError(t *testing.T) {
 	// The raw panic value is unaudited text and must not reach the audit line.
 	if containsStr(logBuf.String(), "simulated handler bug") {
 		t.Errorf("raw panic value leaked into logs: %s", logBuf.String())
+	}
+}
+
+// TestWithRecovery_WiringErrorLogsBrokerAlias pins the diagnostic contract
+// for auth.WiringError panics: when the wrapped handler panics with a
+// typed WiringError value, withRecovery type-switches on it and adds
+// broker_alias + wiring_reason as pre-vetted structured fields on the
+// "tool handler panicked" log record. Every OTHER panic type continues
+// to log only panic_type + stack — TestPanicAuditedAsError covers that
+// path end-to-end with a plain-string panic and asserts no leak.
+//
+// This test calls withRecovery directly rather than routing through the
+// MCP client/server/transport: the behavior under test is entirely
+// inside withRecovery's defer block, and a direct call keeps the test's
+// failure modes matched to the code under test.
+//
+// Without this contract, an operator seeing a wiring panic in production
+// cannot identify which broker's config tripped the invariant — a real
+// gap Andrea raised on PR #149.
+func TestWithRecovery_WiringErrorLogsBrokerAlias(t *testing.T) {
+	var logBuf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(oldLogger)
+
+	const (
+		wantTool   = "wiring-panic-tool"
+		wantAlias  = "prod-east"
+		wantReason = "NewOAuthAuthenticator: exchanger must be non-nil"
+	)
+	handler := withRecovery(wantTool, func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		panic(auth.WiringError{BrokerAlias: wantAlias, Reason: wantReason})
+	})
+
+	result, err := handler(context.Background(), &mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("withRecovery propagated an error instead of recovering: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("withRecovery did not return the sanitized error result on panic: %+v", result)
+	}
+
+	var entry map[string]any
+	for _, raw := range strings.Split(logBuf.String(), "\n") {
+		if raw == "" {
+			continue
+		}
+		var m map[string]any
+		if uerr := json.Unmarshal([]byte(raw), &m); uerr != nil {
+			t.Fatalf("non-JSON log line %q: %v", raw, uerr)
+		}
+		if m["msg"] == "tool handler panicked" && m["tool"] == wantTool {
+			if entry != nil {
+				t.Fatalf("expected exactly 1 recovery-layer panic line, got 2+: %s", logBuf.String())
+			}
+			entry = m
+		}
+	}
+	if entry == nil {
+		t.Fatalf("no recovery-layer panic line found: %s", logBuf.String())
+	}
+
+	if got := entry["panic_type"]; got != "auth.WiringError" {
+		t.Errorf("panic_type = %v, want %q", got, "auth.WiringError")
+	}
+	if got := entry["broker_alias"]; got != wantAlias {
+		t.Errorf("broker_alias = %v, want %q", got, wantAlias)
+	}
+	if got := entry["wiring_reason"]; got != wantReason {
+		t.Errorf("wiring_reason = %v, want %q", got, wantReason)
 	}
 }
 

--- a/test/integration/retry_state_isolation_test.go
+++ b/test/integration/retry_state_isolation_test.go
@@ -101,7 +101,7 @@ func TestSenderRetryStateIsolatedUnderConcurrency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSafeCookieJar: %v", err)
 	}
-	authn := auth.NewBasicAuthenticator("admin", "secret", jar)
+	authn := auth.NewBasicAuthenticator("admin", "secret", "test-broker", jar)
 
 	httpClient := server.Client()
 	httpClient.Jar = jar


### PR DESCRIPTION
## Summary

Makes authenticator constructor panics **diagnosable** — the tool-handler recovery layer can now log the broker alias when a constructor's wiring invariant fires. Also adds the missing symmetric panic-contract tests for `NewOAuthAuthenticator`.

Jira: [SOL-151601](https://sol-jira.atlassian.net/browse/SOL-151601)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes) — dispatcher-guard collapse

## Motivation and Context

Two gaps surfaced by [PR #149](https://github.com/SolaceDev/solace-broker-mcp/pull/149) (SOL-151506) — Andrea Ross raised the diagnostic concern in review:

**Gap 1 — Missing panic-contract test for `NewOAuthAuthenticator`.** SOL-151506 introduced a nil-jar panic in `NewBasicAuthenticator` with tests defending it. `NewOAuthAuthenticator` already had the equivalent nil-exchanger panic (`internal/semp/auth/oauth.go:36-38`) but no test — a future refactor could quietly drop the guard.

**Gap 2 — Constructor panics aren't diagnosable.** Both constructors panicked with a bare string like `"NewBasicAuthenticator: jar must be non-nil"`. When `withRecovery` catches such a panic, secure-logging rules require dropping the panic text (panic values are unaudited, `docs/internal/secure-logging-rules.md`). So the operator saw *"a broker tool panicked"* with no way to identify which broker's config tripped the invariant. The dispatcher's prior error string (`"basic auth requires a cookie jar for broker %q"`) carried the alias — that context regressed when the check moved to the constructor.

## Changes Made

Eight commits, each independently reviewable — the sequence is intentional so `git bisect` stays useful:

1. **`752856b` Add panic-contract tests for NewOAuthAuthenticator** — the two symmetric tests (Part 1 of the ticket): asserts the untyped-nil panic and pins the typed-nil accepted-limit.
2. **`9592ccb` Add WiringError type for authenticator wiring panics** — the typed panic value: `BrokerAlias`, `Reason`. Kept local to `internal/semp/auth` per rule-of-three (2 callers today, both in-package); lift path documented in the type comment.
3. **`b1864ce` Add broker alias parameter to NewBasicAuthenticator** — pure signature threading (11 files, +29/-27). No behavior change; prep for commit 4.
4. **`6461c8c` Panic with WiringError in both authenticator constructors** — both constructors now panic with `auth.WiringError{...}`. The 4 panic-contract tests updated in the same commit to assert the typed shape (type, `BrokerAlias`, `Reason`).
5. **`8a3bd9b` Log broker alias from WiringError panics in tool recovery** — `withRecovery` type-switches on `auth.WiringError` and appends `broker_alias` + `wiring_reason` as pre-vetted structured fields. All other panic types continue to redact per the existing secure-logging rule.
6. **`48c1d1e` Remove redundant nil-exchanger guard from newAuthenticator** — the dispatcher's `if exchanger == nil` block is now dead code; the constructor owns the invariant. Dispatcher goes back to pure auth-mode routing.
7. **`75e6c10` Post-review cleanups from stale-reference sweep** — fixed a stale docstring on `NewBrokerClient` describing the deleted error-return path; softened the cross-reference in HTTP-mux `recovery.HTTPMiddleware` so it no longer claims identical behavior with `withRecovery` after the typed-exception was added; removed the unused `brokerAlias` field from `BasicAuthenticator`'s struct (the constructor still passes it through to the panic, so the operator diagnostic is intact).
8. **`a0cf100` Pass untyped nil at OAuth dispatcher boundary to preserve WiringError** — flagged by @solace-aross: after collapsing the dispatcher guard, `newAuthenticator` was passing the concrete `*tokenexchange.Exchanger` directly into the `tokenExchanger` interface parameter — a typed-nil interface header that silently bypassed the constructor's `== nil` guard. Fixed at the producer boundary (consistent with the "defend at the producer" principle we settled on in PR #149's Basic discussion). Added a defending test at the dispatcher boundary so a future "cleanup" refactor of the pre-conversion check fails loudly.

**Design decision — Design B (typed panic) chosen over Design A (localized string):** The secure-logging contract in `withRecovery` (`internal/tools/register.go:65-70`) drops all panic-value text because panic values are unaudited — a typed panic with named fields is the only shape that survives redaction while keeping the rule intact. Fields are logged because *the field's contract* declares them safe, not because they happen to be strings. See the `WiringError` type doc in `internal/semp/auth/wiring.go`.

## Testing

**Test Environment:**
- Go version: 1.24
- OS: Darwin 24.6.0

**Tests Performed:**
- [x] Unit tests added/updated
- [x] Integration tests — pre-existing `test/integration/retry_state_isolation_test.go` compiles/runs against the new signature
- [ ] E2E tests — not applicable (no wire-protocol changes)
- [x] Tested locally with `go test -race ./cmd/... ./internal/... ./test/...` — green
- [ ] Tested with real Solace broker — not applicable (panic path only fires on wiring bugs; verified via panic-recovery tests)

**Test Coverage:**

Four constructor-side panic-contract tests, symmetric across Basic and OAuth:
- `TestNewBasicAuthenticator_PanicsOnNilJar` / `TestNewOAuthAuthenticator_PanicsOnNilExchanger` — assert panic value is `auth.WiringError` with the exact `BrokerAlias` + `Reason` fields.
- `TestNewBasicAuthenticator_TypedNilJar_DoesNotPanic` / `TestNewOAuthAuthenticator_TypedNilExchanger_DoesNotPanic` — pin the accepted limit of the `== nil` guard (Go's typed-nil-vs-untyped-nil gotcha). Defend at producer, not consumer.

One recovery-layer test:
- `TestWithRecovery_WiringErrorLogsBrokerAlias` — direct unit test on `withRecovery` (no MCP client/server/transport). Asserts the log record contains `broker_alias`, `wiring_reason`, and `panic_type=auth.WiringError`. The sibling `TestPanicAuditedAsError` continues to defend the non-`WiringError` redaction path.

One dispatcher-boundary test:
- `TestNewBrokerClient_OAuth_NilExchanger_PanicsWithWiringError` — pins the `newAuthenticator` → `NewOAuthAuthenticator` boundary contract. With OAuth mode and a nil `*tokenexchange.Exchanger`, `NewBrokerClient` must panic with `auth.WiringError` carrying the broker alias. Defends against a future refactor that "cleans up" the pre-conversion nil check in `newAuthenticator` as redundant and silently re-introduces the typed-nil trap.

## Breaking Changes

**None user-facing.** All changes are internal to `internal/semp/auth` and `internal/tools`. `NewBasicAuthenticator`'s signature grew by one param (`brokerAlias string`), but it's not part of any external API — only production caller is `internal/semp/newAuthenticator` (one line updated), plus test call sites (all updated in the same commit).

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments — see `WiringError` type doc, `withRecovery`'s inline comment on the typed-exception, `newAuthenticator`'s updated docstring on constructor-owned invariants + the interface-conversion hygiene note
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code**
- [x] Followed [secure logging rules](docs/internal/secure-logging-rules.md) — the recovery-layer change is a targeted exception with explicit rationale: `WiringError`'s two fields are declared in-package as safe-to-log (broker alias from config, reason string authored by trusted in-package code). All other panic types continue to redact. Rule not weakened.
- [x] Credential-carrying types implement `slog.LogValuer` — n/a for this change; `WiringError` does not carry credentials
- [x] No security vulnerabilities introduced

### Testing
- [x] All tests pass locally: `go test -race ./cmd/... ./internal/... ./test/...`
- [x] No race conditions detected
- [x] Edge cases covered by tests (typed-nil accepted limit at consumer, typed-nil trap at producer boundary, non-`WiringError` panics still redact)
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

### Documentation
- [x] README.md updated — not applicable, no user-facing changes
- [x] docs/ updated — **docs sweep performed, no updates required.** The `withRecovery` redaction contract lives in code comments only (not in `secure-logging-rules.md`) — updated inline in commit 5, and the sibling `recovery.HTTPMiddleware` comment was softened in commit 7 to reflect the sibling-layer difference. Three planning-doc references to older constructor signatures were found (SOL-150070 architecture-plan.md, SOL-150070 implementation-decisions.md, hardening/fail-fast-on-exchanger-error.md) — all pre-date SOL-151601 and are historical decision logs; edits would falsify the record. Left as-is.
- [x] godoc comments added/updated — `WiringError` type doc, both constructors' updated docstrings, `newAuthenticator`'s tightened docstring, `withRecovery`'s inline comment on the typed exception
- [ ] CHANGELOG.md — not maintained in this repo
- [x] Examples updated — n/a

### Git & CI
- [ ] All commits are signed off (DCO) — **intentionally omitted per team convention.** Happy to adjust if this repo actually enforces DCO on merge.
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (fast-forwarded before starting)
- [x] No merge conflicts

## Additional Notes

### Deliberate scope decisions

- **Commit 6 (dispatcher-guard removal) is slightly beyond the letter of the ticket.** The ticket scope lists: "add tests," "choose A or B, apply symmetrically," "update `withRecovery` if B chosen," "add tests for new payload." It does not explicitly say "collapse the dispatcher-level check." I bundled it because leaving the dispatcher guard in place makes Basic and OAuth handle the same class of wiring bug asymmetrically (Basic panics at construction; OAuth returned an error at dispatch) — which contradicts the ticket's stated symmetry goal.
- **`WiringError` has 2 fields, not 3.** The ticket's Design B example included a `Constructor` field. I omitted it — the constructor name is already in the stack trace, so it would duplicate information. Rationale in `wiring.go`'s type doc.
- **`withRecovery` updated, not a new broker-level `recover` in `NewBrokerClient`.** The ticket permits either ("update `withRecovery` **or** add broker-level `recover`"). I picked the simpler option; the tool-handler goroutine is where the panic fires today (broker clients are built lazily on first request per `pool.go:87-110`).

### Follow-up work identified

- **Domain types for `BrokerAlias` and `Password`/`Secret`.** During review of commit 3 I noticed 3 consecutive `string` params in `NewBasicAuthenticator` — arg-order-swap is compiler-silent. A codebase-wide `type BrokerAlias string` and a `type Password` with a `LogValue()` method would tighten this significantly. 50+ existing production references would need to migrate, so it's a real refactor — filed as a follow-up chip locally; will land as its own SOL ticket if the design pans out.

## Related Issues/PRs

- Jira: [SOL-151601](https://sol-jira.atlassian.net/browse/SOL-151601)
- Parent epic: [SOL-148417](https://sol-jira.atlassian.net/browse/SOL-148417)
- Follow-up from: [SOL-151506](https://sol-jira.atlassian.net/browse/SOL-151506) / PR #149

---

**For Reviewers:**

**Focus Areas:**
1. **Commit 5 (`withRecovery` type-switch)** — this is the security-adjacent commit. Please verify that the secure-logging rule remains intact for every non-`WiringError` panic (still logs only `panic_type` + `stack`, no `panic_message`), and that the two new fields on `WiringError`'s branch are genuinely safe (`BrokerAlias` sourced from config, `Reason` authored by trusted in-package code — both mirrored to other config-sourced structured log fields in the codebase).
2. **Commit 6 (dispatcher guard removal) + Commit 8 (typed-nil trap fix)** — read these together. Commit 6 collapsed the dispatcher-level `nil` guard as redundant; commit 8 restores a `nil` check at the dispatcher for a *different* purpose — emitting an untyped-nil interface value so the constructor's guard actually fires (Go's classic nil-interface header gotcha). The two commits together preserve "constructor owns the invariant" while making sure the dispatcher's interface-conversion is truthful.
3. **`WiringError` type location and shape** — kept local to `internal/semp/auth`; only 2 fields. If you'd prefer it live at a shared location (`internal/semp/wiring.go` or similar), the compiler will drive the rename in a follow-up.

[SOL-151601]: https://sol-jira.atlassian.net/browse/SOL-151601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151601]: https://sol-jira.atlassian.net/browse/SOL-151601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ