### PR TITLE
SOL-151941: Extract groups from OIDC token and attach to request identity

### DIFF
--- a/internal/auth/claims.go
+++ b/internal/auth/claims.go
@@ -18,8 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-
-	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 )
 
 // Claims is the single decoded view of a verified token's payload — the
@@ -45,7 +43,7 @@ func (c Claims) String(key string) (string, error) {
 	}
 	var s string
 	if err := json.Unmarshal(msg, &s); err != nil {
-		return "", fmt.Errorf("%w: claim %q has unexpected type: %v", sdkauth.ErrInvalidToken, key, err)
+		return "", fmt.Errorf("%w: claim %q has unexpected type: %v", errMalformedClaims, key, err)
 	}
 	return s, nil
 }
@@ -67,7 +65,7 @@ func (c Claims) Value(key string) (val any, exists bool, err error) {
 		return nil, false, nil
 	}
 	if err := json.Unmarshal(msg, &val); err != nil {
-		return nil, true, fmt.Errorf("%w: claim %q is malformed: %v", sdkauth.ErrInvalidToken, key, err)
+		return nil, true, fmt.Errorf("%w: claim %q is malformed: %v", errMalformedClaims, key, err)
 	}
 	return val, true, nil
 }

--- a/internal/auth/claims.go
+++ b/internal/auth/claims.go
@@ -1,0 +1,106 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"log/slog"
+)
+
+// groupsSoftCap is the maximum number of group values ResolveGroups returns.
+// Values beyond this are truncated (first N in JWT-array order) and a WARN
+// is emitted. The cap sits above every legitimate IdP-emitted ceiling
+// (Entra 200, Okta 100) and inside typical reverse-proxy header limits.
+const groupsSoftCap = 250
+
+// ResolveGroups extracts the group list at claimName from a decoded JWT
+// claims map. claimName is looked up only as a top-level key — nested paths
+// are not supported, matching the Solace broker's accessLevelGroupsClaimName
+// stance.
+//
+// Return semantics:
+//   - ok == true: groups contains the extracted values (possibly zero-length
+//     for an empty JSON array — distinct from missing, represents
+//     "authenticated user with zero groups").
+//   - ok == false: could not extract usable groups. Every failure reason
+//     (key absent, claims nil, value nil, unusable type, empty scalar string,
+//     array of all non-strings) folds into this single outcome.
+//   - Key present, value is a non-empty scalar string → ([]string{s}, true).
+//   - Key present, value is []any → collect strings, silently drop
+//     non-strings. Empty result from an originally non-empty array still
+//     returns (nil, false). Empty JSON array [] → ([]string{}, true).
+//   - Key present, value is []string (defensive; json.Unmarshal produces
+//     []any) → returned as-is (copy made by caller if needed).
+//   - Duplicates are preserved — dedup happens at Authorize, not here.
+//   - Soft cap: if more than 250 elements survive filtering, truncate to
+//     the first 250 and emit a WARN.
+func ResolveGroups(claims map[string]any, claimName string) (groups []string, ok bool) {
+	v, exists := claims[claimName]
+	if !exists {
+		return nil, false
+	}
+
+	if v == nil {
+		return nil, false
+	}
+
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return nil, false
+		}
+		return []string{val}, true
+
+	case []any:
+		if len(val) == 0 {
+			return []string{}, true
+		}
+		result := make([]string, 0, min(len(val), groupsSoftCap))
+		for _, elem := range val {
+			s, isStr := elem.(string)
+			if !isStr {
+				continue
+			}
+			result = append(result, s)
+			if len(result) >= groupsSoftCap {
+				break
+			}
+		}
+		if len(result) == 0 {
+			return nil, false
+		}
+		if len(result) >= groupsSoftCap && len(val) > groupsSoftCap {
+			slog.Warn("token groups claim exceeded cap; truncated",
+				slog.Int("total", len(val)),
+				slog.Int("cap", groupsSoftCap))
+		}
+		return result, true
+
+	case []string:
+		if len(val) == 0 {
+			return []string{}, true
+		}
+		result := val
+		if len(result) > groupsSoftCap {
+			slog.Warn("token groups claim exceeded cap; truncated",
+				slog.Int("total", len(result)),
+				slog.Int("cap", groupsSoftCap))
+			result = result[:groupsSoftCap]
+		}
+		return result, true
+
+	default:
+		return nil, false
+	}
+}

