### PR TITLE
SOL-151512: Fix data race in tokenexchange test harness (receivedTokens map)

### DIFF
--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -208,9 +208,13 @@ func TestExchange_DifferentKeysRunConcurrently(t *testing.T) {
 		t.Errorf("IdP called %d times, want 2 (different keys should not be deduplicated)", got)
 	}
 
+	// Lock: the httptest handler writes receivedTokens under receivedTokensMu,
+	// and wg tracks Exchange() completion, not the handler goroutine.
+	receivedTokensMu.Lock()
 	if !receivedTokens["tok-A"] || !receivedTokens["tok-B"] {
 		t.Errorf("IdP received subject_tokens = %v, want both tok-A and tok-B", receivedTokens)
 	}
+	receivedTokensMu.Unlock()
 }
 
 func TestExchange_SameTokenDifferentBrokersRunConcurrently(t *testing.T) {
@@ -264,9 +268,13 @@ func TestExchange_SameTokenDifferentBrokersRunConcurrently(t *testing.T) {
 		t.Errorf("IdP called %d times, want 2 (same token + different brokers must not be deduplicated)", got)
 	}
 
+	// Lock: the httptest handler writes receivedTokens under receivedTokensMu,
+	// and wg tracks Exchange() completion, not the handler goroutine.
+	receivedTokensMu.Lock()
 	if !receivedTokens["same-token"] {
 		t.Errorf("IdP received subject_tokens = %v, want same-token", receivedTokens)
 	}
+	receivedTokensMu.Unlock()
 }
 
 // ---------- B04: context cancellation does not affect other callers ----------
@@ -388,12 +396,17 @@ func TestExchange_CancellationScopedToKeyBoundary(t *testing.T) {
 	}
 
 	// Groups 2 and 3 must have reached the IdP with their respective subject tokens.
+	// Lock: group 1's context is cancelled, so its Exchange() returns early via
+	// wg.Done() while the detached-context IdP call's handler may still be writing
+	// receivedTokens. wg tracks Exchange() completion, not the handler goroutine.
+	receivedTokensMu.Lock()
 	if !receivedTokens["user-a-jwt"] {
 		t.Errorf("IdP never received subject_token=user-a-jwt (group 2)")
 	}
 	if !receivedTokens["user-c-jwt"] {
 		t.Errorf("IdP never received subject_token=user-c-jwt (group 3)")
 	}
+	receivedTokensMu.Unlock()
 }
 
 func TestExchange_DifferentTokensSameBrokerRunConcurrently(t *testing.T) {
@@ -451,9 +464,13 @@ func TestExchange_DifferentTokensSameBrokerRunConcurrently(t *testing.T) {
 		t.Errorf("IdP called %d times, want 2 (different tokens + same broker must not be deduplicated)", got)
 	}
 
+	// Lock: the httptest handler writes receivedTokens under receivedTokensMu,
+	// and wg tracks Exchange() completion, not the handler goroutine.
+	receivedTokensMu.Lock()
 	if !receivedTokens["user-a-jwt"] || !receivedTokens["user-c-jwt"] {
 		t.Errorf("IdP received subject_tokens = %v, want both user-a-jwt and user-c-jwt", receivedTokens)
 	}
+	receivedTokensMu.Unlock()
 }
 
 // ---------- B04: context cancellation supersedes error ----------

--- a/internal/tokenexchange/exchange_test.go
+++ b/internal/tokenexchange/exchange_test.go
@@ -396,9 +396,9 @@ func TestExchange_CancellationScopedToKeyBoundary(t *testing.T) {
 	}
 
 	// Groups 2 and 3 must have reached the IdP with their respective subject tokens.
-	// Lock: group 1's context is cancelled, so its Exchange() returns early via
-	// wg.Done() while the detached-context IdP call's handler may still be writing
-	// receivedTokens. wg tracks Exchange() completion, not the handler goroutine.
+	// Lock to establish a happens-before edge with the httptest handler's writes to
+	// receivedTokens (the HTTP round-trip isn't synchronization the race detector
+	// can use).
 	receivedTokensMu.Lock()
 	if !receivedTokens["user-a-jwt"] {
 		t.Errorf("IdP never received subject_token=user-a-jwt (group 2)")


### PR DESCRIPTION
## Summary

Fixes a -race-detected data race in the tokenexchange test harness by synchronizing reads of the receivedTokens map with the existing mutex. Test-only change; no production code affected

Fixes # SOL-151512

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

Fixes a -race failure in internal/tokenexchange tests caused by unsynchronized access to the receivedTokens map. The fake IdP handler writes to the map under receivedTokensMu, but test assertions were reading it without the mutex. This was most visible in cancellation tests where Exchange() could return before the IdP handler finished. The fix synchronizes map access; production behaviour and core test assertions are unchanged.

## Changes Made

<!-- Detailed list of changes. Use bullets for clarity. -->

- Guard the four unguarded `receivedTokens` reads with `receivedTokensMu.Lock()` / `Unlock()`

## Testing

<!-- How was this tested? What cases were covered? -->

**Test Environment:**
- Go version:
- OS:
- Broker version (if applicable):

**Tests Performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Tested locally with `go test -race ./...`
- [ ] Tested with real Solace broker

**Test Coverage:**
<!-- Describe what scenarios were tested -->
-

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

**Impact:**

**Migration Guide:**

## Checklist

<!-- Ensure all items are completed before requesting review -->

### Code Quality
- [ ] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [ ] Self-review completed (checked for typos, logic errors, edge cases)
- [ ] Code is well-commented (explains "why", not "what")
- [ ] Complex logic has explanatory comments
- [ ] No commented-out code or debug statements left in

### Security
- [ ] **No credentials in code** (checked all files, commits, and logs)
- [ ] Followed [secure logging rules](../docs/secure-logging-rules.md)
- [ ] Credential-carrying types implement `slog.LogValuer`
- [ ] No security vulnerabilities introduced (checked with golangci-lint/gosec)

### Testing
- [ ] All tests pass locally: `go test -race ./...`
- [ ] No race conditions detected
- [ ] Edge cases covered by tests
- [ ] Error paths tested
- [ ] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (if user-facing changes)
- [ ] docs/ updated (if architecture/design changes)
- [ ] godoc comments added/updated for exported functions
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Examples updated (if applicable)

### Git & CI
- [ ] All commits are signed off (DCO: `git commit -s`)
- [ ] Commits have clear, descriptive messages
- [ ] Branch is up to date with main (rebased if needed)
- [ ] No merge conflicts
- [ ] CI checks passing (lint, build, test, E2E)

### Breaking Changes (if applicable)
- [ ] Breaking changes documented in commit message
- [ ] Breaking changes documented in PR description
- [ ] Migration guide provided
- [ ] Deprecated functionality marked with comments and deprecation notices

## Screenshots (if applicable)

<!-- Add screenshots for UI changes, CLI output, etc. -->

## Additional Notes

<!-- Any other context, concerns, or follow-up work needed -->

## Related Issues/PRs

<!-- Link to related issues, PRs, or discussions -->

- Related to #
- Depends on #
- Blocks #

---

**For Reviewers:**

**Focus Areas**: <!-- What should reviewers pay special attention to? -->

**Questions**: <!-- Any specific questions for reviewers? -->
