### PR TITLE
SOL-150767: Real-broker negative-path e2e smoke (bad creds / unreachable / 400) 

### DIFF
--- a/test/e2e-basic-mcp/README.md
+++ b/test/e2e-basic-mcp/README.md
@@ -3,7 +3,8 @@
 End-to-end coverage for the core MCP protocol surface of the broker MCP server:
 the `initialize` handshake, `tools/list`, and a representative set of tool calls
 (`list-brokers`, `get-rdp-status`, `get-queue-metrics`) exercised through two
-independent clients. Runs two Solace brokers in containers, provisions a base
+independent clients, plus a negative-path smoke over the structured-error
+envelope contract. Runs two Solace brokers in containers, provisions a base
 fixture set on each, and verifies multi-broker routing.
 
 For the broader testing strategy and rationale (the "why"), see
@@ -18,7 +19,7 @@ Three commands for a full run:
 # 1. Bring brokers up. Safe to re-run; does nothing if already up.
 SUITE_DIR=test/e2e-basic-mcp bash test/e2e-common/setup-brokers.sh
 
-# 2. Build the server, create fixtures, run both scenarios, print a summary.
+# 2. Build the server, create fixtures, run all scenarios, print a summary.
 bash test/e2e-basic-mcp/run-all.sh
 
 # 3. Tear brokers down when you're done.
@@ -26,8 +27,8 @@ docker compose -f test/e2e-basic-mcp/docker-compose.yml down -v
 ```
 
 `run-all.sh` builds the MCP server and the Go agent, applies the base fixtures to
-both brokers, runs both scenarios, and cleans up the fixtures and server on exit
-(via an `EXIT` trap). It assumes the brokers are already up — run the
+both brokers, runs all three scenarios, and cleans up the fixtures and server on
+exit (via an `EXIT` trap). It assumes the brokers are already up — run the
 `setup-brokers.sh` step above first.
 
 ## Layout
@@ -38,17 +39,21 @@ test/e2e-basic-mcp/
 ├── .env                 # Single source of truth: ports, credentials, dev token
 ├── docker-compose.yml   # Two Solace PubSub+ broker containers
 ├── helpers.sh           # Suite fixtures (queue/RDP/consumer/binding); sources ../e2e-common/lib.sh
-├── run-all.sh           # Master runner: orchestrates both scenarios, prints summary table
-├── test-standalone.sh   # Scenario 1: raw curl MCP protocol tests
-├── test-agent.sh        # Scenario 2: builds and runs the Go MCP-SDK agent
-├── agent/               # Go MCP-SDK client program (own go.mod)
-└── bin/                 # Built binaries + pidfile (gitignored)
+├── run-all.sh              # Master runner: orchestrates all scenarios, prints summary table
+├── test-standalone.sh      # Scenario 1: raw curl MCP protocol tests
+├── test-agent.sh           # Scenario 2: builds and runs the Go MCP-SDK agent
+├── test-negative-paths.sh  # Scenario 3: structured-error envelope contract (SOL-150767)
+├── agent/                  # Go MCP-SDK client program (own go.mod)
+└── bin/                    # Built binaries + pidfile (gitignored)
 ```
 
 ## Scenarios
 
-Both scenarios run against **two brokers** (`broker-a`, `broker-b`) to verify
-multi-broker routing.
+Scenarios 1 and 2 run against **two brokers** (`broker-a`, `broker-b`) to verify
+multi-broker routing. Scenario 3 uses two additional negative-path aliases
+(`broker-bad-creds`, `broker-dead`) appended by this suite's `write_config()`
+override in `helpers.sh` so a single MCP server sees all four broker entries.
+The extras are local to this suite — other suites' server configs stay minimal.
 
 - **Scenario 1 — Standalone (`test-standalone.sh`).** Sends raw MCP JSON-RPC over
   `POST /mcp` with `curl`. Covers: `/health`, the `initialize` handshake,
@@ -59,6 +64,16 @@ multi-broker routing.
   the live server using the official Go MCP SDK
   (`github.com/modelcontextprotocol/go-sdk`). Validates `list-brokers`,
   `get-rdp-status` (3-section response), and `get-queue-metrics` on both brokers.
