### PR TITLE
SOL-150759: Add unit tests for TLS / broker-certificate validation (transport layer)

### DIFF
--- a/internal/semp/resilience/transport_test.go
+++ b/internal/semp/resilience/transport_test.go
@@ -85,13 +85,7 @@ func TestResponseHeaderTimeout_TracksOperatorConfiguredRequestTimeout(t *testing
 // default: an unset insecure_skip_verify yields a transport with cert
 // verification on.
 func TestNewTunedTransport_TLSVerificationOnByDefault(t *testing.T) {
-	brokerCfg := &config.BrokerConfig{URL: "https://broker.example.com:1943"}
-	sempCfg := &config.SEMPConfig{
-		MaxConcurrentPerBroker: 10,
-		RequestTimeoutDuration: defaults.DefaultSEMPRequestTimeoutDuration,
-	}
-
-	tr := NewTunedTransport(brokerCfg, sempCfg)
+	tr := NewTunedTransport(&config.BrokerConfig{}, &config.SEMPConfig{})
 
 	if tr.TLSClientConfig == nil {
 		t.Fatal("TLSClientConfig = nil, want non-nil")
@@ -105,16 +99,7 @@ func TestNewTunedTransport_TLSVerificationOnByDefault(t *testing.T) {
 // insecure_skip_verify: true propagates into the transport (dev opt-out
 // for self-signed certs).
 func TestNewTunedTransport_TLSVerificationSkippedWhenConfigured(t *testing.T) {
-	brokerCfg := &config.BrokerConfig{
-		URL:                "https://broker.example.com:1943",
-		InsecureSkipVerify: true,
-	}
-	sempCfg := &config.SEMPConfig{
-		MaxConcurrentPerBroker: 10,
-		RequestTimeoutDuration: defaults.DefaultSEMPRequestTimeoutDuration,
-	}
-
-	tr := NewTunedTransport(brokerCfg, sempCfg)
+	tr := NewTunedTransport(&config.BrokerConfig{InsecureSkipVerify: true}, &config.SEMPConfig{})
 
 	if tr.TLSClientConfig == nil {
 		t.Fatal("TLSClientConfig = nil, want non-nil")

--- a/internal/semp/resilience/transport_test.go
+++ b/internal/semp/resilience/transport_test.go
@@ -81,6 +81,49 @@ func TestResponseHeaderTimeout_TracksOperatorConfiguredRequestTimeout(t *testing
 	}
 }
 
+// TestNewTunedTransport_TLSVerificationOnByDefault locks in the production
+// default: an unset insecure_skip_verify yields a transport with cert
+// verification on.
+func TestNewTunedTransport_TLSVerificationOnByDefault(t *testing.T) {
+	brokerCfg := &config.BrokerConfig{URL: "https://broker.example.com:1943"}
+	sempCfg := &config.SEMPConfig{
+		MaxConcurrentPerBroker: 10,
+		RequestTimeoutDuration: defaults.DefaultSEMPRequestTimeoutDuration,
+	}
+
+	tr := NewTunedTransport(brokerCfg, sempCfg)
+
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig = nil, want non-nil")
+	}
+	if tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify = true for zero-value broker config, want false (verification on)")
+	}
+}
+
+// TestNewTunedTransport_TLSVerificationSkippedWhenConfigured asserts
+// insecure_skip_verify: true propagates into the transport (dev opt-out
+// for self-signed certs).
+func TestNewTunedTransport_TLSVerificationSkippedWhenConfigured(t *testing.T) {
+	brokerCfg := &config.BrokerConfig{
+		URL:                "https://broker.example.com:1943",
+		InsecureSkipVerify: true,
+	}
+	sempCfg := &config.SEMPConfig{
+		MaxConcurrentPerBroker: 10,
+		RequestTimeoutDuration: defaults.DefaultSEMPRequestTimeoutDuration,
+	}
+
+	tr := NewTunedTransport(brokerCfg, sempCfg)
+
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig = nil, want non-nil")
+	}
+	if !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify = false, want true (config opt-out not honoured)")
+	}
+}
+
 // TestNewTunedTransport_MaxConnsPerHostEnforcesConcurrencyCap verifies the
 // per-broker in-flight bound is actually enforced at the transport. The
 // transport supplies a custom TLSClientConfig, which disables Go's automatic

--- a/internal/semp/sempv1/client_test.go
+++ b/internal/semp/sempv1/client_test.go
@@ -514,8 +514,6 @@ func TestNewHTTPClient_TLSWiring(t *testing.T) {
 			RequestTimeoutDuration: 2 * time.Second,
 			Retries:                &retries,
 			RequestMinInterval:     &minInterval,
-			RetryMinInterval:       1 * time.Millisecond,
-			RetryMaxInterval:       10 * time.Millisecond,
 		}
 		jar, err := resilience.NewSafeCookieJar()
 		if err != nil {

--- a/internal/semp/sempv1/client_test.go
+++ b/internal/semp/sempv1/client_test.go
@@ -496,3 +496,63 @@ func TestHTTPClient_LogValue_ExcludesCredentials(t *testing.T) {
 		})
 	}
 }
