### PR TITLE
SOL-151850: Disambiguate clear-queue-stats from delete-queue-messages in tool description

### DIFF
--- a/internal/composite/definitions/tools.yaml
+++ b/internal/composite/definitions/tools.yaml
@@ -749,6 +749,7 @@ tools:
       Reset the statistics counters for a queue. Non-destructive: this resets
       monitoring counters only and does not affect spooled messages or message
       delivery. Useful for establishing a fresh metrics baseline during testing.
+      To purge/drain messages from a queue, use delete-queue-messages instead.
     annotations:
       readOnly: false
       destructive: false


### PR DESCRIPTION
## Summary

Disambiguate `clear-queue-stats` from `delete-queue-messages` in the tool description so LLM agents don't select the wrong tool on prompts like "clear the queue."

Fixes SOL-151850

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

`clear-queue-stats` resets monitoring counters only, while `delete-queue-messages` purges spooled messages. In LLM-driven usage, "clear the queue" is ambiguous and word-overlap alone can steer the model to `clear-queue-stats` when the user's intent is almost always to purge messages.

Observed in the e2e-llm scenario `b1-select-clear-the-queue`: prompted with "Clear queue X in VPN default on broker-a", the agent invoked `clear-queue-stats` instead of surfacing `delete-queue-messages` or asking for confirmation.

## Changes Made

- `internal/composite/definitions/tools.yaml`: appended a sentence to the `clear-queue-stats` description cross-referencing `delete-queue-messages` as the correct tool for purging messages.
- No behavior change to the tool itself; description-only edit.

## Testing

**Test Environment:**
- Go version: as per CI
- OS: Linux
- Broker version: Dockerized brokers via `test/e2e-llm`

**Tests Performed:**
- [x] Tested locally with `go test -race ./...` / `make check`
- [x] `test/e2e-llm` scenario `b1-select-clear-the-queue` passes: on "clear the queue" prompts the agent surfaces `delete-queue-messages` (with confirmation) or asks the user to clarify, and does not silently call `clear-queue-stats`.

**Test Coverage:**
- e2e-llm disambiguation scenario for the ambiguous "clear the queue" phrasing (prompt wording intentionally left unchanged — it's what the test is verifying).

## Breaking Changes

None. Description-only edit; tool contract and behavior unchanged.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] No commented-out code or debug statements

### Security
- [x] No credentials in code
- [x] No secure-logging impact (description-only change)

### Testing
- [x] All tests pass locally
- [x] e2e-llm b1 scenario passes

### Documentation
- [x] Tool description updated in `tools.yaml` (this IS the user-facing doc for LLMs)

### Git & CI
- [x] Commit has a clear, descriptive message (`SOL-151850: Disambiguate clear-queue-stats from delete-queue-messages in tool description`)
- [x] CI checks passing

## Additional Notes

**Out of scope:** Rewording the scenario prompt — the ambiguous phrasing is intentional and is what the scenario tests.

**Acceptance criteria met:**
1. `clear-queue-stats` description explicitly states it does not delete messages and names `delete-queue-messages` as the correct tool for that intent.
2. `b1-select-clear-the-queue` passes without the agent silently invoking `clear-queue-stats`.
3. No behavior change beyond the description.

## Related Issues/PRs

- Related to SOL-150727 (Mode-2 LLM write-tool eval — this scenario lives in that suite)