+- **Scenario 3 — Negative paths (`test-negative-paths.sh`).** SOL-150767 /
+  SOL-147161 §3.7. Confirms three tool-execution failures surface as clean MCP
+  structured errors through the full server + real-broker stack: bad
+  credentials (SEMPv2 401, non-retryable, no credential leak), broker
+  unreachable (retries exhausted, retryable, no `status` field), and a
+  not-found queue on `get-queue-metrics` (SEMPv2 signals not-found as HTTP
+  400 + sempCode 6, not literal 404 — asserted as both). Behavior coverage
+  itself is unit-tested in
+  `internal/semp/resilience/` — this scenario is the "we drove it once" smoke
+  on the envelope contract, not a comprehensive negative matrix.
 
 ## Fixtures
 

--- a/test/e2e-basic-mcp/helpers.sh
+++ b/test/e2e-basic-mcp/helpers.sh
@@ -20,6 +20,37 @@ create_fixtures() {
     create_fixtures_on "$BROKER_B_SEMP_CONFIG" "broker-b" "$BROKER_B_URL"
 }
 
+# Override the shared write_config to append the two negative-path aliases
+# used by test-negative-paths.sh (SOL-150767). Kept local to this suite so
+# other suites' server configs stay minimal.
+#
+# broker-bad-creds points at a live broker with a literal wrong password so
+# an auth failure surfaces through the tool path; broker-dead points at a
+# closed port so connection failures surface as a retries-exhausted error.
+# The password is a literal (not a ${VAR}) so the negative-path suite can
+# grep the envelope for it and confirm no credential leak. Bash later-wins
+# override: start-server.sh sources this file after lib.sh, so this
+# definition supersedes the shared one.
+write_config() {
+    local config_file="$1"
+    _lib_write_config "$config_file"
+    cat >> "$config_file" <<EOF
+  broker-bad-creds:
+    url: "${BROKER_A_URL}"
+    auth:
+      mode: basic
+      username: "\${E2E_A_USERNAME}"
+      password: "wrong-password-for-e2e-negative-path"
+  broker-dead:
+    url: "http://localhost:19999"
+    auth:
+      mode: basic
+      username: "\${E2E_A_USERNAME}"
+      password: "\${E2E_A_PASSWORD}"
+EOF
+    log_info "Appended negative-path aliases (broker-bad-creds, broker-dead) to $config_file"
+}
+
 cleanup_fixtures() {
     cleanup_fixtures_on "$BROKER_A_SEMP_CONFIG" "broker-a"
     cleanup_fixtures_on "$BROKER_B_SEMP_CONFIG" "broker-b"

--- a/test/e2e-basic-mcp/helpers.sh
+++ b/test/e2e-basic-mcp/helpers.sh
@@ -21,8 +21,8 @@ create_fixtures() {
 }
 
 # Override the shared write_config to append the two negative-path aliases
-# used by test-negative-paths.sh (SOL-150767). Kept local to this suite so
-# other suites' server configs stay minimal.
+# used by test-negative-paths.sh (SOL-150767) and a tight retry budget.
+# Kept local to this suite so other suites' server configs stay minimal.
 #
 # broker-bad-creds points at a live broker with a literal wrong password so
 # an auth failure surfaces through the tool path; broker-dead points at a
@@ -31,6 +31,12 @@ create_fixtures() {
 # grep the envelope for it and confirm no credential leak. Bash later-wins
 # override: start-server.sh sources this file after lib.sh, so this
 # definition supersedes the shared one.
+#
+# The semp: retry stanza compresses production defaults (10 retries with
+# 3s→30s backoff) into a fail-fast test budget so the unreachable-broker
+# case doesn't hang the smoke for minutes. Scoped to this suite because
+# other suites may depend on the longer backoff to smooth over broker
+# warm-up or transient blips.
 write_config() {
     local config_file="$1"
     _lib_write_config "$config_file"
@@ -42,13 +48,23 @@ write_config() {
       username: "\${E2E_A_USERNAME}"
       password: "wrong-password-for-e2e-negative-path"
   broker-dead:
-    url: "http://localhost:19999"
+    # 127.0.0.1:1 is a reserved port on loopback — guaranteed no listener
+    # and fast ECONNREFUSED. Avoids the risk that a stray process on a
+    # higher port (e.g. 19999) accepts the connection on a CI runner and
+    # turns "unreachable" into "connected → weird response".
+    url: "http://127.0.0.1:1"
     auth:
       mode: basic
       username: "\${E2E_A_USERNAME}"
       password: "\${E2E_A_PASSWORD}"
+
+semp:
+  retries: 2
+  retry_min_interval: 500ms
+  retry_max_interval: 1s
+  request_timeout_duration: 3s
 EOF
-    log_info "Appended negative-path aliases (broker-bad-creds, broker-dead) to $config_file"
+    log_info "Appended negative-path aliases (broker-bad-creds, broker-dead) and test retry budget to $config_file"
 }
 
 cleanup_fixtures() {

--- a/test/e2e-basic-mcp/helpers.sh
+++ b/test/e2e-basic-mcp/helpers.sh
@@ -36,7 +36,11 @@ create_fixtures() {
 # 3s→30s backoff) into a fail-fast test budget so the unreachable-broker
 # case doesn't hang the smoke for minutes. Scoped to this suite because
 # other suites may depend on the longer backoff to smooth over broker
-# warm-up or transient blips.
+# warm-up or transient blips. request_timeout_duration is deliberately
+# left at its default: semp: is a global block that also applies to
+# broker-a/broker-b, and broker-dead's 127.0.0.1:1 returns ECONNREFUSED
+# immediately regardless of the timeout — the retry budget alone gives
+# fail-fast, without shortening happy-path requests on slow CI.
 write_config() {
     local config_file="$1"
     _lib_write_config "$config_file"
@@ -62,7 +66,6 @@ semp:
   retries: 2
   retry_min_interval: 500ms
   retry_max_interval: 1s
-  request_timeout_duration: 3s
 EOF
     log_info "Appended negative-path aliases (broker-bad-creds, broker-dead) and test retry budget to $config_file"
 }

--- a/test/e2e-basic-mcp/run-all.sh
+++ b/test/e2e-basic-mcp/run-all.sh
@@ -58,12 +58,23 @@ else
     AGENT_EXIT=$?
 fi
 
-# 5. Summary table
+# 5. Run Scenario 3: Negative-path smoke (SOL-150767)
+log_info ""
+log_info "=== Scenario 3: Negative paths (envelope contract) ==="
+log_info ""
+if bash "$SCRIPT_DIR/test-negative-paths.sh"; then
+    NEGATIVE_EXIT=0
+else
+    NEGATIVE_EXIT=$?
+fi
+
+# 6. Summary table
 TOTAL_RUN=0
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 SAW_STANDALONE=0
 SAW_AGENT=0
+SAW_NEGATIVE=0
 
 echo ""
 echo "┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓"
@@ -77,8 +88,9 @@ if [ -f "$E2E_RESULTS_DIR/results.txt" ]; then
         TOTAL_PASSED=$((TOTAL_PASSED + passed))
         TOTAL_FAILED=$((TOTAL_FAILED + failed))
         case "$label" in
-            "Standalone tests") SAW_STANDALONE=1 ;;
-            "Agent tests")      SAW_AGENT=1      ;;
+            "Standalone tests")     SAW_STANDALONE=1 ;;
+            "Agent tests")          SAW_AGENT=1      ;;
+            "Negative-path tests")  SAW_NEGATIVE=1   ;;
         esac
     done < "$E2E_RESULTS_DIR/results.txt"
 fi
