### PR TITLE
SOL-152039: Refine tool-authorization audit event and relocate the claim sanitizer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -687,7 +687,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools, policy)
+	// Pull the configured groups claim name for the missing-claim audit
+	// event. applyDefaults guarantees GroupsClaimName is non-nil whenever
+	// the tool_authorization block is non-nil, so this dereference is safe
+	// under the same gate that produced a non-nil policy. When RBAC is
+	// disabled the string is unused by RegisterWithServer.
+	var groupsClaimName string
+	if policy != nil {
+		groupsClaimName = *cfg.MCPClientAuth.ToolAuthorization.GroupsClaimName
+	}
+	tools.RegisterWithServer(mgr, server, pool, cfg.EnableWriteTools, policy, groupsClaimName)
 	slog.Info("tool registration complete",
 		slog.Bool("enable_write_tools", cfg.EnableWriteTools))
 

--- a/internal/observability/logging/sanitize/sanitize.go
+++ b/internal/observability/logging/sanitize/sanitize.go
@@ -1,0 +1,92 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sanitize centralizes audit-log field hygiene. Admin- or
+// IdP-controlled strings pass through Claim before they reach an slog
+// record, so a hostile or buggy source cannot inject forged log lines
+// (CWE-117) or spoof audit identities via bidi controls (CWE-1007).
+//
+// This package is a leaf: it has no dependencies outside the standard
+// library and imports no other repo packages. Both the tool-authorization
+// audit event and the identity-audit log line depend on it, so hosting
+// the utility here — under the observability tree, alongside correlation —
+// keeps every caller import-cycle-free.
+package sanitize
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// MaxLen is the byte cap applied by Claim. A real IdP-issued sub/jti is
+// 20–50 chars; the cap defends against a hostile or buggy issuer shipping
+// a multi-megabyte claim into audit logs.
+const MaxLen = 256
+
+// VerifierBugSentinel is the audit sentinel emitted by callers when their
+// own verifier stashed a non-string value where a string was expected.
+// Distinct from an "absent" sentinel so log consumers can tell "IdP did
+// not issue this claim" (normal) from "our code put garbage in Extra"
+// (alarm).
+const VerifierBugSentinel = "<verifier-bug>"
+
+// Claim defends against log-injection (CWE-117) and audit-spoofing
+// (CWE-1007) by stripping non-graphic Unicode and capping the result at
+// MaxLen bytes. The four stripped categories are:
+//
+//   - Cc — Control characters. Includes the ASCII C0 block (NUL, TAB, LF,
+//     CR, ESC, …), DEL, and the C1 block (U+0080–U+009F). This is the
+//     CWE-117 surface: LF and CR can break log-line framing.
+//   - Cf — Format characters. Includes bidi/RTL overrides (U+202A–U+202E,
+//     U+2066–U+2069), zero-width joiners, BOM, soft hyphen, language tags.
+//     Bidi controls are the CWE-1007 surface: a sub like
+//     "alice<RLO>nimda" renders as "aliceadmin" in any bidi-aware UI,
+//     misattributing the action to the wrong user in SIEMs/terminals.
+//   - Zl / Zp — Line and Paragraph separator (U+2028, U+2029). Some
+//     renderers honor these as line breaks; they're CWE-117-adjacent.
+//
+// JSON-handler escaping already neutralizes CR/LF for the JSON sink, but
+// field-level sanitization protects re-emission through error messages,
+// panic strings, custom handlers, and metric labels.
+//
+// Allocation and CPU are bounded by MaxLen: the working buffer is sized at
+// min(len(s), MaxLen) and the loop breaks as soon as another rune would
+// exceed the cap. A malicious or buggy IdP shipping a multi-megabyte claim
+// cannot force proportional work here.
+//
+// Truncation lands on a rune boundary — the projected length is checked
+// BEFORE writing, so the output is always valid UTF-8 even if the cap
+// falls inside what would have been a multibyte codepoint.
+func Claim(s string) string {
+	b := strings.Builder{}
+	b.Grow(min(len(s), MaxLen))
+
+	for _, r := range s {
+		// Single filter, complete spec — see godoc above. Cc covers both
+		// ASCII (C0/DEL) and C1 controls, so no separate fast-path is
+		// needed.
+		if unicode.In(r, unicode.Cc, unicode.Cf, unicode.Zl, unicode.Zp) {
+			continue
+		}
+		// Stop before writing a rune that would push us past the cap. This
+		// is both the DoS defense (bounds total work) and the UTF-8 safety
+		// guarantee (never emits half a multibyte codepoint).
+		if b.Len()+utf8.RuneLen(r) > MaxLen {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/internal/observability/logging/sanitize/sanitize_test.go
+++ b/internal/observability/logging/sanitize/sanitize_test.go
@@ -1,0 +1,218 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The tests in this file pin the algorithm the previous unexported
+// sanitizeClaim carried; the relocation from internal/tools/identity.go
+// is a rename-plus-relocation only. A change here that widens or narrows
+// what Claim strips is a public log-contract change, not a refactor.
+
+package sanitize
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestClaim_stripsControlChars(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"CR LF", "foo\r\nbar", "foobar"},
+		{"tab", "foo\tbar", "foobar"},
+		{"ANSI ESC", "foo\x1B[31mred\x1B[0m", "foo[31mred[0m"},
+		{"DEL byte", "foo\x7Fbar", "foobar"},
+		{"NUL byte", "foo\x00bar", "foobar"},
+		{"vertical tab + form feed", "foo\x0B\x0Cbar", "foobar"},
+		{"plain", "auth0|abc123", "auth0|abc123"},
+		{"unicode passes through", "user-éñ", "user-éñ"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Claim(c.in); got != c.want {
+				t.Errorf("Claim(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestClaim_capsAt256Bytes(t *testing.T) {
+	in := strings.Repeat("a", 300)
+	got := Claim(in)
+	if len(got) != MaxLen {
+		t.Errorf("len = %d, want %d", len(got), MaxLen)
+	}
+}
+
+// TestClaim_stripsBidiAndFormatChars pins the CWE-1007 audit-spoofing
+// defense: a malicious IdP issues a sub with a RIGHT-TO-LEFT OVERRIDE
+// between "alice" and "nimda". Without the Cf-category strip, the bytes
+// pass through unchanged, and any bidi-aware UI (SIEM dashboards,
+// terminals, JSON viewers) renders the value visually as "aliceadmin" —
+// misattributing the action to a different user.
+func TestClaim_stripsBidiAndFormatChars(t *testing.T) {
+	// Each test case names the codepoint in the row label (e.g.
+	// "RLO (U+202E)") so a reviewer viewing this file in an editor that
+	// renders bidi controls literally can still identify which character
+	// is under test. The character itself lives inside the input-string
+	// literal; the label is the safe hook to grep on.
+	cases := []struct {
+		name, in, want string
+	}{
+		{"RLO (U+202E)", "alice\u202enimda", "alicenimda"},
+		{"PDF (U+202C)", "x\u202cy", "xy"},
+		{"LRO (U+202D)", "a\u202db", "ab"},
+		{"zero-width joiner (U+200D)", "user\u200dname", "username"},
+		{"zero-width non-joiner (U+200C)", "user\u200cname", "username"},
+		{"BOM (U+FEFF)", "\xef\xbb\xbfuser", "user"},
+		{"soft hyphen (U+00AD)", "ad\u00admin", "admin"},
+		{"line separator (U+2028 Zl)", "a\u2028b", "ab"},
+		{"paragraph separator (U+2029 Zp)", "a\u2029b", "ab"},
+		{"C1 control NEL (U+0085)", "a\u0085b", "ab"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Claim(c.in); got != c.want {
+				t.Errorf("Claim(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestClaim_truncatesOnRuneBoundary_repeated pins the UTF-8 safety
+// property for the simple "all runes have the same width" case: when the
+// cap falls inside what would have been a multibyte codepoint, we stop
+// BEFORE writing the codepoint, never mid-bytes. Output is always
+// utf8.ValidString.
+//
+// The 'e-acute' rune (U+00E9) is 2 bytes in UTF-8 (0xC3 0xA9). 128 of
+// them = 256 bytes exactly, which fits. 129 of them = 258 bytes would
+// overflow the cap; the sanitizer must stop at 128 and return 256 valid
+// bytes — not 257 with a dangling 0xC3.
+func TestClaim_truncatesOnRuneBoundary_repeated(t *testing.T) {
+	in := strings.Repeat("é", 200) // 400 bytes, well over the 256 cap
+	got := Claim(in)
+
+	if !utf8.ValidString(got) {
+		t.Errorf("sanitized output is not valid UTF-8: %q", got)
+	}
+	if len(got) > MaxLen {
+		t.Errorf("len = %d, exceeds cap %d", len(got), MaxLen)
+	}
+	// 128 two-byte runes = 256 bytes exactly.
+	if want := MaxLen; len(got) != want {
+		t.Errorf("len = %d, want exactly %d (128 x 2-byte runes)", len(got), want)
+	}
+}
+
+// TestClaim_boundedWork_largeInput pins the DoS-defense property: the
+// sanitizer must not iterate or allocate proportionally to input length.
+// A 10 MB input is fed and the result is still capped at MaxLen bytes.
+func TestClaim_boundedWork_largeInput(t *testing.T) {
+	in := strings.Repeat("a", 10_000_000)
+	got := Claim(in)
+	if len(got) != MaxLen {
+		t.Errorf("len = %d, want %d (cap must hold against multi-MB input)", len(got), MaxLen)
+	}
+}
+
+// TestClaim_truncatesOnRuneBoundary_explicit pins the "cap falls inside a
+// multi-byte rune" case explicitly, which the simple-repeated form
+// exercises by accident but does not name. Constructs an input where the
+// 257th byte would split a rune: 255 ASCII bytes followed by a 3-byte
+// rune. The sanitizer must stop at 255 (not truncate into the middle of
+// the rune) and produce valid UTF-8.
+//
+// U+3042 (HIRAGANA LETTER A) is 3 bytes in UTF-8 (0xE3 0x81 0x82).
+// Feeding 255 'a's + U+3042 gives a 258-byte input where writing the
+// rune would push the buffer to 258 bytes, overshooting the cap by 2.
+// The sanitizer's projected-length check must observe this and stop at
+// 255.
+func TestClaim_truncatesOnRuneBoundary_explicit(t *testing.T) {
+	in := strings.Repeat("a", 255) + "あ"
+	got := Claim(in)
+
+	if !utf8.ValidString(got) {
+		t.Errorf("output is not valid UTF-8: %q", got)
+	}
+	if len(got) > MaxLen {
+		t.Errorf("len = %d exceeds cap %d", len(got), MaxLen)
+	}
+	// Result must be exactly 255 ASCII bytes — the 3-byte rune could not
+	// be written without overshooting, so it is dropped entirely.
+	if want := strings.Repeat("a", 255); got != want {
+		t.Errorf("output = %q, want %q (the trailing rune must be dropped, not split)", got, want)
+	}
+}
+
+// TestClaim_nonASCIIGraphicUnicodePassesThrough pins the complement of
+// TestClaim_stripsBidiAndFormatChars: legitimate non-ASCII graphic runes
+// (accented Latin, an emoji, a CJK character) must survive unchanged. A
+// future contributor reading the "control-character stripping" contract
+// could interpret it more broadly than the current implementation — this
+// test locks the boundary in.
+func TestClaim_nonASCIIGraphicUnicodePassesThrough(t *testing.T) {
+	cases := []struct {
+		name, in string
+	}{
+		{"accented Latin", "Ünïcödé"},
+		{"emoji", "hello \U0001F680 world"},
+		{"CJK", "訊息代理"},
+		{"mixed graphic", "café-☕-你好"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Claim(c.in); got != c.in {
+				t.Errorf("Claim(%q) = %q, want %q (non-ASCII graphic runes must pass through)", c.in, got, c.in)
+			}
+		})
+	}
+}
+
+// TestClaim_stripsZeroWidthAndBidiMarks is the sharper companion to
+// TestClaim_stripsBidiAndFormatChars: it names three specific characters
+// operators are likely to reach for when writing a SIEM rule
+// ("zero-width joiner", "RTL mark", "byte order mark") and pins that
+// each is stripped, so a future refactor that narrowed the Cf category
+// filter (e.g. "strip only bidi overrides, keep joiners") would fail
+// this test loudly.
+func TestClaim_stripsZeroWidthAndBidiMarks(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"zero-width joiner U+200D", "user\u200dname", "username"},
+		{"right-to-left mark U+200F", "user\u200fname", "username"},
+		{"byte order mark U+FEFF", "\xef\xbb\xbfvalue", "value"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Claim(c.in); got != c.want {
+				t.Errorf("Claim(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestConstants pins the literal values of the exported constants. The
+// values are load-bearing: MaxLen is the audit-log per-field byte cap,
+// VerifierBugSentinel is the string SIEM rules grep for when the
+// middleware stashes a non-string value.
+func TestConstants(t *testing.T) {
+	if MaxLen != 256 {
+		t.Errorf("MaxLen = %d, want 256", MaxLen)
+	}
+	if VerifierBugSentinel != "<verifier-bug>" {
+		t.Errorf("VerifierBugSentinel = %q, want %q", VerifierBugSentinel, "<verifier-bug>")
+	}
+}

--- a/internal/observability/logging/sanitize/sanitize_test.go
+++ b/internal/observability/logging/sanitize/sanitize_test.go
@@ -216,3 +216,53 @@ func TestConstants(t *testing.T) {
 		t.Errorf("VerifierBugSentinel = %q, want %q", VerifierBugSentinel, "<verifier-bug>")
 	}
 }
+
+// TestClaim_exactMaxLenBytesReturnedUnchanged pins the cap as INCLUSIVE:
+// exactly MaxLen bytes of graphic input pass through untouched. A
+// future change that flipped the projected-length check from > to >= would
+// turn a 256-byte value into a 255-byte value silently — every audit-log
+// consumer holding sub-length expectations would see a regression at the
+// boundary. The check is on both length and identity of the returned
+// string so a naive impl that copied only the first 255 bytes fails
+// loudly.
+func TestClaim_exactMaxLenBytesReturnedUnchanged(t *testing.T) {
+	in := strings.Repeat("a", MaxLen)
+	got := Claim(in)
+	if got != in {
+		t.Errorf("MaxLen-byte input was altered; len(got) = %d, want %d and identity-equal to input", len(got), MaxLen)
+	}
+}
+
+// TestClaim_oneByteOverMaxLenReturnsPrefix pins the truncation shape as
+// PREFIX, not (say) suffix, middle window, or reversed. The migrated
+// cap test only pins length; this test pins the specific bytes that
+// survive. SIEM parsers that reason "the first 256 bytes are canonical"
+// depend on this. A future refactor that switched to keeping the last
+// MaxLen bytes (rare, but possible when someone hurriedly reaches for
+// a ring buffer) would break exactly this contract.
+func TestClaim_oneByteOverMaxLenReturnsPrefix(t *testing.T) {
+	in := strings.Repeat("a", MaxLen+1)
+	got := Claim(in)
+	want := strings.Repeat("a", MaxLen)
+	if got != want {
+		t.Errorf("Claim(len=%d) = %q (len=%d); want the first %d bytes of input", len(in), got, len(got), MaxLen)
+	}
+}
+
+// TestClaim_combiningDiacriticPassesThrough pins the strip set's
+// boundary from the OUTSIDE: Unicode category Mn (Mark, non-spacing)
+// includes combining marks such as U+0301 (combining acute accent).
+// These are graphic, not format, and must survive. A future contributor
+// who "broadened" the strip set to include Mn would silently mangle
+// every user identifier in decomposed Latin scripts (Vietnamese,
+// some Spanish/Portuguese normalization forms), CJK combining forms,
+// and any IdP that stores names in NFD normalization form.
+func TestClaim_combiningDiacriticPassesThrough(t *testing.T) {
+	// "e" + combining acute — renders as "é". Two runes, three bytes.
+	// If Mn were stripped we would see just "e".
+	in := "é"
+	got := Claim(in)
+	if got != in {
+		t.Errorf("Claim(%q) = %q, want %q — combining marks (Mn) must survive; only Cc/Cf/Zl/Zp are stripped", in, got, in)
+	}
+}

--- a/internal/tools/authorization.go
+++ b/internal/tools/authorization.go
@@ -65,6 +65,15 @@ const matchedGroupsBound = 32
 // call site, or the record will carry two.
 func withAuthorization(policy *authz.Policy, toolName string, configuredGroupsClaimName string, next mcp.ToolHandler) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Enforce the precondition uniformly across every branch. Without
+		// this guard, nil policy panics on the branch that reaches
+		// policy.Authorize but silently returns a missing-claim deny on
+		// the branch that returns first — the doc's "panic on nil" promise
+		// would then hold on only one input shape.
+		if policy == nil {
+			panic("withAuthorization: nil policy (composition-site invariant violated)")
+		}
+
 		var info *sdkauth.TokenInfo
 		if req.Extra != nil {
 			info = req.Extra.TokenInfo

--- a/internal/tools/authorization.go
+++ b/internal/tools/authorization.go
@@ -29,11 +29,9 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Caller-facing messages. Deliberately identical in v1 so a caller cannot
-// distinguish "your groups don't grant this" from "your token has no groups
-// claim" — that distinction is admin-configuration metadata. Kept as separate
-// identifiers so a future evolution can amend one without touching the other;
-// the audit log distinguishes the outcomes via the decision field.
+// Caller-facing messages. Identical in v1 so a caller cannot distinguish
+// deny from missing-claim — that distinction is admin-configuration
+// metadata, kept on the server-side audit event instead.
 const (
 	authzDeniedMessage       = "You are not authorized to use this tool."
 	authzMissingClaimMessage = "You are not authorized to use this tool."
@@ -58,28 +56,13 @@ const matchedGroupsBound = 32
 // tool-level error result and skips next.
 //
 // Precondition: policy must be non-nil. The composition site
-// (RegisterWithServer) guarantees this by only composing the wrapper on the
-// non-nil-policy branch. A nil policy reaching here is a programmer error
-// that must not silently bypass authorization; the outer withRecovery catches
-// the resulting panic.
+// (RegisterWithServer) enforces this by only wrapping when RBAC is on.
+// A nil arriving here is a programmer error; the outer withRecovery
+// contains the resulting panic.
 //
-// Panic containment (from Authorize or the audit call site) is owned by the
-// outer withRecovery, so this closure reads as straight-line request logic.
-//
-// Audit event: one "tool authorization" slog record per invocation, allow or
-// deny. Correlation ID is stamped by the correlation slog handler from ctx;
-// the call site does not add it manually. Level split: INFO on allow, WARN
-// on both deny outcomes (deny is not an error but is a notable event; a
-// missing groups claim is a configuration event, not a system failure).
-// Decision axis is a two-field split (decision + decision_reason) so
-// operators can filter deny clusters without conflating the "not permitted"
-// case with the "misconfigured token" case.
-//
-// configuredGroupsClaimName is the admin-authored JWT claim name the
-// resolver was told to look for; the missing-claim event names it under
-// expected_claim so operators reading the log can jump straight to the IdP
-// side. It passes through sanitize.Claim before emission because it is an
-// admin string reaching a log record.
+// Correlation ID is stamped onto each emitted record by the correlation
+// slog handler reading it from ctx — do NOT add correlation_id at this
+// call site, or the record will carry two.
 func withAuthorization(policy *authz.Policy, toolName string, configuredGroupsClaimName string, next mcp.ToolHandler) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		var info *sdkauth.TokenInfo
@@ -90,9 +73,9 @@ func withAuthorization(policy *authz.Policy, toolName string, configuredGroupsCl
 
 		groups, present := requestGroups(req)
 		if !present {
-			// Missing-claim: no matched_groups fields on this outcome — the
-			// caller had no groups slice at all, so emitting empty ones would
-			// be dead noise. expected_claim carries the diagnostic instead.
+			// No matched_groups* fields on missing-claim — the caller had
+			// no groups slice, so emitting empty ones would blur the deny
+			// signal. expected_claim carries the diagnostic instead.
 			slog.LogAttrs(ctx, slog.LevelWarn, "tool authorization",
 				slog.String("tool", toolName),
 				slog.String("decision", "denied"),
@@ -104,12 +87,9 @@ func withAuthorization(policy *authz.Policy, toolName string, configuredGroupsCl
 
 		decision := policy.Authorize(groups, toolName)
 		if !decision.Allowed {
-			// Deny: matched_groups is always [] and total is always 0 by
-			// construction (a match would have flipped Allowed). Keeping the
-			// same three fields on deny as on allow gives SIEM parsers a
-			// uniform schema across both outcomes; the truncation bool is
-			// necessarily false. The caller's full extracted groups list is
-			// deliberately NOT logged here — see PR description.
+			// The caller's actual groups are deliberately NOT logged on
+			// deny — see PR description "audit-log disclosure discipline"
+			// for the separation-of-duties rationale.
 			slog.LogAttrs(ctx, slog.LevelWarn, "tool authorization",
 				slog.String("tool", toolName),
 				slog.String("decision", "denied"),
@@ -133,11 +113,9 @@ func withAuthorization(policy *authz.Policy, toolName string, configuredGroupsCl
 	}
 }
 
-// boundMatchedGroups sanitizes each element of matched and applies the
-// matchedGroupsBound cap, preserving the order Authorize returned. Returns
-// the bounded slice, the true count before capping, and whether truncation
-// fired. A nil or empty input produces an empty (non-nil) slice so the slog
-// attribute renders as [] rather than null.
+// boundMatchedGroups sanitizes each element and applies matchedGroupsBound,
+// preserving Authorize's ordering. Returns the bounded slice, the true
+// pre-cap count, and whether truncation fired.
 func boundMatchedGroups(matched []string) (bounded []string, total int, truncated bool) {
 	total = len(matched)
 	limit := total

--- a/internal/tools/authorization.go
+++ b/internal/tools/authorization.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
 	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/logging/sanitize"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -44,6 +45,14 @@ const (
 // exists so a grep finds every exempt-name touchpoint at once.
 const listBrokersToolName = "list-brokers"
 
+// matchedGroupsBound caps how many matched group names the audit event
+// carries on allow. 32 covers the largest realistic caller-group membership
+// without truncation while keeping single log records readable. When a
+// caller has more than 32 matching groups the surplus is dropped from the
+// slice but the true count remains in matched_groups_total and
+// matched_groups_truncated goes true.
+const matchedGroupsBound = 32
+
 // withAuthorization gates every invocation of toolName through policy.
 // On allow, dispatches to next unchanged. On deny or missing-claim, returns a
 // tool-level error result and skips next.
@@ -57,9 +66,21 @@ const listBrokersToolName = "list-brokers"
 // Panic containment (from Authorize or the audit call site) is owned by the
 // outer withRecovery, so this closure reads as straight-line request logic.
 //
-// The audit event is a v1 placeholder — INFO for every outcome, minimal
-// fields. A follow-up ticket refines the level split and field schema.
-func withAuthorization(policy *authz.Policy, toolName string, next mcp.ToolHandler) mcp.ToolHandler {
+// Audit event: one "tool authorization" slog record per invocation, allow or
+// deny. Correlation ID is stamped by the correlation slog handler from ctx;
+// the call site does not add it manually. Level split: INFO on allow, WARN
+// on both deny outcomes (deny is not an error but is a notable event; a
+// missing groups claim is a configuration event, not a system failure).
+// Decision axis is a two-field split (decision + decision_reason) so
+// operators can filter deny clusters without conflating the "not permitted"
+// case with the "misconfigured token" case.
+//
+// configuredGroupsClaimName is the admin-authored JWT claim name the
+// resolver was told to look for; the missing-claim event names it under
+// expected_claim so operators reading the log can jump straight to the IdP
+// side. It passes through sanitize.Claim before emission because it is an
+// admin string reaching a log record.
+func withAuthorization(policy *authz.Policy, toolName string, configuredGroupsClaimName string, next mcp.ToolHandler) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		var info *sdkauth.TokenInfo
 		if req.Extra != nil {
@@ -69,28 +90,66 @@ func withAuthorization(policy *authz.Policy, toolName string, next mcp.ToolHandl
 
 		groups, present := requestGroups(req)
 		if !present {
-			slog.LogAttrs(ctx, slog.LevelInfo, "tool authorization",
+			// Missing-claim: no matched_groups fields on this outcome — the
+			// caller had no groups slice at all, so emitting empty ones would
+			// be dead noise. expected_claim carries the diagnostic instead.
+			slog.LogAttrs(ctx, slog.LevelWarn, "tool authorization",
 				slog.String("tool", toolName),
-				slog.String("decision", "denied_missing_claim"),
+				slog.String("decision", "denied"),
+				slog.String("decision_reason", "missing_claim"),
+				slog.String("expected_claim", sanitize.Claim(configuredGroupsClaimName)),
 				slog.Any("", id))
 			return authzErrorResult(authzMissingClaimMessage), nil
 		}
 
 		decision := policy.Authorize(groups, toolName)
 		if !decision.Allowed {
-			slog.LogAttrs(ctx, slog.LevelInfo, "tool authorization",
+			// Deny: matched_groups is always [] and total is always 0 by
+			// construction (a match would have flipped Allowed). Keeping the
+			// same three fields on deny as on allow gives SIEM parsers a
+			// uniform schema across both outcomes; the truncation bool is
+			// necessarily false. The caller's full extracted groups list is
+			// deliberately NOT logged here — see PR description.
+			slog.LogAttrs(ctx, slog.LevelWarn, "tool authorization",
 				slog.String("tool", toolName),
 				slog.String("decision", "denied"),
+				slog.String("decision_reason", "not_permitted"),
+				slog.Any("matched_groups", []string{}),
+				slog.Int("matched_groups_total", 0),
+				slog.Bool("matched_groups_truncated", false),
 				slog.Any("", id))
 			return authzErrorResult(authzDeniedMessage), nil
 		}
 
+		bounded, total, truncated := boundMatchedGroups(decision.MatchedGroups)
 		slog.LogAttrs(ctx, slog.LevelInfo, "tool authorization",
 			slog.String("tool", toolName),
 			slog.String("decision", "allowed"),
+			slog.Any("matched_groups", bounded),
+			slog.Int("matched_groups_total", total),
+			slog.Bool("matched_groups_truncated", truncated),
 			slog.Any("", id))
 		return next(ctx, req)
 	}
+}
+
+// boundMatchedGroups sanitizes each element of matched and applies the
+// matchedGroupsBound cap, preserving the order Authorize returned. Returns
+// the bounded slice, the true count before capping, and whether truncation
+// fired. A nil or empty input produces an empty (non-nil) slice so the slog
+// attribute renders as [] rather than null.
+func boundMatchedGroups(matched []string) (bounded []string, total int, truncated bool) {
+	total = len(matched)
+	limit := total
+	if limit > matchedGroupsBound {
+		limit = matchedGroupsBound
+		truncated = true
+	}
+	bounded = make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		bounded = append(bounded, sanitize.Claim(matched[i]))
+	}
+	return bounded, total, truncated
 }
 
 // authzErrorResult builds the deny / missing-claim tool-level error result.

--- a/internal/tools/authorization_audit_schema_test.go
+++ b/internal/tools/authorization_audit_schema_test.go
@@ -1,0 +1,483 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The tests in this file pin the audit event's emitted schema — what
+// operators, SIEM parsers, and compliance auditors observe on the
+// "tool authorization" slog record. Each test drives the wrapper
+// through one outcome (allow / deny / missing-claim) and asserts on
+// the captured record. Negative assertions here are load-bearing:
+// caller_groups absence on deny is a privacy contract; the absence
+// of matched_groups* fields on missing-claim is a schema-legibility
+// contract; both must fail loudly on any silent regression.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
+	"github.com/SolaceDev/solace-broker-mcp/internal/config"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/correlation"
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// installCorrelationCapture wraps a JSON slog handler with the correlation
+// slog handler decorator and installs it as slog.Default. Tests that seed
+// a correlation ID on the request context can observe it stamped onto
+// records the same way production observes it — the wrapper never adds
+// correlation_id manually, so this fixture is the only way to confirm
+// the field lands where operators grep for it.
+func installCorrelationCapture(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	base := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	handler := correlation.NewSlogHandler(base)
+	prev := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+// parseAuthzRecord parses the captured buffer, expects exactly one
+// "tool authorization" JSON record, and returns it as a decoded map.
+// Multi-line or non-JSON output fails the test.
+func parseAuthzRecord(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var records []map[string]any
+	for _, raw := range strings.Split(buf.String(), "\n") {
+		if raw == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			t.Fatalf("non-JSON log line: %q\nerr: %v", raw, err)
+		}
+		if m["msg"] == "tool authorization" {
+			records = append(records, m)
+		}
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected exactly 1 audit record, got %d\nbuf:\n%s", len(records), buf.String())
+	}
+	return records[0]
+}
+
+// hasKey reports whether the record has a top-level attribute under key.
+// Negative-assertion tests use this to check that absent-by-schema fields
+// truly are absent — not present-with-zero-value.
+func hasKey(record map[string]any, key string) bool {
+	_, ok := record[key]
+	return ok
+}
+
+// requestWithGroupsAndCorrelation is requestWithGroups plus a seeded
+// correlation ID on the context — used only by tests that assert on the
+// correlation_id field. The correlation handler reads the ID from the
+// record's context (which slog.LogAttrs derives from the ctx passed by
+// the wrapper), not from any wrapper-side attribute.
+func requestWithGroupsAndCorrelation(groups []string) *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Extra: &mcp.RequestExtra{
+			TokenInfo: &sdkauth.TokenInfo{
+				UserID: "alice",
+				Extra: map[string]any{
+					"iss":                          "https://idp.example.com",
+					"client_id":                    "cursor-ide",
+					"jti":                          "jti-audit-1",
+					authz.TokenInfoExtraKeyGroups:  groups,
+				},
+			},
+		},
+	}
+}
+
+// requestMissingClaimWithCorrelation is requestMissingGroupsClaim's
+// counterpart carrying non-empty audit identity fields so identity-field
+// assertions in this file don't collapse to the <absent> sentinel.
+func requestMissingClaimWithCorrelation() *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Extra: &mcp.RequestExtra{
+			TokenInfo: &sdkauth.TokenInfo{
+				UserID: "alice",
+				Extra: map[string]any{
+					"iss":       "https://idp.example.com",
+					"client_id": "cursor-ide",
+					"jti":       "jti-audit-2",
+				},
+			},
+		},
+	}
+}
+
+// TestAuditEvent_Allow_EmitsInfoWithFullSchema pins the complete allow
+// record: level, decision, matched-groups triplet, identity, correlation
+// ID, and — as negative assertions — the absence of every field that
+// belongs to a deny or missing-claim outcome. Reviewers looking for "what
+// SHOULD be on an allow line" find the full schema in one place; a
+// contributor tempted to add decision_reason=allowed as a "harmless
+// consistency" change would fail here loudly.
+func TestAuditEvent_Allow_EmitsInfoWithFullSchema(t *testing.T) {
+	buf, restore := installCorrelationCapture(t)
+	defer restore()
+
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "list-queues"),
+		"list-queues",
+		"groups",
+		newRecordingHandler().handler(),
+	)
+	ctx := correlation.With(context.Background(), "corr-allow")
+	if _, err := wrapped(ctx, requestWithGroupsAndCorrelation([]string{"Ops"})); err != nil {
+		t.Fatalf("wrapper returned error: %v", err)
+	}
+
+	rec := parseAuthzRecord(t, buf)
+
+	if rec["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO", rec["level"])
+	}
+	if rec["decision"] != "allowed" {
+		t.Errorf("decision = %v, want %q", rec["decision"], "allowed")
+	}
+	if rec["tool"] != "list-queues" {
+		t.Errorf("tool = %v, want %q", rec["tool"], "list-queues")
+	}
+	mg, ok := rec["matched_groups"].([]any)
+	if !ok || len(mg) != 1 || mg[0] != "Ops" {
+		t.Errorf("matched_groups = %v, want [\"Ops\"]", rec["matched_groups"])
+	}
+	if got := rec["matched_groups_total"]; got != float64(1) {
+		t.Errorf("matched_groups_total = %v, want 1", got)
+	}
+	if got := rec["matched_groups_truncated"]; got != false {
+		t.Errorf("matched_groups_truncated = %v, want false", got)
+	}
+	for _, k := range []string{"sub", "iss", "client_id", "jti"} {
+		if !hasKey(rec, k) {
+			t.Errorf("identity field %q missing from allow record", k)
+		}
+	}
+	if rec["correlation_id"] != "corr-allow" {
+		t.Errorf("correlation_id = %v, want %q (stamped by correlation slog handler, not by the wrapper)", rec["correlation_id"], "corr-allow")
+	}
+	if hasKey(rec, "decision_reason") {
+		t.Errorf("decision_reason must NOT appear on allow records; got %v", rec["decision_reason"])
+	}
+	if hasKey(rec, "expected_claim") {
+		t.Errorf("expected_claim must NOT appear on allow records; got %v", rec["expected_claim"])
+	}
+	if hasKey(rec, "caller_groups") {
+		t.Errorf("caller_groups must NOT appear on allow records; got %v", rec["caller_groups"])
+	}
+}
+
+// TestAuditEvent_Deny_EmitsWarnWithNotPermittedAndNoCallerGroups pins the
+// deny record's schema AND — critically — the absence of caller_groups.
+// The absence is a load-bearing separation-of-duties decision: MCP
+// operators reading these logs are not necessarily entitled to see the
+// caller's full IdP group membership. A future contributor adding
+// caller_groups "for debuggability" would regress a privacy boundary; the
+// negative assertion below fails loudly if that happens.
+func TestAuditEvent_Deny_EmitsWarnWithNotPermittedAndNoCallerGroups(t *testing.T) {
+	buf, restore := installCorrelationCapture(t)
+	defer restore()
+
+	// Grant list-queues to Ops; caller is in OtherGroup and asks for
+	// delete-queue. Both dimensions miss.
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "list-queues"),
+		"delete-queue",
+		"groups",
+		newRecordingHandler().handler(),
+	)
+	ctx := correlation.With(context.Background(), "corr-deny")
+	if _, err := wrapped(ctx, requestWithGroupsAndCorrelation([]string{"OtherGroup"})); err != nil {
+		t.Fatalf("wrapper returned error: %v", err)
+	}
+
+	rec := parseAuthzRecord(t, buf)
+
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", rec["level"])
+	}
+	if rec["decision"] != "denied" {
+		t.Errorf("decision = %v, want %q", rec["decision"], "denied")
+	}
+	if rec["decision_reason"] != "not_permitted" {
+		t.Errorf("decision_reason = %v, want %q", rec["decision_reason"], "not_permitted")
+	}
+	mg, ok := rec["matched_groups"].([]any)
+	if !ok || len(mg) != 0 {
+		t.Errorf("matched_groups = %v, want [] (schema-uniform with allow but always empty on deny)", rec["matched_groups"])
+	}
+	if got := rec["matched_groups_total"]; got != float64(0) {
+		t.Errorf("matched_groups_total = %v, want 0", got)
+	}
+	if got := rec["matched_groups_truncated"]; got != false {
+		t.Errorf("matched_groups_truncated = %v, want false", got)
+	}
+	for _, k := range []string{"sub", "iss", "client_id", "jti"} {
+		if !hasKey(rec, k) {
+			t.Errorf("identity field %q missing from deny record", k)
+		}
+	}
+	if rec["correlation_id"] != "corr-deny" {
+		t.Errorf("correlation_id = %v, want %q", rec["correlation_id"], "corr-deny")
+	}
+	if hasKey(rec, "expected_claim") {
+		t.Errorf("expected_claim must NOT appear on deny records; got %v", rec["expected_claim"])
+	}
+	// LOAD-BEARING: the caller's actual (extracted) groups list must
+	// never appear on deny events. If this assertion fails, a privacy
+	// boundary was silently regressed; consult the PR description for
+	// the audit-log disclosure discipline before "fixing" the test.
+	if hasKey(rec, "caller_groups") {
+		t.Errorf("caller_groups must NEVER appear on deny records — privacy contract regression: %v", rec["caller_groups"])
+	}
+}
+
+// TestAuditEvent_MissingClaim_EmitsWarnWithExpectedClaimAndNoMatchedGroupsFields
+// pins the missing-claim record's schema. It asserts the presence of
+// expected_claim (the diagnostic field an operator jumps to the IdP with)
+// AND the absence of every matched_groups* field: on missing-claim there
+// is no groups list to describe, so empty-set/zero would be dead noise
+// that dilutes the signal on the outcome operators actually care about.
+func TestAuditEvent_MissingClaim_EmitsWarnWithExpectedClaimAndNoMatchedGroupsFields(t *testing.T) {
+	buf, restore := installCorrelationCapture(t)
+	defer restore()
+
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "list-queues"),
+		"list-queues",
+		"groups",
+		newRecordingHandler().handler(),
+	)
+	ctx := correlation.With(context.Background(), "corr-miss")
+	if _, err := wrapped(ctx, requestMissingClaimWithCorrelation()); err != nil {
+		t.Fatalf("wrapper returned error: %v", err)
+	}
+
+	rec := parseAuthzRecord(t, buf)
+
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", rec["level"])
+	}
+	if rec["decision"] != "denied" {
+		t.Errorf("decision = %v, want %q (missing-claim is a non-allow)", rec["decision"], "denied")
+	}
+	if rec["decision_reason"] != "missing_claim" {
+		t.Errorf("decision_reason = %v, want %q", rec["decision_reason"], "missing_claim")
+	}
+	if rec["expected_claim"] != "groups" {
+		t.Errorf("expected_claim = %v, want %q", rec["expected_claim"], "groups")
+	}
+	for _, k := range []string{"sub", "iss", "client_id", "jti"} {
+		if !hasKey(rec, k) {
+			t.Errorf("identity field %q missing from missing-claim record", k)
+		}
+	}
+	if rec["correlation_id"] != "corr-miss" {
+		t.Errorf("correlation_id = %v, want %q", rec["correlation_id"], "corr-miss")
+	}
+	// The three matched_groups* fields carry no signal on missing-claim
+	// — the caller had no groups slice at all. Emitting empty/zero here
+	// would blur the distinction between "we found groups but none
+	// granted" (deny) and "we found no groups to begin with" (missing).
+	for _, k := range []string{"matched_groups", "matched_groups_total", "matched_groups_truncated"} {
+		if hasKey(rec, k) {
+			t.Errorf("%q must NOT appear on missing-claim records (fields carry signal where they belong); got %v", k, rec[k])
+		}
+	}
+	if hasKey(rec, "caller_groups") {
+		t.Errorf("caller_groups must NEVER appear on missing-claim records — privacy contract regression: %v", rec["caller_groups"])
+	}
+}
+
+// TestAuditEvent_MissingClaim_SanitizesExpectedClaim pins that the
+// configured claim name passes through sanitize.Claim before hitting the
+// slog record. Admin-authored strings reaching a log field must be
+// sanitized — a claim name pasted with a stray zero-width joiner (or
+// worse, an ANSI escape or a newline) would otherwise leak into logs
+// verbatim. This test uses a ZWJ (U+200D) as the canary control
+// character; sanitize.Claim strips it. A future refactor that dropped
+// the sanitize.Claim call would fail here.
+func TestAuditEvent_MissingClaim_SanitizesExpectedClaim(t *testing.T) {
+	buf, restore := installCorrelationCapture(t)
+	defer restore()
+
+	// "groups" + zero-width joiner (U+200D) — U+200D is Unicode category
+	// Cf and is stripped by sanitize.Claim. The claim name is admin-
+	// authored, so this is the exact defense the sanitize call protects.
+	wrapped := withAuthorization(
+		policyGranting(t, []string{"Ops"}, "list-queues"),
+		"list-queues",
+		"groups\u200d",
+		newRecordingHandler().handler(),
+	)
+	if _, err := wrapped(context.Background(), requestMissingClaimWithCorrelation()); err != nil {
+		t.Fatalf("wrapper returned error: %v", err)
+	}
+
+	rec := parseAuthzRecord(t, buf)
+	if rec["expected_claim"] != "groups" {
+		t.Errorf("expected_claim = %q, want %q — sanitize.Claim must strip Cf characters before emission", rec["expected_claim"], "groups")
+	}
+}
+
+// TestAuditEvent_Allow_SanitizesMatchedGroupsElements pins that EVERY
+// element of matched_groups is sanitized, not just the first. Uses two
+// admin-configured group names each carrying a Cf character; both must
+// survive the config validator (whitespace is rejected by validate() but
+// Cf is not) and both must be sanitized before slog sees them. A future
+// refactor with a "sanitize the first, skip the rest" bug would fail
+// here; a refactor that dropped sanitize.Claim entirely would fail here.
+func TestAuditEvent_Allow_SanitizesMatchedGroupsElements(t *testing.T) {
+	buf, restore := installCorrelationCapture(t)
+	defer restore()
+
+	// Both group names carry a zero-width joiner. Authorize matches
+	// byte-exactly against these names — a caller carrying the same
+	// bytes lands in both groups. Post-sanitize, the ZWJ is stripped
+	// so the emitted matched_groups shows the clean names.
+	group1 := "Ops\u200d"
+	group2 := "Reviewers\u200d"
+	cfg := config.ToolAuthorizationConfig{
+		AccessLevelGroups: map[string][]string{
+			group1: {"list-queues"},
+			group2: {"list-queues"},
+		},
+	}
+	policy, err := authz.NewPolicy(cfg)
+	if err != nil {
+		t.Fatalf("NewPolicy: %v", err)
+	}
+	wrapped := withAuthorization(policy, "list-queues", "groups", newRecordingHandler().handler())
+	if _, err := wrapped(context.Background(), requestWithGroupsAndCorrelation([]string{group1, group2})); err != nil {
+		t.Fatalf("wrapper returned error: %v", err)
+	}
+
+	rec := parseAuthzRecord(t, buf)
+	mg, ok := rec["matched_groups"].([]any)
+	if !ok {
+		t.Fatalf("matched_groups is not an array: %v", rec["matched_groups"])
+	}
+	got := make(map[string]bool, len(mg))
+	for _, v := range mg {
+		if s, ok := v.(string); ok {
+			got[s] = true
+		}
+	}
+	if !got["Ops"] || !got["Reviewers"] {
+		t.Errorf("matched_groups = %v, want both %q and %q after sanitization (every element must be sanitized, not just the first)", mg, "Ops", "Reviewers")
+	}
+	// Negative: the raw ZWJ-containing names must NOT appear.
+	if got[group1] || got[group2] {
+		t.Errorf("matched_groups contained un-sanitized element(s); raw values leaked into audit log: %v", mg)
+	}
+}
+
+// TestAuditEvent_MatchedGroupsBounding pins the three axes of the
+// bounding contract: matched_groups_total records the true count
+// (unbounded), matched_groups is capped at exactly the bound, and
+// matched_groups_truncated flips true only when there is at least one
+// group in excess of the bound. Table-driven across three scenarios:
+// bound-under (16), at-bound (32, inclusive-cap boundary), and over-bound
+// by one (33). The at-bound row is load-bearing: a naive impl that
+// truncates when total >= bound would spuriously flip the truncated flag
+// at exactly 32.
+func TestAuditEvent_MatchedGroupsBounding(t *testing.T) {
+	// bound is copied here rather than imported from the wrapper — the
+	// constant is unexported and its value is a contract, not an internal
+	// detail. If the wrapper's bound moves off 32 without the docstrings
+	// doc changing, this test fails and points at the drift.
+	const bound = 32
+	cases := []struct {
+		name          string
+		total         int
+		wantLen       int
+		wantTruncated bool
+	}{
+		{"bound_under_16", 16, 16, false},
+		{"at_bound_inclusive_32", 32, 32, false},
+		{"one_over_bound_33", 33, 32, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buf, restore := installCorrelationCapture(t)
+			defer restore()
+
+			// Build a policy where N distinct groups each grant the same
+			// tool. Caller carries all N groups → union match = all N.
+			groups := make([]string, c.total)
+			access := make(map[string][]string, c.total)
+			for i := 0; i < c.total; i++ {
+				name := fmt.Sprintf("Group%03d", i)
+				groups[i] = name
+				access[name] = []string{"list-queues"}
+			}
+			policy, err := authz.NewPolicy(config.ToolAuthorizationConfig{AccessLevelGroups: access})
+			if err != nil {
+				t.Fatalf("NewPolicy: %v", err)
+			}
+			wrapped := withAuthorization(policy, "list-queues", "groups", newRecordingHandler().handler())
+			if _, err := wrapped(context.Background(), requestWithGroupsAndCorrelation(groups)); err != nil {
+				t.Fatalf("wrapper returned error: %v", err)
+			}
+
+			rec := parseAuthzRecord(t, buf)
+			if got := rec["matched_groups_total"]; got != float64(c.total) {
+				t.Errorf("matched_groups_total = %v, want %d (unbounded true count)", got, c.total)
+			}
+			if got := rec["matched_groups_truncated"]; got != c.wantTruncated {
+				t.Errorf("matched_groups_truncated = %v, want %v (flips true only when total > bound)", got, c.wantTruncated)
+			}
+			mg, ok := rec["matched_groups"].([]any)
+			if !ok {
+				t.Fatalf("matched_groups is not an array: %v", rec["matched_groups"])
+			}
+			if len(mg) != c.wantLen {
+				t.Errorf("len(matched_groups) = %d, want %d (cap = %d, inclusive)", len(mg), c.wantLen, bound)
+			}
+			// When truncation fires, every returned element must still be
+			// one of the input group names — no synthetic filler, no
+			// duplicates. Set-membership check works here because the
+			// input names are unique.
+			seen := make(map[string]bool, len(mg))
+			inputSet := make(map[string]bool, len(groups))
+			for _, g := range groups {
+				inputSet[g] = true
+			}
+			for _, v := range mg {
+				s, isString := v.(string)
+				if !isString {
+					t.Errorf("matched_groups contained non-string element: %v", v)
+					continue
+				}
+				if !inputSet[s] {
+					t.Errorf("matched_groups contained unexpected element %q — not in the caller's group list", s)
+				}
+				if seen[s] {
+					t.Errorf("matched_groups contained duplicate element %q — dedup contract violated", s)
+				}
+				seen[s] = true
+			}
+		})
+	}
+}

--- a/internal/tools/authorization_test.go
+++ b/internal/tools/authorization_test.go
@@ -147,6 +147,7 @@ func TestWithAuthorization_Allow_PassesThroughToNext(t *testing.T) {
 	wrapped := withAuthorization(
 		policyGranting(t, []string{"Ops"}, "get-broker-status"),
 		"get-broker-status",
+		"",
 		rec.handler(),
 	)
 
@@ -171,6 +172,7 @@ func TestWithAuthorization_Allow_EmitsInfoAuditWithDistinctDecision(t *testing.T
 	wrapped := withAuthorization(
 		policyGranting(t, []string{"Ops"}, "get-broker-status"),
 		"get-broker-status",
+		"",
 		newRecordingHandler().handler(),
 	)
 	if _, err := wrapped(context.Background(), requestWithGroups([]string{"Ops"})); err != nil {
@@ -206,6 +208,7 @@ func TestWithAuthorization_Deny_ReturnsToolLevelErrorResult(t *testing.T) {
 	wrapped := withAuthorization(
 		emptyPolicy(t),
 		"delete-queue",
+		"",
 		newRecordingHandler().handler(),
 	)
 
@@ -227,6 +230,7 @@ func TestWithAuthorization_Deny_ResultShapeAndMessage(t *testing.T) {
 	wrapped := withAuthorization(
 		emptyPolicy(t),
 		"delete-queue",
+		"",
 		newRecordingHandler().handler(),
 	)
 	got, _ := wrapped(context.Background(), requestWithGroups([]string{"Contractors"}))
@@ -256,7 +260,7 @@ func TestWithAuthorization_Deny_ResultShapeAndMessage(t *testing.T) {
 // Deny security invariant: next is not called; the tool never runs.
 func TestWithAuthorization_Deny_DoesNotCallNext(t *testing.T) {
 	rec := newRecordingHandler()
-	wrapped := withAuthorization(emptyPolicy(t), "delete-queue", rec.handler())
+	wrapped := withAuthorization(emptyPolicy(t), "delete-queue", "", rec.handler())
 
 	_, _ = wrapped(context.Background(), requestWithGroups([]string{"Contractors"}))
 
@@ -265,30 +269,34 @@ func TestWithAuthorization_Deny_DoesNotCallNext(t *testing.T) {
 	}
 }
 
-// Deny: INFO audit line with decision distinguishable from allow and missing.
-func TestWithAuthorization_Deny_EmitsInfoAuditWithDistinctDecision(t *testing.T) {
+// Deny: WARN audit line with a decision + decision_reason sub-axis that
+// tells the "not permitted" outcome apart from missing-claim.
+func TestWithAuthorization_Deny_EmitsWarnAuditWithDistinctDecision(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
 
-	wrapped := withAuthorization(emptyPolicy(t), "delete-queue", newRecordingHandler().handler())
+	wrapped := withAuthorization(emptyPolicy(t), "delete-queue", "", newRecordingHandler().handler())
 	_, _ = wrapped(context.Background(), requestWithGroups([]string{"Contractors"}))
 
 	lines := authzLogLines(t, buf)
 	if len(lines) != 1 {
 		t.Fatalf("expected exactly 1 audit line, got %d: %s", len(lines), buf.String())
 	}
-	if got := lines[0]["level"]; got != "INFO" {
-		t.Errorf("audit level = %v, want INFO", got)
+	// Deny is a notable but non-error event: WARN, not INFO (which would
+	// bury deny clusters at the same level as normal invocations) and not
+	// ERROR (which would flood on-call pagers designed for system failures).
+	if got := lines[0]["level"]; got != "WARN" {
+		t.Errorf("audit level = %v, want WARN", got)
 	}
 	decision, _ := lines[0]["decision"].(string)
-	if decision == "" {
-		t.Fatalf("audit line missing decision: %v", lines[0])
+	if decision != "denied" {
+		t.Errorf("decision = %q, want %q", decision, "denied")
 	}
-	// Deny's decision must be distinct from missing-claim so operators
-	// can tell "IdP omitted the claim" from "the claim was there but
-	// didn't grant the tool."
-	if decision == "denied_missing_claim" || strings.Contains(strings.ToLower(decision), "allow") {
-		t.Errorf("deny decision %q collides with another outcome value", decision)
+	// The sub-axis field distinguishes "not permitted" from missing-claim.
+	// It must be present on every deny outcome.
+	reason, _ := lines[0]["decision_reason"].(string)
+	if reason != "not_permitted" {
+		t.Errorf("decision_reason = %q, want %q", reason, "not_permitted")
 	}
 }
 
@@ -300,6 +308,7 @@ func TestWithAuthorization_MissingClaim_ReturnsToolLevelErrorResult(t *testing.T
 	wrapped := withAuthorization(
 		policyGranting(t, []string{"Ops"}, "get-broker-status"),
 		"get-broker-status",
+		"",
 		newRecordingHandler().handler(),
 	)
 
@@ -329,6 +338,7 @@ func TestWithAuthorization_MissingClaim_DoesNotCallNext(t *testing.T) {
 	wrapped := withAuthorization(
 		policyGranting(t, []string{"Ops"}, "get-broker-status"),
 		"get-broker-status",
+		"",
 		rec.handler(),
 	)
 
@@ -339,8 +349,10 @@ func TestWithAuthorization_MissingClaim_DoesNotCallNext(t *testing.T) {
 	}
 }
 
-// Missing-claim: decision distinguishable from plain deny so operators can
-// tell IdP misconfig from grant miss.
+// Missing-claim: decision_reason distinguishable from plain deny so operators
+// can tell IdP misconfig from grant miss. Both outcomes share
+// decision=denied (they are both non-allows); the sub-axis field carries
+// the diagnostic distinction.
 func TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision(t *testing.T) {
 	buf, cleanup := captureSlog(t)
 	defer cleanup()
@@ -348,6 +360,7 @@ func TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision(t *testing.
 	wrapped := withAuthorization(
 		policyGranting(t, []string{"Ops"}, "get-broker-status"),
 		"get-broker-status",
+		"groups",
 		newRecordingHandler().handler(),
 	)
 	_, _ = wrapped(context.Background(), requestMissingGroupsClaim())
@@ -357,17 +370,20 @@ func TestWithAuthorization_MissingClaim_EmitsDistinguishableDecision(t *testing.
 		t.Fatalf("expected exactly 1 audit line, got %d: %s", len(lines), buf.String())
 	}
 	decision, _ := lines[0]["decision"].(string)
-	if decision == "" {
-		t.Fatalf("audit line missing decision: %v", lines[0])
+	if decision != "denied" {
+		t.Errorf("decision = %q, want %q (missing-claim is a non-allow)", decision, "denied")
 	}
-	// Missing-claim must be distinguishable from a plain deny — an
-	// operator seeing many missing-claim events knows to check IdP
-	// mapper configuration, not group memberships.
-	if decision == "denied" {
-		t.Errorf("missing-claim decision must differ from plain deny; both were %q", decision)
+	// Missing-claim's diagnostic axis is decision_reason. An operator
+	// seeing many missing_claim reasons knows to check IdP mapper
+	// configuration, not group memberships.
+	reason, _ := lines[0]["decision_reason"].(string)
+	if reason != "missing_claim" {
+		t.Errorf("decision_reason = %q, want %q", reason, "missing_claim")
 	}
-	if strings.Contains(strings.ToLower(decision), "allow") {
-		t.Errorf("missing-claim decision %q looks like an allow value", decision)
+	// expected_claim carries the configured claim name — the actionable
+	// piece of information an operator needs to jump straight to the IdP.
+	if got := lines[0]["expected_claim"]; got != "groups" {
+		t.Errorf("expected_claim = %v, want %q", got, "groups")
 	}
 }
 
@@ -388,6 +404,7 @@ func TestWithAuthorization_NilTokenInfo_TreatsAsMissingClaim(t *testing.T) {
 			wrapped := withAuthorization(
 				policyGranting(t, []string{"Ops"}, "get-broker-status"),
 				"get-broker-status",
+				"",
 				rec.handler(),
 			)
 			got, err := wrapped(context.Background(), tc.req)
@@ -427,7 +444,7 @@ func TestAuthzMessages_IdenticalForV1(t *testing.T) {
 // Nil policy is a precondition violation — wrapper must panic (not silently
 // allow). Outer withRecovery converts the panic to a visible 500.
 func TestWithAuthorization_NilPolicy_Panics(t *testing.T) {
-	wrapped := withAuthorization(nil, "get-broker-status", newRecordingHandler().handler())
+	wrapped := withAuthorization(nil, "get-broker-status", "", newRecordingHandler().handler())
 
 	defer func() {
 		if r := recover(); r == nil {

--- a/internal/tools/authorization_test.go
+++ b/internal/tools/authorization_test.go
@@ -453,3 +453,19 @@ func TestWithAuthorization_NilPolicy_Panics(t *testing.T) {
 	}()
 	_, _ = wrapped(context.Background(), requestWithGroups([]string{"Ops"}))
 }
+
+// Nil policy must panic on every branch — including the branch that would
+// otherwise short-circuit to missing-claim before dereferencing policy.
+// Without the top-of-closure guard, nil + missing-claim would silently
+// return a deny result and the "nil policy is a precondition violation"
+// doc claim would hold on only one input shape.
+func TestWithAuthorization_NilPolicy_PanicsOnMissingClaimBranchToo(t *testing.T) {
+	wrapped := withAuthorization(nil, "get-broker-status", "", newRecordingHandler().handler())
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected wrapper to panic on nil policy even when request has no groups claim; got no panic (doc/code gap)")
+		}
+	}()
+	_, _ = wrapped(context.Background(), requestMissingGroupsClaim())
+}

--- a/internal/tools/identity.go
+++ b/internal/tools/identity.go
@@ -35,10 +35,9 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/logging/sanitize"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -47,18 +46,6 @@ import (
 // the underlying claim was missing or empty. The angle brackets make it
 // visually distinct from any real claim value (RFC 7519 §4.1.2 / OIDC Core §2).
 const absentSentinel = "<absent>"
-
-// verifierBugSentinel marks an identity field whose value was malformed by our
-// own verifier — specifically, a non-string value stashed in TokenInfo.Extra
-// where a string was expected. The sentinel is deliberately distinct from
-// absentSentinel so log consumers can tell "IdP didn't issue this claim"
-// (normal) from "our code put garbage in Extra" (alarm). See plan §14.
-const verifierBugSentinel = "<verifier-bug>"
-
-// claimMaxLen caps each sanitized identity field at 256 bytes. Real sub/jti
-// values from production IdPs are 20–50 chars; the cap fires only on malicious
-// or buggy IdPs and prevents log-flood DoS (plan §4.4).
-const claimMaxLen = 256
 
 // Identity carries the audit-relevant subset of OIDC claims for a single
 // tool invocation.
@@ -109,10 +96,10 @@ func NewIdentityFromTokenInfo(t *sdkauth.TokenInfo) Identity {
 	}
 	return Identity{
 		present:  true,
-		sub:      normalizeAbsent(sanitizeClaim(t.UserID)),
-		iss:      normalizeAbsent(sanitizeClaim(extraString(t, "iss"))),
-		clientID: normalizeAbsent(sanitizeClaim(extraString(t, "client_id"))),
-		jti:      normalizeAbsent(sanitizeClaim(extraString(t, "jti"))),
+		sub:      normalizeAbsent(sanitize.Claim(t.UserID)),
+		iss:      normalizeAbsent(sanitize.Claim(extraString(t, "iss"))),
+		clientID: normalizeAbsent(sanitize.Claim(extraString(t, "client_id"))),
+		jti:      normalizeAbsent(sanitize.Claim(extraString(t, "jti"))),
 	}
 }
 
@@ -123,56 +110,6 @@ func normalizeAbsent(s string) string {
 		return absentSentinel
 	}
 	return s
-}
-
-// sanitizeClaim defends against log-injection (CWE-117) and audit-spoofing
-// (CWE-1007) by stripping non-graphic Unicode and capping the result at
-// claimMaxLen bytes. The four stripped categories are:
-//
-//   - Cc — Control characters. Includes the ASCII C0 block (NUL, TAB, LF,
-//     CR, ESC, …), DEL, and the C1 block (U+0080–U+009F). This is the
-//     CWE-117 surface: LF and CR can break log-line framing.
-//   - Cf — Format characters. Includes bidi/RTL overrides (U+202A–U+202E,
-//     U+2066–U+2069), zero-width joiners, BOM, soft hyphen, language tags.
-//     Bidi controls are the CWE-1007 surface: a sub like
-//     "alice\u202Enimda" renders as "aliceadmin" in any bidi-aware UI,
-//     misattributing the action to the wrong user in SIEMs/terminals.
-//   - Zl / Zp — Line and Paragraph separator (U+2028, U+2029). Some
-//     renderers honor these as line breaks; they're CWE-117-adjacent.
-//
-// Plan §4.4 covers the broader rationale. JSON-handler escaping already
-// neutralizes CR/LF for the JSON sink, but field-level sanitization
-// protects re-emission through error messages, panic strings, custom
-// handlers, and metric labels.
-//
-// Allocation and CPU are bounded by claimMaxLen: the working buffer is sized
-// at min(len(s), claimMaxLen) and the loop breaks as soon as another rune
-// would exceed the cap. A malicious or buggy IdP shipping a multi-megabyte
-// claim cannot force proportional work here.
-//
-// Truncation lands on a rune boundary — we check the projected length BEFORE
-// writing, so the output is always valid UTF-8 even if the cap falls inside
-// what would have been a multibyte codepoint.
-func sanitizeClaim(s string) string {
-	b := strings.Builder{}
-	b.Grow(min(len(s), claimMaxLen))
-
-	for _, r := range s {
-		// Single filter, complete spec — see godoc above. Cc covers both
-		// ASCII (C0/DEL) and C1 controls, so no separate fast-path is
-		// needed.
-		if unicode.In(r, unicode.Cc, unicode.Cf, unicode.Zl, unicode.Zp) {
-			continue
-		}
-		// Stop before writing a rune that would push us past the cap. This
-		// is both the DoS defense (bounds total work) and the UTF-8 safety
-		// guarantee (never emits half a multibyte codepoint).
-		if b.Len()+utf8.RuneLen(r) > claimMaxLen {
-			break
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
 }
 
 // TokenInfo.Extra convention:
@@ -193,7 +130,7 @@ func sanitizeClaim(s string) string {
 //
 //   - Key present, value is NOT a string: contract violation by our own
 //     verifier (audit-field keys stash only strings). We emit an ERROR-level slog
-//     entry naming the key and observed type, then return verifierBugSentinel.
+//     entry naming the key and observed type, then return sanitize.VerifierBugSentinel.
 //     The audit-log line for this request still gets emitted (with the
 //     sentinel as the field value) — the panic version we shipped initially
 //     killed the request before logToolResult's defer registered, inverting
@@ -211,7 +148,7 @@ func extraString(t *sdkauth.TokenInfo, key string) string {
 		slog.Error("internal: TokenInfo.Extra has unexpected type — verifier contract violation",
 			slog.String("key", key),
 			slog.String("got_type", fmt.Sprintf("%T", v)))
-		return verifierBugSentinel
+		return sanitize.VerifierBugSentinel
 	}
 	return s
 }

--- a/internal/tools/identity.go
+++ b/internal/tools/identity.go
@@ -182,8 +182,6 @@ func extraStringSlice(t *sdkauth.TokenInfo, key string) (values []string, presen
 // Reads under authz.TokenInfoExtraKeyGroups. Returns (nil, false) when the
 // groups claim was missing from the token (the day-one IdP misconfiguration
 // case).
-//
-//nolint:unused // Called by withAuthorization (T4 enforcement wrapper, next ticket).
 func requestGroups(req *mcp.CallToolRequest) (groups []string, present bool) {
 	if req == nil {
 		return nil, false

--- a/internal/tools/identity_test.go
+++ b/internal/tools/identity_test.go
@@ -31,9 +31,9 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"unicode/utf8"
 
 	"github.com/SolaceDev/solace-broker-mcp/internal/authz"
+	"github.com/SolaceDev/solace-broker-mcp/internal/observability/logging/sanitize"
 	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
 )
 
@@ -161,8 +161,8 @@ func TestNewIdentityFromTokenInfo_extraKeyMissing_normalizesToAbsent(t *testing.
 //
 // Three properties this test pins:
 //  1. The function does NOT panic (the panic version dropped the audit line).
-//  2. The return value is verifierBugSentinel, NOT absentSentinel — log
-//     consumers must be able to distinguish "claim missing" from "code bug."
+//  2. The return value is sanitize.VerifierBugSentinel, NOT absentSentinel —
+//     log consumers must be able to distinguish "claim missing" from "code bug."
 //  3. An ERROR-level log entry is emitted naming the bad key and the observed
 //     type, so ops alerting can fire on the contract violation.
 func TestExtraString_nonStringValue_emitsErrorAndReturnsSentinel(t *testing.T) {
@@ -178,12 +178,12 @@ func TestExtraString_nonStringValue_emitsErrorAndReturnsSentinel(t *testing.T) {
 	// (1) must not panic
 	id := NewIdentityFromTokenInfo(info)
 
-	// (2) sentinel is verifierBugSentinel, not absentSentinel
-	if id.iss != verifierBugSentinel {
-		t.Errorf("iss = %q, want %q (verifier-bug sentinel)", id.iss, verifierBugSentinel)
+	// (2) sentinel is sanitize.VerifierBugSentinel, not absentSentinel
+	if id.iss != sanitize.VerifierBugSentinel {
+		t.Errorf("iss = %q, want %q (verifier-bug sentinel)", id.iss, sanitize.VerifierBugSentinel)
 	}
-	if verifierBugSentinel == absentSentinel {
-		t.Fatal("verifierBugSentinel must differ from absentSentinel — log consumers rely on the distinction")
+	if sanitize.VerifierBugSentinel == absentSentinel {
+		t.Fatal("sanitize.VerifierBugSentinel must differ from absentSentinel — log consumers rely on the distinction")
 	}
 
 	// (3) an ERROR was emitted naming the key and type
@@ -196,111 +196,6 @@ func TestExtraString_nonStringValue_emitsErrorAndReturnsSentinel(t *testing.T) {
 	}
 	if !strings.Contains(logged, `"got_type":"int"`) {
 		t.Errorf("expected log entry to name the observed type %q, got: %s", "int", logged)
-	}
-}
-
-func TestSanitizeClaim_stripsControlChars(t *testing.T) {
-	cases := []struct {
-		name, in, want string
-	}{
-		{"CR LF", "foo\r\nbar", "foobar"},
-		{"tab", "foo\tbar", "foobar"},
-		{"ANSI ESC", "foo\x1B[31mred\x1B[0m", "foo[31mred[0m"},
-		{"DEL byte", "foo\x7Fbar", "foobar"},
-		{"NUL byte", "foo\x00bar", "foobar"},
-		{"vertical tab + form feed", "foo\x0B\x0Cbar", "foobar"},
-		{"plain", "auth0|abc123", "auth0|abc123"},
-		{"unicode passes through", "user-éñ", "user-éñ"},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := sanitizeClaim(c.in); got != c.want {
-				t.Errorf("sanitizeClaim(%q) = %q, want %q", c.in, got, c.want)
-			}
-		})
-	}
-}
-
-func TestSanitizeClaim_capsAt256Bytes(t *testing.T) {
-	in := strings.Repeat("a", 300)
-	got := sanitizeClaim(in)
-	if len(got) != claimMaxLen {
-		t.Errorf("len = %d, want %d", len(got), claimMaxLen)
-	}
-}
-
-// TestSanitizeClaim_stripsBidiAndFormatChars pins the CWE-1007 audit-spoofing
-// defense raised in PR #74 review. A malicious IdP issues a sub like
-// "alice‮nimda" (RIGHT-TO-LEFT OVERRIDE between "alice" and "nimda").
-// Without the Cf-category strip, the bytes pass through unchanged, and any
-// bidi-aware UI (SIEM dashboards, terminals, JSON viewers) renders the value
-// visually as "aliceadmin" — misattributing the action to a different user.
-// The sanitizer must strip the override and emit a value that renders in
-// source order.
-func TestSanitizeClaim_stripsBidiAndFormatChars(t *testing.T) {
-	// Inputs use \u escapes so this source file stays pure ASCII.
-	// A literal BOM in source would break Go's parser, and literal
-	// bidi controls in source make this file dangerous to view in
-	// any bidi-aware editor (which is the whole point of stripping them).
-	cases := []struct {
-		name, in, want string
-	}{
-		{"RLO (U+202E)", "alice\u202Enimda", "alicenimda"},
-		{"PDF (U+202C)", "x\u202Cy", "xy"},
-		{"LRO (U+202D)", "a\u202Db", "ab"},
-		{"zero-width joiner (U+200D)", "user\u200Dname", "username"},
-		{"zero-width non-joiner (U+200C)", "user\u200Cname", "username"},
-		{"BOM (U+FEFF)", "\uFEFFuser", "user"},
-		{"soft hyphen (U+00AD)", "ad\u00ADmin", "admin"},
-		{"line separator (U+2028 Zl)", "a\u2028b", "ab"},
-		{"paragraph separator (U+2029 Zp)", "a\u2029b", "ab"},
-		{"C1 control NEL (U+0085)", "a\u0085b", "ab"},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := sanitizeClaim(c.in); got != c.want {
-				t.Errorf("sanitizeClaim(%q) = %q, want %q", c.in, got, c.want)
-			}
-		})
-	}
-}
-
-// TestSanitizeClaim_truncatesOnRuneBoundary pins the UTF-8 safety property:
-// when the cap falls inside what would have been a multibyte codepoint, we
-// stop BEFORE writing the codepoint, never mid-bytes. Output is always
-// utf8.ValidString.
-//
-// 'é' is 2 bytes in UTF-8 (0xC3 0xA9). 128 of them = 256 bytes exactly,
-// which fits. 129 of them = 258 bytes would overflow the cap; the
-// sanitizer must stop at 128 and return 256 valid bytes — not 257 with a
-// dangling 0xC3.
-func TestSanitizeClaim_truncatesOnRuneBoundary(t *testing.T) {
-	in := strings.Repeat("é", 200) // 400 bytes, well over the 256 cap
-	got := sanitizeClaim(in)
-
-	if !utf8.ValidString(got) {
-		t.Errorf("sanitized output is not valid UTF-8: %q", got)
-	}
-	if len(got) > claimMaxLen {
-		t.Errorf("len = %d, exceeds cap %d", len(got), claimMaxLen)
-	}
-	// 128 two-byte runes = 256 bytes exactly.
-	if want := claimMaxLen; len(got) != want {
-		t.Errorf("len = %d, want exactly %d (128 × 2-byte runes)", len(got), want)
-	}
-}
-
-// TestSanitizeClaim_boundedWork pins the DoS-defense property: the sanitizer
-// must not iterate or allocate proportionally to input length. We feed in a
-// 10 MB input and assert the result is still capped — the existing 256-byte
-// cap check would pass with the old implementation too, but combined with
-// the rune-boundary check above we cover both halves of Copilot's review
-// note (PR #74).
-func TestSanitizeClaim_boundedWork_largeInput(t *testing.T) {
-	in := strings.Repeat("a", 10_000_000)
-	got := sanitizeClaim(in)
-	if len(got) != claimMaxLen {
-		t.Errorf("len = %d, want %d (cap must hold against multi-MB input)", len(got), claimMaxLen)
 	}
 }
 
@@ -408,7 +303,7 @@ func TestTokenInfoExtra_perKeyTypeConvention(t *testing.T) {
 	// Audit-field keys: must be readable via extraString.
 	for _, key := range []string{"iss", "client_id", "jti"} {
 		v := extraString(info, key)
-		if v == "" || v == verifierBugSentinel {
+		if v == "" || v == sanitize.VerifierBugSentinel {
 			t.Errorf("extraString(%q) = %q; expected a valid string value", key, v)
 		}
 	}

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -122,10 +122,14 @@ func stampCorrelationID(ctx context.Context, result *mcp.CallToolResult) {
 //
 // When policy is non-nil, each handler is wrapped with withAuthorization
 // inside withRecovery, so every dispatch consults the policy before the tool
-// runs. When policy is nil, no authorization frame is composed — the caller
+// runs. groupsClaimName is the admin-configured JWT claim name the
+// auth-middleware resolver was told to look for; the wrapper reports it on
+// the missing-claim audit event so operators can jump straight to the IdP
+// side of a day-one misconfiguration. When policy is nil, no authorization
+// frame is composed and groupsClaimName is unused — the caller
 // (cmd/server/main.go) owns the enable-gate and expresses disablement here
 // as nil.
-func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerPool, enableWriteTools bool, policy *authz.Policy) {
+func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerPool, enableWriteTools bool, policy *authz.Policy, groupsClaimName string) {
 	type registration struct {
 		name    string
 		handler ToolHandler
@@ -177,7 +181,7 @@ func RegisterWithServer(mgr *ToolManager, server *mcp.Server, pool *semp.BrokerP
 		// correlation-ID stamping and panic containment. Nil policy skips
 		// the wrapper entirely — dispatch is byte-identical to pre-RBAC.
 		if policy != nil {
-			callToolHandler = withAuthorization(policy, reg.name, callToolHandler)
+			callToolHandler = withAuthorization(policy, reg.name, groupsClaimName, callToolHandler)
 		}
 
 		server.AddTool(mcpTool, withRecovery(reg.name, callToolHandler))

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -110,7 +110,7 @@ func TestRegisterWithServer(t *testing.T) {
 	mgr.Register(newStubHandler("test-tool"))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true, nil)
+	RegisterWithServer(mgr, server, pool, true, nil, "")
 
 	// No panic = tools registered successfully. The MCP SDK doesn't expose
 	// a way to list registered tools directly, so we verify by checking
@@ -164,7 +164,7 @@ func TestRegisterWithServer_WriteGated(t *testing.T) {
 			mgr.Register(destructiveWrite)
 
 			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-			RegisterWithServer(mgr, server, pool, enableWriteTools, nil)
+			RegisterWithServer(mgr, server, pool, enableWriteTools, nil, "")
 			// No panic; gate behavior verified at integration layer via tools/list.
 		})
 	}
@@ -222,7 +222,7 @@ func TestPanicAuditedAsError(t *testing.T) {
 	mgr.Register(panicking)
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true, nil)
+	RegisterWithServer(mgr, server, pool, true, nil, "")
 
 	ctx := context.Background()
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
@@ -531,7 +531,7 @@ func TestRegisterWithServer_NilPolicy_ByteIdenticalToPreRBAC(t *testing.T) {
 	mgr.Register(newStubHandler("test-tool"))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true, nil)
+	RegisterWithServer(mgr, server, pool, true, nil, "")
 
 	ctx := context.Background()
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
@@ -575,7 +575,7 @@ func TestRegisterWithServer_NonNilPolicy_AuthorizationAuditFires(t *testing.T) {
 	policy := policyGranting(t, []string{"Ops"}, "test-tool")
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true, policy)
+	RegisterWithServer(mgr, server, pool, true, policy, "groups")
 
 	ctx := context.Background()
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
@@ -644,7 +644,7 @@ func TestRegisterListBrokers_NeverComposesWithAuthorization(t *testing.T) {
 	policy := policyGranting(t, []string{"Ops"}, "test-tool")
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	RegisterWithServer(mgr, server, pool, true, policy)
+	RegisterWithServer(mgr, server, pool, true, policy, "groups")
 	RegisterListBrokers(server, pool)
 
 	ctx := context.Background()

--- a/test/integration/correlation_response_meta_test.go
+++ b/test/integration/correlation_response_meta_test.go
@@ -111,7 +111,7 @@ func metaTestServer(t *testing.T, h tools.ToolHandler, withCorrelation bool) *mc
 	mgr.Register(h)
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
-	tools.RegisterWithServer(mgr, server, pool, true, nil)
+	tools.RegisterWithServer(mgr, server, pool, true, nil, "")
 
 	var handler http.Handler = mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
 	if withCorrelation {


### PR DESCRIPTION
## Summary

Refines the placeholder audit event that landed with the tool-authorization
enforcement wrapper into a production-quality audit surface, and relocates
the shared claim-sanitizer utility from `internal/tools/identity.go` to a
new `internal/observability/logging/sanitize` package. Feature ticket:
[SOL-152039](https://sol-jira.atlassian.net/browse/SOL-152039). Parent
epic: SOL-148417 (Claims-Based Tool Authorization).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes) — the sanitizer relocation

## Motivation and Context

The tool-authorization enforcement wrapper landed in a previous ticket
with a placeholder audit event: INFO for every outcome, minimal field
set. That was a deliberate scaffold — the enforcement mechanics needed
to land first so the audit surface could be refined against a working
wrapper. This PR is the refinement: proper level split, decision +
decision_reason two-field sub-axis, bounded matched-groups slice with
truncation flag, and a sanitized expected_claim on missing-claim events.

The sanitizer relocation makes the utility available to the audit event
without forcing `internal/tools/authorization.go` to reach into
`internal/tools/identity.go`'s unexported surface. Pure behavior-
preserving rename — same 256-byte cap on rune boundary, same Cc/Cf/Zl/Zp
strip set. Two-commit structure keeps the relocation reviewable in
isolation from the security-relevant schema change.

## Changes Made

- New package `internal/observability/logging/sanitize` exports
  `Claim(s string) string`, `MaxLen = 256`,
  `VerifierBugSentinel = "<verifier-bug>"`. Algorithm is byte-for-byte
  identical to the pre-move `sanitizeClaim`.
- `internal/tools/identity.go` drops the unexported symbols and routes
  callers through the new package.
- `internal/tools/authorization.go` refines the three audit-event call
  sites (allow / deny / missing-claim). New `configuredGroupsClaimName`
  parameter on `withAuthorization`; new `boundMatchedGroups` helper
  applying the bound of 32 and per-element sanitization.
- `internal/tools/register.go` and `cmd/server/main.go` plumb the
  configured claim name through to the wrapper.
- New test file `internal/tools/authorization_audit_schema_test.go` —
  six tests pinning the refined schema, including load-bearing negative
  assertions on `caller_groups` absence.
- Three additive tests in `internal/observability/logging/sanitize/sanitize_test.go`
  covering inclusive-cap boundary, prefix truncation identity, and
  combining-mark pass-through (Mn exclusion).

## Design rationale — audit-log disclosure discipline

The deny event carries `matched_groups=[]` and `matched_groups_total=0`
but deliberately does NOT carry the caller's actual extracted groups
list. This is a load-bearing separation-of-duties decision that a
future refactor could inadvertently regress; the negative assertion in
`TestAuditEvent_Deny_EmitsWarnWithNotPermittedAndNoCallerGroups` exists
to fail loudly if it does.

In real organizations, MCP server operators (platform/SRE) and IdP
administrators (identity team) are frequently different roles with
different access surfaces. Logging the caller's complete extracted
group membership on every deny would give MCP operators a shadow user
→ group map derived from audit trails — knowledge the identity team
may have deliberately kept internal. This crosses a boundary the IdP
enforces by policy.

Group names themselves can be sensitive. Some organizations use names
that reveal role, seniority, or team affiliation (VP-Direct-Reports,
Legal-Confidential-Reviewers, M&A-Advisory). Emitting these on every
denial would leak organizational structure to whoever tails MCP logs.

There is a deliberate asymmetry with `matched_groups` on allow.
`matched_groups` reveals only which admin-configured groups matched a
specific tool grant — that disclosure is audit-mandatory (the "under
what authority" question compliance auditors ask). `caller_groups` on
deny would reveal the user's complete membership set, most of it
unrelated to the denied tool. Different disclosure category, different
discipline. The audit contract answers "why was this denied?" with
"the tool grants list has none of the caller's groups," which is a
complete audit fact even without enumerating the caller's groups.

If beta feedback shows operators genuinely need `caller_groups` on
deny (regulated-customer scenarios where operator = IdP admin, for
example), a config knob `audit_include_caller_groups` with default
`false` is a backward-compatible add. Default-off preserves the
discipline; opt-in per deployment lets high-trust deployments override.

## Design rationale — audit-event schema and level split

The event carries three matched-groups fields (`matched_groups`,
`matched_groups_total`, `matched_groups_truncated`) rather than the
two the interface design originally proposed. The extra boolean is
not schema noise: operators tailing logs by eye need truncation as an
immediate visual signal. Comparing `len(matched_groups)` against
`matched_groups_total` works for SIEM parsers but not for a human
scanning terminal output; the boolean makes the state legible at a
glance. ~15 extra bytes per line; negligible.

The bound of 32 on `matched_groups` is tuned for log-line readability,
not compliance. 32 group names at ~40 bytes each is ~1.3 KB — under
every SIEM per-field cap and comfortable in both structured JSON and
text-handler console output. Realistic multi-group memberships fit
without truncation; truncation firing is almost certainly a broken
IdP emission or hostile input. When it does fire,
`matched_groups_total` records the true count so nothing is silently
dropped.

The decision axis is a two-field split (`decision`, `decision_reason`),
not a single three-value enum. `decision` carries the primary axis
(allowed vs. denied) that SIEM queries filter on cleanly.
`decision_reason` distinguishes the two non-allow sub-cases
(`not_permitted` vs. `missing_claim`) without flattening them onto the
allow axis. A single enum would blur the "notable but non-error" deny
category with the "configuration event" missing-claim category —
different operator responses, different alerting rules.

Level split is INFO for allow, WARN for both deny outcomes.
Missing-claim is deliberately NOT ERROR: "misconfiguration fails
loudly" in the spec refers to visibility (structured field, distinctive
`decision_reason`), not severity. ERROR would put missing-claim events
on the same footing as system failures (panics, exit-1); an
IdP-misconfigured deployment could flood ERROR-level dashboards and
pagers designed to alert on actual failures. WARN with the reason
field lets operators distinguish missing-claim from deny cleanly
without conflating configuration with system errors.

## Testing

**Test Environment:**
- Go version: 1.25
- OS: darwin arm64

**Tests Performed:**
- [x] Unit tests added/updated — 3 sanitize boundary tests + 6 audit
      schema tests, all in the T5-touched packages.
- [x] Tested locally with `go test -race ./...` — clean.
- [ ] Tested with real Solace broker — not applicable (no broker
      interaction in this change).

**Test Coverage:**
- Inclusive cap at MaxLen; prefix truncation identity at MaxLen+1;
  combining marks survive (Mn exclusion boundary from the outside).
- Every field on every outcome (allow INFO, deny WARN with
  `not_permitted`, missing-claim WARN with `missing_claim` and
  `expected_claim`).
- Load-bearing negative assertions: `caller_groups` absent on deny;
  `matched_groups*` fields absent on missing-claim; `decision_reason`
  and `expected_claim` absent on allow.
- Sanitize applied to `expected_claim` (configured claim name) and to
  every element of `matched_groups` (multi-element test catches
  "sanitize only first" refactor bugs).
- Bounded matched-groups: 16 (under), 32 (inclusive cap), 33 (one
  over) — table-driven, asserts set-membership and dedup rather than
  sequence.
- Correlation ID propagation empirically verified via raw log-line
  dump: `correlation_id` stamped by the correlation slog handler
  reading it from ctx; wrapper never adds it manually.

## Breaking Changes

None. The refined audit event is a new field schema on log records;
downstream SIEM parsers that read the placeholder event will continue
to parse — the tool/decision/identity fields are unchanged, only new
fields appear on the record.

## Checklist

### Code Quality
- [x] Code follows the coding standards.
- [x] Self-review completed.
- [x] Comments explain "why", not "what".
- [x] No commented-out code or debug statements.

### Security
- [x] No credentials in code.
- [x] Secure-logging rules followed — every admin/IdP-controlled
      string reaching a log record passes through `sanitize.Claim`.
- [x] `caller_groups` deliberately omitted from deny events (see
      design rationale above).
- [x] gosec / staticcheck clean via `make check`.

### Testing
- [x] `make check` passes at each commit boundary independently
      (verified via detached-HEAD checkout of the sanitizer-relocation
      commit).
- [x] `go test -race ./internal/tools/... ./internal/observability/...`
      clean.
- [x] Negative assertions carry regression-warning messages so
      future contributors see the contract they would violate.

### Documentation
- [x] Godoc comments on new exported symbols (`sanitize.Claim`,
      `MaxLen`, `VerifierBugSentinel`).
- [x] Design rationale documented in this PR description (not just in
      internal design docs) so the caller_groups decision is visible
      in PR history.

### Git & CI
- [x] Commits have clear, descriptive messages.
- [x] Two-commit-plus-followups structure keeps the sanitizer
      relocation reviewable in isolation from the security-relevant
      audit refinement.
- [ ] Signed off (DCO) — not signed per project convention on this
      repo.

## Related Issues/PRs

- Jira: [SOL-152039](https://sol-jira.atlassian.net/browse/SOL-152039)
- Parent epic: SOL-148417

---

**For Reviewers:**

**Focus areas:**
1. `internal/tools/authorization.go` audit-event call sites — is the
   field ordering / naming what you'd want to see in a SIEM query?
2. The `caller_groups` absence decision — captured in the "audit-log
   disclosure discipline" section above. If you have regulated-customer
   experience where operator = IdP admin, please push back explicitly
   so we can weigh in on the future config knob.
3. `TestAuditEvent_MatchedGroupsBounding` — the bound is set at 32.
   Sanity check: is 32 the right number for your operational context?
4. Commit structure — the sanitizer relocation is pure refactor; the
   audit refinement is the security-relevant change. Reviewing them
   as separate commits, not as one squashed PR, is the intended
   workflow.

[SOL-152039]: https://sol-jira.atlassian.net/browse/SOL-152039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-152039]: https://sol-jira.atlassian.net/browse/SOL-152039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