+
+// TestNewHTTPClient_TLSWiring verifies InsecureSkipVerify threads through
+// NewHTTPClient into the transport by driving a real TLS handshake against
+// httptest.NewTLSServer's self-signed cert.
+func TestNewHTTPClient_TLSWiring(t *testing.T) {
+	newTLSClient := func(t *testing.T, srv *httptest.Server, insecure bool) *HTTPClient {
+		t.Helper()
+		brokerCfg := &config.BrokerConfig{
+			URL:                srv.URL,
+			Auth:               config.AuthConfig{Mode: config.AuthModeBasic},
+			InsecureSkipVerify: insecure,
+		}
+		retries := 0
+		minInterval := time.Duration(0)
+		sempCfg := &config.SEMPConfig{
+			RequestTimeoutDuration: 2 * time.Second,
+			Retries:                &retries,
+			RequestMinInterval:     &minInterval,
+			RetryMinInterval:       1 * time.Millisecond,
+			RetryMaxInterval:       10 * time.Millisecond,
+		}
+		jar, err := resilience.NewSafeCookieJar()
+		if err != nil {
+			t.Fatalf("NewSafeCookieJar: %v", err)
+		}
+		client, err := NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("user", "pass", jar), jar)
+		if err != nil {
+			t.Fatalf("NewHTTPClient: %v", err)
+		}
+		return client
+	}
+
+	t.Run("verification on rejects self-signed cert", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, successEnvelope)
+		}))
+		defer srv.Close()
+
+		client := newTLSClient(t, srv, false)
+		_, err := client.Execute(context.Background(), `<rpc><show><version/></show></rpc>`)
+		if err == nil {
+			t.Fatal("expected TLS verification error, got nil")
+		}
+		if !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "certificate") {
+			t.Errorf("err = %v, want an x509/certificate verification error", err)
+		}
+	})
+
+	t.Run("verification skipped accepts self-signed cert", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, successEnvelope)
+		}))
+		defer srv.Close()
+
+		client := newTLSClient(t, srv, true)
+		if _, err := client.Execute(context.Background(), `<rpc><show><version/></show></rpc>`); err != nil {
+			t.Fatalf("Execute with InsecureSkipVerify=true: unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/semp/sempv1/client_test.go
+++ b/internal/semp/sempv1/client_test.go
@@ -3,6 +3,7 @@ package sempv1
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"errors"
 	"io"
 	"log/slog"
@@ -537,8 +538,9 @@ func TestNewHTTPClient_TLSWiring(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected TLS verification error, got nil")
 		}
-		if !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "certificate") {
-			t.Errorf("err = %v, want an x509/certificate verification error", err)
+		var unknownCA x509.UnknownAuthorityError
+		if !errors.As(err, &unknownCA) {
+			t.Errorf("err = %v, want errors.As(_, *x509.UnknownAuthorityError)", err)
 		}
 	})
 

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -1041,3 +1041,74 @@ func TestClient_TransportPool_ReusesConnections(t *testing.T) {
 			afterBatch2-afterBatch1, afterBatch1, afterBatch2)
 	}
 }