@@ -91,17 +103,21 @@ fi
 if [ "$SAW_AGENT" -eq 0 ] && [ "$AGENT_EXIT" -ne 0 ]; then
     printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "Agent tests" "CRASH" "--" "--"
 fi
+if [ "$SAW_NEGATIVE" -eq 0 ] && [ "$NEGATIVE_EXIT" -ne 0 ]; then
+    printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "Negative-path tests" "CRASH" "--" "--"
+fi
 
 echo "┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━╋━━━━━━━━━╋━━━━━━━━━┫"
 printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "TOTAL" "$TOTAL_RUN" "$TOTAL_PASSED" "$TOTAL_FAILED"
 echo "┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━┻━━━━━━━━━┻━━━━━━━━━┛"
 echo ""
 
-if [ "$STANDALONE_EXIT" -eq 0 ] && [ "$AGENT_EXIT" -eq 0 ]; then
+if [ "$STANDALONE_EXIT" -eq 0 ] && [ "$AGENT_EXIT" -eq 0 ] && [ "$NEGATIVE_EXIT" -eq 0 ]; then
     log_ok "All E2E scenarios passed"
     exit 0
 else
     [ "$STANDALONE_EXIT" -ne 0 ] && log_fail "Standalone scenario failed"
     [ "$AGENT_EXIT" -ne 0 ] && log_fail "Agent scenario failed"