--- a/internal/auth/claims.go
+++ b/internal/auth/claims.go
@@ -15,8 +15,62 @@
 package auth
 
 import (
+	"encoding/json"
+	"fmt"
 	"log/slog"
+
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 )
+
+// Claims is the single decoded view of a verified token's payload — the
+// canonical representation at the auth boundary. All claim access goes
+// through typed accessor methods with exact, case-sensitive key lookup
+// (RFC 7519 claim names are case-sensitive); the raw form never escapes
+// this package. Consumers with new type requirements add an accessor
+// method here rather than reshaping the map to their preference — the
+// boundary owns the representation, consumers adapt to the boundary.
+type Claims struct {
+	raw map[string]json.RawMessage
+}
+
+// String extracts an optional string claim. An absent claim returns
+// ("", nil). A present claim of any non-string JSON type is a hard
+// failure — callers depend on these values for identity, auditing, and
+// scope parsing, so a type mismatch means the token cannot be safely
+// interpreted.
+func (c Claims) String(key string) (string, error) {
+	msg, ok := c.raw[key]
+	if !ok {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(msg, &s); err != nil {
+		return "", fmt.Errorf("%w: claim %q has unexpected type: %v", sdkauth.ErrInvalidToken, key, err)
+	}
+	return s, nil
+}
+
+// Value hydrates a single claim into its generic Go form (string, float64,
+// bool, []any, map[string]any, or nil for JSON null), lazily and on demand.
+// exists reports whether the key is present; a present JSON null yields
+// (nil, true, nil). Hydration is deterministic — every caller sees the
+// identical value for the same key — so lazy per-claim access cannot
+// reintroduce a parser differential.
+//
+// The error branch is defensive: the top-level document parse already
+// validated every stored RawMessage, so re-hydration cannot fail on syntax
+// today. If a future change ever makes it fire, fail closed rather than
+// compute an authorization decision over a partial claim set.
+func (c Claims) Value(key string) (val any, exists bool, err error) {
+	msg, ok := c.raw[key]
+	if !ok {
+		return nil, false, nil
+	}
+	if err := json.Unmarshal(msg, &val); err != nil {
+		return nil, true, fmt.Errorf("%w: claim %q is malformed: %v", sdkauth.ErrInvalidToken, key, err)
+	}
+	return val, true, nil
+}
 
 // groupsSoftCap is the maximum number of group values ResolveGroups returns.
 // Values beyond this are truncated (first N in JWT-array order) and a WARN
@@ -28,6 +82,11 @@ const groupsSoftCap = 250
 // claims map. claimName is looked up only as a top-level key — nested paths
 // are not supported, matching the Solace broker's accessLevelGroupsClaimName
 // stance.
+//
+// This is a thin lookup wrapper over resolveGroupsValue, which holds all
+// value semantics. The auth boundary (buildTokenInfo) performs its own
+// exact-key lookup via Claims.Value and calls resolveGroupsValue directly;
+// this map-based entry point is retained for existing callers and tests.
 //
 // Return semantics:
 //   - ok == true: groups contains the extracted values (possibly zero-length
@@ -50,7 +109,21 @@ func ResolveGroups(claims map[string]any, claimName string) (groups []string, ok
 	if !exists {
 		return nil, false
 	}
+	return resolveGroupsValue(v)
+}
 
+// resolveGroupsValue extracts a group list from a single hydrated claim
+// value. All type-switch semantics documented on ResolveGroups live here;
+// the two entry points cannot drift because ResolveGroups delegates to
+// this function unconditionally after its key lookup.
+//
+// NOTE (open policy, see buildTokenInfo): a present-but-unusable value —
+// wrong type, empty scalar, array of all non-strings — currently folds into
+// ok == false, and mixed arrays silently drop non-string elements. If the
+// team decides malformed groups should hard-reject the token, this function
+// grows a third "malformed" return state and buildTokenInfo maps it to
+// sdkauth.ErrInvalidToken.
+func resolveGroupsValue(v any) (groups []string, ok bool) {
 	if v == nil {
 		return nil, false
 	}

--- a/internal/auth/claims.go
+++ b/internal/auth/claims.go
@@ -139,23 +139,24 @@ func resolveGroupsValue(v any) (groups []string, ok bool) {
 		if len(val) == 0 {
 			return []string{}, true
 		}
+		var count int
 		result := make([]string, 0, min(len(val), groupsSoftCap))
 		for _, elem := range val {
 			s, isStr := elem.(string)
 			if !isStr {
 				continue
 			}
-			result = append(result, s)
-			if len(result) >= groupsSoftCap {
-				break
+			count++
+			if len(result) < groupsSoftCap {
+				result = append(result, s)
 			}
 		}
 		if len(result) == 0 {
 			return nil, false
 		}
-		if len(result) >= groupsSoftCap && len(val) > groupsSoftCap {
+		if count > groupsSoftCap {
 			slog.Warn("token groups claim exceeded cap; truncated",
-				slog.Int("total", len(val)),
+				slog.Int("total", count),
 				slog.Int("cap", groupsSoftCap))
 		}
 		return result, true

--- a/internal/auth/claims_test.go
+++ b/internal/auth/claims_test.go
@@ -1,0 +1,177 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+)
+
+func TestResolveGroups(t *testing.T) {
+	tests := []struct {
+		name       string
+		claims     map[string]any
+		claimName  string
+		wantGroups []string
+		wantOK     bool
+	}{
+		{
+			name:      "key absent",
+			claims:    map[string]any{"other": "value"},
+			claimName: "groups",
+			wantOK:    false,
+		},
+		{
+			name:      "value is JSON null",
+			claims:    map[string]any{"groups": nil},
+			claimName: "groups",
+			wantOK:    false,
+		},
+		{
+			name:       "non-empty scalar string",
+			claims:     map[string]any{"groups": "admins"},
+			claimName:  "groups",
+			wantGroups: []string{"admins"},
+			wantOK:     true,
+		},
+		{
+			name:      "empty scalar string",
+			claims:    map[string]any{"groups": ""},
+			claimName: "groups",
+			wantOK:    false,
+		},
+		{
+			name:       "string array",
+			claims:     map[string]any{"groups": []any{"admin", "ops"}},
+			claimName:  "groups",
+			wantGroups: []string{"admin", "ops"},
+			wantOK:     true,
+		},
+		{
+			name:       "empty array",
+			claims:     map[string]any{"groups": []any{}},
+			claimName:  "groups",
+			wantGroups: []string{},
+			wantOK:     true,
+		},
+		{
+			name:       "mixed array filters non-strings",
+			claims:     map[string]any{"groups": []any{"admin", float64(42), true, nil, "ops"}},
+			claimName:  "groups",
+			wantGroups: []string{"admin", "ops"},
+			wantOK:     true,
+		},
+		{
+			name:      "array with nil elements only",
+			claims:    map[string]any{"groups": []any{nil, nil}},
+			claimName: "groups",
+			wantOK:    false,
+		},
+		{
+			name:      "array of all non-strings",
+			claims:    map[string]any{"groups": []any{float64(1), float64(2), true}},
+			claimName: "groups",
+			wantOK:    false,
+		},
+		{
+			name:      "nested object",
+			claims:    map[string]any{"groups": map[string]any{"nested": "value"}},
+			claimName: "groups",
+			wantOK:    false,
+		},
+		{
+			name:       "duplicates preserved",
+			claims:     map[string]any{"groups": []any{"admin", "admin", "ops"}},
+			claimName:  "groups",
+			wantGroups: []string{"admin", "admin", "ops"},
+			wantOK:     true,
+		},
+		{
+			name:       "whitespace-only string treated as group",
+			claims:     map[string]any{"groups": "   "},
+			claimName:  "groups",
+			wantGroups: []string{"   "},
+			wantOK:     true,
+		},
+		{
+			name:       "case preserved",
+			claims:     map[string]any{"groups": []any{"Admin", "ADMIN", "admin"}},
+			claimName:  "groups",
+			wantGroups: []string{"Admin", "ADMIN", "admin"},
+			wantOK:     true,
+		},
+		{
+			name:       "order preserved",
+			claims:     map[string]any{"groups": []any{"c", "a", "b"}},
+			claimName:  "groups",
+			wantGroups: []string{"c", "a", "b"},
+			wantOK:     true,
+		},
+		{
+			name:      "float64 value",
+			claims:    map[string]any{"groups": float64(42)},
+			claimName: "groups",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups, ok := ResolveGroups(tt.claims, tt.claimName)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				if groups != nil {
+					t.Errorf("groups = %v, want nil when ok is false", groups)
+				}
+				return
+			}
+			if len(groups) != len(tt.wantGroups) {
+				t.Fatalf("groups len = %d, want %d; got %v", len(groups), len(tt.wantGroups), groups)
+			}
+			for i, g := range groups {
+				if g != tt.wantGroups[i] {
+					t.Errorf("groups[%d] = %q, want %q", i, g, tt.wantGroups[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveGroups_SoftCap(t *testing.T) {
+	elems := make([]any, 251)
+	for i := range elems {
+		elems[i] = "g"
+	}
+	claims := map[string]any{"groups": elems}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	slog.SetDefault(logger)
+	defer slog.SetDefault(slog.Default())
+
+	groups, ok := ResolveGroups(claims, "groups")
+	if !ok {
+		t.Fatal("expected ok = true")
+	}
+	if len(groups) != groupsSoftCap {
+		t.Errorf("len(groups) = %d, want %d", len(groups), groupsSoftCap)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("exceeded cap")) {
+		t.Error("expected WARN log about exceeded cap")
+	}
+}

--- a/internal/auth/claims_test.go
+++ b/internal/auth/claims_test.go
@@ -16,9 +16,153 @@ package auth
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
 	"testing"
 )
+
+// --- Claims accessor tests ---------------------------------------------------
+
+func makeClaims(t *testing.T, payload string) Claims {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		t.Fatalf("makeClaims: %v", err)
+	}
+	return Claims{raw: raw}
+}
+
+func TestClaims_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		key     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "present string",
+			payload: `{"sub": "user-42"}`,
+			key:     "sub",
+			want:    "user-42",
+		},
+		{
+			name:    "absent key",
+			payload: `{"sub": "user-42"}`,
+			key:     "jti",
+			want:    "",
+		},
+		{
+			name:    "empty string",
+			payload: `{"sub": ""}`,
+			key:     "sub",
+			want:    "",
+		},
+		{
+			name:    "wrong type number",
+			payload: `{"sub": 42}`,
+			key:     "sub",
+			wantErr: true,
+		},
+		{
+			name:    "wrong type array",
+			payload: `{"scope": ["read", "write"]}`,
+			key:     "scope",
+			wantErr: true,
+		},
+		{
+			name:    "wrong type boolean",
+			payload: `{"sub": true}`,
+			key:     "sub",
+			wantErr: true,
+		},
+		{
+			name:    "null value unmarshals to empty string",
+			payload: `{"jti": null}`,
+			key:     "jti",
+			want:    "",
+		},
+		{
+			name:    "case sensitive lookup",
+			payload: `{"Sub": "upper", "sub": "lower"}`,
+			key:     "sub",
+			want:    "lower",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := makeClaims(t, tt.payload)
+			got, err := c.String(tt.key)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("String(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaims_Value(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    string
+		key        string
+		wantExists bool
+		wantNil    bool
+	}{
+		{
+			name:       "present string",
+			payload:    `{"groups": "admin"}`,
+			key:        "groups",
+			wantExists: true,
+		},
+		{
+			name:       "present array",
+			payload:    `{"groups": ["a", "b"]}`,
+			key:        "groups",
+			wantExists: true,
+		},
+		{
+			name:       "present null",
+			payload:    `{"groups": null}`,
+			key:        "groups",
+			wantExists: true,
+			wantNil:    true,
+		},
+		{
+			name:       "absent key",
+			payload:    `{"other": "value"}`,
+			key:        "groups",
+			wantExists: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := makeClaims(t, tt.payload)
+			val, exists, err := c.Value(tt.key)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if exists != tt.wantExists {
+				t.Fatalf("exists = %v, want %v", exists, tt.wantExists)
+			}
+			if tt.wantNil && val != nil {
+				t.Errorf("val = %v, want nil", val)
+			}
+		})
+	}
+}
+
+// --- ResolveGroups tests (map-based entry point) -----------------------------
 
 func TestResolveGroups(t *testing.T) {
 	tests := []struct {

--- a/internal/auth/claims_test.go
+++ b/internal/auth/claims_test.go
@@ -160,9 +160,10 @@ func TestResolveGroups_SoftCap(t *testing.T) {
 	claims := map[string]any{"groups": elems}
 
 	var buf bytes.Buffer
+	prev := slog.Default()
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 	slog.SetDefault(logger)
-	defer slog.SetDefault(slog.Default())
+	defer slog.SetDefault(prev)
 
 	groups, ok := ResolveGroups(claims, "groups")
 	if !ok {

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,56 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+)
+
+// Category sentinels for token rejection. Each wraps sdkauth.ErrInvalidToken
+// so the SDK's RequireBearerToken routes them as 401 with WWW-Authenticate.
+// Sentinel text is client-visible (the SDK writes err.Error() into the 401
+// response body), so every string here is static, pre-audited, category-level
+// text (CWE-209). Never embed dynamic values.
+var (
+	errVerificationFailed = fmt.Errorf("%w: verification failed", sdkauth.ErrInvalidToken)
+	errMalformedClaims    = fmt.Errorf("%w: malformed claims", sdkauth.ErrInvalidToken)
+	errNoSubject          = fmt.Errorf("%w: token has no subject", sdkauth.ErrInvalidToken)
+)
+
+// categorySentinels lists every category in sanitization precedence order.
+// More specific categories precede broader ones so sanitizeTokenError
+// reports the most useful static text.
+var categorySentinels = []error{
+	errNoSubject,
+	errVerificationFailed,
+	errMalformedClaims,
+}
+
+// sanitizeTokenError maps any internal token-rejection error to the static
+// category sentinel a client is allowed to see. Rich internal errors (with
+// claim names, json detail, go-oidc messages) must be logged by the caller
+// BEFORE sanitizing; this function discards everything except the category.
+// Unrecognized errors fall back to the bare SDK sentinel.
+func sanitizeTokenError(err error) error {
+	for _, s := range categorySentinels {
+		if errors.Is(err, s) {
+			return s
+		}
+	}
+	return sdkauth.ErrInvalidToken
+}

--- a/internal/auth/errors_test.go
+++ b/internal/auth/errors_test.go
@@ -1,0 +1,112 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+)
+
+func TestSentinelsUnwrapToSDK(t *testing.T) {
+	for _, s := range []struct {
+		name     string
+		sentinel error
+	}{
+		{"errVerificationFailed", errVerificationFailed},
+		{"errMalformedClaims", errMalformedClaims},
+		{"errNoSubject", errNoSubject},
+	} {
+		t.Run(s.name, func(t *testing.T) {
+			if !errors.Is(s.sentinel, sdkauth.ErrInvalidToken) {
+				t.Errorf("%s does not unwrap to sdkauth.ErrInvalidToken", s.name)
+			}
+		})
+	}
+}
+
+func TestSanitizeTokenError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "errNoSubject passes through",
+			err:  errNoSubject,
+			want: errNoSubject,
+		},
+		{
+			name: "errVerificationFailed passes through",
+			err:  errVerificationFailed,
+			want: errVerificationFailed,
+		},
+		{
+			name: "errMalformedClaims passes through",
+			err:  errMalformedClaims,
+			want: errMalformedClaims,
+		},
+		{
+			name: "wrapped errMalformedClaims maps to sentinel",
+			err:  fmt.Errorf("%w: claim %q has unexpected type: some detail", errMalformedClaims, "scope"),
+			want: errMalformedClaims,
+		},
+		{
+			name: "wrapped errNoSubject maps to sentinel",
+			err:  fmt.Errorf("extra context: %w", errNoSubject),
+			want: errNoSubject,
+		},
+		{
+			name: "unknown error falls back to SDK sentinel",
+			err:  errors.New("something unexpected"),
+			want: sdkauth.ErrInvalidToken,
+		},
+		{
+			name: "bare SDK sentinel falls back to itself",
+			err:  sdkauth.ErrInvalidToken,
+			want: sdkauth.ErrInvalidToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeTokenError(tt.err)
+			if got != tt.want {
+				t.Errorf("sanitizeTokenError() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSentinelTextIsStatic(t *testing.T) {
+	tests := []struct {
+		sentinel error
+		want     string
+	}{
+		{errVerificationFailed, "invalid token: verification failed"},
+		{errMalformedClaims, "invalid token: malformed claims"},
+		{errNoSubject, "invalid token: token has no subject"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.sentinel.Error(); got != tt.want {
+				t.Errorf("sentinel.Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -19,6 +19,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -105,7 +106,7 @@ func createStaticTokenVerifier(expectedToken string) sdkauth.TokenVerifier {
 	return func(ctx context.Context, token string, req *http.Request) (*sdkauth.TokenInfo, error) {
 		// Use constant-time comparison to prevent timing attacks
 		if subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) != 1 {
-			return nil, sdkauth.ErrInvalidToken
+			return nil, errVerificationFailed
 		}
 		return &sdkauth.TokenInfo{
 			Scopes:     []string{},
@@ -145,99 +146,49 @@ func createOIDCTokenVerifier(cfg *config.ServerConfig, httpClient *http.Client) 
 	})
 
 	return func(ctx context.Context, token string, req *http.Request) (*sdkauth.TokenInfo, error) {
-		// Verify JWT signature and standard claims (iss, aud, exp)
 		idToken, err := verifier.Verify(ctx, token)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", sdkauth.ErrInvalidToken, err)
+			slog.Warn("token verification failed",
+				slog.String("error", err.Error()))
+			return nil, errVerificationFailed
 		}
 
-		// SINGLE claim decode.
-		//
-		// The claims payload is parsed exactly once, into
-		// map[string]json.RawMessage. All downstream extraction — the
-		// spec-defined identity claims AND the admin-configured groups
-		// claim — reads from this one view.
-		//
-		// This deliberately replaces the previous two-pass approach
-		// (typed struct + generic map). encoding/json v1 matches struct
-		// fields case-insensitively with last-match-wins semantics and
-		// folds ſ (U+017F) / K (U+212A) to s / k, while map keys match
-		// exactly. Two decodes of the same bytes could therefore
-		// disagree about which claims exist — a parser differential
-		// between the audit-log identity surface (SOL-149606) and the
-		// authz groups path. One parse means one interpretation; the
-		// exact, case-sensitive key lookup below matches RFC 7519's
-		// case-sensitive claim names and the remediation the MCP go-sdk
-		// itself applied in GHSA-wvj2-96wp-fq3f.
-		//
-		// Residual v1 limitation: exact-duplicate top-level keys still
-		// resolve last-wins silently. Both identity and groups now see
-		// the same winner, so no differential remains; encoding/json/v2
-		// (jsontext duplicate-name rejection) can close this fully once
-		// adopted.
+		// Single decode into map[string]json.RawMessage — identity and
+		// groups claims read from one parse, eliminating the parser
+		// differential that existed with the prior struct+map two-pass.
 		var raw map[string]json.RawMessage
 		if err := idToken.Claims(&raw); err != nil {
-			// FAIL CLOSED. Verification is not complete until the claims
-			// this server depends on are extracted and well-formed
-			// (RFC 8725 §3: reject the entire JWT when validation fails).
-			// The previous warn-and-continue produced authenticated
-			// requests with an empty UserID and blank audit identity.
-			return nil, fmt.Errorf("%w: decoding claims: %v", sdkauth.ErrInvalidToken, err)
+			slog.Warn("token claims undecodable",
+				slog.String("error", err.Error()))
+			return nil, errMalformedClaims
 		}
 
-		return buildTokenInfo(cfg, Claims{raw: raw}, idToken.Expiry)
+		info, err := buildTokenInfo(cfg, Claims{raw: raw}, idToken.Expiry)
+		if err != nil {
+			slog.Warn("token rejected",
+				slog.String("error", err.Error()))
+			return nil, sanitizeTokenError(err)
+		}
+		return info, nil
 	}, nil
 }
 
-// buildTokenInfo assembles the TokenInfo for a verified token from a single
-// decode of its claim bytes. Split from the verifier closure so the
-// extraction semantics (exact key match, fail-closed on malformed or missing
-// security-relevant claims) are unit-testable without an IdP.
+// buildTokenInfo assembles the TokenInfo for a verified token. Split from
+// the verifier closure so claim extraction is unit-testable without an IdP.
 //
-// Claim requirement profile (deliberate, spec-grounded — do not "fix" by
-// making everything required or everything lenient):
-//
-//   - Enforced upstream by the go-oidc verifier before this runs:
-//     signature, iss, aud, exp. Three of RFC 9068's required claims are
-//     therefore already mandatory in effect.
-//   - Hard-required here: sub, non-blank. Required by RFC 9068 §2.2 for
-//     OAuth access tokens, and the audit surface (SOL-149606) is
-//     meaningless without it. (RFC 7519 alone leaves sub optional; the
-//     access-token profile is the binding one for this server.)
-//   - Tolerated-absent, fatal-if-malformed: scope, client_id, jti.
-//     RFC 9068 requires client_id and jti, but widely deployed IdPs do
-//     not emit them on access tokens (Keycloak and Auth0's default
-//     profile use azp; Azure AD uses appid/azp), so hard-requiring them
-//     would reject stock deployments of real customer IdPs. A present
-//     claim with the wrong JSON type is still rejected: absence is a
-//     sparse token, malformation means the payload can no longer be
-//     safely interpreted. Scope, when present, must be a space-delimited
-//     string per RFC 6749 §3.3 / RFC 9068.
-//   - Groups (authz enabled): absent claim → no groups key → authz
-//     denies by default.
-//
-// Any fail-closed violation returns sdkauth.ErrInvalidToken.
+// Claim policy: sub is hard-required (RFC 9068 §2.2); scope, client_id,
+// jti are tolerated-absent but fatal-if-malformed (real IdPs often omit
+// them); groups absent → authz denies by default.
 func buildTokenInfo(cfg *config.ServerConfig, claims Claims, expiry time.Time) (*sdkauth.TokenInfo, error) {
 	sub, err := claims.String("sub")
 	if err != nil {
 		return nil, err
 	}
 	if strings.TrimSpace(sub) == "" {
-		// An authenticated principal with no visible subject is never a
-		// valid state: every audit row it generated would be anonymous.
-		// TrimSpace is used ONLY as a rejection predicate here — the
-		// stored UserID below is the exact claim bytes. Normalizing the
-		// value would conflate subjects the IdP considers distinct
-		// (RFC 7519 claims compare byte-for-byte), which is an identity
-		// mapping the IdP owns, not this server.
-		return nil, fmt.Errorf("%w: token has no subject", sdkauth.ErrInvalidToken)
+		// TrimSpace for rejection only — UserID stores the exact bytes.
+		return nil, errNoSubject
 	}
 
-	// Scope is a space-separated string per OAuth 2.0 (RFC 6749 §3.3).
-	// IdPs that emit an array here (e.g. some Azure AD / Keycloak
-	// configurations) previously caused a partially-populated struct plus
-	// a swallowed warning; now they are rejected explicitly so the
-	// misconfiguration surfaces at the door.
 	scopeStr, err := claims.String("scope")
 	if err != nil {
 		return nil, err
@@ -247,10 +198,6 @@ func buildTokenInfo(cfg *config.ServerConfig, claims Claims, expiry time.Time) (
 		scopes = strings.Split(scopeStr, " ")
 	}
 
-	// iss, client_id, and jti feed the per-invocation audit-log identity
-	// surface (SOL-149606). They are stashed in TokenInfo.Extra under the
-	// exact keys "iss", "client_id", "jti"; internal/tools/identity.go
-	// reads them by those keys. Drift-detection tests pin the allowlist.
 	iss, err := claims.String("iss")
 	if err != nil {
 		return nil, err
@@ -271,16 +218,9 @@ func buildTokenInfo(cfg *config.ServerConfig, claims Claims, expiry time.Time) (
 	}
 
 	if config.ToolAuthorizationEnabled(cfg) {
+		// GroupsClaimName is guaranteed non-nil here: config.validate
+		// defaults it to "groups" when the tool_authorization block is present.
 		name := *cfg.MCPClientAuth.ToolAuthorization.GroupsClaimName
-		// The admin-configured groups claim is hydrated lazily from THE
-		// SAME decoded view as the identity claims above, so the identity
-		// the audit log records and the groups the authz layer evaluates
-		// are by construction drawn from one interpretation of the token.
-		// ResolveGroups documents flat top-level lookup only (matching
-		// the broker's accessLevelGroupsClaimName stance), so exactly one
-		// claim is hydrated. Future consumers with different type needs
-		// get their own accessor method on Claims — never a per-consumer
-		// conversion loop here at the boundary.
 		val, exists, err := claims.Value(name)
 		if err != nil {
 			return nil, err
@@ -300,7 +240,6 @@ func buildTokenInfo(cfg *config.ServerConfig, claims Claims, expiry time.Time) (
 		Extra:      extra,
 	}, nil
 }
-
 
 // NewProtectedResourceMetadataHandler creates an HTTP handler that serves
 // OAuth 2.0 Protected Resource Metadata (RFC 9728) for the MCP server.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/SolaceDev/solace-broker-mcp/internal/idpclient"
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -174,15 +176,46 @@ func createOIDCTokenVerifier(cfg *config.ServerConfig, httpClient *http.Client) 
 			scopes = strings.Split(claims.Scope, " ")
 		}
 
+		extra := map[string]any{
+			"iss":       claims.Iss,
+			"client_id": claims.ClientID,
+			"jti":       claims.Jti,
+		}
+
+		if !config.ToolAuthorizationEnabled(cfg) {
+			return &sdkauth.TokenInfo{
+				UserID:     claims.Sub,
+				Scopes:     scopes,
+				Expiration: idToken.Expiry,
+				Extra:      extra,
+			}, nil
+		}
+
+		// Second decode: extract the admin-configured groups claim.
+		//
+		// Token verification already succeeded (go-oidc verified signature,
+		// issuer, audience, expiry) and the first-pass struct decode extracted
+		// the spec-defined known fields. This second decode into a generic map
+		// extracts the admin-configured groups claim whose JSON key is only
+		// known at runtime (via groups_claim_name in the config). The two-pass
+		// approach preserves compile-time type safety on the known fields while
+		// supporting arbitrary claim names for groups.
+		var raw map[string]any
+		if err := idToken.Claims(&raw); err != nil {
+			slog.Warn("failed to decode raw claims for groups extraction; treating as missing-claim",
+				slog.String("error", err.Error()))
+		} else {
+			groups, ok := ResolveGroups(raw, *cfg.MCPClientAuth.ToolAuthorization.GroupsClaimName)
+			if ok {
+				extra[authz.TokenInfoExtraKeyGroups] = groups
+			}
+		}
+
 		return &sdkauth.TokenInfo{
 			UserID:     claims.Sub,
 			Scopes:     scopes,
 			Expiration: idToken.Expiry,
-			Extra: map[string]any{
-				"iss":       claims.Iss,
-				"client_id": claims.ClientID,
-				"jti":       claims.Jti,
-			},
+			Extra:      extra,
 		}, nil
 	}, nil
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -17,8 +17,8 @@ package auth
 import (
 	"context"
 	"crypto/subtle"
+	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -151,73 +151,153 @@ func createOIDCTokenVerifier(cfg *config.ServerConfig, httpClient *http.Client) 
 			return nil, fmt.Errorf("%w: %v", sdkauth.ErrInvalidToken, err)
 		}
 
-		// Extract claims.
+		// SINGLE claim decode.
 		//
-		// iss, client_id, and jti feed the per-invocation audit-log identity
-		// surface (SOL-149606). They are stashed in TokenInfo.Extra under the
-		// exact keys "iss", "client_id", "jti"; internal/tools/identity.go
-		// reads them by those keys. Drift-detection tests in that package pin
-		// the allowlist.
-		var claims struct {
-			Sub      string `json:"sub"`
-			Scope    string `json:"scope"`
-			Iss      string `json:"iss"`
-			ClientID string `json:"client_id"`
-			Jti      string `json:"jti"`
-		}
-
-		if err := idToken.Claims(&claims); err != nil {
-			slog.Warn("failed to extract claims",
-				slog.String("error", err.Error()))
-		}
-
-		// Parse scopes from JWT (space-separated string per OAuth 2.0 spec)
-		scopes := []string{}
-		if claims.Scope != "" {
-			scopes = strings.Split(claims.Scope, " ")
-		}
-
-		extra := map[string]any{
-			"iss":       claims.Iss,
-			"client_id": claims.ClientID,
-			"jti":       claims.Jti,
-		}
-
-		if !config.ToolAuthorizationEnabled(cfg) {
-			return &sdkauth.TokenInfo{
-				UserID:     claims.Sub,
-				Scopes:     scopes,
-				Expiration: idToken.Expiry,
-				Extra:      extra,
-			}, nil
-		}
-
-		// Second decode: extract the admin-configured groups claim.
+		// The claims payload is parsed exactly once, into
+		// map[string]json.RawMessage. All downstream extraction — the
+		// spec-defined identity claims AND the admin-configured groups
+		// claim — reads from this one view.
 		//
-		// Token verification already succeeded (go-oidc verified signature,
-		// issuer, audience, expiry) and the first-pass struct decode extracted
-		// the spec-defined known fields. This second decode into a generic map
-		// extracts the admin-configured groups claim whose JSON key is only
-		// known at runtime (via groups_claim_name in the config). The two-pass
-		// approach preserves compile-time type safety on the known fields while
-		// supporting arbitrary claim names for groups.
-		var raw map[string]any
+		// This deliberately replaces the previous two-pass approach
+		// (typed struct + generic map). encoding/json v1 matches struct
+		// fields case-insensitively with last-match-wins semantics and
+		// folds ſ (U+017F) / K (U+212A) to s / k, while map keys match
+		// exactly. Two decodes of the same bytes could therefore
+		// disagree about which claims exist — a parser differential
+		// between the audit-log identity surface (SOL-149606) and the
+		// authz groups path. One parse means one interpretation; the
+		// exact, case-sensitive key lookup below matches RFC 7519's
+		// case-sensitive claim names and the remediation the MCP go-sdk
+		// itself applied in GHSA-wvj2-96wp-fq3f.
+		//
+		// Residual v1 limitation: exact-duplicate top-level keys still
+		// resolve last-wins silently. Both identity and groups now see
+		// the same winner, so no differential remains; encoding/json/v2
+		// (jsontext duplicate-name rejection) can close this fully once
+		// adopted.
+		var raw map[string]json.RawMessage
 		if err := idToken.Claims(&raw); err != nil {
-			slog.Warn("failed to extract claims",
-				slog.String("error", err.Error()))
-		} else {
-			groups, ok := ResolveGroups(raw, *cfg.MCPClientAuth.ToolAuthorization.GroupsClaimName)
+			// FAIL CLOSED. Verification is not complete until the claims
+			// this server depends on are extracted and well-formed
+			// (RFC 8725 §3: reject the entire JWT when validation fails).
+			// The previous warn-and-continue produced authenticated
+			// requests with an empty UserID and blank audit identity.
+			return nil, fmt.Errorf("%w: decoding claims: %v", sdkauth.ErrInvalidToken, err)
+		}
+
+		return buildTokenInfo(cfg, Claims{raw: raw}, idToken.Expiry)
+	}, nil
+}
+
+// buildTokenInfo assembles the TokenInfo for a verified token from a single
+// decode of its claim bytes. Split from the verifier closure so the
+// extraction semantics (exact key match, fail-closed on malformed or missing
+// security-relevant claims) are unit-testable without an IdP.
+//
+// Claim requirement profile (deliberate, spec-grounded — do not "fix" by
+// making everything required or everything lenient):
+//
+//   - Enforced upstream by the go-oidc verifier before this runs:
+//     signature, iss, aud, exp. Three of RFC 9068's required claims are
+//     therefore already mandatory in effect.
+//   - Hard-required here: sub, non-blank. Required by RFC 9068 §2.2 for
+//     OAuth access tokens, and the audit surface (SOL-149606) is
+//     meaningless without it. (RFC 7519 alone leaves sub optional; the
+//     access-token profile is the binding one for this server.)
+//   - Tolerated-absent, fatal-if-malformed: scope, client_id, jti.
+//     RFC 9068 requires client_id and jti, but widely deployed IdPs do
+//     not emit them on access tokens (Keycloak and Auth0's default
+//     profile use azp; Azure AD uses appid/azp), so hard-requiring them
+//     would reject stock deployments of real customer IdPs. A present
+//     claim with the wrong JSON type is still rejected: absence is a
+//     sparse token, malformation means the payload can no longer be
+//     safely interpreted. Scope, when present, must be a space-delimited
+//     string per RFC 6749 §3.3 / RFC 9068.
+//   - Groups (authz enabled): absent claim → no groups key → authz
+//     denies by default.
+//
+// Any fail-closed violation returns sdkauth.ErrInvalidToken.
+func buildTokenInfo(cfg *config.ServerConfig, claims Claims, expiry time.Time) (*sdkauth.TokenInfo, error) {
+	sub, err := claims.String("sub")
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(sub) == "" {
+		// An authenticated principal with no visible subject is never a
+		// valid state: every audit row it generated would be anonymous.
+		// TrimSpace is used ONLY as a rejection predicate here — the
+		// stored UserID below is the exact claim bytes. Normalizing the
+		// value would conflate subjects the IdP considers distinct
+		// (RFC 7519 claims compare byte-for-byte), which is an identity
+		// mapping the IdP owns, not this server.
+		return nil, fmt.Errorf("%w: token has no subject", sdkauth.ErrInvalidToken)
+	}
+
+	// Scope is a space-separated string per OAuth 2.0 (RFC 6749 §3.3).
+	// IdPs that emit an array here (e.g. some Azure AD / Keycloak
+	// configurations) previously caused a partially-populated struct plus
+	// a swallowed warning; now they are rejected explicitly so the
+	// misconfiguration surfaces at the door.
+	scopeStr, err := claims.String("scope")
+	if err != nil {
+		return nil, err
+	}
+	scopes := []string{}
+	if scopeStr != "" {
+		scopes = strings.Split(scopeStr, " ")
+	}
+
+	// iss, client_id, and jti feed the per-invocation audit-log identity
+	// surface (SOL-149606). They are stashed in TokenInfo.Extra under the
+	// exact keys "iss", "client_id", "jti"; internal/tools/identity.go
+	// reads them by those keys. Drift-detection tests pin the allowlist.
+	iss, err := claims.String("iss")
+	if err != nil {
+		return nil, err
+	}
+	clientID, err := claims.String("client_id")
+	if err != nil {
+		return nil, err
+	}
+	jti, err := claims.String("jti")
+	if err != nil {
+		return nil, err
+	}
+
+	extra := map[string]any{
+		"iss":       iss,
+		"client_id": clientID,
+		"jti":       jti,
+	}
+
+	if config.ToolAuthorizationEnabled(cfg) {
+		name := *cfg.MCPClientAuth.ToolAuthorization.GroupsClaimName
+		// The admin-configured groups claim is hydrated lazily from THE
+		// SAME decoded view as the identity claims above, so the identity
+		// the audit log records and the groups the authz layer evaluates
+		// are by construction drawn from one interpretation of the token.
+		// ResolveGroups documents flat top-level lookup only (matching
+		// the broker's accessLevelGroupsClaimName stance), so exactly one
+		// claim is hydrated. Future consumers with different type needs
+		// get their own accessor method on Claims — never a per-consumer
+		// conversion loop here at the boundary.
+		val, exists, err := claims.Value(name)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			groups, ok := resolveGroupsValue(val)
 			if ok {
 				extra[authz.TokenInfoExtraKeyGroups] = groups
 			}
 		}
+	}
 
-		return &sdkauth.TokenInfo{
-			UserID:     claims.Sub,
-			Scopes:     scopes,
-			Expiration: idToken.Expiry,
-			Extra:      extra,
-		}, nil
+	return &sdkauth.TokenInfo{
+		UserID:     sub,
+		Scopes:     scopes,
+		Expiration: expiry,
+		Extra:      extra,
 	}, nil
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -167,7 +167,8 @@ func createOIDCTokenVerifier(cfg *config.ServerConfig, httpClient *http.Client) 
 		}
 
 		if err := idToken.Claims(&claims); err != nil {
-			return nil, fmt.Errorf("failed to extract claims: %w", err)
+			slog.Warn("failed to extract claims",
+				slog.String("error", err.Error()))
 		}
 
 		// Parse scopes from JWT (space-separated string per OAuth 2.0 spec)
@@ -202,7 +203,7 @@ func createOIDCTokenVerifier(cfg *config.ServerConfig, httpClient *http.Client) 
 		// supporting arbitrary claim names for groups.
 		var raw map[string]any
 		if err := idToken.Claims(&raw); err != nil {
-			slog.Warn("failed to decode raw claims for groups extraction; treating as missing-claim",
+			slog.Warn("failed to extract claims",
 				slog.String("error", err.Error()))
 		} else {
 			groups, ok := ResolveGroups(raw, *cfg.MCPClientAuth.ToolAuthorization.GroupsClaimName)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -229,7 +229,13 @@ func buildTokenInfo(cfg *config.ServerConfig, claims Claims, expiry time.Time) (
 			groups, ok := resolveGroupsValue(val)
 			if ok {
 				extra[authz.TokenInfoExtraKeyGroups] = groups
+			} else {
+				slog.Debug("groups claim present but not resolvable",
+					slog.String("claim", name))
 			}
+		} else {
+			slog.Debug("groups claim not found in token",
+				slog.String("claim", name))
 		}
 	}
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1086,3 +1086,93 @@ func Test_OIDCVerifier_GroupsExtraction(t *testing.T) {
 		}
 	})
 }
+
+// --- buildTokenInfo unit tests (no IdP needed) -------------------------------
+
+func TestBuildTokenInfo(t *testing.T) {
+	baseCfg := &config.ServerConfig{
+		MCPClientAuth: config.MCPClientAuthConfig{
+			Mode: config.AuthModeOAuth,
+		},
+	}
+
+	t.Run("happy path extracts all claims", func(t *testing.T) {
+		c := makeClaims(t, `{
+			"sub": "user-42",
+			"scope": "read write",
+			"iss": "https://idp.example.com",
+			"client_id": "cursor-ide",
+			"jti": "abc-123"
+		}`)
+
+		info, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.UserID != "user-42" {
+			t.Errorf("UserID = %q, want %q", info.UserID, "user-42")
+		}
+		if len(info.Scopes) != 2 || info.Scopes[0] != "read" || info.Scopes[1] != "write" {
+			t.Errorf("Scopes = %v, want [read write]", info.Scopes)
+		}
+		if info.Extra["iss"] != "https://idp.example.com" {
+			t.Errorf("Extra[iss] = %v", info.Extra["iss"])
+		}
+		if info.Extra["client_id"] != "cursor-ide" {
+			t.Errorf("Extra[client_id] = %v", info.Extra["client_id"])
+		}
+		if info.Extra["jti"] != "abc-123" {
+			t.Errorf("Extra[jti] = %v", info.Extra["jti"])
+		}
+	})
+
+	t.Run("missing sub is rejected", func(t *testing.T) {
+		c := makeClaims(t, `{"iss": "https://idp.example.com"}`)
+		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
+		if err == nil {
+			t.Fatal("expected error for missing sub")
+		}
+	})
+
+	t.Run("blank sub is rejected", func(t *testing.T) {
+		c := makeClaims(t, `{"sub": "   "}`)
+		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
+		if err == nil {
+			t.Fatal("expected error for blank sub")
+		}
+	})
+
+	t.Run("scope with wrong type is rejected", func(t *testing.T) {
+		c := makeClaims(t, `{"sub": "user-1", "scope": ["read", "write"]}`)
+		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
+		if err == nil {
+			t.Fatal("expected error for array scope")
+		}
+	})
+
+	t.Run("missing optional claims produce empty strings", func(t *testing.T) {
+		c := makeClaims(t, `{"sub": "user-1"}`)
+		info, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, key := range []string{"client_id", "jti"} {
+			v, ok := info.Extra[key]
+			if !ok {
+				t.Errorf("Extra[%q] missing", key)
+				continue
+			}
+			if s, isStr := v.(string); !isStr || s != "" {
+				t.Errorf("Extra[%q] = %v (%T), want \"\"", key, v, v)
+			}
+		}
+	})
+
+	t.Run("client_id with wrong type is rejected", func(t *testing.T) {
+		c := makeClaims(t, `{"sub": "user-1", "client_id": 42}`)
+		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
+		if err == nil {
+			t.Fatal("expected error for non-string client_id")
+		}
+	})
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1126,27 +1127,36 @@ func TestBuildTokenInfo(t *testing.T) {
 		}
 	})
 
-	t.Run("missing sub is rejected", func(t *testing.T) {
+	t.Run("missing sub is rejected with errNoSubject", func(t *testing.T) {
 		c := makeClaims(t, `{"iss": "https://idp.example.com"}`)
 		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
 		if err == nil {
 			t.Fatal("expected error for missing sub")
 		}
+		if !errors.Is(err, errNoSubject) {
+			t.Errorf("error = %v, want errNoSubject", err)
+		}
 	})
 
-	t.Run("blank sub is rejected", func(t *testing.T) {
+	t.Run("blank sub is rejected with errNoSubject", func(t *testing.T) {
 		c := makeClaims(t, `{"sub": "   "}`)
 		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
 		if err == nil {
 			t.Fatal("expected error for blank sub")
 		}
+		if !errors.Is(err, errNoSubject) {
+			t.Errorf("error = %v, want errNoSubject", err)
+		}
 	})
 
-	t.Run("scope with wrong type is rejected", func(t *testing.T) {
+	t.Run("scope with wrong type is rejected with errMalformedClaims", func(t *testing.T) {
 		c := makeClaims(t, `{"sub": "user-1", "scope": ["read", "write"]}`)
 		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
 		if err == nil {
 			t.Fatal("expected error for array scope")
+		}
+		if !errors.Is(err, errMalformedClaims) {
+			t.Errorf("error = %v, want errMalformedClaims", err)
 		}
 	})
 
@@ -1168,11 +1178,14 @@ func TestBuildTokenInfo(t *testing.T) {
 		}
 	})
 
-	t.Run("client_id with wrong type is rejected", func(t *testing.T) {
+	t.Run("client_id with wrong type is rejected with errMalformedClaims", func(t *testing.T) {
 		c := makeClaims(t, `{"sub": "user-1", "client_id": 42}`)
 		_, err := buildTokenInfo(baseCfg, c, time.Now().Add(time.Hour))
 		if err == nil {
 			t.Fatal("expected error for non-string client_id")
+		}
+		if !errors.Is(err, errMalformedClaims) {
+			t.Errorf("error = %v, want errMalformedClaims", err)
 		}
 	})
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -15,6 +15,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -23,6 +24,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -925,6 +927,75 @@ func Test_NewTokenVerifier_TLSWithSSLCertFile(t *testing.T) {
 func boolPtr(b bool) *bool       { return &b }
 func strPtr(s string) *string    { return &s }
 
+// Test_OIDCVerifier_SanitizedErrorResponse verifies that when buildTokenInfo
+// rejects a token, the HTTP 401 response body contains only the static
+// sentinel text — no claim names, json type errors, or go-oidc detail.
+func Test_OIDCVerifier_SanitizedErrorResponse(t *testing.T) {
+	mock := newMockOIDCServer(t)
+	defer mock.close()
+
+	cfg := &config.ServerConfig{
+		Port: 9090,
+		MCPClientAuth: config.MCPClientAuthConfig{
+			Mode:        config.AuthModeOAuth,
+			Issuer:      mock.issuer,
+			Audience:    mock.audience,
+			ResourceURL: "http://localhost:9090/mcp",
+		},
+	}
+
+	middleware, err := NewAuthMiddleware(cfg, nil, dummyHandler)
+	if err != nil {
+		t.Fatalf("NewAuthMiddleware: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		claims   map[string]interface{}
+		wantBody string
+	}{
+		{
+			name:     "blank sub returns sanitized errNoSubject",
+			claims:   map[string]interface{}{"sub": ""},
+			wantBody: errNoSubject.Error(),
+		},
+		{
+			name:     "wrong type scope returns sanitized errMalformedClaims",
+			claims:   map[string]interface{}{"sub": "user1", "scope": []string{"read"}},
+			wantBody: errMalformedClaims.Error(),
+		},
+		{
+			name:     "wrong type client_id returns sanitized errMalformedClaims",
+			claims:   map[string]interface{}{"sub": "user1", "client_id": 999},
+			wantBody: errMalformedClaims.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := mock.createToken(tt.claims)
+			if err != nil {
+				t.Fatalf("createToken: %v", err)
+			}
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rec := httptest.NewRecorder()
+			middleware.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", rec.Code)
+			}
+
+			body := strings.TrimSpace(rec.Body.String())
+			if body != tt.wantBody {
+				t.Errorf("response body = %q, want %q", body, tt.wantBody)
+			}
+		})
+	}
+}
+
 func Test_OIDCVerifier_GroupsExtraction(t *testing.T) {
 	mock := newMockOIDCServer(t)
 	defer mock.close()
@@ -1186,6 +1257,63 @@ func TestBuildTokenInfo(t *testing.T) {
 		}
 		if !errors.Is(err, errMalformedClaims) {
 			t.Errorf("error = %v, want errMalformedClaims", err)
+		}
+	})
+
+	t.Run("absent groups claim logs DEBUG diagnostic", func(t *testing.T) {
+		t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
+
+		authzCfg := &config.ServerConfig{
+			MCPClientAuth: config.MCPClientAuthConfig{
+				Mode: config.AuthModeOAuth,
+				ToolAuthorization: &config.ToolAuthorizationConfig{
+					Enabled:         boolPtr(true),
+					GroupsClaimName: strPtr("roles"),
+				},
+			},
+		}
+		c := makeClaims(t, `{"sub": "user-1"}`)
+
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+		defer slog.SetDefault(prev)
+
+		_, err := buildTokenInfo(authzCfg, c, time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "groups claim not found in token") {
+			t.Errorf("expected DEBUG log for absent groups claim, got: %s", buf.String())
+		}
+	})
+
+	t.Run("unresolvable groups claim logs DEBUG diagnostic", func(t *testing.T) {
+		t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
+
+		authzCfg := &config.ServerConfig{
+			MCPClientAuth: config.MCPClientAuthConfig{
+				Mode: config.AuthModeOAuth,
+				ToolAuthorization: &config.ToolAuthorizationConfig{
+					Enabled:         boolPtr(true),
+					GroupsClaimName: strPtr("groups"),
+				},
+			},
+		}
+		// groups claim present but wrong type (number) — resolveGroupsValue returns ok=false
+		c := makeClaims(t, `{"sub": "user-1", "groups": 42}`)
+
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+		defer slog.SetDefault(prev)
+
+		_, err := buildTokenInfo(authzCfg, c, time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "groups claim present but not resolvable") {
+			t.Errorf("expected DEBUG log for unresolvable groups claim, got: %s", buf.String())
 		}
 	})
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -916,6 +917,172 @@ func Test_NewTokenVerifier_TLSWithSSLCertFile(t *testing.T) {
 		_, err := NewTokenVerifier(cfg, nil)
 		if err != nil {
 			t.Errorf("expected success with SSL_CERT_FILE set, got: %v", err)
+		}
+	})
+}
+
+func boolPtr(b bool) *bool       { return &b }
+func strPtr(s string) *string    { return &s }
+
+func Test_OIDCVerifier_GroupsExtraction(t *testing.T) {
+	mock := newMockOIDCServer(t)
+	defer mock.close()
+
+	t.Run("feature disabled omits groups key", func(t *testing.T) {
+		t.Setenv("ENABLE_TOOL_AUTHORIZATION", "false")
+
+		cfg := &config.ServerConfig{
+			MCPClientAuth: config.MCPClientAuthConfig{
+				Mode:     config.AuthModeOAuth,
+				Issuer:   mock.issuer,
+				Audience: mock.audience,
+			},
+		}
+
+		verifier, err := NewTokenVerifier(cfg, nil)
+		if err != nil {
+			t.Fatalf("NewTokenVerifier: %v", err)
+		}
+
+		token, err := mock.createToken(map[string]interface{}{
+			"groups": []interface{}{"admin"},
+		})
+		if err != nil {
+			t.Fatalf("createToken: %v", err)
+		}
+
+		info, err := verifier(context.Background(), token, nil)
+		if err != nil {
+			t.Fatalf("verifier: %v", err)
+		}
+
+		if _, exists := info.Extra[authz.TokenInfoExtraKeyGroups]; exists {
+			t.Error("Extra should not contain groups key when feature is disabled")
+		}
+	})
+
+	t.Run("feature enabled with usable groups", func(t *testing.T) {
+		t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
+
+		cfg := &config.ServerConfig{
+			MCPClientAuth: config.MCPClientAuthConfig{
+				Mode:     config.AuthModeOAuth,
+				Issuer:   mock.issuer,
+				Audience: mock.audience,
+				ToolAuthorization: &config.ToolAuthorizationConfig{
+					Enabled:         boolPtr(true),
+					GroupsClaimName: strPtr("groups"),
+				},
+			},
+		}
+
+		verifier, err := NewTokenVerifier(cfg, nil)
+		if err != nil {
+			t.Fatalf("NewTokenVerifier: %v", err)
+		}
+
+		token, err := mock.createToken(map[string]interface{}{
+			"groups": []interface{}{"admin", "ops"},
+		})
+		if err != nil {
+			t.Fatalf("createToken: %v", err)
+		}
+
+		info, err := verifier(context.Background(), token, nil)
+		if err != nil {
+			t.Fatalf("verifier: %v", err)
+		}
+
+		raw, exists := info.Extra[authz.TokenInfoExtraKeyGroups]
+		if !exists {
+			t.Fatal("Extra should contain groups key")
+		}
+		groups, ok := raw.([]string)
+		if !ok {
+			t.Fatalf("groups value type = %T, want []string", raw)
+		}
+		if len(groups) != 2 || groups[0] != "admin" || groups[1] != "ops" {
+			t.Errorf("groups = %v, want [admin ops]", groups)
+		}
+	})
+
+	t.Run("feature enabled with absent claim", func(t *testing.T) {
+		t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
+
+		cfg := &config.ServerConfig{
+			MCPClientAuth: config.MCPClientAuthConfig{
+				Mode:     config.AuthModeOAuth,
+				Issuer:   mock.issuer,
+				Audience: mock.audience,
+				ToolAuthorization: &config.ToolAuthorizationConfig{
+					Enabled:         boolPtr(true),
+					GroupsClaimName: strPtr("groups"),
+				},
+			},
+		}
+
+		verifier, err := NewTokenVerifier(cfg, nil)
+		if err != nil {
+			t.Fatalf("NewTokenVerifier: %v", err)
+		}
+
+		token, err := mock.createToken(map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("createToken: %v", err)
+		}
+
+		info, err := verifier(context.Background(), token, nil)
+		if err != nil {
+			t.Fatalf("verifier: %v", err)
+		}
+
+		if _, exists := info.Extra[authz.TokenInfoExtraKeyGroups]; exists {
+			t.Error("Extra should not contain groups key when claim is absent")
+		}
+	})
+
+	t.Run("feature enabled with empty array", func(t *testing.T) {
+		t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
+
+		cfg := &config.ServerConfig{
+			MCPClientAuth: config.MCPClientAuthConfig{
+				Mode:     config.AuthModeOAuth,
+				Issuer:   mock.issuer,
+				Audience: mock.audience,
+				ToolAuthorization: &config.ToolAuthorizationConfig{
+					Enabled:         boolPtr(true),
+					GroupsClaimName: strPtr("groups"),
+				},
+			},
+		}
+
+		verifier, err := NewTokenVerifier(cfg, nil)
+		if err != nil {
+			t.Fatalf("NewTokenVerifier: %v", err)
+		}
+
+		token, err := mock.createToken(map[string]interface{}{
+			"groups": []interface{}{},
+		})
+		if err != nil {
+			t.Fatalf("createToken: %v", err)
+		}
+
+		info, err := verifier(context.Background(), token, nil)
+		if err != nil {
+			t.Fatalf("verifier: %v", err)
+		}
+
+		raw, exists := info.Extra[authz.TokenInfoExtraKeyGroups]
+		if !exists {
+			t.Fatal("Extra should contain groups key for empty array (authenticated with zero groups)")
+		}
+		groups, ok := raw.([]string)
+		if !ok {
+			t.Fatalf("groups value type = %T, want []string", raw)
+		}
+		if len(groups) != 0 {
+			t.Errorf("groups = %v, want empty slice", groups)
 		}
 	})
 }

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -53,7 +53,8 @@ func (p *Policy) LogValue() slog.Value {
 // MatchedGroups is exported so callers can read it for audit logging, but
 // Decision implements slog.LogValuer to prevent accidental leakage: any
 // slog call that includes a Decision emits only Allowed and the count of
-// matched groups, never the group names themselves.
+// matched groups, never the group names themselves. fmt and json.Marshal
+// still render MatchedGroups — log only via slog.
 type Decision struct {
 	Allowed       bool
 	MatchedGroups []string

--- a/internal/tools/identity.go
+++ b/internal/tools/identity.go
@@ -231,9 +231,9 @@ func extraStringSlice(t *sdkauth.TokenInfo, key string) (values []string, presen
 	}
 	s, isSlice := v.([]string)
 	if !isSlice {
-		slog.Error("TokenInfo.Extra: expected []string but found different type",
+		slog.Error("internal: TokenInfo.Extra has unexpected type — verifier contract violation",
 			slog.String("key", key),
-			slog.String("type_seen", fmt.Sprintf("%T", v)))
+			slog.String("got_type", fmt.Sprintf("%T", v)))
 		return nil, false
 	}
 	cp := make([]string, len(s))

--- a/internal/tools/identity.go
+++ b/internal/tools/identity.go
@@ -38,7 +38,9 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // absentSentinel is the single value any audit-log identity field takes when
@@ -173,6 +175,13 @@ func sanitizeClaim(s string) string {
 	return b.String()
 }
 
+// TokenInfo.Extra convention:
+//   - Audit-field keys (iss, client_id, jti) carry string values, read via
+//     extraString. These are the Identity audit schema fields.
+//   - Other keys carry per-key typed values, read via a per-key accessor
+//     (e.g. extraStringSlice for authz.TokenInfoExtraKeyGroups). The drift
+//     test asserts by key, not by blanket type.
+//
 // extraString reads a string-typed claim from TokenInfo.Extra by key.
 //
 // Three outcomes:
@@ -205,4 +214,48 @@ func extraString(t *sdkauth.TokenInfo, key string) string {
 		return verifierBugSentinel
 	}
 	return s
+}
+
+// extraStringSlice reads a []string-typed value from TokenInfo.Extra by key.
+// Missing keys return (nil, false). Present keys with the wrong type trigger
+// the same verifier-bug slog.Error path as extraString, then return
+// (nil, false). Present keys with a valid []string return a defensive copy
+// so callers may mutate freely without affecting request-scoped storage.
+func extraStringSlice(t *sdkauth.TokenInfo, key string) (values []string, present bool) {
+	if t == nil {
+		return nil, false
+	}
+	v, ok := t.Extra[key]
+	if !ok {
+		return nil, false
+	}
+	s, isSlice := v.([]string)
+	if !isSlice {
+		slog.Error("TokenInfo.Extra: expected []string but found different type",
+			slog.String("key", key),
+			slog.String("type_seen", fmt.Sprintf("%T", v)))
+		return nil, false
+	}
+	cp := make([]string, len(s))
+	copy(cp, s)
+	return cp, true
+}
+
+// requestGroups extracts the caller's groups from the request identity.
+// Reads under authz.TokenInfoExtraKeyGroups. Returns (nil, false) when the
+// groups claim was missing from the token (the day-one IdP misconfiguration
+// case).
+//
+//nolint:unused // Called by withAuthorization (T4 enforcement wrapper, next ticket).
+func requestGroups(req *mcp.CallToolRequest) (groups []string, present bool) {
+	if req == nil {
+		return nil, false
+	}
+	if req.Extra == nil {
+		return nil, false
+	}
+	if req.Extra.TokenInfo == nil {
+		return nil, false
+	}
+	return extraStringSlice(req.Extra.TokenInfo, authz.TokenInfoExtraKeyGroups)
 }

--- a/internal/tools/identity.go
+++ b/internal/tools/identity.go
@@ -192,7 +192,7 @@ func sanitizeClaim(s string) string {
 //   - Key present, value is a string: returns the string. Happy path.
 //
 //   - Key present, value is NOT a string: contract violation by our own
-//     verifier (commit 1 stashes only strings). We emit an ERROR-level slog
+//     verifier (audit-field keys stash only strings). We emit an ERROR-level slog
 //     entry naming the key and observed type, then return verifierBugSentinel.
 //     The audit-log line for this request still gets emitted (with the
 //     sentinel as the field value) — the panic version we shipped initially

--- a/internal/tools/identity_test.go
+++ b/internal/tools/identity_test.go
@@ -376,7 +376,8 @@ func TestTokenInfoStruct_hasExpectedFields(t *testing.T) {
 
 // TestTokenInfoExtra_isMapStringAny pins the type of TokenInfo.Extra. If the
 // SDK ever changes Extra to a strongly-typed struct or a different map shape,
-// our extraString helper breaks; this test catches it at compile/test time.
+// our extraString / extraStringSlice helpers break; this test catches it at
+// compile/test time.
 func TestTokenInfoExtra_isMapStringAny(t *testing.T) {
 	field, ok := reflect.TypeOf(sdkauth.TokenInfo{}).FieldByName("Extra")
 	if !ok {
@@ -385,6 +386,60 @@ func TestTokenInfoExtra_isMapStringAny(t *testing.T) {
 	want := reflect.TypeOf(map[string]any{})
 	if field.Type != want {
 		t.Errorf("TokenInfo.Extra type = %v, want %v", field.Type, want)
+	}
+}
+
+// TestTokenInfoExtra_perKeyTypeConvention pins the widened Extra convention:
+// audit-field keys (iss, client_id, jti) carry string values; the groups key
+// carries []string. An accessor exists for each key type. Unknown keys are
+// not permitted — adding one requires updating this test, the accessor set,
+// and the convention comment on extraString.
+func TestTokenInfoExtra_perKeyTypeConvention(t *testing.T) {
+	info := &sdkauth.TokenInfo{
+		Extra: map[string]any{
+			"iss":       "https://idp.example.com",
+			"client_id": "cursor-ide",
+			"jti":       "jti-1",
+			"groups":    []string{"Ops", "Monitoring"},
+		},
+	}
+
+	// Audit-field keys: must be readable via extraString.
+	for _, key := range []string{"iss", "client_id", "jti"} {
+		v := extraString(info, key)
+		if v == "" || v == verifierBugSentinel {
+			t.Errorf("extraString(%q) = %q; expected a valid string value", key, v)
+		}
+	}
+
+	// Groups key: must be readable via extraStringSlice.
+	groups, present := extraStringSlice(info, "groups")
+	if !present {
+		t.Fatal("extraStringSlice(\"groups\") returned present=false; expected true")
+	}
+	if len(groups) != 2 || groups[0] != "Ops" || groups[1] != "Monitoring" {
+		t.Errorf("extraStringSlice(\"groups\") = %v; expected [Ops Monitoring]", groups)
+	}
+
+	// Defensive copy: mutating the returned slice must not affect the
+	// underlying Extra storage.
+	groups[0] = "MUTATED"
+	original, _ := info.Extra["groups"].([]string)
+	if original[0] == "MUTATED" {
+		t.Error("extraStringSlice returned a reference instead of a defensive copy")
+	}
+
+	// Completeness: no unknown keys are permitted in Extra.
+	allowedKeys := map[string]bool{
+		"iss":       true,
+		"client_id": true,
+		"jti":       true,
+		"groups":    true,
+	}
+	for k := range info.Extra {
+		if !allowedKeys[k] {
+			t.Errorf("unexpected key %q in TokenInfo.Extra — update the convention comment, accessor set, and this test", k)
+		}
 	}
 }
 

--- a/internal/tools/identity_test.go
+++ b/internal/tools/identity_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 )
 
@@ -400,7 +401,7 @@ func TestTokenInfoExtra_perKeyTypeConvention(t *testing.T) {
 			"iss":       "https://idp.example.com",
 			"client_id": "cursor-ide",
 			"jti":       "jti-1",
-			"groups":    []string{"Ops", "Monitoring"},
+			authz.TokenInfoExtraKeyGroups: []string{"Ops", "Monitoring"},
 		},
 	}
 
@@ -413,28 +414,28 @@ func TestTokenInfoExtra_perKeyTypeConvention(t *testing.T) {
 	}
 
 	// Groups key: must be readable via extraStringSlice.
-	groups, present := extraStringSlice(info, "groups")
+	groups, present := extraStringSlice(info, authz.TokenInfoExtraKeyGroups)
 	if !present {
-		t.Fatal("extraStringSlice(\"groups\") returned present=false; expected true")
+		t.Fatalf("extraStringSlice(%q) returned present=false; expected true", authz.TokenInfoExtraKeyGroups)
 	}
 	if len(groups) != 2 || groups[0] != "Ops" || groups[1] != "Monitoring" {
-		t.Errorf("extraStringSlice(\"groups\") = %v; expected [Ops Monitoring]", groups)
+		t.Errorf("extraStringSlice(%q) = %v; expected [Ops Monitoring]", authz.TokenInfoExtraKeyGroups, groups)
 	}
 
 	// Defensive copy: mutating the returned slice must not affect the
 	// underlying Extra storage.
 	groups[0] = "MUTATED"
-	original, _ := info.Extra["groups"].([]string)
+	original, _ := info.Extra[authz.TokenInfoExtraKeyGroups].([]string)
 	if original[0] == "MUTATED" {
 		t.Error("extraStringSlice returned a reference instead of a defensive copy")
 	}
 
 	// Completeness: no unknown keys are permitted in Extra.
 	allowedKeys := map[string]bool{
-		"iss":       true,
-		"client_id": true,
-		"jti":       true,
-		"groups":    true,
+		"iss":                        true,
+		"client_id":                  true,
+		"jti":                        true,
+		authz.TokenInfoExtraKeyGroups: true,
 	}
 	for k := range info.Extra {
 		if !allowedKeys[k] {


### PR DESCRIPTION
## Summary

Extends the OIDC middleware to extract the admin-configured groups claim from verified JWTs and attach it to `TokenInfo.Extra` for downstream tool authorization (T3 of SOL-151440). Along the way, fixes two pre-existing issues in the middleware's error handling on `main`.

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Tool authorization (T4, next ticket) needs to know which groups the caller belongs to. The middleware already owns token verification and stashes audit claims in `TokenInfo.Extra`, so it's the natural place to extract groups.

## Why the middleware needed more than just a groups feature

On `main`, the verifier decodes claims into a single typed Go struct:

```go
var claims struct {
    Sub      string `json:"sub"`
    Scope    string `json:"scope"`
    // ...
}
idToken.Claims(&claims)
```

Groups extraction needs to read a **dynamic** claim name (`groups_claim_name` from config), which a fixed struct can't express. The straightforward approach would be to add a second `idToken.Claims()` call into a `map[string]any` — but this creates a parser differential: `encoding/json` v1 matches struct fields **case-insensitively** but map keys **exactly**. A token with `"Sub": "alice"` would populate the struct's `Sub` field but produce no `"sub"` key in the map. This is the same class of bug the MCP go-sdk fixed in GHSA-wvj2-96wp-fq3f.

Instead, we replaced the struct decode entirely with a single decode into `map[string]json.RawMessage` and a typed `Claims` accessor layer on top. Identity claims, audit fields, and groups all read from the same decoded view — no differential possible.

While doing this refactor, we discovered and fixed two pre-existing issues on `main`:

### Missing SDK sentinel on claims decode failure

On `main`, the `Claims()` error path uses `fmt.Errorf("failed to extract claims: %w", err)` — this wraps the raw error but **not** `sdkauth.ErrInvalidToken`. The SDK's `RequireBearerToken` checks `errors.Is(err, ErrInvalidToken)` to decide between a 401 (with `WWW-Authenticate` header for OAuth recovery) and a generic error. Without the sentinel, this path breaks the client's OAuth recovery flow.

### Error leakage to callers (CWE-209)

The SDK writes `err.Error()` directly into the HTTP 401 response body — it does no sanitization and no server-side logging. On `main`, the verifier returns errors containing go-oidc messages and json parse errors, which can include attacker-influenced content like claim names and type details. Operators had zero visibility into token rejections.

## How the middleware works now

### Single decode

The verifier closure decodes the verified token once into `map[string]json.RawMessage`. The `Claims` type wraps this map and provides typed accessors (`String`, `Value`) that do exact case-sensitive key lookup per RFC 7519. Identity claims, audit fields, and groups all read from the same decoded view.

### Error boundary

`buildTokenInfo` is extracted from the verifier closure so claim extraction is unit-testable without an IdP. It returns **rich errors** — with claim names, json type detail, and error categories — so tests can assert on specific failure modes.

The verifier closure catches these at the trust boundary and does two things:

1. **Logs the detail** server-side via `slog.Warn` — operator sees exactly what went wrong
2. **Returns a sanitized sentinel** via `sanitizeTokenError` — client sees only static text like `"invalid token: malformed claims"`

Three category sentinels (`errVerificationFailed`, `errMalformedClaims`, `errNoSubject`) all wrap `sdkauth.ErrInvalidToken`, so the SDK always routes them as 401 with the `WWW-Authenticate` header.

`sanitizeTokenError` classifies errors by walking the sentinel list with `errors.Is`. Rich errors that wrap a category sentinel map back to that sentinel. Unknown errors fall back to `sdkauth.ErrInvalidToken` directly. This is the only place in the auth package that couples to the SDK's error sentinels.

### Claim policy

- `sub`: hard-required, non-blank (RFC 9068 §2.2)
- `scope`, `client_id`, `jti`: tolerated-absent but fatal-if-malformed (real IdPs often omit them)
- Groups: feature-gated behind `ToolAuthorizationEnabled`. Absent claim → no groups key in Extra → authz denies by default. Unresolvable claim (wrong type) → DEBUG diagnostic, no groups key.

go-oidc provides defense in depth for `sub` — it decodes standard claims during verification, so a wrong-type `sub` (e.g. `"sub": 42`) fails at `Verify()` before reaching `buildTokenInfo`. Our code is the only defense for claims go-oidc doesn't validate (`scope`, `client_id`, `jti`, groups).

### Groups extraction

When `config.ToolAuthorizationEnabled(cfg)` is true, `buildTokenInfo` reads the claim named by `GroupsClaimName` (defaulted to `"groups"` by config validation). `resolveGroupsValue` handles the shapes real IdPs emit: string arrays, scalar strings, mixed arrays (non-strings filtered), with a soft cap at 250 entries. The result is attached to `Extra[authz.TokenInfoExtraKeyGroups]` as `[]string`.

## Behavior changes from main

| What | Main | This PR |
|---|---|---|
| Claims decode | Typed struct | Single `map[string]json.RawMessage` with typed accessors |
| Wrong-type `scope`/`client_id`/`jti` | Silently zero-valued via struct decode | Rejected with `errMalformedClaims` |
| Missing/blank `sub` | Accepted (empty UserID, `<absent>` audit) | Rejected with `errNoSubject` |
| Claims decode failure | Missing sentinel → not routed as 401 | Returns `errMalformedClaims` → proper 401 |
| 401 response body | Raw go-oidc/json error text | Static sentinel text only |
| Server-side logging | None for rejections | `slog.Warn` on every rejection path |
| Groups extraction | N/A | Feature-gated behind `ToolAuthorizationEnabled` |

## Files

| File | What |
|---|---|
| `internal/auth/claims.go` | `Claims` type with `String`/`Value` accessors, `ResolveGroups`, `resolveGroupsValue` |
| `internal/auth/errors.go` | Category sentinels, `sanitizeTokenError` |
| `internal/auth/middleware.go` | Single decode, `buildTokenInfo`, verifier error boundary, groups extraction with DEBUG diagnostics |
| `internal/auth/errors_test.go` | Sentinel unwrap, sanitization mapping, static text pinning |
| `internal/auth/claims_test.go` | `Claims.String` (8), `Claims.Value` (4), `ResolveGroups` (15 + soft cap) |
| `internal/auth/middleware_test.go` | `buildTokenInfo` (8 cases), sanitized response body (3), verifier groups extraction (4), groups diagnostic logs (2) |
| `internal/tools/identity.go` | `extraStringSlice`, `requestGroups` (T4 placeholders), `TokenInfo.Extra` convention doc |
| `internal/tools/identity_test.go` | Drift test for Extra key allowlist using `authz.TokenInfoExtraKeyGroups` |
| `internal/authz/authz.go` | `Decision` godoc leak warning for fmt/json.Marshal |

## Review feedback addressed

From @bczoma's review:

| # | Finding | Resolution |
|---|---|---|
| 🔴1 | Warn-and-continue on claims decode (fail-open) | **Fixed.** Single-decode refactor eliminated the two-pass. `buildTokenInfo` fail-closes on all claim errors. |
| 🟡2 | Spurious truncation WARN in `[]any` path | **Fixed.** Now counts only string elements. |
| 🟡3 | Divergent log messages between `extraString`/`extraStringSlice` | **Fixed.** Unified message text and attribute key. |
| 🟡4 | CHANGELOG entry for auth loosening | **No longer needed.** Behavior is now stricter than main, not looser. |
| 💡5 | `GroupsClaimName` nil deref | Config validation defaults it to `"groups"` when the block is present. Added inline comment. |
| 💡6 | Raw `err.Error()` from attacker input (Rule 5) | **Fixed.** Verifier logs detail server-side, returns static sentinels. |
| 💡7 | Unresolved-groups silence | **Fixed.** DEBUG-level diagnostics for absent and unresolvable groups claims, with test coverage. |
| 💡8 | `[]string` branch aliasing | Deferred — low risk, no production impact. |
| 💡9 | Duplicated truncation WARN block | Deferred — minor DRY opportunity. |
| 💡10 | `requestGroups` nil paths untested | Deferred — T4 placeholder, no production caller yet. |
| 💡11 | Drift test hardcoded strings | **Fixed.** Uses `authz.TokenInfoExtraKeyGroups` constant. |

## Testing

| Component | Cases | What it covers |
|---|---|---|
| `Claims.String` | 8 | Every JSON type, absent key, null, case sensitivity |
| `Claims.Value` | 4 | String, array, null, absent |
| `ResolveGroups` | 15 + soft cap | Every realistic claim shape an IdP can emit |
| `buildTokenInfo` | 8 | Happy path, missing/blank sub, wrong-type scope/client_id, missing optionals, groups diagnostics — with `errors.Is` on error category |
| Sanitized response | 3 | Malformed tokens through full middleware stack → 401 body contains only static sentinel text (CWE-209) |
| Verifier integration | 4 | Feature-flag gate, groups round-trip, absent claim, empty array |
| Sentinels unwrap | 3 | Every sentinel → `sdkauth.ErrInvalidToken` |
| `sanitizeTokenError` | 7 | Direct sentinels, wrapped errors, unknown fallback |
| Sentinel text | 3 | Pins exact client-visible strings |
| Drift test | 1 | Extra key allowlist and type contract across auth/tools boundary |

## Checklist

- [x] Self-review completed
- [x] No credentials in code
- [x] Secure logging rules followed — error sanitization at trust boundary (CWE-209)
- [x] All tests pass: `go test -race ./...`
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main

## Related

- Parent epic: SOL-148417
- Story: SOL-151941
- Depends on: PR #181 (SOL-151907, merged)