+
+// TestClient_TLSWiring verifies InsecureSkipVerify threads through
+// NewHTTPClient into the transport by driving a real TLS handshake against
+// httptest.NewTLSServer's self-signed cert.
+func TestClient_TLSWiring(t *testing.T) {
+	newTLSClient := func(t *testing.T, srv *httptest.Server, insecure bool) *sempv2.HTTPClient {
+		t.Helper()
+		brokerCfg := &config.BrokerConfig{
+			URL:                srv.URL,
+			Auth:               config.AuthConfig{Mode: "basic"},
+			InsecureSkipVerify: insecure,
+		}
+		retries := 0
+		minInterval := time.Duration(0)
+		sempCfg := &config.SEMPConfig{
+			RequestTimeoutDuration: 2 * time.Second,
+			Retries:                &retries,
+			RequestMinInterval:     &minInterval,
+			RetryMinInterval:       1 * time.Millisecond,
+			RetryMaxInterval:       10 * time.Millisecond,
+		}
+		jar, err := resilience.NewSafeCookieJar()
+		if err != nil {
+			t.Fatalf("NewSafeCookieJar: %v", err)
+		}
+		client, err := sempv2.NewHTTPClient(brokerCfg, sempCfg, resilience.NewSemaphore(10), auth.NewBasicAuthenticator("admin", "secret", jar), jar)
+		if err != nil {
+			t.Fatalf("NewHTTPClient: %v", err)
+		}
+		return client
+	}
+
+	op := &sempv2.Operation{
+		ID:     "getMsgVpn",
+		Method: "GET",
+		Path:   "/SEMP/v2/monitor/msgVpns/{msgVpnName}",
+		Parameters: []sempv2.Parameter{
+			{Name: "msgVpnName", In: "path"},
+		},
+	}
+
+	t.Run("verification on rejects self-signed cert", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{}, "meta": map[string]any{}})
+		}))
+		defer srv.Close()
+
+		client := newTLSClient(t, srv, false)
+		_, err := client.Execute(context.Background(), op, map[string]any{"msgVpnName": "default"})
+		if err == nil {
+			t.Fatal("expected TLS verification error, got nil")
+		}
+		if !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "certificate") {
+			t.Errorf("err = %v, want an x509/certificate verification error", err)
+		}
+	})
+
+	t.Run("verification skipped accepts self-signed cert", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{}, "meta": map[string]any{}})
+		}))
+		defer srv.Close()
+
+		client := newTLSClient(t, srv, true)
+		if _, err := client.Execute(context.Background(), op, map[string]any{"msgVpnName": "default"}); err != nil {
+			t.Fatalf("Execute with InsecureSkipVerify=true: unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -1059,8 +1059,6 @@ func TestClient_TLSWiring(t *testing.T) {
 			RequestTimeoutDuration: 2 * time.Second,
 			Retries:                &retries,
 			RequestMinInterval:     &minInterval,
-			RetryMinInterval:       1 * time.Millisecond,
-			RetryMaxInterval:       10 * time.Millisecond,
 		}
 		jar, err := resilience.NewSafeCookieJar()
 		if err != nil {

--- a/internal/semp/sempv2/client_test.go
+++ b/internal/semp/sempv2/client_test.go
@@ -3,6 +3,7 @@ package sempv2_test
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"net"
@@ -1092,8 +1093,9 @@ func TestClient_TLSWiring(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected TLS verification error, got nil")
 		}
-		if !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "certificate") {
-			t.Errorf("err = %v, want an x509/certificate verification error", err)
+		var unknownCA x509.UnknownAuthorityError
+		if !errors.As(err, &unknownCA) {
+			t.Errorf("err = %v, want errors.As(_, *x509.UnknownAuthorityError)", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Adds unit tests closing the transport-layer gap identified by the Broker MCP Quality Plan review (SOL-147161, §3.3): nothing was asserting that the constructed `tls.Config` actually honoured broker config. Config-level rules (production HTTPS enforcement, `insecure_skip_verify` warning) were already covered; the transport itself was not.

Fixes [SOL-150759](https://sol-jira.atlassian.net/browse/SOL-150759)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Certificate verification is safety-critical: a broken wire between `broker_config.yaml` and the actual `tls.Config` would silently disable verification without any config-level test failing. Two failure modes to lock down:

1. Zero-value `InsecureSkipVerify` (the common case — operator omitted the field) must produce a transport that verifies certs.
2. `insecure_skip_verify: true` (dev opt-out) must actually propagate to the transport.

Both SEMPv1 and SEMPv2 clients construct their transport via `resilience.NewTunedTransport`, so each protocol needs its own wiring assertion.

## Changes Made

- `internal/semp/resilience/transport_test.go` — two new tests asserting `TLSClientConfig.InsecureSkipVerify` matches broker config for the default (verification on) and opt-in (verification skipped) cases.
- `internal/semp/sempv1/client_test.go` — `TestNewHTTPClient_TLSWiring` with two subtests. Behavioural check via `httptest.NewTLSServer` (self-signed cert): with verification on the handshake fails with an x509 error; with verification skipped `Execute` succeeds.
- `internal/semp/sempv2/client_test.go` — `TestClient_TLSWiring` mirroring the sempv1 structure.

Behavioural (real handshake against a self-signed cert) chosen over field-poking so the tests survive refactors of the internal sender/transport ownership chain. Still fully unit — no real broker.

## Testing

**Test Environment:**
- Go version: go1.26.3
- OS: darwin (Darwin 25.5.0)
- Broker version (if applicable): n/a — unit tests only

**Tests Performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Tested locally with `go test -race ./...`
- [ ] Tested with real Solace broker

**Test Coverage:**
- Transport: `InsecureSkipVerify` false (zero value / production default) and true (dev opt-out).
- SEMPv1 client: self-signed cert rejected when verification is on; accepted when skipped.
- SEMPv2 client: same, exercised through `Execute` with a monitor path operation.

## Breaking Changes

None.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Code follows the coding standards
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code
- [x] Followed secure logging rules
- [x] Credential-carrying types implement `slog.LogValuer` (n/a — no new types)
- [x] No security vulnerabilities introduced

### Testing
- [x] All tests pass locally: `go test -race ./...` (new tests; unrelated pre-existing `staticcheck SA5011` lint findings on `main` are untouched)
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (n/a — internal test-only change)
- [ ] docs/ updated (n/a)
- [ ] godoc comments added/updated for exported functions (n/a — no exported API changes)
- [ ] CHANGELOG.md updated (n/a)
- [ ] Examples updated (n/a)

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main
- [x] No merge conflicts
- [ ] CI checks passing (lint, build, test, E2E) — pending

## Related Issues/PRs

- Related to SOL-147161 (Broker MCP Quality Plan, §3.3)

---

**For Reviewers:**

**Focus Areas**: The choice of behavioural TLS testing (real handshake against `httptest.NewTLSServer`'s self-signed cert) vs. direct field assertion. Behavioural is refactor-resistant and closer to what we actually care about; costs ~ms per subtest.

**Questions**: None.

[SOL-150759]: https://sol-jira.atlassian.net/browse/SOL-150759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