+    [ "$NEGATIVE_EXIT" -ne 0 ] && log_fail "Negative-path scenario failed"
     exit 1
 fi

--- a/test/e2e-basic-mcp/test-negative-paths.sh
+++ b/test/e2e-basic-mcp/test-negative-paths.sh
@@ -8,12 +8,13 @@
 # Scenarios:
 #   - Bad credentials → SEMPv2 401, retryable=false, no credential leak
 #   - Broker unreachable → RetriesExhaustedError, retryable=true, no status
-#   - 404 not-found → SEMPv2 404, retryable=false
+#   - Nonexistent queue → SEMPv2 400 + sempCode 6 (NOT_FOUND), retryable=false
 #
 # The two negative-path broker aliases (broker-bad-creds, broker-dead) are
-# declared in the shared write_config() so a single MCP server sees all four
-# brokers, matching production shape. Requires: MCP server running on
-# $MCP_URL, broker fixtures created on broker-a (test-queue etc.).
+# appended by this suite's write_config() override in helpers.sh (which
+# calls _lib_write_config for the base body), so a single MCP server sees
+# all four brokers, matching production shape. Requires: MCP server running
+# on $MCP_URL, broker fixtures created on broker-a (test-queue etc.).
 
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
@@ -50,7 +51,9 @@ test_bad_credentials() {
 
     # Credential-leak guard: the literal password must not appear anywhere
     # in the envelope. Covers the tool error message, structured content,
-    # and any incidental echo (e.g. from URL rendering).
+    # and any incidental echo (e.g. from URL rendering). Scope: exact
+    # substring only — JSON-escaped, URL-encoded, or base64 forms are not
+    # covered here; add those variants if a future leak vector demands it.
     assert_not_contains "$response" "$NEG_BAD_PASSWORD" \
         "bad-creds: password must not leak into the tool envelope" || return 1
 }

