### PR TITLE
Open-source release: disclaimers, compliance artifacts, Vault URL hardening

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -127,8 +127,9 @@ When deploying the Solace Broker MCP Server, follow these security guidelines:
 ### Write and destructive tools
 
 Write tools (`enable_write_tools: true`) let an AI assistant delete queued
-messages, disconnect clients, reset statistics, and manage VPN, queue, and
-topic-endpoint configuration. Leave `enable_write_tools` off unless an operator
+messages, disconnect clients, reset statistics, and manage VPN, queue,
+topic-endpoint, and REST delivery point configuration. Leave `enable_write_tools`
+off unless an operator
 deliberately needs these actions, and enable them only with
 `mcp_client_auth.mode: oauth` so every invocation is attributable in the audit
 log.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -124,6 +124,15 @@ When deploying the Solace Broker MCP Server, follow these security guidelines:
 - **Enable Dependabot**: Repository admins should enable Dependabot for automated updates
 - **Review security advisories**: Check https://github.com/advisories for Go ecosystem vulnerabilities
 
+### Write and destructive tools
+
+Write tools (`enable_write_tools: true`) let an AI assistant delete queued
+messages, disconnect clients, reset statistics, and manage VPN, queue, and
+topic-endpoint configuration. Leave `enable_write_tools` off unless an operator
+deliberately needs these actions, and enable them only with
+`mcp_client_auth.mode: oauth` so every invocation is attributable in the audit
+log.
+
 ## Known Security Considerations
 
 ### Broker Credentials

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -16,7 +16,6 @@
     },
     "secrets": {
       "vault": {
-        "url": "https://vault.maas-vault-prod.solace.cloud:8200",
         "secret_path": "secret/data/tools/githubactions",
         "role": "cicd-workflows-secret-read-role"
       }

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
   fossa_scan:
     if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     name: FOSSA Scan
-    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       use_vault: true
       config_file: '.github/workflow-config.json'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,6 +28,9 @@ jobs:
     with:
       use_vault: true
       config_file: '.github/workflow-config.json'
+    secrets:
+      # Vault address is injected from an org/repo secret, not committed to the repo.
+      VAULT_URL: ${{ secrets.VAULT_URL }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -25,3 +25,6 @@ jobs:
     with:
       use_vault: true
       config_file: '.github/workflow-config.json'
+    secrets:
+      # Vault address is injected from an org/repo secret, not committed to the repo.
+      VAULT_URL: ${{ secrets.VAULT_URL }}

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -25,3 +25,6 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       use_vault: true
       config_file: '.github/workflow-config.json'
+    secrets:
+      # Vault address is injected from an org/repo secret, not committed to the repo.
+      VAULT_URL: ${{ secrets.VAULT_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       git_ref: ${{ github.ref_name }}
       use_vault: true
       config_file: '.github/workflow-config.json'
+    secrets:
+      # Vault address is injected from an org/repo secret, not committed to the repo.
+      VAULT_URL: ${{ secrets.VAULT_URL }}
 
   build-binaries:
     needs: test

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,30 @@
+Solace Broker MCP Server
+Copyright 2024-2026 Solace Corporation
+
+This product includes software developed at Solace Corporation.
+
+Licensed under the Apache License, Version 2.0. See the LICENSE file for the
+full terms.
+
+--------------------------------------------------------------------------------
+Third-party software
+
+This product includes third-party software. Each component and its license is
+listed in THIRD_PARTY_LICENSES.md, and can be reproduced from go.mod / go.sum.
+
+Components licensed under the Mozilla Public License 2.0
+(github.com/hashicorp/go-retryablehttp, github.com/hashicorp/go-cleanhttp) are
+used unmodified; their source is available from the repositories named in their
+module paths.
+
+--------------------------------------------------------------------------------
+Required attributions propagated from bundled dependencies
+
+github.com/coreos/go-oidc
+  Copyright 2014 CoreOS, Inc.
+  Licensed under the Apache License, Version 2.0.
+
+gopkg.in/yaml.v3
+  Copyright 2011-2019 Canonical Ltd. Licensed under the Apache License 2.0.
+  Portions derived from libyaml are licensed under the MIT License
+  (Copyright 2006-2010 Kirill Simonov).

--- a/README.md
+++ b/README.md
@@ -29,18 +29,19 @@ An MCP (Model Context Protocol) server for Solace event brokers, built with Go u
 - [CI](#ci)
 - [Contributing](#contributing)
 - [Security](#security)
+- [Disclaimer](#disclaimer)
 - [License](#license)
 
 ## Overview
 
-An HTTP service that exposes Solace event broker management and monitoring to AI assistants through the Model Context Protocol (MCP). The server provides 17 read-only tools that query event broker status, inspect queues, diagnose client issues, and monitor message traffic using SEMP v1 and v2 API calls.
+An HTTP service that exposes Solace event broker management and monitoring to AI assistants through the Model Context Protocol (MCP). The server provides 33 tools: 17 read-only tools that query event broker status, inspect queues, diagnose client issues, and monitor message traffic, plus 16 optional write and action tools (off by default) for operational actions and configuration. It uses SEMP v1 and v2 API calls.
 
 MCP-compatible clients, for example Claude Code, invoke these tools using natural language. The AI assistant translates requests into tool calls. The server handles authentication, rate limiting, retries, and response formatting.
 
 ## Features
 
 - **17 read-only monitoring tools** — Event broker status, message VPNs, queues, clients, and REST delivery points
-- **Optional action tools** — Disconnect clients, delete queued messages, and reset statistics; gated behind `enable_write_tools` (off by default)
+- **16 optional write and action tools** — Disconnect clients, delete queued messages, reset statistics, and create, update, or delete message VPNs, queues, topic endpoints, and REST delivery points; gated behind `enable_write_tools` (off by default)
 - **Client authentication** — Development mode (no auth), static bearer tokens, or OAuth 2.1/OIDC with JWT validation
 - **Multi-broker configuration** — Connect to multiple brokers and address them by configured alias
 - **Retry and rate limiting** — Configurable backoff intervals and concurrent request limits per broker
@@ -66,7 +67,7 @@ The server implements the MCP HTTP transport specification and exposes event bro
 │                  │                    │   Broker MCP Server      │                      │                  │
 │   AI Agent       │ ────────────────▶ │                          │  ──────────────────▶ │  Solace          │
 │  (Claude Code,   │   JSON-RPC         │  • Auth (OAuth / token)  │   HTTP(S) /SEMP      │  Event           │
-│  Claude Desktop) │   + Bearer JWT     │  • 17 read-only tools    │                      │  Broker(s)       │
+│  Claude Desktop) │   + Bearer JWT     │  • 17 read + 16 write    │                      │  Broker(s)       │
 │                  │                    │  • Rate-limit + retry    │                      │                  │
 │                  │ ◀──────────────── │  • SEMP client pool      │ ◀──────────────────  │                  │
 └──────────────────┘                    └──────────────────────────┘   basic / bearer     └──────────────────┘
@@ -75,6 +76,9 @@ The server implements the MCP HTTP transport specification and exposes event bro
 ## Tools
 
 The server exposes read-only tools grouped by what they inspect, plus write tools for operational actions and configuration management. Every tool except `list-brokers` takes a `broker` parameter naming a configured broker alias. See the [Tools Reference](docs/tools-reference.md) for full per-tool parameters, output shape, and example invocations; the [user guide](docs/user-guide.md#tools-reference) has the narrative overview.
+
+> **Note:** Results are interpreted and acted on by an AI assistant. Treat tool output as input to a human decision, not as verified fact, and confirm any write or destructive action before allowing it. See the [Disclaimer](#disclaimer).
+
 | Category | Tools | Description |
 |---|---|---|
 | Discovery | `list-brokers` | List configured broker aliases for use as the `broker` parameter |
@@ -86,9 +90,9 @@ The server exposes read-only tools grouped by what they inspect, plus write tool
 | REST Delivery Points | `list-rdps`, `get-rdp-status` | List RDPs; inspect bindings, REST consumers, and last failure reason |
 | Discards | `get-discard-stats`, `list-queue-discards` | Broker-wide and per-VPN discard aggregates; per-queue discard counters |
 | Actions | `delete-queue-messages`, `clear-queue-stats`, `disconnect-client`, `clear-client-stats` | One tool per operational action. Destructive tools (`delete-queue-messages`, `disconnect-client`) are annotated `destructiveHint` so clients can prompt before invocation, and their descriptions ask the model to confirm; the `clear-*-stats` tools are non-destructive. |
-| Management | `create-message-vpn`, `update-message-vpn`, `delete-message-vpn`, `create-queue`, `update-queue`, `delete-queue`, `create-topic-endpoint`, `update-topic-endpoint`, `delete-topic-endpoint` | Create, update, and delete Config-API objects (Message VPNs, queues, topic endpoints). `delete-*` and the service-affecting `update-*` tools are annotated `destructiveHint` so clients can prompt before invocation, and their descriptions ask the model to confirm; `create-*` is additive and not annotated. |
+| Management | `create-message-vpn`, `update-message-vpn`, `delete-message-vpn`, `create-queue`, `update-queue`, `delete-queue`, `create-topic-endpoint`, `update-topic-endpoint`, `delete-topic-endpoint`, `create-rdp`, `update-rdp`, `delete-rdp` | Create, update, and delete Config-API objects (Message VPNs, queues, topic endpoints, REST delivery points). `delete-*` and the service-affecting `update-*` tools are annotated `destructiveHint` so clients can prompt before invocation, and their descriptions ask the model to confirm; `create-*` is additive and not annotated. |
 
-**The action and management tools are write tools, gated behind `enable_write_tools: true` in the config — default off; not registered in `tools/list` when disabled.** That's 13 write tools in total, on top of the 17 read-only tools.
+**The action and management tools are write tools, gated behind `enable_write_tools: true` in the config — default off; not registered in `tools/list` when disabled.** That's 16 write tools in total (4 action, 12 management), on top of the 17 read-only tools.
 
 > **Confirmation is not enforced.** `enable_write_tools` is the only enforced control. `destructiveHint` and the confirmation text in tool descriptions are hints, not enforced by the MCP protocol — whether the user is actually prompted depends on the client and the model.
 
@@ -404,8 +408,22 @@ Please read our [Code of Conduct](.github/CODE_OF_CONDUCT.md) before participati
 
 For security vulnerability reporting, please see [SECURITY.md](.github/SECURITY.md).
 
+## Disclaimer
+
+This software is provided under the Apache License 2.0 on an "AS IS" basis, without warranties or conditions of any kind. See the [LICENSE](LICENSE) file for the full terms. Use it at your own risk.
+
+This is a community-supported open-source project. It is provided on a best-effort basis with no service-level commitment, and it is not a supported Solace product.
+
+You are responsible for ensuring your use of this server complies with the terms governing your brokers and any laws, regulations, or policies that apply to you.
+
+**Production brokers.** This server issues real SEMP calls against the brokers you configure, including production brokers. Read operations add monitoring load; write operations (see [Tools](#tools)) change broker state. Test against a non-production broker before using it against production.
+
+**AI-generated output.** This server is driven by AI assistants that interpret broker data and decide which tools to call. AI models can misread data, draw wrong conclusions, and select the wrong tool or arguments. Review the server's responses before acting on them, and review every proposed write or destructive action before you allow it.
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+
+Attribution and third-party components are listed in [NOTICE](NOTICE) and [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).
 
 Copyright 2024-2026 Solace Corporation. All rights reserved.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -96,6 +96,7 @@ Before tagging:
 
 1. Confirm `main` is green: `gh run list --branch main --limit 1`.
 2. Update `CHANGELOG.md` on `main`: move the `[Unreleased]` items into a new version section and update the comparison links at the bottom.
+3. Regenerate the third-party license inventory from the toolchain: `go-licenses report ./cmd/server` supplies the module, version, and license data for `THIRD_PARTY_LICENSES.md`. Reconcile it against the FOSSA scan, which remains the authoritative check.
 
 After pushing the tag:
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,71 @@
+# Third-Party Licenses
+
+This file lists the third-party components compiled into the `solace-broker-mcp`
+binary, with their versions and licenses. It is the human-readable OSS compliance
+inventory that accompanies the release.
+
+**Generated** 2026-07-17 with
+[`go-licenses`](https://github.com/google/go-licenses) against
+`./cmd/server`. Regenerate before each release. The FOSSA scan in CI is the
+authoritative automated check; this file complements it.
+
+All components are compatible with distribution under the Apache License 2.0.
+No strong-copyleft licenses (GPL, LGPL, AGPL, EPL, CDDL) are linked into the
+binary.
+
+## Weak-copyleft components (MPL-2.0)
+
+Two components are licensed under the Mozilla Public License 2.0. MPL-2.0 is
+file-level copyleft and is compatible with an Apache 2.0 distribution. We use
+them unmodified, preserve their license text and headers, and keep their source
+available at the URLs below. If we ever modify their source files, we must make
+those modified files available under MPL-2.0.
+
+| Component | Version | License | Source |
+|---|---|---|---|
+| `github.com/hashicorp/go-cleanhttp` | v0.5.2 | MPL-2.0 | [license](https://github.com/hashicorp/go-cleanhttp/blob/v0.5.2/LICENSE) |
+| `github.com/hashicorp/go-retryablehttp` | v0.7.8 | MPL-2.0 | [license](https://github.com/hashicorp/go-retryablehttp/blob/v0.7.8/LICENSE) |
+
+## Permissive components
+
+| Component | Version | License | Source |
+|---|---|---|---|
+| `github.com/coreos/go-oidc/v3/oidc` | v3.18.0 | Apache-2.0 | [license](https://github.com/coreos/go-oidc/blob/v3.18.0/LICENSE) |
+| `github.com/dolthub/maphash` | v0.1.0 | Apache-2.0 | [license](https://github.com/dolthub/maphash/blob/v0.1.0/LICENSE) |
+| `github.com/gammazero/deque` | v0.2.1 | MIT | [license](https://github.com/gammazero/deque/blob/v0.2.1/LICENSE) |
+| `github.com/getkin/kin-openapi` | v0.134.0 | MIT | [license](https://github.com/getkin/kin-openapi/blob/v0.134.0/LICENSE) |
+| `github.com/go-jose/go-jose/v4` | v4.1.4 | Apache-2.0 | [license](https://github.com/go-jose/go-jose/blob/v4.1.4/LICENSE) |
+| `github.com/go-jose/go-jose/v4/json` | v4.1.4 | BSD-3-Clause | [license](https://github.com/go-jose/go-jose/blob/v4.1.4/json/LICENSE) |
+| `github.com/go-openapi/jsonpointer` | v0.21.0 | Apache-2.0 | [license](https://github.com/go-openapi/jsonpointer/blob/v0.21.0/LICENSE) |
+| `github.com/go-openapi/swag` | v0.23.0 | Apache-2.0 | [license](https://github.com/go-openapi/swag/blob/v0.23.0/LICENSE) |
+| `github.com/google/jsonschema-go/jsonschema` | v0.4.2 | MIT | [license](https://github.com/google/jsonschema-go/blob/v0.4.2/LICENSE) |
+| `github.com/josharian/intern` | v1.0.0 | MIT | [license](https://github.com/josharian/intern/blob/v1.0.0/license.md) |
+| `github.com/mailru/easyjson` | v0.7.7 | MIT | [license](https://github.com/mailru/easyjson/blob/v0.7.7/LICENSE) |
+| `github.com/maypok86/otter` | v1.2.4 | Apache-2.0 | [license](https://github.com/maypok86/otter/blob/v1.2.4/LICENSE) |
+| `github.com/modelcontextprotocol/go-sdk` | v1.5.0 | Apache-2.0 | [license](https://github.com/modelcontextprotocol/go-sdk/blob/v1.5.0/LICENSE) |
+| `github.com/mohae/deepcopy` | c48cc78d4826 | MIT | [license](https://github.com/mohae/deepcopy/blob/c48cc78d4826/LICENSE) |
+| `github.com/oasdiff/yaml` | a3ea61cb4d4c | MIT | [license](https://github.com/oasdiff/yaml/blob/a3ea61cb4d4c/LICENSE) |
+| `github.com/oasdiff/yaml3` | 61cd415a242b | MIT | [license](https://github.com/oasdiff/yaml3/blob/61cd415a242b/LICENSE) |
+| `github.com/perimeterx/marshmallow` | v1.1.5 | MIT | [license](https://github.com/perimeterx/marshmallow/blob/v1.1.5/LICENSE) |
+| `github.com/segmentio/asm` | v1.1.3 | MIT | [license](https://github.com/segmentio/asm/blob/v1.1.3/LICENSE) |
+| `github.com/segmentio/encoding` | v0.5.4 | MIT | [license](https://github.com/segmentio/encoding/blob/v0.5.4/LICENSE) |
+| `github.com/woodsbury/decimal128` | v1.3.0 | 0BSD | [license](https://github.com/woodsbury/decimal128/blob/v1.3.0/LICENCE) |
+| `github.com/xeipuuv/gojsonpointer` | 4e3ac2762d5f | Apache-2.0 | [license](https://github.com/xeipuuv/gojsonpointer/blob/4e3ac2762d5f/LICENSE-APACHE-2.0.txt) |
+| `github.com/xeipuuv/gojsonreference` | bd5ef7bd5415 | Apache-2.0 | [license](https://github.com/xeipuuv/gojsonreference/blob/bd5ef7bd5415/LICENSE-APACHE-2.0.txt) |
+| `github.com/xeipuuv/gojsonschema` | v1.2.0 | Apache-2.0 | [license](https://github.com/xeipuuv/gojsonschema/blob/v1.2.0/LICENSE-APACHE-2.0.txt) |
+| `github.com/yosida95/uritemplate/v3` | v3.0.2 | BSD-3-Clause | [license](https://github.com/yosida95/uritemplate/blob/v3.0.2/LICENSE) |
+| `golang.org/x/oauth2` | v0.36.0 | BSD-3-Clause | [license](https://cs.opensource.google/go/x/oauth2/+/v0.36.0:LICENSE) |
+| `golang.org/x/sync` | v0.20.0 | BSD-3-Clause | [license](https://cs.opensource.google/go/x/sync/+/v0.20.0:LICENSE) |
+| `golang.org/x/sys/cpu` | v0.41.0 | BSD-3-Clause | [license](https://cs.opensource.google/go/x/sys/+/v0.41.0:LICENSE) |
+| `gopkg.in/yaml.v3` | v3.0.1 | MIT | [license](https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE) |
+
+## Notes
+
+- `github.com/go-jose/go-jose/v4` bundles a `json` subpackage under BSD-3-Clause
+  (a copy of the Go standard library's encoding/json); both are permissive.
+- `github.com/modelcontextprotocol/go-sdk` is mid-transition from MIT to
+  Apache 2.0; un-relicensed files may remain MIT. Both are permissive.
+- `gopkg.in/yaml.v3` ships a NOTICE (Apache 2.0) alongside MIT-licensed
+  libyaml-derived files; its required attribution is reproduced in `NOTICE`.
+- Commit-pinned modules (`mohae/deepcopy`, `oasdiff/*`, `xeipuuv/*`) carry a
+  clear license at the pinned commit.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -17,18 +17,19 @@ binary.
 
 Two components are licensed under the Mozilla Public License 2.0. MPL-2.0 is
 file-level copyleft and is compatible with an Apache 2.0 distribution. We use
-them unmodified, preserve their license text and headers, and keep their source
-available at the URLs below. If we ever modify their source files, we must make
-those modified files available under MPL-2.0.
+them unmodified and preserve their license text and copyright headers. Their
+source is publicly available at the repositories named in their module paths. If
+we ever modify their source files, we must make those modified files available
+under MPL-2.0.
 
-| Component | Version | License | Source |
+| Component | Version | License | License text |
 |---|---|---|---|
 | `github.com/hashicorp/go-cleanhttp` | v0.5.2 | MPL-2.0 | [license](https://github.com/hashicorp/go-cleanhttp/blob/v0.5.2/LICENSE) |
 | `github.com/hashicorp/go-retryablehttp` | v0.7.8 | MPL-2.0 | [license](https://github.com/hashicorp/go-retryablehttp/blob/v0.7.8/LICENSE) |
 
 ## Permissive components
 
-| Component | Version | License | Source |
+| Component | Version | License | License text |
 |---|---|---|---|
 | `github.com/coreos/go-oidc/v3/oidc` | v3.18.0 | Apache-2.0 | [license](https://github.com/coreos/go-oidc/blob/v3.18.0/LICENSE) |
 | `github.com/dolthub/maphash` | v0.1.0 | Apache-2.0 | [license](https://github.com/dolthub/maphash/blob/v0.1.0/LICENSE) |

--- a/broker-config.example.yaml
+++ b/broker-config.example.yaml
@@ -77,6 +77,8 @@ mcp_client_auth:
 # not appear in tools/list unless this is explicitly true. Leave off for trial /
 # dev deployments; flip on only when an operator deliberately wants the action
 # tools available.
+# When enabled, an AI assistant can invoke destructive actions (delete queued
+# messages, disconnect clients) against the configured brokers.
 # enable_write_tools: false
 
 # SEMP client settings — controls how the server talks to brokers.

--- a/broker-config.example.yaml
+++ b/broker-config.example.yaml
@@ -77,8 +77,9 @@ mcp_client_auth:
 # not appear in tools/list unless this is explicitly true. Leave off for trial /
 # dev deployments; flip on only when an operator deliberately wants the action
 # tools available.
-# When enabled, an AI assistant can invoke destructive actions (delete queued
-# messages, disconnect clients) against the configured brokers.
+# When enabled, an AI assistant can delete queued messages, disconnect clients,
+# reset statistics, and create, update, or delete broker configuration (message
+# VPNs, queues, topic endpoints, REST delivery points) on the configured brokers.
 # enable_write_tools: false
 
 # SEMP client settings — controls how the server talks to brokers.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -542,8 +542,8 @@ func main() {
 	// internal/banner (those are reserved for security-mode signals and must not
 	// be diluted). Emitted here in the bootstrap-INFO window — before the slog
 	// handler is reconfigured to cfg.LogLevel — so it stays visible even when the
-	// operator sets a higher log level. Wording tracks the README Disclaimer and
-	// is finalized by Legal; see DISCLAIMERS.md item 7.
+	// operator sets a higher log level. Wording tracks the README Disclaimer
+	// section and is finalized by Legal.
 	slog.Info("Community-supported open-source software, provided AS IS with no warranty. " +
 		"AI-driven; review output before acting. See the Disclaimer in the README.")
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -537,6 +537,16 @@ func main() {
 
 	slog.Info("server starting", slog.String("version", version.Version()))
 
+	// One-line release disclaimer, emitted once on every startup regardless of
+	// auth mode. It is deliberately SEPARATE from the insecure-mode banners in
+	// internal/banner (those are reserved for security-mode signals and must not
+	// be diluted). Emitted here in the bootstrap-INFO window — before the slog
+	// handler is reconfigured to cfg.LogLevel — so it stays visible even when the
+	// operator sets a higher log level. Wording tracks the README Disclaimer and
+	// is finalized by Legal; see DISCLAIMERS.md item 7.
+	slog.Info("Community-supported open-source software, provided AS IS with no warranty. " +
+		"AI-driven; review output before acting. See the Disclaimer in the README.")
+
 	// 1. Load config. config.Load handles path resolution internally
 	//    (CONFIG_FILE env var, then /etc/mcp-server/config.yaml, then
 	//    ./broker-config.yaml). See config.Load docs for exact semantics.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -5,8 +5,12 @@ parameters, output shape, an example invocation, and an example natural-language
 request. For task-oriented walkthroughs see [Examples](examples.md); for a
 narrative overview see the [User Guide](user-guide.md).
 
-The server exposes **17 read-only tools** plus **13 write tools** — 4 action
-tools and 9 Config-API management tools. The write tools are gated behind
+> **Note:** Results are interpreted and acted on by an AI assistant. Treat tool
+> output as input to a human decision, not as verified fact, and confirm any
+> write or destructive action before allowing it.
+
+The server exposes **17 read-only tools** plus **16 write tools** — 4 action
+tools and 12 Config-API management tools. The write tools are gated behind
 `enable_write_tools` (off by default) and are not registered with the MCP server
 when disabled — see
 [Action tools and `enable_write_tools`](#action-tools-and-enable_write_tools).


### PR DESCRIPTION
Prepares `solace-broker-mcp` for public open-source release under Apache 2.0. Companion to the launch plan (Broker MCP Launch Plans and Concerns), items 1 (disclaimers/support) and 2 (the Apache 2.0 commitment).

## What's in this PR

- **Compliance artifacts:** `NOTICE` and `THIRD_PARTY_LICENSES.md` (generated via `go-licenses`). Satisfies Legal's requirement to ship an OSS compliance artifact.
- **Disclaimers** (placement-ready drafts; Legal confirms final wording):
  - README `## Disclaimer` section: no-warranty, community/no-SLA, responsibility, production-broker caution, AI-accuracy.
  - AI-accuracy note at the top of the Tools section and `docs/tools-reference.md`.
  - `SECURITY.md` write/destructive-tools subsection.
  - `broker-config.example.yaml` blast-radius clause.
  - One-line startup disclaimer in `cmd/server/main.go` (INFO, separate from the insecure-mode banners; not injected into tool payloads).
- **Vault URL hardening:** the internal Vault URL is now read from the `VAULT_URL` GitHub Actions secret (already set at repo level) instead of being committed; removed from `.github/workflow-config.json` (`secret_path` and `role` remain).
- **Docs accuracy:** corrected the tool count to 33 (17 read-only + 16 write) across the README and tools reference, added the missing RDP management tools to the README table, and documented `THIRD_PARTY_LICENSES` regeneration in `RELEASING.md`.

## Verification

`go build`, `go vet`, `gofmt`, and `go test ./cmd/...` pass. The disclaimer work was independently reviewed.

## Not in this PR (tracked elsewhere)

- Legal review and sign-off.
- CC BY 4.0 FOSSA finding: already reviewed and accepted (Legal agreed by email in May; recorded as an accepted exception in FOSSA, which reports clean). Documentation to be attached to the compliance record.
- Org-level `VAULT_URL` secret so other repos inherit it.
- Repo admin settings and the public-visibility flip.

Draft until the legal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
