### PR TITLE
SOL-151978: Enforce tool authorization at request time via a wrapper composed inside withRecovery

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -470,29 +470,17 @@ func newTokenExchanger(oauthCfg *config.BrokerOAuthConfig) (*tokenexchange.Excha
 	return exchanger, nil
 }
 
-// buildToolPolicy is the single, testable decision point for whether the
-// server should run with tool authorization and, if so, which compiled
-// Policy to use. Extracted from main so the invariant "gate enabled ⟺
-// returned policy is non-nil" is a postcondition of a named function
-// rather than a convention scattered across startup wiring — same
-// technique used for buildRootHandler and buildMCPEndpoint so the
-// assembled shape is asserted against real code rather than a hand-
-// rebuilt copy.
+// buildToolPolicy is the single, tested decision point for whether the server
+// runs with tool authorization and which compiled Policy to use. Extracted so
+// the invariant "gate enabled ⟺ returned policy is non-nil" is a
+// postcondition of a named function rather than folklore scattered across
+// startup.
 //
-// Return contract:
-//
-//   - Gate off (config.ToolAuthorizationEnabled(cfg) == false): returns
-//     (nil, nil). RegisterWithServer receives nil and skips the wrapper.
-//   - Gate on, NewPolicy succeeds: returns (policy, nil). RegisterWithServer
-//     composes withAuthorization on every registered tool.
-//   - Gate on, NewPolicy fails: returns (nil, err). Caller must fail
-//     startup — a partial RBAC state must never reach the request path.
-//
-// A non-nil policy is never returned when the gate is off. main's
-// fail-closed guard immediately after this call asserts the mirror
-// invariant (gate on ⟹ policy non-nil) so any future refactor that
-// breaks this function's contract aborts startup rather than silently
-// bypasses authorization on every OAuth request.
+// Returns (nil, nil) when the gate is off, (policy, nil) on success,
+// (nil, err) on compilation failure — callers must fail startup on the last.
+// Main's fail-closed guard immediately after this call asserts the mirror
+// direction so any future refactor that breaks the postcondition aborts
+// startup rather than silently bypassing authorization.
 func buildToolPolicy(cfg *config.ServerConfig) (*authz.Policy, error) {
 	if !config.ToolAuthorizationEnabled(cfg) {
 		return nil, nil
@@ -685,14 +673,10 @@ func main() {
 	registerMixedTools(mgr)
 
 	// Compile the tool-authorization policy. buildToolPolicy owns the
-	// gate-and-compile decision so the "enabled ⟺ policy non-nil"
-	// invariant is a named, tested postcondition of one function rather
-	// than a convention scattered across main. RegisterWithServer still
-	// receives a *authz.Policy that is nil iff RBAC is off; the fail-
-	// closed check below guards against a future refactor breaking the
-	// invariant (e.g. gate flipped on but constructor accidentally
-	// skipped) — silent fail-open on a security switch is exactly the
-	// SOL-149989 failure class this feature exists to prevent.
+	// gate-and-compile decision so the "enabled ⟺ policy non-nil" invariant
+	// is a tested postcondition of one function. The guard below defends
+	// against a future refactor breaking that postcondition — silent
+	// fail-open on a security switch is the SOL-149989 failure class.
 	policy, err := buildToolPolicy(cfg)
 	if err != nil {
 		slog.Error("tool authorization startup failed", slog.String("error", err.Error()))
@@ -707,23 +691,15 @@ func main() {
 	slog.Info("tool registration complete",
 		slog.Bool("enable_write_tools", cfg.EnableWriteTools))
 
-	// list-brokers is a discovery tool registered directly on the MCP
-	// server (it doesn't need broker resolution or the ToolManager pipeline).
-	// It also does not compose withAuthorization — the exemption is
-	// structural: RegisterListBrokers takes no policy argument and every
-	// authenticated caller keeps discovery regardless of the RBAC state.
+	// list-brokers is registered directly (no broker resolution needed) and
+	// takes no policy — the RBAC exemption is expressed structurally at this
+	// API surface.
 	tools.RegisterListBrokers(server, pool)
 
-	// Validate every configured tool name against the full registered
-	// handler set + list-brokers, now that both registrations have
-	// populated it. A typo in the admin's YAML would silently fail to
-	// grant what the admin thinks — an admin intending to grant
-	// delete-queue-messages who writes delete-que-messages would see
-	// the grant simply not take effect at request time, with no signal
-	// anywhere that the config is wrong. Catching that at startup is
-	// fatal by design: refuse to accept any request under a config
-	// whose grants do not mean what the admin thinks they mean.
-	// Skipped when RBAC is off.
+	// Validate every configured tool name now that both registrations have
+	// populated mgr. An admin typo would silently produce a grant that never
+	// takes effect at request time; catching it at startup is fatal by
+	// design. Skipped when RBAC is off.
 	if policy != nil {
 		if err := tools.ValidatePolicyToolNames(*cfg.MCPClientAuth.ToolAuthorization, mgr); err != nil {
 			slog.Error("tool authorization startup failed", slog.String("error", err.Error()))
@@ -732,13 +708,10 @@ func main() {
 		slog.Info("tool authorization is enabled",
 			slog.Any("policy", policy))
 	} else {
-		// Symmetric announcement: name the reason so a restart's startup
-		// log unambiguously records the RBAC posture. The config
-		// validator rejects a tool_authorization block outside oauth
-		// mode and rejects an oauth-mode block that omits the enabled
-		// key, so at this point exactly two disabled-paths are
-		// possible: auth mode is not oauth (block absent by contract),
-		// or auth mode is oauth and enabled is explicitly false.
+		// Announce the RBAC posture with the reason so startup logs are
+		// unambiguous. Config validator rejects a block outside oauth mode
+		// and requires enabled to be set in oauth mode, so exactly two
+		// disabled paths remain: non-oauth mode, or oauth with enabled:false.
 		if cfg.MCPClientAuth.Mode == config.AuthModeOAuth {
 			slog.Info("tool authorization is disabled (enabled=false in config)")
 		} else {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -470,6 +470,36 @@ func newTokenExchanger(oauthCfg *config.BrokerOAuthConfig) (*tokenexchange.Excha
 	return exchanger, nil
 }
 
+// buildToolPolicy is the single, testable decision point for whether the
+// server should run with tool authorization and, if so, which compiled
+// Policy to use. Extracted from main so the invariant "gate enabled ⟺
+// returned policy is non-nil" is a postcondition of a named function
+// rather than a convention scattered across startup wiring — same
+// technique used for buildRootHandler and buildMCPEndpoint so the
+// assembled shape is asserted against real code rather than a hand-
+// rebuilt copy.
+//
+// Return contract:
+//
+//   - Gate off (config.ToolAuthorizationEnabled(cfg) == false): returns
+//     (nil, nil). RegisterWithServer receives nil and skips the wrapper.
+//   - Gate on, NewPolicy succeeds: returns (policy, nil). RegisterWithServer
+//     composes withAuthorization on every registered tool.
+//   - Gate on, NewPolicy fails: returns (nil, err). Caller must fail
+//     startup — a partial RBAC state must never reach the request path.
+//
+// A non-nil policy is never returned when the gate is off. main's
+// fail-closed guard immediately after this call asserts the mirror
+// invariant (gate on ⟹ policy non-nil) so any future refactor that
+// breaks this function's contract aborts startup rather than silently
+// bypasses authorization on every OAuth request.
+func buildToolPolicy(cfg *config.ServerConfig) (*authz.Policy, error) {
+	if !config.ToolAuthorizationEnabled(cfg) {
+		return nil, nil
+	}
+	return authz.NewPolicy(*cfg.MCPClientAuth.ToolAuthorization)
+}
+
 func main() {
 	if len(os.Args) == 2 && (os.Args[1] == "-version" || os.Args[1] == "--version") {
 		fmt.Println(version.Version())
@@ -654,18 +684,23 @@ func main() {
 	registerSEMPv1Tools(mgr)
 	registerMixedTools(mgr)
 
-	// Compile the tool-authorization policy when the composition-time gate
-	// says RBAC is on. NewPolicy runs BEFORE RegisterWithServer because the
-	// wrapper it composes needs the compiled *Policy. When the gate is off,
-	// policy stays nil and RegisterWithServer skips the wrapper — dispatch
-	// is byte-identical to the pre-RBAC path.
-	var policy *authz.Policy
-	if config.ToolAuthorizationEnabled(cfg) {
-		policy, err = authz.NewPolicy(*cfg.MCPClientAuth.ToolAuthorization)
-		if err != nil {
-			slog.Error("tool authorization startup failed", slog.String("error", err.Error()))
-			os.Exit(1)
-		}
+	// Compile the tool-authorization policy. buildToolPolicy owns the
+	// gate-and-compile decision so the "enabled ⟺ policy non-nil"
+	// invariant is a named, tested postcondition of one function rather
+	// than a convention scattered across main. RegisterWithServer still
+	// receives a *authz.Policy that is nil iff RBAC is off; the fail-
+	// closed check below guards against a future refactor breaking the
+	// invariant (e.g. gate flipped on but constructor accidentally
+	// skipped) — silent fail-open on a security switch is exactly the
+	// SOL-149989 failure class this feature exists to prevent.
+	policy, err := buildToolPolicy(cfg)
+	if err != nil {
+		slog.Error("tool authorization startup failed", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if config.ToolAuthorizationEnabled(cfg) && policy == nil {
+		slog.Error("tool authorization is enabled in config but no policy was compiled — refusing to start rather than silently bypass authorization")
+		os.Exit(1)
 	}
 
 	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools, policy)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -717,8 +717,13 @@ func main() {
 	// Validate every configured tool name against the full registered
 	// handler set + list-brokers, now that both registrations have
 	// populated it. A typo in the admin's YAML would silently fail to
-	// grant what the admin thinks; catching it at startup is fatal by
-	// design (spec goal 7). Skipped when RBAC is off.
+	// grant what the admin thinks — an admin intending to grant
+	// delete-queue-messages who writes delete-que-messages would see
+	// the grant simply not take effect at request time, with no signal
+	// anywhere that the config is wrong. Catching that at startup is
+	// fatal by design: refuse to accept any request under a config
+	// whose grants do not mean what the admin thinks they mean.
+	// Skipped when RBAC is off.
 	if policy != nil {
 		if err := tools.ValidatePolicyToolNames(*cfg.MCPClientAuth.ToolAuthorization, mgr); err != nil {
 			slog.Error("tool authorization startup failed", slog.String("error", err.Error()))
@@ -728,10 +733,12 @@ func main() {
 			slog.Any("policy", policy))
 	} else {
 		// Symmetric announcement: name the reason so a restart's startup
-		// log unambiguously records the RBAC posture. When the auth mode
-		// is not oauth the block cannot be present (config validator I1);
-		// when the mode is oauth the block must set enabled explicitly
-		// (I3), so the only remaining false path is enabled: false.
+		// log unambiguously records the RBAC posture. The config
+		// validator rejects a tool_authorization block outside oauth
+		// mode and rejects an oauth-mode block that omits the enabled
+		// key, so at this point exactly two disabled-paths are
+		// possible: auth mode is not oauth (block absent by contract),
+		// or auth mode is oauth and enabled is explicitly false.
 		if cfg.MCPClientAuth.Mode == config.AuthModeOAuth {
 			slog.Info("tool authorization is disabled (enabled=false in config)")
 		} else {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/auth"
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
 	"github.com/SolaceDev/solace-broker-mcp/internal/banner"
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite"
 	"github.com/SolaceDev/solace-broker-mcp/internal/composite/definitions"
@@ -652,13 +653,57 @@ func main() {
 	mgr := tools.NewToolManagerFromComposite(pool, compositeTools, executor)
 	registerSEMPv1Tools(mgr)
 	registerMixedTools(mgr)
-	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools)
+
+	// Compile the tool-authorization policy when the composition-time gate
+	// says RBAC is on. NewPolicy runs BEFORE RegisterWithServer because the
+	// wrapper it composes needs the compiled *Policy. When the gate is off,
+	// policy stays nil and RegisterWithServer skips the wrapper — dispatch
+	// is byte-identical to the pre-RBAC path.
+	var policy *authz.Policy
+	if config.ToolAuthorizationEnabled(cfg) {
+		policy, err = authz.NewPolicy(*cfg.MCPClientAuth.ToolAuthorization)
+		if err != nil {
+			slog.Error("tool authorization startup failed", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+	}
+
+	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools, policy)
 	slog.Info("tool registration complete",
 		slog.Bool("enable_write_tools", cfg.EnableWriteTools))
 
 	// list-brokers is a discovery tool registered directly on the MCP
 	// server (it doesn't need broker resolution or the ToolManager pipeline).
+	// It also does not compose withAuthorization — the exemption is
+	// structural: RegisterListBrokers takes no policy argument and every
+	// authenticated caller keeps discovery regardless of the RBAC state.
 	tools.RegisterListBrokers(server, pool)
+
+	// Validate every configured tool name against the full registered
+	// handler set + list-brokers, now that both registrations have
+	// populated it. A typo in the admin's YAML would silently fail to
+	// grant what the admin thinks; catching it at startup is fatal by
+	// design (spec goal 7). Skipped when RBAC is off.
+	if policy != nil {
+		if err := tools.ValidatePolicyToolNames(*cfg.MCPClientAuth.ToolAuthorization, mgr); err != nil {
+			slog.Error("tool authorization startup failed", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+		slog.Info("tool authorization is enabled",
+			slog.Any("policy", policy))
+	} else {
+		// Symmetric announcement: name the reason so a restart's startup
+		// log unambiguously records the RBAC posture. When the auth mode
+		// is not oauth the block cannot be present (config validator I1);
+		// when the mode is oauth the block must set enabled explicitly
+		// (I3), so the only remaining false path is enabled: false.
+		if cfg.MCPClientAuth.Mode == config.AuthModeOAuth {
+			slog.Info("tool authorization is disabled (enabled=false in config)")
+		} else {
+			slog.Info("tool authorization is disabled",
+				slog.String("auth_mode", cfg.MCPClientAuth.Mode))
+		}
+	}
 
 	slog.Info("all tools registered")
 

--- a/cmd/server/tool_policy_test.go
+++ b/cmd/server/tool_policy_test.go
@@ -20,20 +20,11 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 )
 
-// These tests pin the buildToolPolicy postcondition that main relies on:
-// tool authorization enabled ⟺ returned *authz.Policy is non-nil. That
-// biconditional is what lets RegisterWithServer treat nil-policy as
-// "skip the wrapper" without ambiguity — the invariant is a property of
-// this function, not folklore scattered across the composition site.
-// The mirror direction (gate on ⟹ policy non-nil) is asserted by main
-// itself via a fail-closed guard immediately after the call; if a future
-// refactor accidentally makes buildToolPolicy return (nil, nil) on the
-// gate-on branch, this test suite fails first, and if this suite is
-// bypassed the guard aborts startup before the server accepts requests.
+// These tests pin buildToolPolicy's postcondition: gate enabled ⟺ returned
+// *authz.Policy is non-nil. Main's fail-closed guard asserts the mirror
+// direction; a break here fails these tests first.
 
-// makeEnabledConfig returns a minimal ServerConfig whose gate resolves
-// to true. Uses the smallest set of fields both ToolAuthorizationEnabled
-// and NewPolicy actually read.
+// makeEnabledConfig returns a minimal ServerConfig whose gate resolves to true.
 func makeEnabledConfig() *config.ServerConfig {
 	enabled := true
 	return &config.ServerConfig{
@@ -49,13 +40,9 @@ func makeEnabledConfig() *config.ServerConfig {
 	}
 }
 
-// TestBuildToolPolicy_GateOff_ReturnsNilNil pins the disabled-deployment
-// side of the biconditional: when the feature flag is absent, the gate
-// short-circuits to false regardless of config shape, and buildToolPolicy
-// must return (nil, nil). That nil is the signal RegisterWithServer keys
-// off to skip the authorization wrapper.
+// Gate off (feature flag unset) → (nil, nil) regardless of config contents.
 func TestBuildToolPolicy_GateOff_ReturnsNilNil(t *testing.T) {
-	// Feature flag not set: gate is off even with a fully-populated block.
+	// Feature flag unset: gate is off even with a populated RBAC block.
 	t.Setenv("ENABLE_TOOL_AUTHORIZATION", "")
 	cfg := makeEnabledConfig()
 
@@ -68,11 +55,7 @@ func TestBuildToolPolicy_GateOff_ReturnsNilNil(t *testing.T) {
 	}
 }
 
-// TestBuildToolPolicy_GateOn_ReturnsNonNilPolicy pins the enabled-
-// deployment side: with the feature flag set and a valid RBAC block,
-// the gate is true and NewPolicy succeeds — buildToolPolicy returns a
-// non-nil compiled Policy and no error. This is the postcondition
-// RegisterWithServer relies on to compose the authorization wrapper.
+// Gate on + valid block → non-nil Policy, no error.
 func TestBuildToolPolicy_GateOn_ReturnsNonNilPolicy(t *testing.T) {
 	t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
 	cfg := makeEnabledConfig()
@@ -86,10 +69,8 @@ func TestBuildToolPolicy_GateOn_ReturnsNonNilPolicy(t *testing.T) {
 	}
 }
 
-// TestBuildToolPolicy_NonOAuthMode_GateFalse pins that the gate stays
-// off in non-OAuth deployments even when the feature flag is set —
-// tool authorization only runs when identity is available in tokens.
-// buildToolPolicy therefore returns (nil, nil), matching the gate.
+// Non-OAuth mode with flag set → gate off, (nil, nil). Tool authorization
+// only runs when identity is available in tokens.
 func TestBuildToolPolicy_NonOAuthMode_GateFalse(t *testing.T) {
 	t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
 	cfg := makeEnabledConfig()

--- a/cmd/server/tool_policy_test.go
+++ b/cmd/server/tool_policy_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+)
+
+// These tests pin the buildToolPolicy postcondition that main relies on:
+// tool authorization enabled ⟺ returned *authz.Policy is non-nil. That
+// biconditional is what lets RegisterWithServer treat nil-policy as
+// "skip the wrapper" without ambiguity — the invariant is a property of
+// this function, not folklore scattered across the composition site.
+// The mirror direction (gate on ⟹ policy non-nil) is asserted by main
+// itself via a fail-closed guard immediately after the call; if a future
+// refactor accidentally makes buildToolPolicy return (nil, nil) on the
+// gate-on branch, this test suite fails first, and if this suite is
+// bypassed the guard aborts startup before the server accepts requests.
+
+// makeEnabledConfig returns a minimal ServerConfig whose gate resolves
+// to true. Uses the smallest set of fields both ToolAuthorizationEnabled
+// and NewPolicy actually read.
+func makeEnabledConfig() *config.ServerConfig {
+	enabled := true
+	return &config.ServerConfig{
+		MCPClientAuth: config.MCPClientAuthConfig{
+			Mode: config.AuthModeOAuth,
+			ToolAuthorization: &config.ToolAuthorizationConfig{
+				Enabled: &enabled,
+				AccessLevelGroups: map[string][]string{
+					"Ops": {"get-broker-status"},
+				},
+			},
+		},
+	}
+}
+
+// TestBuildToolPolicy_GateOff_ReturnsNilNil pins the disabled-deployment
+// side of the biconditional: when the feature flag is absent, the gate
+// short-circuits to false regardless of config shape, and buildToolPolicy
+// must return (nil, nil). That nil is the signal RegisterWithServer keys
+// off to skip the authorization wrapper.
+func TestBuildToolPolicy_GateOff_ReturnsNilNil(t *testing.T) {
+	// Feature flag not set: gate is off even with a fully-populated block.
+	t.Setenv("ENABLE_TOOL_AUTHORIZATION", "")
+	cfg := makeEnabledConfig()
+
+	policy, err := buildToolPolicy(cfg)
+	if err != nil {
+		t.Fatalf("buildToolPolicy on disabled gate: unexpected error: %v", err)
+	}
+	if policy != nil {
+		t.Fatalf("buildToolPolicy on disabled gate: got non-nil policy, want nil")
+	}
+}
+
+// TestBuildToolPolicy_GateOn_ReturnsNonNilPolicy pins the enabled-
+// deployment side: with the feature flag set and a valid RBAC block,
+// the gate is true and NewPolicy succeeds — buildToolPolicy returns a
+// non-nil compiled Policy and no error. This is the postcondition
+// RegisterWithServer relies on to compose the authorization wrapper.
+func TestBuildToolPolicy_GateOn_ReturnsNonNilPolicy(t *testing.T) {
+	t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
+	cfg := makeEnabledConfig()
+
+	policy, err := buildToolPolicy(cfg)
+	if err != nil {
+		t.Fatalf("buildToolPolicy on enabled gate: unexpected error: %v", err)
+	}
+	if policy == nil {
+		t.Fatalf("buildToolPolicy on enabled gate: got nil policy, want non-nil")
+	}
+}
+
+// TestBuildToolPolicy_NonOAuthMode_GateFalse pins that the gate stays
+// off in non-OAuth deployments even when the feature flag is set —
+// tool authorization only runs when identity is available in tokens.
+// buildToolPolicy therefore returns (nil, nil), matching the gate.
+func TestBuildToolPolicy_NonOAuthMode_GateFalse(t *testing.T) {
+	t.Setenv("ENABLE_TOOL_AUTHORIZATION", "true")
+	cfg := makeEnabledConfig()
+	cfg.MCPClientAuth.Mode = config.AuthModeStatic
+
+	policy, err := buildToolPolicy(cfg)
+	if err != nil {
+		t.Fatalf("buildToolPolicy in non-OAuth mode: unexpected error: %v", err)
+	}
+	if policy != nil {
+		t.Fatalf("buildToolPolicy in non-OAuth mode: got non-nil policy, want nil")
+	}
+}

--- a/internal/tools/authorization.go
+++ b/internal/tools/authorization.go
@@ -28,61 +28,37 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// authzDeniedMessage is the caller-facing text returned when the compiled
-// policy denies a tool invocation. Uniform, minimum-information — no tool
-// name, no group names, no reason code — so an unauthorized caller learns
-// nothing about the policy shape. Full diagnostic detail lives in the
-// server-side authorization-decision log, joined to this response by the
-// correlation ID that flows through the outer withRecovery wrapper.
-const authzDeniedMessage = "You are not authorized to use this tool."
+// Caller-facing messages. Deliberately identical in v1 so a caller cannot
+// distinguish "your groups don't grant this" from "your token has no groups
+// claim" — that distinction is admin-configuration metadata. Kept as separate
+// identifiers so a future evolution can amend one without touching the other;
+// the audit log distinguishes the outcomes via the decision field.
+const (
+	authzDeniedMessage       = "You are not authorized to use this tool."
+	authzMissingClaimMessage = "You are not authorized to use this tool."
+)
 
-// authzMissingClaimMessage is the caller-facing text returned when the
-// caller's token does not carry the configured groups claim. Value is
-// intentionally identical to authzDeniedMessage: the caller cannot fix
-// either case themselves and any distinguishing detail (which claim was
-// expected, whether the token was structurally deficient vs merely
-// unprivileged) is admin-configuration metadata that must not reach an
-// unauthenticated-authorization caller. The two constants stay separate
-// identifiers so a future evolution can amend one without touching the
-// other; the audit log distinguishes the outcomes structurally.
-const authzMissingClaimMessage = "You are not authorized to use this tool."
-
-// listBrokersToolName names the discovery tool that is structurally
-// exempt from tool authorization. The exemption is expressed at the
-// registration API (RegisterListBrokers takes no policy argument);
-// this file uses the constant in ValidatePolicyToolNames' two
-// exempt-name branches and in its exempt-tool WARN attribute so a
-// contributor can grep for one identifier to find every exemption
-// touchpoint at once.
+// listBrokersToolName is the discovery tool that is structurally exempt from
+// tool authorization. Exemption lives at the registration API
+// (RegisterListBrokers takes no policy argument), not here — this constant
+// exists so a grep finds every exempt-name touchpoint at once.
 const listBrokersToolName = "list-brokers"
 
 // withAuthorization gates every invocation of toolName through policy.
+// On allow, dispatches to next unchanged. On deny or missing-claim, returns a
+// tool-level error result and skips next.
 //
-// On allow: emits an INFO-level "tool authorization" audit event, then
-// dispatches to next unchanged. The wrapper does not mutate ctx or req;
-// dispatch is byte-identical to the pre-RBAC path after the audit line.
+// Precondition: policy must be non-nil. The composition site
+// (RegisterWithServer) guarantees this by only composing the wrapper on the
+// non-nil-policy branch. A nil policy reaching here is a programmer error
+// that must not silently bypass authorization; the outer withRecovery catches
+// the resulting panic.
 //
-// On deny or missing-claim: emits the audit event, then returns a
-// tool-level error result (IsError: true, retryable: false) carrying the
-// uniform authzDeniedMessage / authzMissingClaimMessage. The result mirrors
-// withRecovery's panic branch shape so reviewers see one denial shape
-// across authorization, panic recovery, and validation errors.
+// Panic containment (from Authorize or the audit call site) is owned by the
+// outer withRecovery, so this closure reads as straight-line request logic.
 //
-// Nil policy is a precondition violation: the composition site
-// (RegisterWithServer) guarantees this wrapper is only composed when
-// policy is non-nil. A nil policy reaching this call is a programmer
-// error, not a runtime condition — the wrapper panics, the outer
-// withRecovery catches it, and the request fails visibly rather than
-// silently bypassing authorization.
-//
-// Panics from authz.Authorize or the audit call site are not recovered
-// here — the outer withRecovery wrapper owns panic containment, so this
-// wrapper reads as straight-line request logic.
-//
-// The audit event emitted here is a v1 placeholder: INFO level for every
-// outcome, minimal field set (identity, tool, decision string). A
-// follow-up ticket refines the level split, adds the bounded matched-
-// groups slice, and finalizes the audit field schema.
+// The audit event is a v1 placeholder — INFO for every outcome, minimal
+// fields. A follow-up ticket refines the level split and field schema.
 func withAuthorization(policy *authz.Policy, toolName string, next mcp.ToolHandler) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		var info *sdkauth.TokenInfo
@@ -117,10 +93,9 @@ func withAuthorization(policy *authz.Policy, toolName string, next mcp.ToolHandl
 	}
 }
 
-// authzErrorResult builds the tool-level error result returned on deny
-// and missing-claim branches. Shape mirrors withRecovery's panic branch:
-// IsError true, StructuredContent with the uniform message and
-// retryable=false, plus a TextContent copy of the message.
+// authzErrorResult builds the deny / missing-claim tool-level error result.
+// Shape mirrors withRecovery's panic branch so callers see one denial shape
+// across authorization, panic recovery, and validation errors.
 func authzErrorResult(message string) *mcp.CallToolResult {
 	return &mcp.CallToolResult{
 		StructuredContent: map[string]any{
@@ -132,27 +107,14 @@ func authzErrorResult(message string) *mcp.CallToolResult {
 	}
 }
 
-// ValidatePolicyToolNames verifies every tool name the admin wrote in
-// cfg.AccessLevelGroups resolves to a registered handler on mgr, or to
-// the structurally exempt "list-brokers" tool. Called from cmd/server/main.go
-// after RegisterWithServer and RegisterListBrokers return, before
-// server.Run — the union of mgr.Handlers() and "list-brokers" must be
-// fully populated by then.
+// ValidatePolicyToolNames checks every tool name in cfg.AccessLevelGroups
+// against the union of mgr.Handlers() and list-brokers. Call after both
+// registrations have populated mgr.
 //
-// Unknown tool names are collected across every group and returned as
-// one error per unknown tool, alphabetized, joined via errors.Join.
-// Format: `unknown tool "<name>" (referenced by groups: <g1>, <g2>, ...)`.
-// Deduplication is on the tool name (one bug, one report), but each row
-// carries the alphabetized list of every group that referenced it so the
-// admin's YAML edit is a self-contained fix task.
-//
-// Grants of "list-brokers" are known-tool grants (the union accepts the
-// literal), but the tool is structurally exempt from tool authorization —
-// the grant has no effect. Each such grant is reported via slog.Warn with
-// the referencing group list; they do not surface as errors and do not
-// block startup.
-//
-// Returns nil when every configured tool name resolves.
+// Returns one error row per unknown tool (deduped on the tool name so one
+// typo is one report), alphabetized by tool then by referencing group, joined
+// via errors.Join. Grants of list-brokers are inert — emitted as a WARN, not
+// an error — because the tool is exempt from authorization.
 func ValidatePolicyToolNames(cfg config.ToolAuthorizationConfig, mgr *ToolManager) error {
 	known := make(map[string]struct{})
 	for _, h := range mgr.Handlers() {
@@ -210,8 +172,7 @@ func ValidatePolicyToolNames(cfg config.ToolAuthorizationConfig, mgr *ToolManage
 	return errors.Join(rowErrs...)
 }
 
-// sortedKeys returns the keys of set in alphabetical order. Small helper
-// used by ValidatePolicyToolNames to produce deterministic error rows.
+// sortedKeys returns the keys of set in alphabetical order.
 func sortedKeys(set map[string]struct{}) []string {
 	out := make([]string, 0, len(set))
 	for k := range set {

--- a/internal/tools/authorization.go
+++ b/internal/tools/authorization.go
@@ -1,0 +1,218 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// authzDeniedMessage is the caller-facing text returned when the compiled
+// policy denies a tool invocation. Uniform, minimum-information — no tool
+// name, no group names, no reason code — so an unauthorized caller learns
+// nothing about the policy shape. Full diagnostic detail lives in the
+// server-side authorization-decision log, joined to this response by the
+// correlation ID that flows through the outer withRecovery wrapper.
+const authzDeniedMessage = "You are not authorized to use this tool."
+
+// authzMissingClaimMessage is the caller-facing text returned when the
+// caller's token does not carry the configured groups claim. Value is
+// intentionally identical to authzDeniedMessage: the caller cannot fix
+// either case themselves and any distinguishing detail (which claim was
+// expected, whether the token was structurally deficient vs merely
+// unprivileged) is admin-configuration metadata that must not reach an
+// unauthenticated-authorization caller. The two constants stay separate
+// identifiers so a future evolution can amend one without touching the
+// other; the audit log distinguishes the outcomes structurally.
+const authzMissingClaimMessage = "You are not authorized to use this tool."
+
+// listBrokersToolName is the exempt discovery tool. Named here (rather
+// than hardcoding the literal at ValidatePolicyToolNames' use site) so
+// the exemption is visible to a grep for the constant.
+const listBrokersToolName = "list-brokers"
+
+// withAuthorization gates every invocation of toolName through policy.
+//
+// On allow: emits an INFO-level "tool authorization" audit event, then
+// dispatches to next unchanged. The wrapper does not mutate ctx or req;
+// dispatch is byte-identical to the pre-RBAC path after the audit line.
+//
+// On deny or missing-claim: emits the audit event, then returns a
+// tool-level error result (IsError: true, retryable: false) carrying the
+// uniform authzDeniedMessage / authzMissingClaimMessage. The result mirrors
+// withRecovery's panic branch shape so reviewers see one denial shape
+// across authorization, panic recovery, and validation errors.
+//
+// Nil policy is a precondition violation: the composition site
+// (RegisterWithServer) guarantees this wrapper is only composed when
+// policy is non-nil. A nil policy reaching this call is a programmer
+// error, not a runtime condition — the wrapper panics, the outer
+// withRecovery catches it, and the request fails visibly rather than
+// silently bypassing authorization.
+//
+// Panics from authz.Authorize or the audit call site are not recovered
+// here — the outer withRecovery wrapper owns panic containment, so this
+// wrapper reads as straight-line request logic.
+//
+// The audit event emitted here is a v1 placeholder: INFO level for every
+// outcome, minimal field set (identity, tool, decision string). A
+// follow-up ticket refines the level split, adds the bounded matched-
+// groups slice, and finalizes the audit field schema.
+func withAuthorization(policy *authz.Policy, toolName string, next mcp.ToolHandler) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var info *sdkauth.TokenInfo
+		if req.Extra != nil {
+			info = req.Extra.TokenInfo
+		}
+		id := NewIdentityFromTokenInfo(info)
+
+		groups, present := requestGroups(req)
+		if !present {
+			slog.LogAttrs(ctx, slog.LevelInfo, "tool authorization",
+				slog.String("tool", toolName),
+				slog.String("decision", "denied_missing_claim"),
+				slog.Any("", id))
+			return authzErrorResult(authzMissingClaimMessage), nil
+		}
+
+		decision := policy.Authorize(groups, toolName)
+		if !decision.Allowed {
+			slog.LogAttrs(ctx, slog.LevelInfo, "tool authorization",
+				slog.String("tool", toolName),
+				slog.String("decision", "denied"),
+				slog.Any("", id))
+			return authzErrorResult(authzDeniedMessage), nil
+		}
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "tool authorization",
+			slog.String("tool", toolName),
+			slog.String("decision", "allowed"),
+			slog.Any("", id))
+		return next(ctx, req)
+	}
+}
+
+// authzErrorResult builds the tool-level error result returned on deny
+// and missing-claim branches. Shape mirrors withRecovery's panic branch:
+// IsError true, StructuredContent with the uniform message and
+// retryable=false, plus a TextContent copy of the message.
+func authzErrorResult(message string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		StructuredContent: map[string]any{
+			"error":     message,
+			"retryable": false,
+		},
+		Content: []mcp.Content{&mcp.TextContent{Text: message}},
+		IsError: true,
+	}
+}
+
+// ValidatePolicyToolNames verifies every tool name the admin wrote in
+// cfg.AccessLevelGroups resolves to a registered handler on mgr, or to
+// the structurally exempt "list-brokers" tool. Called from cmd/server/main.go
+// after RegisterWithServer and RegisterListBrokers return, before
+// server.Run — the union of mgr.Handlers() and "list-brokers" must be
+// fully populated by then.
+//
+// Unknown tool names are collected across every group and returned as
+// one error per unknown tool, alphabetized, joined via errors.Join.
+// Format: `unknown tool "<name>" (referenced by groups: <g1>, <g2>, ...)`.
+// Deduplication is on the tool name (one bug, one report), but each row
+// carries the alphabetized list of every group that referenced it so the
+// admin's YAML edit is a self-contained fix task.
+//
+// Grants of "list-brokers" are known-tool grants (the union accepts the
+// literal), but the tool is structurally exempt from tool authorization —
+// the grant has no effect. Each such grant is reported via slog.Warn with
+// the referencing group list; they do not surface as errors and do not
+// block startup.
+//
+// Returns nil when every configured tool name resolves.
+func ValidatePolicyToolNames(cfg config.ToolAuthorizationConfig, mgr *ToolManager) error {
+	known := make(map[string]struct{})
+	for _, h := range mgr.Handlers() {
+		known[h.Metadata().Name] = struct{}{}
+	}
+	known[listBrokersToolName] = struct{}{}
+
+	unknownToGroups := make(map[string]map[string]struct{})
+	exemptToGroups := make(map[string]struct{})
+
+	for groupName, tools := range cfg.AccessLevelGroups {
+		for _, tool := range tools {
+			if tool == listBrokersToolName {
+				exemptToGroups[groupName] = struct{}{}
+				continue
+			}
+			if _, ok := known[tool]; ok {
+				continue
+			}
+			groupsForTool, ok := unknownToGroups[tool]
+			if !ok {
+				groupsForTool = make(map[string]struct{})
+				unknownToGroups[tool] = groupsForTool
+			}
+			groupsForTool[groupName] = struct{}{}
+		}
+	}
+
+	if len(exemptToGroups) > 0 {
+		sortedExempt := sortedKeys(exemptToGroups)
+		slog.Warn("tool authorization grant has no effect; tool is exempt and always available to authenticated callers",
+			slog.String("exempt_tool", listBrokersToolName),
+			slog.String("referenced_by_groups", strings.Join(sortedExempt, ", ")))
+	}
+
+	if len(unknownToGroups) == 0 {
+		return nil
+	}
+
+	sortedTools := make([]string, 0, len(unknownToGroups))
+	for tool := range unknownToGroups {
+		sortedTools = append(sortedTools, tool)
+	}
+	sort.Strings(sortedTools)
+
+	rowErrs := make([]error, 0, len(sortedTools))
+	for _, tool := range sortedTools {
+		sortedGroups := sortedKeys(unknownToGroups[tool])
+		rowErrs = append(rowErrs, fmt.Errorf(
+			"unknown tool %q (referenced by groups: %s)",
+			tool,
+			strings.Join(sortedGroups, ", "),
+		))
+	}
+	return errors.Join(rowErrs...)
+}
+
+// sortedKeys returns the keys of set in alphabetical order. Small helper
+// used by ValidatePolicyToolNames to produce deterministic error rows.
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/tools/authorization.go
+++ b/internal/tools/authorization.go
@@ -47,9 +47,13 @@ const authzDeniedMessage = "You are not authorized to use this tool."
 // other; the audit log distinguishes the outcomes structurally.
 const authzMissingClaimMessage = "You are not authorized to use this tool."
 
-// listBrokersToolName is the exempt discovery tool. Named here (rather
-// than hardcoding the literal at ValidatePolicyToolNames' use site) so
-// the exemption is visible to a grep for the constant.
+// listBrokersToolName names the discovery tool that is structurally
+// exempt from tool authorization. The exemption is expressed at the
+// registration API (RegisterListBrokers takes no policy argument);
+// this file uses the constant in ValidatePolicyToolNames' two
+// exempt-name branches and in its exempt-tool WARN attribute so a
+// contributor can grep for one identifier to find every exemption
+// touchpoint at once.
 const listBrokersToolName = "list-brokers"
 
 // withAuthorization gates every invocation of toolName through policy.

--- a/internal/tools/authorization_test.go
+++ b/internal/tools/authorization_test.go
@@ -28,16 +28,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// The wrapper tests exercise withAuthorization in isolation — no MCP SDK
-// transport loop, no ToolManager pipeline. Each test drives the wrapper
-// with a hand-built *mcp.CallToolRequest and asserts on the returned
-// *mcp.CallToolResult, whether the stub `next` handler ran, and the
-// slog "tool authorization" audit line the operator sees.
+// These tests exercise withAuthorization in isolation. Each drives a
+// hand-built request and asserts on the returned result, whether the stub
+// `next` ran, and the emitted "tool authorization" slog line.
 
-// captureSlog replaces slog.Default with a JSON handler writing to buf,
-// returning the buffer plus a cleanup func the test defers. The audit
-// line is the operator's window; JSON output lets tests read exact
-// field values without regex-fragility.
+// captureSlog swaps slog.Default for a JSON handler writing to buf.
 func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
 	t.Helper()
 	buf := &bytes.Buffer{}
@@ -46,8 +41,7 @@ func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
 	return buf, func() { slog.SetDefault(prev) }
 }
 
-// authzLogLines returns every JSON log line in buf whose msg is
-// "tool authorization" — the audit surface the wrapper emits.
+// authzLogLines returns every "tool authorization" JSON log line in buf.
 func authzLogLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
 	t.Helper()
 	var out []map[string]any
@@ -66,10 +60,8 @@ func authzLogLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
 	return out
 }
 
-// policyGranting builds a real *authz.Policy that grants each tool in
-// tools to each group in groups. The wrapper's tests use a real Policy
-// (not a mock) so drift between wrapper and Policy surfaces at test
-// time.
+// policyGranting builds a real *authz.Policy granting each tool to each
+// group. Tests use a real Policy so wrapper/policy drift surfaces here.
 func policyGranting(t *testing.T, groups []string, tools ...string) *authz.Policy {
 	t.Helper()
 	access := make(map[string][]string, len(groups))
@@ -85,8 +77,7 @@ func policyGranting(t *testing.T, groups []string, tools ...string) *authz.Polic
 	return p
 }
 
-// emptyPolicy builds a policy with no grants. Every Authorize call
-// returns Allowed=false.
+// emptyPolicy builds a policy with no grants — every Authorize returns deny.
 func emptyPolicy(t *testing.T) *authz.Policy {
 	t.Helper()
 	p, err := authz.NewPolicy(config.ToolAuthorizationConfig{
@@ -98,9 +89,8 @@ func emptyPolicy(t *testing.T) *authz.Policy {
 	return p
 }
 
-// requestWithGroups builds a *mcp.CallToolRequest carrying the given
-// groups under the SDK-sanctioned Extra key. Mirrors what the auth
-// middleware writes on the enabled path.
+// requestWithGroups builds a request carrying groups under the Extra key
+// the middleware writes on the enabled path.
 func requestWithGroups(groups []string) *mcp.CallToolRequest {
 	return &mcp.CallToolRequest{
 		Extra: &mcp.RequestExtra{
@@ -114,9 +104,8 @@ func requestWithGroups(groups []string) *mcp.CallToolRequest {
 	}
 }
 
-// requestMissingGroupsClaim builds a *mcp.CallToolRequest with a
-// TokenInfo but no groups key in Extra — the "IdP omitted the claim"
-// case the middleware surfaces by leaving the key absent.
+// requestMissingGroupsClaim builds a request with TokenInfo but no groups
+// key in Extra — the "IdP omitted the claim" surface.
 func requestMissingGroupsClaim() *mcp.CallToolRequest {
 	return &mcp.CallToolRequest{
 		Extra: &mcp.RequestExtra{
@@ -129,8 +118,7 @@ func requestMissingGroupsClaim() *mcp.CallToolRequest {
 }
 
 // recordingHandler is a stub `next` handler that records every call and
-// returns a fixed sentinel result. Tests use its counter to assert
-// whether the wrapper dispatched or short-circuited.
+// returns a fixed sentinel result.
 type recordingHandler struct {
 	calls    int
 	returned *mcp.CallToolResult
@@ -153,10 +141,7 @@ func (r *recordingHandler) handler() mcp.ToolHandler {
 
 // --- Allow path ---
 
-// TestWithAuthorization_Allow_PassesThroughToNext pins the caller-facing
-// contract on the allow branch: the wrapper returns what next returned
-// (same pointer) and next runs exactly once. Any drift here breaks
-// every RBAC deployment's happy path.
+// Allow: next runs exactly once, wrapper returns its result pointer-identical.
 func TestWithAuthorization_Allow_PassesThroughToNext(t *testing.T) {
 	rec := newRecordingHandler()
 	wrapped := withAuthorization(
@@ -177,13 +162,8 @@ func TestWithAuthorization_Allow_PassesThroughToNext(t *testing.T) {
 	}
 }
 
-// TestWithAuthorization_Allow_EmitsInfoAuditWithDistinctDecision pins
-// the operator-facing contract: allow decisions emit an INFO
-// "tool authorization" audit line naming the tool and carrying a
-// decision value distinguishable from deny and missing-claim. The
-// exact decision string schema is finalized in the audit-refinement
-// follow-up ticket; this test locks distinguishability, not the
-// literal.
+// Allow: one INFO "tool authorization" line; decision distinguishable from
+// deny/missing (distinguishability, not literal — schema is v1 placeholder).
 func TestWithAuthorization_Allow_EmitsInfoAuditWithDistinctDecision(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -220,13 +200,8 @@ func TestWithAuthorization_Allow_EmitsInfoAuditWithDistinctDecision(t *testing.T
 
 // --- Deny path ---
 
-// TestWithAuthorization_Deny_ReturnsToolLevelErrorResult pins the
-// caller-facing distinction between tool-level errors and JSON-RPC
-// protocol errors: denials must return (*CallToolResult{IsError:true},
-// nil), not (nil, error). MCP clients treat a Go error return as a
-// session-level failure; the tool-level error result is what tells the
-// agent "the tool ran and produced an error outcome" — which is what
-// a policy denial is semantically.
+// Deny: returns (*CallToolResult{IsError:true}, nil) — a tool-level error the
+// agent surfaces, not a JSON-RPC error that kills the session.
 func TestWithAuthorization_Deny_ReturnsToolLevelErrorResult(t *testing.T) {
 	wrapped := withAuthorization(
 		emptyPolicy(t),
@@ -246,11 +221,8 @@ func TestWithAuthorization_Deny_ReturnsToolLevelErrorResult(t *testing.T) {
 	}
 }
 
-// TestWithAuthorization_Deny_ResultShapeAndMessage pins the caller-
-// facing payload: StructuredContent carries error+retryable with the
-// uniform authzDeniedMessage, and TextContent echoes the same message.
-// The retryable=false value tells the agent not to loop on the same
-// denied call.
+// Deny: StructuredContent carries error+retryable, TextContent echoes the
+// message. retryable=false tells the agent not to loop on the denial.
 func TestWithAuthorization_Deny_ResultShapeAndMessage(t *testing.T) {
 	wrapped := withAuthorization(
 		emptyPolicy(t),
@@ -281,9 +253,7 @@ func TestWithAuthorization_Deny_ResultShapeAndMessage(t *testing.T) {
 	}
 }
 
-// TestWithAuthorization_Deny_DoesNotCallNext is the security invariant:
-// a denied call must not reach the tool handler. If next ran on deny,
-// the tool's side effects would happen despite the denial.
+// Deny security invariant: next is not called; the tool never runs.
 func TestWithAuthorization_Deny_DoesNotCallNext(t *testing.T) {
 	rec := newRecordingHandler()
 	wrapped := withAuthorization(emptyPolicy(t), "delete-queue", rec.handler())
@@ -295,9 +265,7 @@ func TestWithAuthorization_Deny_DoesNotCallNext(t *testing.T) {
 	}
 }
 
-// TestWithAuthorization_Deny_EmitsInfoAuditWithDistinctDecision pins
-// the operator's ability to distinguish deny events from allow and
-// missing-claim events in the log stream.
+// Deny: INFO audit line with decision distinguishable from allow and missing.
 func TestWithAuthorization_Deny_EmitsInfoAuditWithDistinctDecision(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -326,12 +294,8 @@ func TestWithAuthorization_Deny_EmitsInfoAuditWithDistinctDecision(t *testing.T)
 
 // --- Missing-claim path ---
 
-// TestWithAuthorization_MissingClaim_ReturnsToolLevelErrorResult pins
-// the same tool-level-error contract as the deny path for the missing-
-// claim branch. The two branches share result-shape code but the
-// upstream trigger differs — locking both preserves the wrapper's
-// two-branch structure against a refactor that accidentally collapses
-// one into the other.
+// Missing-claim: same tool-level-error contract as deny, but with the
+// missing-claim message and shape.
 func TestWithAuthorization_MissingClaim_ReturnsToolLevelErrorResult(t *testing.T) {
 	wrapped := withAuthorization(
 		policyGranting(t, []string{"Ops"}, "get-broker-status"),
@@ -359,10 +323,7 @@ func TestWithAuthorization_MissingClaim_ReturnsToolLevelErrorResult(t *testing.T
 	}
 }
 
-// TestWithAuthorization_MissingClaim_DoesNotCallNext is the security
-// invariant for the missing-claim branch: an IdP misconfiguration
-// (token missing the groups claim) must not silently succeed as if
-// the caller were in every group.
+// Missing-claim security invariant: next is not called on IdP misconfig.
 func TestWithAuthorization_MissingClaim_DoesNotCallNext(t *testing.T) {
 	rec := newRecordingHandler()
 	wrapped := withAuthorization(
@@ -378,10 +339,8 @@ func TestWithAuthorization_MissingClaim_DoesNotCallNext(t *testing.T) {
 	}
 }
 
-// TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision pins
-// the operator's ability to tell "IdP misconfigured (no groups
-// claim)" from "caller's groups don't grant this tool" — two failure
-// classes requiring different remediations.
+// Missing-claim: decision distinguishable from plain deny so operators can
+// tell IdP misconfig from grant miss.
 func TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -414,11 +373,7 @@ func TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision(t *testing.
 
 // --- Nil/absent TokenInfo path ---
 
-// TestWithAuthorization_NilTokenInfo_TreatsAsMissingClaim covers the
-// bare-CallToolRequest case that test scaffolding and disabled-auth
-// deployments hit: req.Extra or req.Extra.TokenInfo is nil. The
-// wrapper must treat this as missing-claim rather than crashing or
-// silently allowing.
+// Nil Extra or nil TokenInfo → treated as missing-claim (no crash, no bypass).
 func TestWithAuthorization_NilTokenInfo_TreatsAsMissingClaim(t *testing.T) {
 	cases := []struct {
 		name string
@@ -455,11 +410,8 @@ func TestWithAuthorization_NilTokenInfo_TreatsAsMissingClaim(t *testing.T) {
 
 // --- Message constants ---
 
-// TestAuthzMessages_IdenticalForV1 locks in the v1 design decision
-// that deny and missing-claim callers see the same string. Any drift
-// (one message adds detail, the other doesn't) would leak the class
-// of denial to the caller — exactly the caller-side disclosure
-// discipline that keeps configuration metadata operator-only.
+// v1 messages are identical — any drift would leak the denial class
+// to the caller.
 func TestAuthzMessages_IdenticalForV1(t *testing.T) {
 	if authzDeniedMessage != authzMissingClaimMessage {
 		t.Errorf("v1 requires identical caller-facing messages; got denied=%q, missing=%q",
@@ -472,13 +424,8 @@ func TestAuthzMessages_IdenticalForV1(t *testing.T) {
 
 // --- Precondition ---
 
-// TestWithAuthorization_NilPolicy_Panics locks the fail-loud
-// precondition: composing the wrapper with a nil policy is a
-// programmer error. If the wrapper silently allowed on nil, every
-// RBAC-enabled deployment could accidentally bypass authorization
-// after a composition-site refactor — the exact silent-fail-open
-// class the feature exists to prevent. Panic + outer withRecovery
-// converts this to a visible 500 rather than a security regression.
+// Nil policy is a precondition violation — wrapper must panic (not silently
+// allow). Outer withRecovery converts the panic to a visible 500.
 func TestWithAuthorization_NilPolicy_Panics(t *testing.T) {
 	wrapped := withAuthorization(nil, "get-broker-status", newRecordingHandler().handler())
 

--- a/internal/tools/authorization_test.go
+++ b/internal/tools/authorization_test.go
@@ -1,0 +1,491 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The wrapper tests exercise withAuthorization in isolation — no MCP SDK
+// transport loop, no ToolManager pipeline. Each test drives the wrapper
+// with a hand-built *mcp.CallToolRequest and asserts on the returned
+// *mcp.CallToolResult, whether the stub `next` handler ran, and the
+// slog "tool authorization" audit line the operator sees.
+
+// captureSlog replaces slog.Default with a JSON handler writing to buf,
+// returning the buffer plus a cleanup func the test defers. The audit
+// line is the operator's window; JSON output lets tests read exact
+// field values without regex-fragility.
+func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+// authzLogLines returns every JSON log line in buf whose msg is
+// "tool authorization" — the audit surface the wrapper emits.
+func authzLogLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, raw := range strings.Split(buf.String(), "\n") {
+		if raw == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+			t.Fatalf("non-JSON log line %q: %v", raw, err)
+		}
+		if entry["msg"] == "tool authorization" {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// policyGranting builds a real *authz.Policy that grants each tool in
+// tools to each group in groups. The wrapper's tests use a real Policy
+// (not a mock) so drift between wrapper and Policy surfaces at test
+// time.
+func policyGranting(t *testing.T, groups []string, tools ...string) *authz.Policy {
+	t.Helper()
+	access := make(map[string][]string, len(groups))
+	for _, g := range groups {
+		access[g] = tools
+	}
+	p, err := authz.NewPolicy(config.ToolAuthorizationConfig{
+		AccessLevelGroups: access,
+	})
+	if err != nil {
+		t.Fatalf("NewPolicy: %v", err)
+	}
+	return p
+}
+
+// emptyPolicy builds a policy with no grants. Every Authorize call
+// returns Allowed=false.
+func emptyPolicy(t *testing.T) *authz.Policy {
+	t.Helper()
+	p, err := authz.NewPolicy(config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{},
+	})
+	if err != nil {
+		t.Fatalf("NewPolicy: %v", err)
+	}
+	return p
+}
+
+// requestWithGroups builds a *mcp.CallToolRequest carrying the given
+// groups under the SDK-sanctioned Extra key. Mirrors what the auth
+// middleware writes on the enabled path.
+func requestWithGroups(groups []string) *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Extra: &mcp.RequestExtra{
+			TokenInfo: &sdkauth.TokenInfo{
+				UserID: "alice",
+				Extra: map[string]any{
+					authz.TokenInfoExtraKeyGroups: groups,
+				},
+			},
+		},
+	}
+}
+
+// requestMissingGroupsClaim builds a *mcp.CallToolRequest with a
+// TokenInfo but no groups key in Extra — the "IdP omitted the claim"
+// case the middleware surfaces by leaving the key absent.
+func requestMissingGroupsClaim() *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Extra: &mcp.RequestExtra{
+			TokenInfo: &sdkauth.TokenInfo{
+				UserID: "alice",
+				Extra:  map[string]any{},
+			},
+		},
+	}
+}
+
+// recordingHandler is a stub `next` handler that records every call and
+// returns a fixed sentinel result. Tests use its counter to assert
+// whether the wrapper dispatched or short-circuited.
+type recordingHandler struct {
+	calls    int
+	returned *mcp.CallToolResult
+}
+
+func newRecordingHandler() *recordingHandler {
+	return &recordingHandler{
+		returned: &mcp.CallToolResult{
+			StructuredContent: map[string]any{"sentinel": true},
+		},
+	}
+}
+
+func (r *recordingHandler) handler() mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		r.calls++
+		return r.returned, nil
+	}
+}
+
+// --- Allow path ---
+
+// TestWithAuthorization_Allow_PassesThroughToNext pins the caller-facing
+// contract on the allow branch: the wrapper returns what next returned
+// (same pointer) and next runs exactly once. Any drift here breaks
+// every RBAC deployment's happy path.
+func TestWithAuthorization_Allow_PassesThroughToNext(t *testing.T) {
+	rec := newRecordingHandler()
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "get-broker-status"),
+		"get-broker-status",
+		rec.handler(),
+	)
+
+	got, err := wrapped(context.Background(), requestWithGroups([]string{"Ops"}))
+	if err != nil {
+		t.Fatalf("wrapper returned error on allow: %v", err)
+	}
+	if got != rec.returned {
+		t.Errorf("wrapper did not pass next's result through; got %p, want %p", got, rec.returned)
+	}
+	if rec.calls != 1 {
+		t.Errorf("next called %d times, want exactly 1", rec.calls)
+	}
+}
+
+// TestWithAuthorization_Allow_EmitsInfoAuditWithDistinctDecision pins
+// the operator-facing contract: allow decisions emit an INFO
+// "tool authorization" audit line naming the tool and carrying a
+// decision value distinguishable from deny and missing-claim. The
+// exact decision string schema is finalized in the audit-refinement
+// follow-up ticket; this test locks distinguishability, not the
+// literal.
+func TestWithAuthorization_Allow_EmitsInfoAuditWithDistinctDecision(t *testing.T) {
+	buf, cleanup := captureSlog(t)
+	defer cleanup()
+
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "get-broker-status"),
+		"get-broker-status",
+		newRecordingHandler().handler(),
+	)
+	if _, err := wrapped(context.Background(), requestWithGroups([]string{"Ops"})); err != nil {
+		t.Fatalf("wrapper returned error: %v", err)
+	}
+
+	lines := authzLogLines(t, buf)
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 audit line, got %d: %s", len(lines), buf.String())
+	}
+	if got := lines[0]["level"]; got != "INFO" {
+		t.Errorf("audit level = %v, want INFO", got)
+	}
+	if got := lines[0]["tool"]; got != "get-broker-status" {
+		t.Errorf("audit tool = %v, want get-broker-status", got)
+	}
+	decision, ok := lines[0]["decision"].(string)
+	if !ok || decision == "" {
+		t.Fatalf("audit line missing decision field: %v", lines[0])
+	}
+	// Allow's decision must not collide with either deny outcome — the
+	// operator needs to grep for each independently.
+	if decision == "denied" || decision == "denied_missing_claim" {
+		t.Errorf("allow decision %q collides with a deny decision value; must be distinguishable", decision)
+	}
+}
+
+// --- Deny path ---
+
+// TestWithAuthorization_Deny_ReturnsToolLevelErrorResult pins the
+// caller-facing distinction between tool-level errors and JSON-RPC
+// protocol errors: denials must return (*CallToolResult{IsError:true},
+// nil), not (nil, error). MCP clients treat a Go error return as a
+// session-level failure; the tool-level error result is what tells the
+// agent "the tool ran and produced an error outcome" — which is what
+// a policy denial is semantically.
+func TestWithAuthorization_Deny_ReturnsToolLevelErrorResult(t *testing.T) {
+	wrapped := withAuthorization(
+		emptyPolicy(t),
+		"delete-queue",
+		newRecordingHandler().handler(),
+	)
+
+	got, err := wrapped(context.Background(), requestWithGroups([]string{"Contractors"}))
+	if err != nil {
+		t.Fatalf("wrapper returned Go error on deny; want tool-level result. err=%v", err)
+	}
+	if got == nil {
+		t.Fatal("wrapper returned nil result on deny")
+	}
+	if !got.IsError {
+		t.Errorf("deny result IsError = false, want true")
+	}
+}
+
+// TestWithAuthorization_Deny_ResultShapeAndMessage pins the caller-
+// facing payload: StructuredContent carries error+retryable with the
+// uniform authzDeniedMessage, and TextContent echoes the same message.
+// The retryable=false value tells the agent not to loop on the same
+// denied call.
+func TestWithAuthorization_Deny_ResultShapeAndMessage(t *testing.T) {
+	wrapped := withAuthorization(
+		emptyPolicy(t),
+		"delete-queue",
+		newRecordingHandler().handler(),
+	)
+	got, _ := wrapped(context.Background(), requestWithGroups([]string{"Contractors"}))
+
+	sc, ok := got.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("StructuredContent is not map[string]any: %T", got.StructuredContent)
+	}
+	if sc["error"] != authzDeniedMessage {
+		t.Errorf("StructuredContent.error = %v, want authzDeniedMessage %q", sc["error"], authzDeniedMessage)
+	}
+	if sc["retryable"] != false {
+		t.Errorf("StructuredContent.retryable = %v, want false", sc["retryable"])
+	}
+	if len(got.Content) != 1 {
+		t.Fatalf("expected exactly 1 Content block, got %d", len(got.Content))
+	}
+	tc, ok := got.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("Content[0] is not *TextContent: %T", got.Content[0])
+	}
+	if tc.Text != authzDeniedMessage {
+		t.Errorf("TextContent.Text = %q, want authzDeniedMessage %q", tc.Text, authzDeniedMessage)
+	}
+}
+
+// TestWithAuthorization_Deny_DoesNotCallNext is the security invariant:
+// a denied call must not reach the tool handler. If next ran on deny,
+// the tool's side effects would happen despite the denial.
+func TestWithAuthorization_Deny_DoesNotCallNext(t *testing.T) {
+	rec := newRecordingHandler()
+	wrapped := withAuthorization(emptyPolicy(t), "delete-queue", rec.handler())
+
+	_, _ = wrapped(context.Background(), requestWithGroups([]string{"Contractors"}))
+
+	if rec.calls != 0 {
+		t.Errorf("next called %d times on deny, want 0 (tool must not run on denial)", rec.calls)
+	}
+}
+
+// TestWithAuthorization_Deny_EmitsInfoAuditWithDistinctDecision pins
+// the operator's ability to distinguish deny events from allow and
+// missing-claim events in the log stream.
+func TestWithAuthorization_Deny_EmitsInfoAuditWithDistinctDecision(t *testing.T) {
+	buf, cleanup := captureSlog(t)
+	defer cleanup()
+
+	wrapped := withAuthorization(emptyPolicy(t), "delete-queue", newRecordingHandler().handler())
+	_, _ = wrapped(context.Background(), requestWithGroups([]string{"Contractors"}))
+
+	lines := authzLogLines(t, buf)
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 audit line, got %d: %s", len(lines), buf.String())
+	}
+	if got := lines[0]["level"]; got != "INFO" {
+		t.Errorf("audit level = %v, want INFO", got)
+	}
+	decision, _ := lines[0]["decision"].(string)
+	if decision == "" {
+		t.Fatalf("audit line missing decision: %v", lines[0])
+	}
+	// Deny's decision must be distinct from missing-claim so operators
+	// can tell "IdP omitted the claim" from "the claim was there but
+	// didn't grant the tool."
+	if decision == "denied_missing_claim" || strings.Contains(strings.ToLower(decision), "allow") {
+		t.Errorf("deny decision %q collides with another outcome value", decision)
+	}
+}
+
+// --- Missing-claim path ---
+
+// TestWithAuthorization_MissingClaim_ReturnsToolLevelErrorResult pins
+// the same tool-level-error contract as the deny path for the missing-
+// claim branch. The two branches share result-shape code but the
+// upstream trigger differs — locking both preserves the wrapper's
+// two-branch structure against a refactor that accidentally collapses
+// one into the other.
+func TestWithAuthorization_MissingClaim_ReturnsToolLevelErrorResult(t *testing.T) {
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "get-broker-status"),
+		"get-broker-status",
+		newRecordingHandler().handler(),
+	)
+
+	got, err := wrapped(context.Background(), requestMissingGroupsClaim())
+	if err != nil {
+		t.Fatalf("wrapper returned Go error on missing-claim: %v", err)
+	}
+	if got == nil || !got.IsError {
+		t.Fatalf("missing-claim result IsError = %v, want true", got)
+	}
+	sc, _ := got.StructuredContent.(map[string]any)
+	if sc["error"] != authzMissingClaimMessage {
+		t.Errorf("StructuredContent.error = %v, want authzMissingClaimMessage %q", sc["error"], authzMissingClaimMessage)
+	}
+	if sc["retryable"] != false {
+		t.Errorf("StructuredContent.retryable = %v, want false", sc["retryable"])
+	}
+	tc, ok := got.Content[0].(*mcp.TextContent)
+	if !ok || tc.Text != authzMissingClaimMessage {
+		t.Errorf("TextContent.Text = %v, want authzMissingClaimMessage %q", got.Content[0], authzMissingClaimMessage)
+	}
+}
+
+// TestWithAuthorization_MissingClaim_DoesNotCallNext is the security
+// invariant for the missing-claim branch: an IdP misconfiguration
+// (token missing the groups claim) must not silently succeed as if
+// the caller were in every group.
+func TestWithAuthorization_MissingClaim_DoesNotCallNext(t *testing.T) {
+	rec := newRecordingHandler()
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "get-broker-status"),
+		"get-broker-status",
+		rec.handler(),
+	)
+
+	_, _ = wrapped(context.Background(), requestMissingGroupsClaim())
+
+	if rec.calls != 0 {
+		t.Errorf("next called %d times on missing-claim, want 0", rec.calls)
+	}
+}
+
+// TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision pins
+// the operator's ability to tell "IdP misconfigured (no groups
+// claim)" from "caller's groups don't grant this tool" — two failure
+// classes requiring different remediations.
+func TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision(t *testing.T) {
+	buf, cleanup := captureSlog(t)
+	defer cleanup()
+
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "get-broker-status"),
+		"get-broker-status",
+		newRecordingHandler().handler(),
+	)
+	_, _ = wrapped(context.Background(), requestMissingGroupsClaim())
+
+	lines := authzLogLines(t, buf)
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 audit line, got %d: %s", len(lines), buf.String())
+	}
+	decision, _ := lines[0]["decision"].(string)
+	if decision == "" {
+		t.Fatalf("audit line missing decision: %v", lines[0])
+	}
+	// Missing-claim must be distinguishable from a plain deny — an
+	// operator seeing many missing-claim events knows to check IdP
+	// mapper configuration, not group memberships.
+	if decision == "denied" {
+		t.Errorf("missing-claim decision must differ from plain deny; both were %q", decision)
+	}
+	if strings.Contains(strings.ToLower(decision), "allow") {
+		t.Errorf("missing-claim decision %q looks like an allow value", decision)
+	}
+}
+
+// --- Nil/absent TokenInfo path ---
+
+// TestWithAuthorization_NilTokenInfo_TreatsAsMissingClaim covers the
+// bare-CallToolRequest case that test scaffolding and disabled-auth
+// deployments hit: req.Extra or req.Extra.TokenInfo is nil. The
+// wrapper must treat this as missing-claim rather than crashing or
+// silently allowing.
+func TestWithAuthorization_NilTokenInfo_TreatsAsMissingClaim(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *mcp.CallToolRequest
+	}{
+		{"nil Extra", &mcp.CallToolRequest{}},
+		{"nil TokenInfo", &mcp.CallToolRequest{Extra: &mcp.RequestExtra{}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newRecordingHandler()
+			wrapped := withAuthorization(
+				policyGranting(t, []string{"Ops"}, "get-broker-status"),
+				"get-broker-status",
+				rec.handler(),
+			)
+			got, err := wrapped(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("wrapper returned Go error: %v", err)
+			}
+			if got == nil || !got.IsError {
+				t.Fatalf("expected tool-level error result, got %v", got)
+			}
+			sc, _ := got.StructuredContent.(map[string]any)
+			if sc["error"] != authzMissingClaimMessage {
+				t.Errorf("expected missing-claim message, got %v", sc["error"])
+			}
+			if rec.calls != 0 {
+				t.Errorf("next called %d times, want 0", rec.calls)
+			}
+		})
+	}
+}
+
+// --- Message constants ---
+
+// TestAuthzMessages_IdenticalForV1 locks in the v1 design decision
+// that deny and missing-claim callers see the same string. Any drift
+// (one message adds detail, the other doesn't) would leak the class
+// of denial to the caller — exactly the caller-side disclosure
+// discipline that keeps configuration metadata operator-only.
+func TestAuthzMessages_IdenticalForV1(t *testing.T) {
+	if authzDeniedMessage != authzMissingClaimMessage {
+		t.Errorf("v1 requires identical caller-facing messages; got denied=%q, missing=%q",
+			authzDeniedMessage, authzMissingClaimMessage)
+	}
+	if authzDeniedMessage == "" {
+		t.Error("authzDeniedMessage must not be empty; callers see this string")
+	}
+}
+
+// --- Precondition ---
+
+// TestWithAuthorization_NilPolicy_Panics locks the fail-loud
+// precondition: composing the wrapper with a nil policy is a
+// programmer error. If the wrapper silently allowed on nil, every
+// RBAC-enabled deployment could accidentally bypass authorization
+// after a composition-site refactor — the exact silent-fail-open
+// class the feature exists to prevent. Panic + outer withRecovery
+// converts this to a visible 500 rather than a security regression.
+func TestWithAuthorization_NilPolicy_Panics(t *testing.T) {
+	wrapped := withAuthorization(nil, "get-broker-status", newRecordingHandler().handler())
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected wrapper to panic on nil policy; got no panic (silent bypass would be a security fail-open)")
+		}
+	}()
+	_, _ = wrapped(context.Background(), requestWithGroups([]string{"Ops"}))
+}

--- a/internal/tools/authorization_validate_test.go
+++ b/internal/tools/authorization_validate_test.go
@@ -1,0 +1,327 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+)
+
+// The ValidatePolicyToolNames tests exercise the startup gate that
+// catches admin typos in tool_authorization YAML before the server
+// accepts requests. Assertions are about what the operator sees in
+// the startup log (error rows, WARN lines) and the aggregate return
+// contract — nil vs an errors.Join'd chain — that main.go branches on.
+
+// validateTestManager builds a ToolManager whose only registered
+// handlers are stubs named after the given tool names. Used to
+// simulate the "registered tool set" ValidatePolicyToolNames checks
+// against.
+func validateTestManager(t *testing.T, toolNames ...string) *ToolManager {
+	t.Helper()
+	pool := newRegTestPool(t)
+	mgr := NewToolManager(pool)
+	for _, name := range toolNames {
+		mgr.Register(newStubHandler(name))
+	}
+	return mgr
+}
+
+// warnLinesMentioning returns every JSON slog line at WARN level whose
+// serialization contains the substring. Used to assert on the WARN
+// operators see about list-brokers grants without over-specifying the
+// message wording.
+func warnLinesMentioning(t *testing.T, buf *bytes.Buffer, substr string) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, raw := range strings.Split(buf.String(), "\n") {
+		if raw == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+			t.Fatalf("non-JSON log line %q: %v", raw, err)
+		}
+		if entry["level"] != "WARN" {
+			continue
+		}
+		if strings.Contains(raw, substr) {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// errorRowCount counts the newline-joined rows in an errors.Join'd
+// error's rendered string. Used to assert on row counts without
+// coupling to the internal error-chain iteration API.
+func errorRowCount(err error) int {
+	if err == nil {
+		return 0
+	}
+	// errors.Join renders each wrapped error on its own line.
+	return strings.Count(err.Error(), "\n") + 1
+}
+
+// TestValidatePolicyToolNames_AllKnown_ReturnsNil pins the happy-path
+// contract: every configured tool name resolves to a registered handler
+// → nil error AND no operator-facing log output. The two assertions
+// together prove a silent no-op; either alone would miss a regression
+// that surfaced a spurious WARN on a clean config (masking real WARNs
+// operators care about) or that changed the return contract.
+func TestValidatePolicyToolNames_AllKnown_ReturnsNil(t *testing.T) {
+	buf, cleanup := captureSlog(t)
+	defer cleanup()
+
+	mgr := validateTestManager(t, "get-broker-status", "list-queues")
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			"Ops":        {"get-broker-status", "list-queues"},
+			"Monitoring": {"get-broker-status"},
+		},
+	}
+
+	if err := ValidatePolicyToolNames(cfg, mgr); err != nil {
+		t.Errorf("expected nil error for all-known config, got: %v", err)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("expected zero log output on all-known config; got: %s", buf.String())
+	}
+}
+
+// TestValidatePolicyToolNames_OneUnknown_ReportsToolAndGroup covers
+// the baseline error: one typo produces one error row naming both
+// the tool the admin wrote and the group that references it. The row
+// must be actionable — the admin should be able to grep their YAML
+// for either identifier.
+func TestValidatePolicyToolNames_OneUnknown_ReportsToolAndGroup(t *testing.T) {
+	mgr := validateTestManager(t, "list-queues")
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			"Ops": {"list-queues", "not-a-real-tool"},
+		},
+	}
+
+	err := ValidatePolicyToolNames(cfg, mgr)
+	if err == nil {
+		t.Fatal("expected error for unknown tool, got nil")
+	}
+	if got := errorRowCount(err); got != 1 {
+		t.Errorf("expected 1 error row, got %d: %s", got, err.Error())
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "not-a-real-tool") {
+		t.Errorf("error missing unknown tool name; got: %s", msg)
+	}
+	if !strings.Contains(msg, "Ops") {
+		t.Errorf("error missing referencing group name; got: %s", msg)
+	}
+}
+
+// TestValidatePolicyToolNames_SameUnknownAcrossGroups_DedupedToOneRow
+// covers the dedup discipline: one typo referenced across N groups
+// produces one row, not N rows. Without dedup, an admin whose group
+// list references a common typo would see the same error N times —
+// noise that scales with grant count instead of with bug count. The
+// referencing groups must appear alphabetized on the single row so
+// the admin can fix each spot without re-reading the message.
+func TestValidatePolicyToolNames_SameUnknownAcrossGroups_DedupedToOneRow(t *testing.T) {
+	mgr := validateTestManager(t, "list-queues")
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			"Zeta":  {"missing-tool"},
+			"Alpha": {"missing-tool"},
+			"Mu":    {"missing-tool"},
+		},
+	}
+
+	err := ValidatePolicyToolNames(cfg, mgr)
+	if err == nil {
+		t.Fatal("expected error for unknown tool, got nil")
+	}
+	if got := errorRowCount(err); got != 1 {
+		t.Errorf("expected 1 deduped row for one typo referenced 3 times, got %d rows: %s", got, err.Error())
+	}
+	msg := err.Error()
+	alphaIdx := strings.Index(msg, "Alpha")
+	muIdx := strings.Index(msg, "Mu")
+	zetaIdx := strings.Index(msg, "Zeta")
+	if alphaIdx < 0 || muIdx < 0 || zetaIdx < 0 {
+		t.Fatalf("expected all three group names in error message; got: %s", msg)
+	}
+	if alphaIdx >= muIdx || muIdx >= zetaIdx {
+		t.Errorf("expected referencing groups alphabetized (Alpha < Mu < Zeta); got: %s", msg)
+	}
+}
+
+// TestValidatePolicyToolNames_MultipleUnknowns_AlphabeticalOrder pins
+// the determinism operators need to diff startup logs across
+// environments and process restarts. Go map iteration is
+// non-deterministic; the validator must sort before emitting.
+func TestValidatePolicyToolNames_MultipleUnknowns_AlphabeticalOrder(t *testing.T) {
+	mgr := validateTestManager(t)
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			"g1": {"zebra-tool", "apple-tool", "mango-tool"},
+		},
+	}
+
+	err := ValidatePolicyToolNames(cfg, mgr)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := errorRowCount(err); got != 3 {
+		t.Errorf("expected 3 rows, got %d: %s", got, err.Error())
+	}
+	msg := err.Error()
+	appleIdx := strings.Index(msg, "apple-tool")
+	mangoIdx := strings.Index(msg, "mango-tool")
+	zebraIdx := strings.Index(msg, "zebra-tool")
+	if appleIdx >= mangoIdx || mangoIdx >= zebraIdx {
+		t.Errorf("expected unknown-tool rows alphabetized (apple < mango < zebra); got: %s", msg)
+	}
+}
+
+// TestValidatePolicyToolNames_ListBrokersGrant_WarnsNotError covers
+// the exempt-tool disclosure: an admin grant of list-brokers is
+// legal (list-brokers is in the known-name union) but inert —
+// list-brokers is structurally exempt. The operator sees a WARN
+// naming the redundant grant; the function returns nil so startup
+// proceeds.
+func TestValidatePolicyToolNames_ListBrokersGrant_WarnsNotError(t *testing.T) {
+	buf, cleanup := captureSlog(t)
+	defer cleanup()
+
+	mgr := validateTestManager(t, "get-broker-status")
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			"Ops": {"get-broker-status", "list-brokers"},
+		},
+	}
+
+	if err := ValidatePolicyToolNames(cfg, mgr); err != nil {
+		t.Errorf("list-brokers grant must not surface as an error; got: %v", err)
+	}
+
+	warns := warnLinesMentioning(t, buf, "list-brokers")
+	if len(warns) != 1 {
+		t.Fatalf("expected exactly 1 WARN line about list-brokers, got %d: %s", len(warns), buf.String())
+	}
+	// The WARN must name the referencing group so the admin can find
+	// the inert grant in their YAML.
+	if !strings.Contains(buf.String(), "Ops") {
+		t.Errorf("WARN missing referencing group name Ops: %s", buf.String())
+	}
+}
+
+// TestValidatePolicyToolNames_UnknownsAndListBrokers_BothSurface
+// covers the interaction: a config with BOTH real typos AND
+// list-brokers grants must surface both signals — the error return
+// blocks startup for the typo, and the WARN separately informs the
+// admin their list-brokers grant is inert. A regression that
+// suppressed one when the other fired would either mask a security-
+// relevant typo or silently accept an inert grant the admin should
+// know about.
+func TestValidatePolicyToolNames_UnknownsAndListBrokers_BothSurface(t *testing.T) {
+	buf, cleanup := captureSlog(t)
+	defer cleanup()
+
+	mgr := validateTestManager(t, "get-broker-status")
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			"Ops":         {"get-broker-status", "delet-queue", "list-brokers"},
+			"Contractors": {"list-brokers"},
+		},
+	}
+
+	err := ValidatePolicyToolNames(cfg, mgr)
+	if err == nil {
+		t.Fatal("expected error for typo, got nil")
+	}
+	if !strings.Contains(err.Error(), "delet-queue") {
+		t.Errorf("error missing typo name; got: %s", err.Error())
+	}
+
+	warns := warnLinesMentioning(t, buf, "list-brokers")
+	if len(warns) != 1 {
+		t.Fatalf("expected 1 WARN even with typo present, got %d: %s", len(warns), buf.String())
+	}
+}
+
+// TestValidatePolicyToolNames_CaseMismatchIsUnknown pins case-
+// sensitive comparison against list-brokers. Silent case-folding
+// would change security semantics: "List-Brokers" (title case) is
+// not the exempt tool, so it must produce an unknown-tool error
+// rather than a silent WARN. Anywhere in RBAC where a string
+// comparison could accidentally case-fold, an admin's YAML typo
+// changes access outcomes without the admin noticing.
+func TestValidatePolicyToolNames_CaseMismatchIsUnknown(t *testing.T) {
+	buf, cleanup := captureSlog(t)
+	defer cleanup()
+
+	mgr := validateTestManager(t)
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			"Ops": {"List-Brokers"},
+		},
+	}
+
+	err := ValidatePolicyToolNames(cfg, mgr)
+	if err == nil {
+		t.Fatal("expected error for case-mismatched list-brokers, got nil (silent case-folding would be a security drift)")
+	}
+	if !strings.Contains(err.Error(), "List-Brokers") {
+		t.Errorf("error missing case-mismatched name; got: %s", err.Error())
+	}
+	// And no list-brokers WARN — case-folded match would have emitted one.
+	if warns := warnLinesMentioning(t, buf, "list-brokers is exempt"); len(warns) > 0 {
+		t.Errorf("case-mismatched name should not trigger list-brokers WARN; got: %s", buf.String())
+	}
+}
+
+// TestValidatePolicyToolNames_EmptyAccessLevelGroups_ReturnsNil
+// covers the nil/empty edge: a config whose AccessLevelGroups is nil
+// or empty must return nil cleanly. In production this state is
+// blocked by the config validator upstream, but the function must
+// not panic if reached — same fail-safe posture as elsewhere in the
+// RBAC path.
+func TestValidatePolicyToolNames_EmptyAccessLevelGroups_ReturnsNil(t *testing.T) {
+	mgr := validateTestManager(t, "get-broker-status")
+	cases := []struct {
+		name string
+		alg  map[string][]string
+	}{
+		{"nil map", nil},
+		{"empty map", map[string][]string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, cleanup := captureSlog(t)
+			defer cleanup()
+
+			cfg := config.ToolAuthorizationConfig{AccessLevelGroups: tc.alg}
+			if err := ValidatePolicyToolNames(cfg, mgr); err != nil {
+				t.Errorf("expected nil for %s, got: %v", tc.name, err)
+			}
+			if buf.Len() > 0 {
+				t.Errorf("expected no log output for %s, got: %s", tc.name, buf.String())
+			}
+		})
+	}
+}

--- a/internal/tools/authorization_validate_test.go
+++ b/internal/tools/authorization_validate_test.go
@@ -23,16 +23,11 @@ import (
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
 )
 
-// The ValidatePolicyToolNames tests exercise the startup gate that
-// catches admin typos in tool_authorization YAML before the server
-// accepts requests. Assertions are about what the operator sees in
-// the startup log (error rows, WARN lines) and the aggregate return
-// contract — nil vs an errors.Join'd chain — that main.go branches on.
+// These tests cover the startup validator that catches admin typos in
+// tool_authorization YAML. Assertions target the startup log (error rows,
+// WARN lines) and the aggregate return contract main.go branches on.
 
-// validateTestManager builds a ToolManager whose only registered
-// handlers are stubs named after the given tool names. Used to
-// simulate the "registered tool set" ValidatePolicyToolNames checks
-// against.
+// validateTestManager builds a ToolManager with stubs for the given names.
 func validateTestManager(t *testing.T, toolNames ...string) *ToolManager {
 	t.Helper()
 	pool := newRegTestPool(t)
@@ -43,10 +38,7 @@ func validateTestManager(t *testing.T, toolNames ...string) *ToolManager {
 	return mgr
 }
 
-// warnLinesMentioning returns every JSON slog line at WARN level whose
-// serialization contains the substring. Used to assert on the WARN
-// operators see about list-brokers grants without over-specifying the
-// message wording.
+// warnLinesMentioning returns every WARN JSON slog line containing substr.
 func warnLinesMentioning(t *testing.T, buf *bytes.Buffer, substr string) []map[string]any {
 	t.Helper()
 	var out []map[string]any
@@ -68,23 +60,15 @@ func warnLinesMentioning(t *testing.T, buf *bytes.Buffer, substr string) []map[s
 	return out
 }
 
-// errorRowCount counts the newline-joined rows in an errors.Join'd
-// error's rendered string. Used to assert on row counts without
-// coupling to the internal error-chain iteration API.
+// errorRowCount counts newline-joined rows in an errors.Join'd error string.
 func errorRowCount(err error) int {
 	if err == nil {
 		return 0
 	}
-	// errors.Join renders each wrapped error on its own line.
 	return strings.Count(err.Error(), "\n") + 1
 }
 
-// TestValidatePolicyToolNames_AllKnown_ReturnsNil pins the happy-path
-// contract: every configured tool name resolves to a registered handler
-// → nil error AND no operator-facing log output. The two assertions
-// together prove a silent no-op; either alone would miss a regression
-// that surfaced a spurious WARN on a clean config (masking real WARNs
-// operators care about) or that changed the return contract.
+// All-known config → nil error and zero log output (silent no-op).
 func TestValidatePolicyToolNames_AllKnown_ReturnsNil(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -105,11 +89,7 @@ func TestValidatePolicyToolNames_AllKnown_ReturnsNil(t *testing.T) {
 	}
 }
 
-// TestValidatePolicyToolNames_OneUnknown_ReportsToolAndGroup covers
-// the baseline error: one typo produces one error row naming both
-// the tool the admin wrote and the group that references it. The row
-// must be actionable — the admin should be able to grep their YAML
-// for either identifier.
+// One unknown tool → one error row naming both the tool and the group.
 func TestValidatePolicyToolNames_OneUnknown_ReportsToolAndGroup(t *testing.T) {
 	mgr := validateTestManager(t, "list-queues")
 	cfg := config.ToolAuthorizationConfig{
@@ -134,13 +114,7 @@ func TestValidatePolicyToolNames_OneUnknown_ReportsToolAndGroup(t *testing.T) {
 	}
 }
 
-// TestValidatePolicyToolNames_SameUnknownAcrossGroups_DedupedToOneRow
-// covers the dedup discipline: one typo referenced across N groups
-// produces one row, not N rows. Without dedup, an admin whose group
-// list references a common typo would see the same error N times —
-// noise that scales with grant count instead of with bug count. The
-// referencing groups must appear alphabetized on the single row so
-// the admin can fix each spot without re-reading the message.
+// Same typo across N groups → one deduped row; groups alphabetized.
 func TestValidatePolicyToolNames_SameUnknownAcrossGroups_DedupedToOneRow(t *testing.T) {
 	mgr := validateTestManager(t, "list-queues")
 	cfg := config.ToolAuthorizationConfig{
@@ -170,10 +144,7 @@ func TestValidatePolicyToolNames_SameUnknownAcrossGroups_DedupedToOneRow(t *test
 	}
 }
 
-// TestValidatePolicyToolNames_MultipleUnknowns_AlphabeticalOrder pins
-// the determinism operators need to diff startup logs across
-// environments and process restarts. Go map iteration is
-// non-deterministic; the validator must sort before emitting.
+// Multiple unknown tools → rows alphabetized (deterministic across restarts).
 func TestValidatePolicyToolNames_MultipleUnknowns_AlphabeticalOrder(t *testing.T) {
 	mgr := validateTestManager(t)
 	cfg := config.ToolAuthorizationConfig{
@@ -198,12 +169,7 @@ func TestValidatePolicyToolNames_MultipleUnknowns_AlphabeticalOrder(t *testing.T
 	}
 }
 
-// TestValidatePolicyToolNames_ListBrokersGrant_WarnsNotError covers
-// the exempt-tool disclosure: an admin grant of list-brokers is
-// legal (list-brokers is in the known-name union) but inert —
-// list-brokers is structurally exempt. The operator sees a WARN
-// naming the redundant grant; the function returns nil so startup
-// proceeds.
+// list-brokers grant → WARN, not error; startup proceeds.
 func TestValidatePolicyToolNames_ListBrokersGrant_WarnsNotError(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -223,21 +189,13 @@ func TestValidatePolicyToolNames_ListBrokersGrant_WarnsNotError(t *testing.T) {
 	if len(warns) != 1 {
 		t.Fatalf("expected exactly 1 WARN line about list-brokers, got %d: %s", len(warns), buf.String())
 	}
-	// The WARN must name the referencing group so the admin can find
-	// the inert grant in their YAML.
+	// WARN must name the referencing group so the admin can find it.
 	if !strings.Contains(buf.String(), "Ops") {
 		t.Errorf("WARN missing referencing group name Ops: %s", buf.String())
 	}
 }
 
-// TestValidatePolicyToolNames_UnknownsAndListBrokers_BothSurface
-// covers the interaction: a config with BOTH real typos AND
-// list-brokers grants must surface both signals — the error return
-// blocks startup for the typo, and the WARN separately informs the
-// admin their list-brokers grant is inert. A regression that
-// suppressed one when the other fired would either mask a security-
-// relevant typo or silently accept an inert grant the admin should
-// know about.
+// Typo + list-brokers grant on one config → both surfaces fire independently.
 func TestValidatePolicyToolNames_UnknownsAndListBrokers_BothSurface(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -264,13 +222,7 @@ func TestValidatePolicyToolNames_UnknownsAndListBrokers_BothSurface(t *testing.T
 	}
 }
 
-// TestValidatePolicyToolNames_CaseMismatchIsUnknown pins case-
-// sensitive comparison against list-brokers. Silent case-folding
-// would change security semantics: "List-Brokers" (title case) is
-// not the exempt tool, so it must produce an unknown-tool error
-// rather than a silent WARN. Anywhere in RBAC where a string
-// comparison could accidentally case-fold, an admin's YAML typo
-// changes access outcomes without the admin noticing.
+// Case-mismatched "List-Brokers" is unknown (not exempt) — no silent case-folding.
 func TestValidatePolicyToolNames_CaseMismatchIsUnknown(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -295,12 +247,7 @@ func TestValidatePolicyToolNames_CaseMismatchIsUnknown(t *testing.T) {
 	}
 }
 
-// TestValidatePolicyToolNames_EmptyAccessLevelGroups_ReturnsNil
-// covers the nil/empty edge: a config whose AccessLevelGroups is nil
-// or empty must return nil cleanly. In production this state is
-// blocked by the config validator upstream, but the function must
-// not panic if reached — same fail-safe posture as elsewhere in the
-// RBAC path.
+// Nil or empty AccessLevelGroups → nil, no log output (fail-safe).
 func TestValidatePolicyToolNames_EmptyAccessLevelGroups_ReturnsNil(t *testing.T) {
 	mgr := validateTestManager(t, "get-broker-status")
 	cases := []struct {

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -115,24 +115,16 @@ func stampCorrelationID(ctx context.Context, result *mcp.CallToolResult) {
 }
 
 // RegisterWithServer registers all tools from the ToolManager with the MCP
-// server. For each handler, it builds an mcp.Tool from the handler's Metadata
-// (with the broker parameter injected into the input schema) and creates a
-// handler closure that delegates to ToolManager.CallTool.
+// server. For each handler it builds an mcp.Tool (with the broker parameter
+// injected) and a closure that delegates to ToolManager.CallTool. This is
+// the translation boundary between our ToolHandler / Metadata vocabulary and
+// the SDK's mcp.Tool.
 //
-// This function is the translation boundary between the ToolManager's
-// ToolHandler / Metadata vocabulary and the SDK's mcp.Tool. Handlers and
-// the manager work in our own vocabulary; this is where it crosses over
-// to the SDK. RegisterListBrokers builds its own mcp.Tool independently
-// because list-brokers has no ToolHandler backing it (it's a discovery
-// primitive, not a broker operation).
-//
-// When policy is non-nil, each registered handler is additionally wrapped
-// with withAuthorization inside withRecovery, so every dispatch consults
-// the compiled tool-authorization policy before the tool runs. When policy
-// is nil, dispatch is byte-identical to the pre-RBAC path — no
-// authorization frame is composed and no per-request policy lookup fires.
-// The caller (cmd/server/main.go) owns the enable-gate; a nil argument is
-// how disablement is expressed to this function.
+// When policy is non-nil, each handler is wrapped with withAuthorization
+// inside withRecovery, so every dispatch consults the policy before the tool
+// runs. When policy is nil, no authorization frame is composed — the caller
+// (cmd/server/main.go) owns the enable-gate and expresses disablement here
+// as nil.
 func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerPool, enableWriteTools bool, policy *authz.Policy) {
 	type registration struct {
 		name    string
@@ -171,11 +163,9 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 			if err := json.Unmarshal(req.Params.Arguments, &params); err != nil {
 				return nil, fmt.Errorf("parsing tool arguments: %w", err)
 			}
-			// Extract per-invocation audit identity from the SDK request
-			// extras (SOL-149606). Both req.Extra and req.Extra.TokenInfo
-			// can be nil in disabled mode (no middleware) or under test
-			// scaffolding that constructs a bare CallToolRequest; the
-			// constructor handles nil cleanly.
+			// Per-invocation audit identity from the SDK extras (SOL-149606).
+			// Extra and TokenInfo can be nil in disabled mode or under test
+			// scaffolding; NewIdentityFromTokenInfo handles nil cleanly.
 			var info *sdkauth.TokenInfo
 			if req.Extra != nil {
 				info = req.Extra.TokenInfo
@@ -183,13 +173,9 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 			return mgr.CallTool(ctx, reg.name, params, NewIdentityFromTokenInfo(info))
 		}
 
-		// Compose the authorization wrapper INSIDE withRecovery so denials
-		// inherit correlation-ID stamping and panic containment. When
-		// policy is nil, no wrapper is composed and the outer withRecovery
-		// wraps callToolHandler directly — dispatch is byte-identical to
-		// the pre-RBAC path. list-brokers is exempt structurally: it
-		// registers via RegisterListBrokers, which never receives a policy
-		// argument and never composes withAuthorization.
+		// Compose withAuthorization INSIDE withRecovery so denials inherit
+		// correlation-ID stamping and panic containment. Nil policy skips
+		// the wrapper entirely — dispatch is byte-identical to pre-RBAC.
 		if policy != nil {
 			callToolHandler = withAuthorization(policy, reg.name, callToolHandler)
 		}

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
 	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
 	"github.com/SolaceDev/solace-broker-mcp/internal/semp"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
@@ -121,7 +122,15 @@ func stampCorrelationID(ctx context.Context, result *mcp.CallToolResult) {
 // This function is the only translation boundary between our internal Metadata
 // type and the SDK's mcp.Tool. Handlers and the manager work in our own
 // vocabulary; this is where it crosses over to the SDK.
-func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerPool, enableWriteTools bool) {
+//
+// When policy is non-nil, each registered handler is additionally wrapped
+// with withAuthorization inside withRecovery, so every dispatch consults
+// the compiled tool-authorization policy before the tool runs. When policy
+// is nil, dispatch is byte-identical to the pre-RBAC path — no
+// authorization frame is composed and no per-request policy lookup fires.
+// The caller (cmd/server/main.go) owns the enable-gate; a nil argument is
+// how disablement is expressed to this function.
+func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerPool, enableWriteTools bool, policy *authz.Policy) {
 	type registration struct {
 		name    string
 		handler ToolHandler
@@ -154,7 +163,7 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 
 		mcpTool := toMCPTool(reg.meta, pool)
 
-		server.AddTool(mcpTool, withRecovery(reg.name, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var callToolHandler mcp.ToolHandler = func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			var params map[string]any
 			if err := json.Unmarshal(req.Params.Arguments, &params); err != nil {
 				return nil, fmt.Errorf("parsing tool arguments: %w", err)
@@ -169,7 +178,20 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 				info = req.Extra.TokenInfo
 			}
 			return mgr.CallTool(ctx, reg.name, params, NewIdentityFromTokenInfo(info))
-		}))
+		}
+
+		// Compose the authorization wrapper INSIDE withRecovery so denials
+		// inherit correlation-ID stamping and panic containment. When
+		// policy is nil, no wrapper is composed and the outer withRecovery
+		// wraps callToolHandler directly — dispatch is byte-identical to
+		// the pre-RBAC path. list-brokers is exempt structurally: it
+		// registers via RegisterListBrokers, which never receives a policy
+		// argument and never composes withAuthorization.
+		if policy != nil {
+			callToolHandler = withAuthorization(policy, reg.name, callToolHandler)
+		}
+
+		server.AddTool(mcpTool, withRecovery(reg.name, callToolHandler))
 	}
 }
 

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -119,9 +119,12 @@ func stampCorrelationID(ctx context.Context, result *mcp.CallToolResult) {
 // (with the broker parameter injected into the input schema) and creates a
 // handler closure that delegates to ToolManager.CallTool.
 //
-// This function is the only translation boundary between our internal Metadata
-// type and the SDK's mcp.Tool. Handlers and the manager work in our own
-// vocabulary; this is where it crosses over to the SDK.
+// This function is the translation boundary between the ToolManager's
+// ToolHandler / Metadata vocabulary and the SDK's mcp.Tool. Handlers and
+// the manager work in our own vocabulary; this is where it crosses over
+// to the SDK. RegisterListBrokers builds its own mcp.Tool independently
+// because list-brokers has no ToolHandler backing it (it's a discovery
+// primitive, not a broker operation).
 //
 // When policy is non-nil, each registered handler is additionally wrapped
 // with withAuthorization inside withRecovery, so every dispatch consults

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -495,21 +495,12 @@ func containsStr(s, substr string) bool {
 
 // --- Composition-site wiring tests (tool-authorization wrapper) ---
 //
-// These three tests pin the observable behavior of the composition
-// site inside RegisterWithServer: nil policy means no authorization
-// frame is composed and dispatch is byte-identical to pre-RBAC;
-// non-nil policy means the wrapper is composed and every tool call
-// emits the authorization audit event; and RegisterListBrokers never
-// composes the wrapper regardless of policy state, so list-brokers
-// remains available to every authenticated caller.
-//
 // Each test drives a real client→server call via mcp.NewInMemoryTransports
-// so the assertion is on what the operator sees in the log stream and
-// what the caller sees in the tool result — not on internal composition
-// state.
+// and asserts on observable outputs (log stream, tool result), not internal
+// composition state.
 
-// hasAuthzAuditLine reports whether buf contains any log record with
-// msg=="tool authorization" for the given tool name.
+// hasAuthzAuditLine reports whether buf contains a "tool authorization" log
+// record for the given tool name.
 func hasAuthzAuditLine(t *testing.T, buf *bytes.Buffer, tool string) bool {
 	t.Helper()
 	for _, raw := range strings.Split(buf.String(), "\n") {
@@ -527,13 +518,8 @@ func hasAuthzAuditLine(t *testing.T, buf *bytes.Buffer, tool string) bool {
 	return false
 }
 
-// TestRegisterWithServer_NilPolicy_ByteIdenticalToPreRBAC pins the
-// non-RBAC guarantee: when policy is nil, the composition site skips
-// withAuthorization and dispatch is byte-identical to the pre-RBAC
-// path. The existing "tool invoked" audit line fires; no
-// "tool authorization" line fires. A regression that accidentally
-// composed the wrapper anyway would secretly enable RBAC on every
-// non-RBAC deployment.
+// Nil policy → pre-RBAC "tool invoked" audit still fires; no
+// "tool authorization" line (wrapper is not composed).
 func TestRegisterWithServer_NilPolicy_ByteIdenticalToPreRBAC(t *testing.T) {
 	var logBuf bytes.Buffer
 	oldLogger := slog.Default()
@@ -572,19 +558,10 @@ func TestRegisterWithServer_NilPolicy_ByteIdenticalToPreRBAC(t *testing.T) {
 	}
 }
 
-// TestRegisterWithServer_NonNilPolicy_AuthorizationAuditFires pins the
-// enable side of the composition: when policy is non-nil, every
-// registered tool has the wrapper composed AND the wrapper actually
-// consults the policy on each request. Two assertions together prove
-// this: (1) a tool-authorization audit line appears, and (2) its
-// decision value matches what the policy would produce for this
-// caller. Asserting only on presence would pass even if the wrapper
-// emitted an unconditional log without running Authorize.
-//
-// The test drives via the SDK transport without OAuth middleware, so
-// req.Extra.TokenInfo is nil — the wrapper takes the missing-claim
-// branch. That path is uniquely identifiable by the decision value
-// AND by the caller-facing deny result, so both are asserted.
+// Non-nil policy → wrapper is composed AND consulted. The audit line fires
+// AND the decision value matches the caller-facing outcome (asserting only
+// on line presence would miss a wrapper emitting unconditional logs).
+// No OAuth middleware here, so TokenInfo is nil → missing-claim branch.
 func TestRegisterWithServer_NonNilPolicy_AuthorizationAuditFires(t *testing.T) {
 	var logBuf bytes.Buffer
 	oldLogger := slog.Default()
@@ -617,18 +594,13 @@ func TestRegisterWithServer_NonNilPolicy_AuthorizationAuditFires(t *testing.T) {
 		t.Fatalf("CallTool: %v", err)
 	}
 
-	// The wrapper must produce a tool-level deny result rather than
-	// letting the call through — no TokenInfo means missing-claim
-	// branch fires.
+	// Missing-claim branch → tool-level deny result.
 	if !res.IsError {
 		t.Errorf("expected IsError=true from missing-claim path; the wrapper was not composed or did not consult policy")
 	}
 
-	// The audit line must fire AND its decision must reflect the
-	// missing-claim outcome the wrapper actually took. If the
-	// wrapper emitted an unconditional "allowed" log while denying
-	// on the result path (or vice versa), only this assertion
-	// catches it.
+	// Audit decision must match the outcome — catches a wrapper that emits
+	// an unconditional "allowed" log while denying on the result path.
 	lines := authzLogLines(t, &logBuf)
 	toolLines := make([]map[string]any, 0, 1)
 	for _, l := range lines {
@@ -655,17 +627,8 @@ func TestRegisterWithServer_NonNilPolicy_AuthorizationAuditFires(t *testing.T) {
 	}
 }
 
-// TestRegisterListBrokers_NeverComposesWithAuthorization pins the
-// structural exemption of the discovery tool. list-brokers registers
-// via a dedicated function that takes no policy argument — an
-// invariant expressed at the API surface. This test drives a full
-// call to list-brokers alongside a policy-enabled RegisterWithServer,
-// with a policy that would deny list-brokers if it were wrapped, and
-// asserts that the call succeeds and no authorization audit line
-// fires. A regression that accidentally applied the wrapper to
-// list-brokers (e.g. a refactor that unified the two registration
-// paths) would make every authenticated caller lose broker
-// discovery.
+// list-brokers is structurally exempt. Even under a policy that grants it
+// nothing, the call succeeds and no "tool authorization" audit line fires.
 func TestRegisterListBrokers_NeverComposesWithAuthorization(t *testing.T) {
 	var logBuf bytes.Buffer
 	oldLogger := slog.Default()
@@ -676,9 +639,8 @@ func TestRegisterListBrokers_NeverComposesWithAuthorization(t *testing.T) {
 	mgr := NewToolManager(pool)
 	mgr.Register(newStubHandler("test-tool"))
 
-	// Policy that grants nothing to list-brokers — if the wrapper
-	// were accidentally composed on list-brokers, this policy would
-	// deny it.
+	// If the wrapper were accidentally composed on list-brokers, this
+	// policy (which grants nothing to it) would deny the call.
 	policy := policyGranting(t, []string{"Ops"}, "test-tool")
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -493,7 +493,7 @@ func containsStr(s, substr string) bool {
 	return false
 }
 
-// --- Composition-site wiring tests (T4 enforcement wrapper) ---
+// --- Composition-site wiring tests (tool-authorization wrapper) ---
 //
 // These three tests pin the observable behavior of the composition
 // site inside RegisterWithServer: nil policy means no authorization

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -110,7 +110,7 @@ func TestRegisterWithServer(t *testing.T) {
 	mgr.Register(newStubHandler("test-tool"))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true)
+	RegisterWithServer(mgr, server, pool, true, nil)
 
 	// No panic = tools registered successfully. The MCP SDK doesn't expose
 	// a way to list registered tools directly, so we verify by checking
@@ -164,7 +164,7 @@ func TestRegisterWithServer_WriteGated(t *testing.T) {
 			mgr.Register(destructiveWrite)
 
 			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-			RegisterWithServer(mgr, server, pool, enableWriteTools)
+			RegisterWithServer(mgr, server, pool, enableWriteTools, nil)
 			// No panic; gate behavior verified at integration layer via tools/list.
 		})
 	}
@@ -222,7 +222,7 @@ func TestPanicAuditedAsError(t *testing.T) {
 	mgr.Register(panicking)
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true)
+	RegisterWithServer(mgr, server, pool, true, nil)
 
 	ctx := context.Background()
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -492,3 +492,218 @@ func containsStr(s, substr string) bool {
 	}
 	return false
 }
+
+// --- Composition-site wiring tests (T4 enforcement wrapper) ---
+//
+// These three tests pin the observable behavior of the composition
+// site inside RegisterWithServer: nil policy means no authorization
+// frame is composed and dispatch is byte-identical to pre-RBAC;
+// non-nil policy means the wrapper is composed and every tool call
+// emits the authorization audit event; and RegisterListBrokers never
+// composes the wrapper regardless of policy state, so list-brokers
+// remains available to every authenticated caller.
+//
+// Each test drives a real client→server call via mcp.NewInMemoryTransports
+// so the assertion is on what the operator sees in the log stream and
+// what the caller sees in the tool result — not on internal composition
+// state.
+
+// hasAuthzAuditLine reports whether buf contains any log record with
+// msg=="tool authorization" for the given tool name.
+func hasAuthzAuditLine(t *testing.T, buf *bytes.Buffer, tool string) bool {
+	t.Helper()
+	for _, raw := range strings.Split(buf.String(), "\n") {
+		if raw == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+			t.Fatalf("non-JSON log line %q: %v", raw, err)
+		}
+		if entry["msg"] == "tool authorization" && entry["tool"] == tool {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRegisterWithServer_NilPolicy_ByteIdenticalToPreRBAC pins the
+// non-RBAC guarantee: when policy is nil, the composition site skips
+// withAuthorization and dispatch is byte-identical to the pre-RBAC
+// path. The existing "tool invoked" audit line fires; no
+// "tool authorization" line fires. A regression that accidentally
+// composed the wrapper anyway would secretly enable RBAC on every
+// non-RBAC deployment.
+func TestRegisterWithServer_NilPolicy_ByteIdenticalToPreRBAC(t *testing.T) {
+	var logBuf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(oldLogger)
+
+	pool := newRegTestPool(t)
+	mgr := NewToolManager(pool)
+	mgr.Register(newStubHandler("test-tool"))
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	RegisterWithServer(mgr, server, pool, true, nil)
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	go func() { _ = server.Run(ctx, serverTransport) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.1.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer session.Close()
+
+	args := map[string]any{"broker": "dev", "msgVpnName": "default"}
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "test-tool", Arguments: args}); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	if len(auditLines(t, &logBuf, "test-tool")) != 1 {
+		t.Errorf("pre-RBAC path must still emit exactly 1 tool-invoked audit line; got %d: %s",
+			len(auditLines(t, &logBuf, "test-tool")), logBuf.String())
+	}
+	if hasAuthzAuditLine(t, &logBuf, "test-tool") {
+		t.Error("nil-policy composition emitted a tool-authorization audit line; the wrapper must NOT be composed when policy is nil (silent RBAC on non-RBAC deployment)")
+	}
+}
+
+// TestRegisterWithServer_NonNilPolicy_AuthorizationAuditFires pins the
+// enable side of the composition: when policy is non-nil, every
+// registered tool has the wrapper composed AND the wrapper actually
+// consults the policy on each request. Two assertions together prove
+// this: (1) a tool-authorization audit line appears, and (2) its
+// decision value matches what the policy would produce for this
+// caller. Asserting only on presence would pass even if the wrapper
+// emitted an unconditional log without running Authorize.
+//
+// The test drives via the SDK transport without OAuth middleware, so
+// req.Extra.TokenInfo is nil — the wrapper takes the missing-claim
+// branch. That path is uniquely identifiable by the decision value
+// AND by the caller-facing deny result, so both are asserted.
+func TestRegisterWithServer_NonNilPolicy_AuthorizationAuditFires(t *testing.T) {
+	var logBuf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(oldLogger)
+
+	pool := newRegTestPool(t)
+	mgr := NewToolManager(pool)
+	mgr.Register(newStubHandler("test-tool"))
+
+	policy := policyGranting(t, []string{"Ops"}, "test-tool")
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	RegisterWithServer(mgr, server, pool, true, policy)
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	go func() { _ = server.Run(ctx, serverTransport) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.1.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer session.Close()
+
+	args := map[string]any{"broker": "dev", "msgVpnName": "default"}
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "test-tool", Arguments: args})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	// The wrapper must produce a tool-level deny result rather than
+	// letting the call through — no TokenInfo means missing-claim
+	// branch fires.
+	if !res.IsError {
+		t.Errorf("expected IsError=true from missing-claim path; the wrapper was not composed or did not consult policy")
+	}
+
+	// The audit line must fire AND its decision must reflect the
+	// missing-claim outcome the wrapper actually took. If the
+	// wrapper emitted an unconditional "allowed" log while denying
+	// on the result path (or vice versa), only this assertion
+	// catches it.
+	lines := authzLogLines(t, &logBuf)
+	toolLines := make([]map[string]any, 0, 1)
+	for _, l := range lines {
+		if l["tool"] == "test-tool" {
+			toolLines = append(toolLines, l)
+		}
+	}
+	if len(toolLines) != 1 {
+		t.Fatalf("expected exactly 1 tool-authorization audit line for test-tool, got %d: %s", len(toolLines), logBuf.String())
+	}
+	decision, _ := toolLines[0]["decision"].(string)
+	if decision == "" {
+		t.Fatalf("audit line missing decision field: %v", toolLines[0])
+	}
+	// The audit's decision value must not indicate allow — that would
+	// mean the wrapper is either not consulting policy or emitting an
+	// unconditional log that says the call was permitted despite the
+	// deny result the caller received above. The exact decision string
+	// schema is finalized in the audit-refinement follow-up ticket;
+	// this test locks the composition contract (wrapper ran, decision
+	// matches the deny-side outcome), not the literal string.
+	if strings.Contains(strings.ToLower(decision), "allow") {
+		t.Errorf("audit decision %q indicates allow but the caller-facing result was IsError=true; wrapper is inconsistent with its own outcome", decision)
+	}
+}
+
+// TestRegisterListBrokers_NeverComposesWithAuthorization pins the
+// structural exemption of the discovery tool. list-brokers registers
+// via a dedicated function that takes no policy argument — an
+// invariant expressed at the API surface. This test drives a full
+// call to list-brokers alongside a policy-enabled RegisterWithServer,
+// with a policy that would deny list-brokers if it were wrapped, and
+// asserts that the call succeeds and no authorization audit line
+// fires. A regression that accidentally applied the wrapper to
+// list-brokers (e.g. a refactor that unified the two registration
+// paths) would make every authenticated caller lose broker
+// discovery.
+func TestRegisterListBrokers_NeverComposesWithAuthorization(t *testing.T) {
+	var logBuf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(oldLogger)
+
+	pool := newRegTestPool(t)
+	mgr := NewToolManager(pool)
+	mgr.Register(newStubHandler("test-tool"))
+
+	// Policy that grants nothing to list-brokers — if the wrapper
+	// were accidentally composed on list-brokers, this policy would
+	// deny it.
+	policy := policyGranting(t, []string{"Ops"}, "test-tool")
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
+	RegisterWithServer(mgr, server, pool, true, policy)
+	RegisterListBrokers(server, pool)
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	go func() { _ = server.Run(ctx, serverTransport) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.1.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list-brokers", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("list-brokers returned IsError=true under a policy-enabled server; the exemption is broken. Content=%v", res.Content)
+	}
+	if hasAuthzAuditLine(t, &logBuf, "list-brokers") {
+		t.Errorf("list-brokers emitted a tool-authorization audit line; the wrapper must not be composed on the exempt tool: %s", logBuf.String())
+	}
+}

--- a/test/integration/correlation_response_meta_test.go
+++ b/test/integration/correlation_response_meta_test.go
@@ -111,7 +111,7 @@ func metaTestServer(t *testing.T, h tools.ToolHandler, withCorrelation bool) *mc
 	mgr.Register(h)
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	tools.RegisterWithServer(mgr, server, pool, true)
+	tools.RegisterWithServer(mgr, server, pool, true, nil)
 
 	var handler http.Handler = mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
 	if withCorrelation {


### PR DESCRIPTION
## Summary

Adds the request-time enforcement layer for claims-based tool authorization. An OAuth-authenticated caller's `groups` claim is now checked against a compiled `*authz.Policy` before each tool call. Denials return a uniform tool-level error result; the tool never runs. `list-brokers` is structurally exempt so every authenticated caller keeps discovery. When tool authorization is off, dispatch is byte-identical to the pre-RBAC path.

Part of [SOL-151440](https://sol-jira.atlassian.net/browse/SOL-151440) (Claims-Based Tool Authorization), ticket [SOL-151978](https://sol-jira.atlassian.net/browse/SOL-151978).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Prior to this PR, any authenticated OAuth caller could invoke any tool the server exposed — including destructive ones (`delete-queue`, `disconnect-client`, etc.). The parent feature SOL-151440 closes that gap by introducing group-based authorization derived from an OIDC `groups` claim. T1 landed the config schema, T2 landed the leaf `internal/authz` decision engine, T3 landed the middleware that extracts the groups claim onto `TokenInfo.Extra`. This PR wires those pieces into request dispatch: a wrapper reads the groups off the request, asks the compiled policy for a decision, and either passes through to the tool handler or returns a uniform "not authorized" tool-level error result.

**How it works at request time:**

```
Client sends tool call over MCP
    ↓
withRecovery (outer — panics, correlation ID)
    ↓
withAuthorization  ← reads req.Extra.TokenInfo.Extra["groups"]
    │             ← calls policy.Authorize(groups, toolName)
    │             ← emits INFO audit line (allowed/denied/denied_missing_claim)
    ↓
tool handler runs OR uniform deny result returned
```

**How it works at startup:**

```
buildToolPolicy(cfg)
    │
    ├─ gate off → returns (nil, nil)
    └─ gate on  → returns (compiled Policy, nil)
    ↓
fail-closed guard: gate on AND policy nil → slog.Error + os.Exit(1)
    ↓
RegisterWithServer(..., policy)
    ├─ policy == nil → skips withAuthorization; dispatch byte-identical to pre-RBAC
    └─ policy != nil → composes withAuthorization inside withRecovery on every tool
    ↓
RegisterListBrokers(server, pool)  ← never receives policy; structurally exempt
    ↓
ValidatePolicyToolNames(cfg, mgr)  ← catches YAML typos; fatal on unknown tools
    ↓
Startup INFO announcement naming the RBAC posture on both enabled and disabled paths
```

## Design rationale — three-layer separation of concerns

The extraction / plumbing / interpretation split across the three components in this feature is a load-bearing discipline. Recording it here explicitly so a future contributor understands which layer owns which failure-handling responsibility, and doesn't drift one layer's job into another.

Three distinct jobs, three distinct owners:

1. **Resolver** (`ResolveGroups` in `internal/auth/claims.go`) — structural detector. Given a decoded claims map and a claim name, it either produces a usable `[]string` or signals it can't. It owns *only that signal*. It does not know why any caller cares, does not shape any diagnostic, and does not decide what to do next.

2. **Middleware** (`createOIDCTokenVerifier` in `internal/auth/middleware.go`) — claim-plumbing carrier. Runs the detector, decides whether the outcome is worth recording on the request (structural anomalies get a WARN), and attaches the outcome to `TokenInfo.Extra` for the next layer to read. It does not interpret. It does not shape user-facing responses. It does not decide policy.

3. **Enforcement wrapper** (`withAuthorization` in `internal/tools/authorization.go`) — policy interpreter. It reads the plumbing off the request, applies the compiled policy (`Policy.Authorize`), and shapes the two observable outcomes: the audit event on the server log side and the caller-facing response on the wire side (uniform "not authorized" string, no configuration metadata).

Consequences worth defending against drift:

- **The resolver's signal is not diagnostic surface.** Its one-bit answer is consumed by machine (the middleware's `if !ok` branch); if a future contributor is tempted to enrich its message with the configured claim name or similar, that's a layering violation — claim-name context is the wrapper's diagnostic input, not the resolver's output.
- **The middleware does not shape user-facing behavior.** If a future contributor is tempted to make the middleware return 401 on `!ok`, that's a layering violation — the token *is* authenticated (verifier already ran), just not carrying the groups claim. Token validity and authorization are different concerns.
- **The wrapper owns the "shout."** The loud, actionable diagnostic (which claim was missing, which correlation ID to grep, which subject) is emitted by the wrapper's audit event, not by the resolver or middleware.

**Test this layering by asking:** would a change to the caller-facing wording touch the resolver? No — it touches the wrapper. Would a change to the resolver's coalescing rules touch the wrapper? No — only the resolver's edge-case tests. Would a change to which structured fields appear in the audit event touch the middleware? No — only the wrapper's audit call site. Three orthogonal axes of change.

## Design Decisions

**Why the wrapper composes INSIDE `withRecovery`, not outside:**
The composition order is `withRecovery(name, withAuthorization(policy, name, next))`. If reversed, three concrete failures appear. First, a panic anywhere inside the authorization wrapper (e.g. a future bug in the audit-emission code) would escape uncaught and crash the goroutine — the SDK has no recover of its own. Second, deny results would not get the correlation ID stamp `withRecovery` applies, so a caller receiving a "not authorized" message would have no correlation ID to hand to an admin for the log lookup. Third, the audit event fires before `next` runs on the allow path; if `withAuthorization` sat outside, an allow followed by a tool-handler panic would produce an "allowed" audit line *and* a recovered error, and reviewers might interpret the pairing as a successful allow followed by a separate failure rather than one request that never completed. Current nesting means allow/deny/panic all get uniform correlation and containment.

**Why `RegisterWithServer` uses `policy != nil` as the "RBAC on" signal instead of a separate boolean:**
The two facts (RBAC enabled, compiled policy exists) are perfectly coupled by the invariant `buildToolPolicy` enforces (gate enabled ⟺ policy non-nil). Encoding one bit of information as one value gives zero representable invalid states. The alternative I initially proposed — splitting into `enableAuthorization bool + policy *authz.Policy` — creates four states, two invalid (`{true, nil}` and `{false, non-nil}`), which converts a documentation problem into a synchronization problem: every caller now has to keep the two arguments consistent, including test scaffolding. The stdlib does the same thing (`http.Server.ErrorLog`, `tls.Config.VerifyPeerCertificate`) — nil-for-optional is the standard idiom when the single check-point is well-documented, which this one is.

**Why `buildToolPolicy` was extracted from `main` even though it's five lines:**
The invariant "gate enabled ⟺ policy non-nil" is the contract `RegisterWithServer` relies on to interpret its nil-policy path as "RBAC off." If that invariant were established inline in `main`, it would be an implicit convention scattered across startup wiring. Extracting to `buildToolPolicy` makes it a postcondition of a named function that tests can pin (`tool_policy_test.go` asserts both directions and the non-oauth-mode edge case). The pattern matches `buildRootHandler` and `buildMCPEndpoint` elsewhere in `main`, which the codebase adopted for exactly this reason — the assembled shape gets tested against real code rather than a hand-rebuilt copy in the test file.

**Why there's a fail-closed guard immediately after `buildToolPolicy` even though it's structurally unreachable today:**
```go
if config.ToolAuthorizationEnabled(cfg) && policy == nil {
    slog.Error("tool authorization is enabled in config but no policy was compiled — refusing to start rather than silently bypass authorization")
    os.Exit(1)
}
```
Under the current `buildToolPolicy` implementation the guard cannot fire — the function returns non-nil exactly when the gate is on. The guard defends against a future refactor that accidentally breaks the postcondition (e.g. someone adds an early-return branch in `buildToolPolicy` that returns `(nil, nil)` under a new condition). If that ever happens without the tests catching it, this guard converts a silent fail-open (every OAuth request bypasses authorization) into a loud, immediate startup crash naming the failure. SOL-149989 is the prior incident where a fail-open on the auth path went undetected for a period; this guard is proportionate defense-in-depth against that class.

**Why `authzDeniedMessage` and `authzMissingClaimMessage` are two constants with identical values in v1:**
The caller-facing distinction between "your groups don't grant this tool" and "your token has no groups claim at all" would be information disclosure — an unauthenticated-authorization caller learning that the server knows about a groups claim tells them the RBAC feature is enabled, and telling them their token is structurally incomplete is admin-configuration metadata they can't act on. Both branches return the same uniform string, so a caller cannot distinguish which fired. The audit log on the server side does distinguish (via the `decision` field: `denied` vs `denied_missing_claim`) so operators can tell the two failure classes apart. The two constants stay as separate identifiers so a future evolution can amend one without touching the other; `TestAuthzMessages_IdenticalForV1` locks the v1 identity constraint against accidental divergence.

**Why the deny result shape mirrors `withRecovery`'s panic branch:**
```go
&mcp.CallToolResult{
    StructuredContent: map[string]any{"error": msg, "retryable": false},
    Content:           []mcp.Content{&mcp.TextContent{Text: msg}},
    IsError:           true,
}
```
Same fields, same values, same `retryable: false` marker. A reviewer looking at any tool-level error result in this codebase sees one shape across authorization, panic recovery, and validation errors. `retryable: false` tells the agent client not to loop on the same denied call — retries won't change the outcome. Returning `(*CallToolResult, nil)` rather than `(nil, error)` means it's a tool-level error the agent surfaces to its user, not a JSON-RPC protocol error that would kill the session.

**Why `list-brokers` is exempt structurally (via a separate registration function) rather than as a runtime check inside the wrapper:**
`RegisterListBrokers` takes no `policy` argument and never composes `withAuthorization`. The exemption is expressed at the registration API's shape, meaning a YAML typo, a policy misconfiguration, or a bug in the wrapper cannot disable discovery. Every authenticated caller — regardless of group membership or claim structure — can list brokers and see which aliases the server knows about, which is the minimum discovery primitive the MCP contract requires. If the exemption lived inside `withAuthorization` as a name check (e.g. `if toolName == "list-brokers" { return next(...) }`), a refactor that split or renamed the wrapper could accidentally drop the check. Test `TestRegisterListBrokers_NeverComposesWithAuthorization` locks the current shape.

**Why `ValidatePolicyToolNames` collects unknown-tool errors via `errors.Join` with one row per unknown tool:**
Admin authors YAML in group-first form. A single typo (e.g. `delete-que-messages` instead of `delete-queue-messages`) referenced across three groups is *one* bug the admin needs to fix, not three. The function collects a map from unknown tool name to the set of referencing groups, sorts both dimensions alphabetically, and emits one row per unknown tool with the group list joined:
```
unknown tool "delete-que-messages" (referenced by groups: Contractors, Ops, Support)
```
Sorted output means the error is byte-identical across startup restarts — no dependency on Go's randomized map iteration order — so operators can diff startup logs across environments reliably. `list-brokers` grants are inert (the tool is exempt) but not errors; they surface as WARN so an admin who added `list-brokers` to a group intending some effect learns their grant has none.

**Why the audit event fires at INFO for every outcome in this PR (allow/deny/missing) rather than splitting levels:**
The audit-level split (deny at WARN for alerting, allow at INFO) requires refining the audit field schema (bounded matched-groups slice, correlation-ID field naming, structured decision codes) that this PR intentionally does not touch. Splitting audit refinement into its own ticket keeps this PR focused on the enforcement wiring and lets reviewers see one concern at a time. This PR's audit line is a v1 placeholder: INFO level always, minimal field set (identity, tool, decision string). A follow-up ticket refines. Tests assert on distinguishability of decision values rather than the literal schema so the follow-up doesn't churn these tests.

## Changes Made

- **`internal/tools/authorization.go`** (new):
  - `withAuthorization(policy, toolName, next) mcp.ToolHandler` — the enforcement wrapper. Reads groups via `requestGroups`, calls `policy.Authorize`, emits the decision audit line, dispatches to `next` on allow or returns a uniform tool-level error on deny/missing-claim.
  - `authzDeniedMessage` and `authzMissingClaimMessage` constants — identical strings for v1; separate identifiers for future evolution.
  - `authzErrorResult(message)` — builds the uniform deny/missing `*CallToolResult` (IsError:true, retryable:false, StructuredContent + TextContent).
  - `ValidatePolicyToolNames(cfg, mgr)` — startup check that every tool name in `AccessLevelGroups` resolves to a registered handler or is `list-brokers`. Alphabetized, deduped, one row per unknown tool via `errors.Join`. WARN on list-brokers grants (inert but noticeable).
  - `listBrokersToolName` constant — names the exemption target so a grep finds every touchpoint.

- **`internal/tools/register.go`**:
  - `RegisterWithServer` gains a `policy *authz.Policy` parameter.
  - Tool-registration loop composes `withRecovery(name, withAuthorization(policy, name, closure))` when policy is non-nil; keeps the pre-RBAC `withRecovery(name, closure)` shape when nil.
  - `RegisterListBrokers` is unchanged — signature deliberately does not accept a policy so exemption is enforced at compile time.
  - Godoc comments refreshed to reflect the new composition and the exemption.

- **`cmd/server/main.go`**:
  - New `buildToolPolicy(cfg) (*authz.Policy, error)` — single testable decision point returning `(nil, nil)` when gate is off, `(policy, nil)` when gate is on and compilation succeeds, `(nil, err)` on compilation failure.
  - Composition-time gate wires the flow: `buildToolPolicy` → fail-closed guard → `RegisterWithServer(..., policy)` → `RegisterListBrokers` → `ValidatePolicyToolNames` (when gate is on).
  - Startup INFO announcement naming the RBAC posture on both enabled and disabled paths, with reason on disabled (auth mode vs feature flag).
  - `slog.Error` + `os.Exit(1)` on any startup failure — partial RBAC state must never reach the request path.

- **`internal/tools/authorization_test.go`** (new): 12 wrapper unit tests.
- **`internal/tools/authorization_validate_test.go`** (new): 8 startup-validator tests.
- **`internal/tools/register_test.go`**: 3 composition-site integration tests appended (drive real client-server calls via `mcp.NewInMemoryTransports`).
- **`cmd/server/tool_policy_test.go`** (new): 3 `buildToolPolicy` postcondition tests.

## Testing

**Test Environment:**
- Go version: 1.26.0
- OS: darwin/arm64

**Tests Performed:**
- [x] Unit tests added
- [x] Integration-style composition-site tests added
- [x] `go test -race ./internal/tools/...` and `go test -race ./cmd/server/...` pass
- [x] Full `make check` passes

**Test Coverage — `withAuthorization` wrapper (12 tests):**

Allow path:
- `next` handler is called exactly once and its result is returned pointer-identical
- INFO `"tool authorization"` audit line fires with `tool` name and a `decision` value distinguishable from deny/missing values

Deny path (caller has groups, but none grant the tool):
- Returns `(*CallToolResult, nil)` — tool-level error, not JSON-RPC error
- `IsError: true` on the result
- `StructuredContent` carries `error = authzDeniedMessage` and `retryable = false`
- `Content` contains one `*TextContent` whose `Text` equals `authzDeniedMessage`
- `next` is NOT called
- INFO audit line fires with `decision` value distinguishable from allow and missing-claim

Missing-claim path (caller's token has no groups key in `TokenInfo.Extra`):
- Same result shape as deny, but `error = authzMissingClaimMessage`
- `next` is NOT called
- INFO audit line fires with `decision` distinguishable from plain deny (operator can tell IdP misconfig from grant miss)

Edge cases:
- Nil `req.Extra` → treated as missing-claim (test scaffolding safety)
- Nil `req.Extra.TokenInfo` → treated as missing-claim (disabled-mode safety)
- `authzDeniedMessage == authzMissingClaimMessage` — v1 identity constraint locked; also asserts both are non-empty
- Nil `*authz.Policy` passed to wrapper → panics on first call (precondition violation is loud, not silent — outer `withRecovery` catches it)

**Test Coverage — `ValidatePolicyToolNames` (8 tests):**

Happy path:
- All configured tool names resolve → `err == nil` AND zero log output (silent no-op)

Error return shape:
- One unknown tool referenced by one group → single error row naming both identifiers
- Same unknown tool referenced across three groups → one deduped row, group names alphabetized
- Three distinct unknown tools → three rows, alphabetized by tool name (deterministic across restarts)
- Unknown tool AND `list-brokers` grant on the same config → both surface independently (error return + WARN log)

`list-brokers` handling:
- Grant of `list-brokers` alone → `err == nil`, exactly one WARN log line naming the referencing group
- Case-mismatched `List-Brokers` → treated as unknown tool (unknown-tool error, NO list-brokers WARN); prevents silent case-folding drift on the exempt name

Empty inputs:
- Nil or empty `AccessLevelGroups` → `err == nil`, zero log output

**Test Coverage — composition-site wiring (3 tests, full MCP SDK loop):**

- Nil policy → dispatch is byte-identical to pre-RBAC: existing `"tool invoked"` audit line still fires, no `"tool authorization"` line appears
- Non-nil policy → wrapper is composed and consulted: caller receives `IsError:true` (missing-claim branch under no-middleware test scaffold), exactly one `"tool authorization"` audit line fires, decision value is consistent with the deny result (doesn't contain "allow")
- `RegisterListBrokers` under a policy-enabled server where the policy grants nothing for `list-brokers` → call succeeds (`IsError:false`), no `"tool authorization"` line fires (structural exemption verified end-to-end)

**Test Coverage — `buildToolPolicy` postcondition (3 tests):**

- Feature flag unset → `(nil, nil)` regardless of RBAC block contents in cfg (gate-off is total)
- Feature flag set + valid RBAC block + oauth mode → non-nil `*Policy`, `err == nil`
- Feature flag set + non-oauth mode → `(nil, nil)` (gate still off; tool authorization requires OAuth for identity)

**Test discipline notes:**
- No test asserts on the literal `decision` string schema. Assertions are "does not contain 'allow'" or "differs from 'denied'" so the audit-refinement follow-up ticket can rename fields without churning these tests.
- No test uses mocks for `*authz.Policy`. Real policies are constructed via `authz.NewPolicy`, so drift between wrapper and policy surfaces at test time.
- Composition-site tests drive real SDK transport (`mcp.NewInMemoryTransports`), not mocked wiring — regressions in the SDK's `RequestExtra` population would be caught.

## Independent review passes

Ran two independent principal-architect review passes on the branch — an architecture/design lens and a security lens — before opening this PR.

**Architecture review** (design decisions, layering, dependency direction, testability): overall verdict **Approve as-is**. All eight assessed decisions returned "Solid — no change needed" except the fail-closed guard, marked "Marginal — worth a follow-up comment but not blocking." No structural changes recommended.

**Security review** (SECURE framework — fail-open detection, silent bypass, information disclosure, panic containment): overall verdict **Ship with follow-ups**. No Critical or High findings. Three Low/Informational items surfaced for future tickets, none blocking:
- Add wrapper-level test for `[]string{}` empty-but-present groups edge case (belt-and-suspenders; behavior is correct today)
- Add `authz.Authorize` case-mismatch test for group names and document case-sensitivity in operator guide (documentation gap, not vulnerability)
- Consider whether the nil-policy panic path (unreachable in production due to startup guard) should be moved to a `defer`-based audit for zero-gap coverage (code hygiene)

Both reviewers praised: the three-layer separation actually honored in code (not just docs), the `policy != nil` convention + fail-closed guard, the leaf-package split of `authz`, the composition order, and the uniform-message + separate-constant pattern with `TestAuthzMessages_IdenticalForV1` as the drift guard.

## Breaking Changes

None. `RegisterWithServer` gained a new parameter, but this function is called from exactly one call site (`cmd/server/main.go`) which this PR also updates. No external consumers.

## What is deliberately not in this PR

- **Audit event refinement.** Level split (deny at WARN), bounded matched-groups slice, full field schema — separate follow-up ticket.
- **E2E OAuth flow tests.** Separate follow-up ticket owns the real-broker OAuth end-to-end coverage.
- **Admin-facing documentation for the RBAC config block.** Separate follow-up ticket.
- **`RegisterWithServer` → `RegisterAuthProtected` rename.** Was originally in scope, then descoped mid-implementation to keep this PR focused on the security-sensitive wrapper wiring rather than a codebase-wide naming refactor.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what")
- [x] Comment scan for workflow-internal labels — three found and removed in a follow-up commit on this branch
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code**
- [x] Followed secure logging rules — `/check-logs` scan passed
- [x] `authzDeniedMessage` and `authzMissingClaimMessage` are identical in v1; locked by test
- [x] `authz.Policy` and `authz.Decision` have `LogValue` implementations (from T2) that emit counts only, never group/tool names
- [x] Fail-closed guard defends the "gate on ⟹ policy non-nil" invariant against future refactor
- [x] `list-brokers` exemption is structural (registration API shape), not a runtime check that can be bypassed
- [x] Independent principal-level security review pass completed — no Critical/High findings

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered (nil TokenInfo, empty groups, unknown tools, empty tool names, case-mismatched exempt name)
- [x] Security-critical invariants explicitly locked: "next NOT called on deny", "next NOT called on missing-claim", "nil policy panics (no silent bypass)"
- [x] Test names describe observable behavior, not implementation

### Documentation
- [x] godoc comments added for all exported symbols in `authorization.go`
- [x] `RegisterWithServer` godoc updated to describe the new `policy` parameter and nil-vs-non-nil semantics
- [x] `buildToolPolicy` godoc names the invariant it enforces and the failure classes it protects against

### Git & CI
- [x] Commits have clear, descriptive messages (four commits: implementation, invariant refactor, tests, comment hygiene)
- [x] Branch is up to date with main
- [x] No merge conflicts

## Related Issues/PRs

- Part of epic [SOL-148417](https://sol-jira.atlassian.net/browse/SOL-148417) (Claims-Based Tool Authorization)
- Depends on:
  - #178 — T1: config schema + validation
  - #180 — T2: `internal/authz` decision engine
  - #183 — T3: middleware groups extraction
- Blocks: follow-up audit-refinement ticket, follow-up E2E OAuth ticket, follow-up admin-docs ticket

---

**For Reviewers:**

**Focus Areas:**
- **Fail-closed posture.** `buildToolPolicy` postcondition + the guard immediately after + the wrapper's nil-policy panic form a three-layer defense against silent RBAC bypass. If a bug in any of them makes an OAuth request quietly skip authorization, that's the disaster case this PR must prevent.
- **`list-brokers` exemption.** Verified by `TestRegisterListBrokers_NeverComposesWithAuthorization`. Is there a code path where a `list-brokers` request could still hit the wrapper?
- **Caller-side information disclosure.** Deny and missing-claim must be indistinguishable to the caller. Any observable difference (timing, error shape, extra fields, message wording) between the two branches would leak the claim-structure state to an unauthenticated-authorization caller.
- **Composition order.** `withAuthorization` inside `withRecovery` — reversing this breaks panic containment and correlation-ID stamping. Test-locked, but the ordering is the kind of thing that could regress in a well-meaning refactor.

**Questions:**
- The audit event's `decision` string values (`"allowed"` / `"denied"` / `"denied_missing_claim"`) are v1 placeholder. Tests assert on distinguishability, not literals. Is there a preferred schema convention I should match for the follow-up ticket, or is that up to the audit-refinement work?
- The `list-brokers` WARN in `ValidatePolicyToolNames` is one WARN per config-load, not one per grant (dedup on the exempt tool name). Is that the right calibration, or would per-grant WARNs be more actionable for a busy admin?

## Note on the DCO checklist item

Per team convention I do not sign commits with `-s`. Leaving that checkbox unchecked deliberately; happy to discuss if the DCO enforcement bot flags it.


[SOL-151440]: https://sol-jira.atlassian.net/browse/SOL-151440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-151978]: https://sol-jira.atlassian.net/browse/SOL-151978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-148417]: https://sol-jira.atlassian.net/browse/SOL-148417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