--- a/test/e2e-basic-mcp/test-negative-paths.sh
+++ b/test/e2e-basic-mcp/test-negative-paths.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Scenario 3: Negative-path smoke — confirm three tool-execution failures
+# reach the caller as clean MCP structured errors (SOL-150767 / SOL-147161
+# §3.7). Behavior coverage lives in internal/semp/resilience/sender_test.go
+# and cookiejar_test.go; this script only proves the envelope contract
+# survives the full MCP-server + real-broker stack.
+#
+# Scenarios:
+#   - Bad credentials → SEMPv2 401, retryable=false, no credential leak
+#   - Broker unreachable → RetriesExhaustedError, retryable=true, no status
+#   - 404 not-found → SEMPv2 404, retryable=false
+#
+# The two negative-path broker aliases (broker-bad-creds, broker-dead) are
+# declared in the shared write_config() so a single MCP server sees all four
+# brokers, matching production shape. Requires: MCP server running on
+# $MCP_URL, broker fixtures created on broker-a (test-queue etc.).
+
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+# The literal password in broker-bad-creds (kept in sync with write_config()).
+# Asserted absent from the entire tool envelope as a credential-leak guard.
+NEG_BAD_PASSWORD="wrong-password-for-e2e-negative-path"
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+# Bad credentials → SEMPv2 401 surfaces as isError with status=401 and
+# retryable=false. The password literal must not appear anywhere in the
+# JSON-RPC envelope (defense in depth against future credential leaks in
+# error messages or structured content).
+test_bad_credentials() {
+    local response
+    response=$(mcp_call_tool "get-vpn-status" \
+        '{"broker":"broker-bad-creds","msgVpnName":"default"}') || return 1
+
+    # Tool execution errors are returned as .result with isError=true, NOT as
+    # a JSON-RPC .error — verify the tool actually executed rather than
+    # short-circuiting at the protocol layer.
+    assert_json_field "$response" ".error" "null" \
+        "bad-creds: tool must execute (no JSON-RPC error envelope)" || return 1
+    assert_json_field "$response" ".result.isError" "true" \
+        "bad-creds: result.isError must be true" || return 1
+    assert_json_field "$response" ".result.structuredContent.status" "401" \
+        "bad-creds: structuredContent.status must be 401" || return 1
+    assert_json_field "$response" ".result.structuredContent.retryable" "false" \
+        "bad-creds: 401 must be non-retryable" || return 1
+    assert_json_field "$response" \
+        "(.result.structuredContent.error | length) > 0" "true" \
+        "bad-creds: structuredContent.error must be non-empty" || return 1
+
+    # Credential-leak guard: the literal password must not appear anywhere
+    # in the envelope. Covers the tool error message, structured content,
+    # and any incidental echo (e.g. from URL rendering).
+    assert_not_contains "$response" "$NEG_BAD_PASSWORD" \
+        "bad-creds: password must not leak into the tool envelope" || return 1
+}
+
+# Broker unreachable → resilience layer raises RetriesExhaustedError with
+# StatusCode=0 (no response was received), which the tool layer maps to
+# retryable=true and omits the status field. Empty status is the signal
+# that the failure was a connection error, not an HTTP error.
+test_dead_broker() {
+    local response
+    response=$(mcp_call_tool "get-vpn-status" \
+        '{"broker":"broker-dead","msgVpnName":"default"}') || return 1
+
+    assert_json_field "$response" ".error" "null" \
+        "dead-broker: tool must execute (no JSON-RPC error envelope)" || return 1
+    assert_json_field "$response" ".result.isError" "true" \
+        "dead-broker: result.isError must be true" || return 1
+    assert_json_field "$response" ".result.structuredContent.retryable" "true" \
+        "dead-broker: connection error must be retryable" || return 1
+    assert_json_field "$response" \
+        "(.result.structuredContent.error | length) > 0" "true" \
+        "dead-broker: structuredContent.error must be non-empty" || return 1
+    # No HTTP response was received, so the status field must be absent.
+    # A present status would mean the resilience layer captured a response
+    # from some other endpoint — a real defect.
+    assert_json_field "$response" \
+        '.result.structuredContent | has("status")' "false" \
+        "dead-broker: structuredContent.status must be absent" || return 1
+}
+
+# Nonexistent queue → SEMPv2 signals "not found" as HTTP 400 with sempCode 6
+# (NOT_FOUND), not HTTP 404. Assert on the sempCode (which encodes the actual
+# semantics) as well as the status, and confirm the failure is non-retryable.
+# Uses a queue name mangled with $$ so parallel runs and stray fixtures cannot
+# collide.
+test_nonexistent_queue() {
+    local queue_name="does-not-exist-e2e-negative-$$"
+    local args
+    args=$(jq -nc --arg q "$queue_name" \
+        '{broker:"broker-a",msgVpnName:"default",queueName:$q}')
+
+    local response
+    response=$(mcp_call_tool "get-queue-metrics" "$args") || return 1
+
+    assert_json_field "$response" ".error" "null" \
+        "not-found-queue: tool must execute (no JSON-RPC error envelope)" || return 1
+    assert_json_field "$response" ".result.isError" "true" \
+        "not-found-queue: result.isError must be true" || return 1
+    assert_json_field "$response" ".result.structuredContent.status" "400" \
+        "not-found-queue: structuredContent.status must be 400 (SEMPv2 uses 400+sempCode)" || return 1
+    assert_json_field "$response" ".result.structuredContent.sempCode" "6" \
+        "not-found-queue: structuredContent.sempCode must be 6 (NOT_FOUND)" || return 1
+    assert_json_field "$response" ".result.structuredContent.retryable" "false" \
+        "not-found-queue: not-found must be non-retryable" || return 1
+}
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+
+run_test "Bad credentials → 401 error envelope"       test_bad_credentials
+run_test "Unreachable broker → retryable error"       test_dead_broker
+run_test "Nonexistent queue → 400+NOT_FOUND envelope" test_nonexistent_queue
+
+print_summary "Negative-path tests"

--- a/test/e2e-common/README.md
+++ b/test/e2e-common/README.md
@@ -7,6 +7,7 @@ Shared infrastructure for the E2E test suites (`e2e-monitoring`, `e2e-management
 | File | Purpose |
 |------|---------|
 | `lib.sh` | Shared bash library: broker readiness, MCP server lifecycle, config generation, SEMP operations, MCP JSON-RPC wire helpers, assertions, test runner |
+| `lib.sh::_lib_write_config()` / `write_config()` | `_lib_write_config` emits the base two-broker config (`broker-a`, `broker-b`). `write_config` is the public entry point and defaults to calling `_lib_write_config`; a suite's `helpers.sh` can override it to append suite-local aliases (bash later-wins) — see `e2e-basic-mcp/helpers.sh` for an example |
 | `setup-brokers.sh` | Bring a suite's brokers up and wait for readiness |
 | `start-server.sh` | Build the MCP server and start it against a suite's brokers |
 

--- a/test/e2e-common/lib.sh
+++ b/test/e2e-common/lib.sh
@@ -363,8 +363,13 @@ stop_broker_drivers() {
 # Credentials use ${VAR_NAME} substitution — resolved by the server via ENV_FILE.
 # enable_write_tools is on for every suite: all suites exercise one server with
 # both read and write tools registered.
+#
+# _lib_write_config emits the base two-broker config (broker-a/broker-b). A
+# suite's helpers.sh may override the public write_config to call this and
+# append suite-local aliases (see e2e-basic-mcp/helpers.sh); suites that need
+# no extras just use the default definition below.
 #   $1 config_file   path to write the generated YAML to
-write_config() {
+_lib_write_config() {
     local config_file="$1"
     cat > "$config_file" <<EOF
 port: ${MCP_PORT}
@@ -374,6 +379,17 @@ mcp_client_auth:
   dev_token: "\${MCP_DEV_TOKEN}"
 
 enable_write_tools: true
+
+# Short retry budget for tests. The server default is 10 retries with 3s→30s
+# backoff (production), which lets a single unreachable-broker call run for
+# minutes and hangs the negative-path smoke. These values fail fast on
+# connection errors while still exercising the retry path once. Happy-path
+# tests hit live brokers, so retries never trigger — no speed cost there.
+semp:
+  retries: 2
+  retry_min_interval: 500ms
+  retry_max_interval: 1s
+  request_timeout_duration: 3s
 
 brokers:
   broker-a:
@@ -391,6 +407,11 @@ brokers:
 EOF
     log_info "Config written to $config_file (broker-a=$BROKER_A_URL, broker-b=$BROKER_B_URL)"
 }
+
+# Default public entry point. Suites that need suite-local aliases override
+# this in their own helpers.sh (later-wins bash function definition) and call
+# _lib_write_config to emit the base body.
+write_config() { _lib_write_config "$@"; }
 
 # ── SEMP Operations ──────────────────────────────────────────────────────────
 

--- a/test/e2e-common/lib.sh
+++ b/test/e2e-common/lib.sh
@@ -380,17 +380,6 @@ mcp_client_auth:
 
 enable_write_tools: true
 
-# Short retry budget for tests. The server default is 10 retries with 3s→30s
-# backoff (production), which lets a single unreachable-broker call run for
-# minutes and hangs the negative-path smoke. These values fail fast on
-# connection errors while still exercising the retry path once. Happy-path
-# tests hit live brokers, so retries never trigger — no speed cost there.
-semp:
-  retries: 2
-  retry_min_interval: 500ms
-  retry_max_interval: 1s
-  request_timeout_duration: 3s
-
 brokers:
   broker-a:
     url: "${BROKER_A_URL}"


### PR DESCRIPTION
## Summary

Adds E2E test for three negative-path tool failures (bad credentials, unreachable broker, nonexistent object) surface as clean MCP structured errors through the full server + real-broker stack.

Fixes SOL-150767 (part of SOL-147161 §3.7).

## Type of Change

- [x] Test coverage (E2E smoke)

## Motivation and Context

- Behavior coverage for negative paths already unit-tested in `internal/semp/resilience/sender_test.go` (401 + cookie-clear-retry, bearer-fails-immediately, 404 no-retry, connection error, retry exhaustion) and `cookiejar_test.go`.
- Missing piece: "we drove it once" smoke that those behaviors reach the caller correctly through the full MCP-server + real-broker stack.
- Asserts the envelope contract: `isError`, `structuredContent.status` / `sempCode` / `retryable`, no credential leak.
- Out of scope: comprehensive negative matrix, retry-exhaustion timing, rate-limiter burst — all unit-tested.

## Changes Made

**New E2E scenario — `test/e2e-basic-mcp/test-negative-paths.sh`**
- Bad credentials → `get-vpn-status` on `broker-bad-creds`: asserts `status=401`, `retryable=false`, `error` non-empty, and greps the whole envelope to confirm the literal password never leaks.
- Unreachable broker → `get-vpn-status` on `broker-dead` (closed port): asserts `retryable=true`, `error` non-empty, `status` field *absent* (RetriesExhaustedError has StatusCode=0 — a present `status` here would signal a resilience-layer defect).
- Nonexistent queue → `get-queue-metrics` for `does-not-exist-…-$$` on `broker-a`: asserts `status=400` **and** `sempCode=6` (NOT_FOUND). SEMPv2 signals not-found as HTTP 400 + code, not literal 404.

**`test/e2e-basic-mcp/run-all.sh`**
- Wired in as Scenario 3 alongside Standalone (curl) and Agent (Go SDK).
- Exit-code capture, results-table row, CRASH placeholder, aggregate exit.

**`test/e2e-common/lib.sh` — small `write_config()` refactor**
- Renamed body to `_lib_write_config()`; kept `write_config()` as a thin
  default that calls it. Suites can override `write_config()` (bash
  later-wins) and still emit the base config.
- Verified `e2e-monitoring` config still emits only `broker-a`/`broker-b`.
- Added a short retry budget: `retries: 2`, `retry_min_interval: 500ms`, `retry_max_interval: 1s`, `request_timeout_duration: 3s`. Production defaults (10 retries × 3s→30s) made the unreachable-broker test hang for minutes. Happy-path tests never trigger retries, so no speed cost.

**`test/e2e-basic-mcp/helpers.sh`**
- Overrides `write_config()` to append `broker-bad-creds` and`broker-dead` after the base body.
- Wrong password is a **literal** (not `${VAR}`) so the credential-leak grep has a concrete string to look for.

**READMEs**
- `test/e2e-basic-mcp/README.md`: Scenario 3 paragraph, layout entry, four-alias note.
- `test/e2e-common/README.md`: documents the `_lib_write_config` / `write_config` split and the suite-override pattern.

## Testing

**Test Environment:**
- Go version: per `go.mod`
- OS: Linux (Fedora)
- Broker: PubSub+ dockerized via `test/e2e-basic-mcp/docker-compose.yml`

**Tests Performed:**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] E2E tests added/updated
- [x] `go test -race ./...` (sanity only — no Go changes)
- [x] Tested with real Solace broker (dockerized)

**Test Coverage:**
- All three negative-path scenarios pass in `test/e2e-basic-mcp/run-all.sh`.
- `e2e-basic-mcp` override emits all four aliases in the correct order.
- `bash -n` clean on all modified scripts.

## Breaking Changes

None.
- `write_config()` remains the public entry point.
- Suites that don't override it get the same base config, now with a tighter test-appropriate retry budget.

## Checklist

### Code Quality
- [x] Code follows coding standards
- [x] Self-review completed
- [x] Comments explain "why", not "what"
- [x] Complex logic commented (retry budget, override pattern,  literal-password rationale, absent-status rationale)
- [x] No commented-out code or debug statements

### Security
- [x] No credentials in code — the literal `wrong-password-for-e2e-negative-path` is a deliberately-invalid test string used to detect leaks
- [x] Followed secure-logging rules
- [x] `slog.LogValuer` unchanged (no Go changes)
- [x] No new vulnerabilities — this PR is itself a defense-in-depth check

### Testing
- [x] All tests pass locally
- [x] No race conditions (no Go changes)
- [x] Edge cases: three distinct failure modes, each with distinct envelope
- [x] Error paths tested — entirely about error paths
- [x] Test names describe what is tested

### Documentation
- [x] README.md updated (basic-mcp + e2e-common)
- [ ] docs/ — N/A
- [ ] godoc — N/A (no Go changes)
- [ ] CHANGELOG.md — N/A
- [ ] Examples — N/A

### Git & CI
- [ ] All commits signed off (DCO: `git commit -s`)
- [ ] Clear commit messages
- [ ] Rebased on main
- [ ] No merge conflicts
- [ ] CI passing — the `e2e-basic-mcp` job exercises the new scenario

## Additional Notes

**Two plan corrections found during implementation:**
- Plan referenced `get-vpn-health`; actual tool is `get-vpn-status`
  (verified against `internal/composite/definitions/tools.yaml` and
  `internal/tools/sempv1/`).
- Plan assumed HTTP 404 for nonexistent-queue; SEMPv2 returns HTTP 400 +
  `sempCode: 6`. Both are now asserted.

**Retry budget** is a broader improvement (production defaults are wrong
for tests) but was motivated by this PR — the dead-broker case would
otherwise hang for several minutes.