### PR TITLE
docs(ua): incremental knowledge-graph refresh through c4955e9

### DIFF
--- a/.ua/.understandignore
+++ b/.ua/.understandignore
@@ -12,6 +12,10 @@
 # server code and its unit tests. Remove this line to include it.
 test/
 
+# Generated SEMP swagger specs (~6.7MB machine-generated OpenAPI JSON). Each
+# collapses to a single low-value node; embed.go represents the specs package.
+internal/semp/sempv2/specs/*.json
+
 # --- From .gitignore (uncomment to exclude) ---
 
 # *.exe

--- a/.ua/fingerprints.json
+++ b/.ua/fingerprints.json
@@ -1,8 +1,125 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "c1f193ea253213b0d4019e829217170cdd416473",
-  "generatedAt": "2026-07-21T16:49:34.403Z",
+  "gitCommitHash": "c4955e9172cf021b9640e932f9f05c1800cd88f6",
+  "generatedAt": "2026-07-23T17:53:12.004Z",
   "files": {
+    ".claude/hooks/changelog-reminder.sh": {
+      "filePath": ".claude/hooks/changelog-reminder.sh",
+      "contentHash": "518464d5869ffdc26b08a1eab4b280e1e2a1834fcec05230de53c1b4ba562eb2",
+      "functions": [
+        {
+          "name": "extract_unreleased",
+          "params": [],
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    ".claude/review-balance-history.tsv": {
+      "filePath": ".claude/review-balance-history.tsv",
+      "contentHash": "0587c542638be07bb5af309166940edf870c9d1d9b4cc411c647d2131bdb87bb",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 11,
+      "hasStructuralAnalysis": false
+    },
+    ".claude/review-balance.json": {
+      "filePath": ".claude/review-balance.json",
+      "contentHash": "20aea0a9186732fdec29e0bafb128d2bd36fcb69c7ced185d26fc71d7bb6892f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 17,
+      "hasStructuralAnalysis": true
+    },
+    ".claude/settings.json": {
+      "filePath": ".claude/settings.json",
+      "contentHash": "29c3d16d90ad51dd93c17753b86f467165a4ba84f08ae6b8d1babaac5bcb0f46",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    ".claude/skills/add-logs/SKILL.md": {
+      "filePath": ".claude/skills/add-logs/SKILL.md",
+      "contentHash": "80290d62462e52688f55be9028497b533af8f453e844ba67e2188d92f6b37fef",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 118,
+      "hasStructuralAnalysis": true
+    },
+    ".claude/skills/changelog/SKILL.md": {
+      "filePath": ".claude/skills/changelog/SKILL.md",
+      "contentHash": "6a85cda9bc6b41a2d9f42cdbae80fb552db967eff320225d19889aabc5f21976",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 126,
+      "hasStructuralAnalysis": true
+    },
+    ".claude/skills/check-logs/SKILL.md": {
+      "filePath": ".claude/skills/check-logs/SKILL.md",
+      "contentHash": "ee3f059f538e8ecf5fb26c0b67062401df2ce5058564e3aa426334c5966c0a69",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 116,
+      "hasStructuralAnalysis": true
+    },
+    ".claude/skills/cut-release/SKILL.md": {
+      "filePath": ".claude/skills/cut-release/SKILL.md",
+      "contentHash": "4db8af39ce64d235053ece84a8d0bc289a824225d2c0ab240806e70a28b85d84",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 208,
+      "hasStructuralAnalysis": true
+    },
+    ".dockerignore": {
+      "filePath": ".dockerignore",
+      "contentHash": "03cd9bd558c538ff80fba7efa70e90d381db27e4fd69b06a2b13fa7c06d3b648",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 20,
+      "hasStructuralAnalysis": false
+    },
+    ".fossa.yml": {
+      "filePath": ".fossa.yml",
+      "contentHash": "f77c9af880eda5019e9f7d8258e456357563a67c0648463769c6aa2a5281c127",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 34,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ADMIN_SETUP.md": {
+      "filePath": ".github/ADMIN_SETUP.md",
+      "contentHash": "7692d1cc560cacb94bfa83d9972ca4faa63ea97618dd06b2c6bb44254f1d889c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 284,
+      "hasStructuralAnalysis": true
+    },
     ".github/CODEOWNERS": {
       "filePath": ".github/CODEOWNERS",
       "contentHash": "dbe07a12344204d3718942727af9625eea6e6aff09c305cf8c66b5b0371ece6f",
@@ -13,15 +130,272 @@
       "totalLines": 4,
       "hasStructuralAnalysis": false
     },
-    ".ua/.understandignore": {
-      "filePath": ".ua/.understandignore",
-      "contentHash": "69e523ac20ab9169737877bfd0c8b24a51c6a1b41f04b298f659a9e32cc199a8",
+    ".github/CODE_OF_CONDUCT.md": {
+      "filePath": ".github/CODE_OF_CONDUCT.md",
+      "contentHash": "74383470c75f9160c508f9c107ccaf388363a9fd89fc22fe478b2ac1749765aa",
       "functions": [],
       "classes": [],
       "imports": [],
       "exports": [],
-      "totalLines": 102,
-      "hasStructuralAnalysis": false
+      "totalLines": 86,
+      "hasStructuralAnalysis": true
+    },
+    ".github/CONTRIBUTING.md": {
+      "filePath": ".github/CONTRIBUTING.md",
+      "contentHash": "0be7b78d0e86f30b7090a4502c6e3dc994bcced6e36e1afcc4fbebe39b96b9c3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 271,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/bug_report.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "contentHash": "abd00f4a1fa4f65934f4f4b39d8edca3bad5691f97e1d2ce72df64deeecafd0c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 143,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/config.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/config.yml",
+      "contentHash": "1cda2f56190308c4493dd99ca5b0da4cd270bfe84adc5d8bc78af8f8e75c4f7f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 12,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/feature_request.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "contentHash": "6323d247cfabb95561310ab750f2b94138e1bc4b0643392129acfcee7a361aac",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 128,
+      "hasStructuralAnalysis": true
+    },
+    ".github/OPEN_SOURCE_STATUS.md": {
+      "filePath": ".github/OPEN_SOURCE_STATUS.md",
+      "contentHash": "1209c43f2c1a1a72b3bdd72a041e10f7661b5118b9a47a62c38c7b54fe6ff8d2",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 186,
+      "hasStructuralAnalysis": true
+    },
+    ".github/PULL_REQUEST_TEMPLATE.md": {
+      "filePath": ".github/PULL_REQUEST_TEMPLATE.md",
+      "contentHash": "f317eeb2dab1b09bb0b92695181cb5215cdafaae64af56eccfe9e68b0f88a642",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 126,
+      "hasStructuralAnalysis": true
+    },
+    ".github/SECURITY.md": {
+      "filePath": ".github/SECURITY.md",
+      "contentHash": "2643c67a472668acb643873257b2a750041bb926342070b12a1fb5d983f98e14",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 200,
+      "hasStructuralAnalysis": true
+    },
+    ".github/renovate.json": {
+      "filePath": ".github/renovate.json",
+      "contentHash": "fdb65cb0fe3960fff7709536312990907f83aa7aea46961c3c60a73422b5a702",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 29,
+      "hasStructuralAnalysis": true
+    },
+    ".github/scripts/changelog-check.sh": {
+      "filePath": ".github/scripts/changelog-check.sh",
+      "contentHash": "bfa06f59af0c602d27a65713b26681e63aaa19e24f43d446069c8db499bdf330",
+      "functions": [
+        {
+          "name": "extract_unreleased",
+          "params": [],
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 81,
+      "hasStructuralAnalysis": true
+    },
+    ".github/scripts/extract-release-notes.sh": {
+      "filePath": ".github/scripts/extract-release-notes.sh",
+      "contentHash": "716f5b2b8498b695ac50be3ebc66b4d62a80945523f49c60a015c24f94a18d5c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 36,
+      "hasStructuralAnalysis": true
+    },
+    ".github/scripts/production-surface.sh": {
+      "filePath": ".github/scripts/production-surface.sh",
+      "contentHash": "9939eb86449b0501477d5f8130d75696cfaf50f4b08e8a30811e160046612f3f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflow-config.json": {
+      "filePath": ".github/workflow-config.json",
+      "contentHash": "7116175769cd6afa3ef95c94afc62e9684b4313439ebd956bb364116afc08b8d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 25,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/build-and-test.yml": {
+      "filePath": ".github/workflows/build-and-test.yml",
+      "contentHash": "3e9a9bee54b38bfa81e6693ca64acd063a586d978cf95097b69f4996dafabb62",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 292,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/ci-pr.yaml": {
+      "filePath": ".github/workflows/ci-pr.yaml",
+      "contentHash": "ba089bbbfc631f679c45e68e60398ac7da187ac01d82bfe44fd2c4ffbfc8dd9d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 51,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/fossa-scan.yaml": {
+      "filePath": ".github/workflows/fossa-scan.yaml",
+      "contentHash": "7b108a2ce81dc3f53d5b9c98c63b6494652b1adf5421201d285f68319b1f0c23",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 31,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/llm-eval.yml": {
+      "filePath": ".github/workflows/llm-eval.yml",
+      "contentHash": "acf065e2adb3a2cccefea5a99f054e6126386f66c5495add355e39d7978708cd",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 123,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/release.yml": {
+      "filePath": ".github/workflows/release.yml",
+      "contentHash": "b83522f1add96ec4964b077ad86efe8edd78bdb7bbd8f9f019c5c11d25eb969b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 180,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/transition_on_merge.yaml": {
+      "filePath": ".github/workflows/transition_on_merge.yaml",
+      "contentHash": "1b99690d4ab737e8dffb5fe464da809a7df53d736bc17f3d3e3ca8f71517333f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 14,
+      "hasStructuralAnalysis": true
+    },
+    ".golangci.yml": {
+      "filePath": ".golangci.yml",
+      "contentHash": "8a5c74b82894fadd0e5c93c32a10f9f36505d4d19be415b23ab904321d91bc03",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 41,
+      "hasStructuralAnalysis": true
+    },
+    "CHANGELOG.md": {
+      "filePath": "CHANGELOG.md",
+      "contentHash": "f29695b1ec15dcb300a49bcc811775017d4794ee13ffbc931d4745f2ea60de3e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 305,
+      "hasStructuralAnalysis": true
+    },
+    "CLAUDE.md": {
+      "filePath": "CLAUDE.md",
+      "contentHash": "4728184accd6d85bd955445407a23b0472c2bb4ec3fdff87288f2219a0648753",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 55,
+      "hasStructuralAnalysis": true
+    },
+    "DISCLAIMERS.md": {
+      "filePath": "DISCLAIMERS.md",
+      "contentHash": "8bd9d8f2b2430c7f041d47f90554e57a6ff7d5c7882a89ce8f11dd4e09a9d8fb",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 219,
+      "hasStructuralAnalysis": true
+    },
+    "Dockerfile": {
+      "filePath": "Dockerfile",
+      "contentHash": "4ae3fa843c5c8f9ed40a47ffae5cb0ed1057fb864044991c8e5a9df9ae8cdef2",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 29,
+      "hasStructuralAnalysis": true
+    },
+    "EXAMPLES.md": {
+      "filePath": "EXAMPLES.md",
+      "contentHash": "3bf24488f5080fe422b6999f4ad5e43ca81ae23e9d630bb8e2c31e4276b8df9f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 14,
+      "hasStructuralAnalysis": true
+    },
+    "Makefile": {
+      "filePath": "Makefile",
+      "contentHash": "3c45e7ff7fb3714ced3a570fa15174588250662dda528bc3995d25b86354348f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 177,
+      "hasStructuralAnalysis": true
     },
     "NOTICE": {
       "filePath": "NOTICE",
@@ -32,6 +406,56 @@
       "exports": [],
       "totalLines": 31,
       "hasStructuralAnalysis": false
+    },
+    "README.md": {
+      "filePath": "README.md",
+      "contentHash": "a04df2a2286392c7668fafd267d62c16b7b459b41f90f734062522ef1533877b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 431,
+      "hasStructuralAnalysis": true
+    },
+    "RELEASING.md": {
+      "filePath": "RELEASING.md",
+      "contentHash": "813b4e481fc0a14496c8e661cf96bb03df1c34e7fcaf7eaf32620c0da6265adf",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 134,
+      "hasStructuralAnalysis": true
+    },
+    "THIRD_PARTY_LICENSES.md": {
+      "filePath": "THIRD_PARTY_LICENSES.md",
+      "contentHash": "188536ded1d3cdf4d5e8291d954f0ffd2f8d892d886bff0516eee461f00266f1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 73,
+      "hasStructuralAnalysis": true
+    },
+    "TOOLS.md": {
+      "filePath": "TOOLS.md",
+      "contentHash": "3185a792658b308794814f2c1e764c7ec50d1a617973db8bcf7c7509ae5213f0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "broker-config.example.yaml": {
+      "filePath": "broker-config.example.yaml",
+      "contentHash": "bdba004ba3b6fe642339107a27e02b74bc4189187c8487bf9bb718a32979750f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 110,
+      "hasStructuralAnalysis": true
     },
     "cmd/server/body_limit_test.go": {
       "filePath": "cmd/server/body_limit_test.go",
@@ -277,7 +701,7 @@
     },
     "cmd/server/main.go": {
       "filePath": "cmd/server/main.go",
-      "contentHash": "dc95c0bcdc4bee1af11bced829f927176d6f3a417df5680d20e3eba9433f2169",
+      "contentHash": "70db621ee2bc68a29e77f6202d1ad03186ef7725526793095db298cc434a6bd6",
       "functions": [
         {
           "name": "redactSecretAttr",
@@ -430,7 +854,7 @@
           ],
           "returnType": "(*tokenexchange.Exchanger, error)",
           "exported": false,
-          "lineCount": 28
+          "lineCount": 39
         },
         {
           "name": "buildToolPolicy",
@@ -703,7 +1127,7 @@
         }
       ],
       "exports": [],
-      "totalLines": 879,
+      "totalLines": 895,
       "hasStructuralAnalysis": true
     },
     "cmd/server/main_test.go": {
@@ -1614,6 +2038,336 @@
       ],
       "totalLines": 87,
       "hasStructuralAnalysis": true
+    },
+    "deploy/kubernetes/configmap.yaml": {
+      "filePath": "deploy/kubernetes/configmap.yaml",
+      "contentHash": "fbe0a42c3cca29e7a3348d298cc5242038743c5b03b4e1c093102d874ef30906",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "deploy/kubernetes/deployment.yaml": {
+      "filePath": "deploy/kubernetes/deployment.yaml",
+      "contentHash": "d7d13fd057014c8165a61118bbe04f8e42ab3fe33849b8d0fd7d9f5692fa498b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 100,
+      "hasStructuralAnalysis": true
+    },
+    "deploy/kubernetes/secret.yaml": {
+      "filePath": "deploy/kubernetes/secret.yaml",
+      "contentHash": "06718fad4155460b3d14d7879c807ba3001b3e5f95eca73d52e48953b6cc0f71",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": true
+    },
+    "deploy/kubernetes/service.yaml": {
+      "filePath": "deploy/kubernetes/service.yaml",
+      "contentHash": "cb0eb5b3139acbcbd909a915612a66200073ae508d2d59fb1dd301190929b2ea",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "docs/authentication.md": {
+      "filePath": "docs/authentication.md",
+      "contentHash": "a332b01eacd1058dcfa124e26b6a2b47ffb3fe75f199159599ad0b605fbaec73",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 471,
+      "hasStructuralAnalysis": true
+    },
+    "docs/configuration.md": {
+      "filePath": "docs/configuration.md",
+      "contentHash": "85b138695ffbca6e8a1b7d395a14ce7e3ea71c04e8efdab09d95eccf54adebdf",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 121,
+      "hasStructuralAnalysis": true
+    },
+    "docs/examples.md": {
+      "filePath": "docs/examples.md",
+      "contentHash": "bac04e35e1ebc367a6ebbcbe137d723eddac566a59d0d3da839dd7ea00c6f8c7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 295,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/architecture.md": {
+      "filePath": "docs/internal/architecture.md",
+      "contentHash": "1cb9b9b51db40def1f9585ee3d2d955fa7f333eb7325022e7e8579a8dde54545",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 471,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/e2e-testing.md": {
+      "filePath": "docs/internal/e2e-testing.md",
+      "contentHash": "e6255b1b9b5b264eae665a0434b859a36bb5959cdebf3021466fff7c6a68e3f1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 322,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/packaging-release.md": {
+      "filePath": "docs/internal/packaging-release.md",
+      "contentHash": "557e9da2f03af9b619ab3b89223a18fa88171ba93a3213bdcd4e5948577b0b51",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 328,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/secure-logging-rules.md": {
+      "filePath": "docs/internal/secure-logging-rules.md",
+      "contentHash": "306269932e38e7a03de4e33800051028d1c115c2cb7317a6d770396df308060d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 89,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/semp/get-broker-status-curated-fields.md": {
+      "filePath": "docs/internal/semp/get-broker-status-curated-fields.md",
+      "contentHash": "006058d468cb706857f238a59b3c658850c35aebd46d30d08327d60efef65a44",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 324,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/semp/get-discard-stats-curated-fields.md": {
+      "filePath": "docs/internal/semp/get-discard-stats-curated-fields.md",
+      "contentHash": "3da1d89ab289d785c1ac0ed89a70100041cfbdacd4b7ea4be0871a64ed77d958",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 230,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/semp/sempv1-client-design.md": {
+      "filePath": "docs/internal/semp/sempv1-client-design.md",
+      "contentHash": "7662d0e915db8c151fdc175793bff6ed3411542f4b6845d4cf21a2d19fd30a34",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 623,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/todo-gaps.md": {
+      "filePath": "docs/internal/todo-gaps.md",
+      "contentHash": "92a028a99aea220fcbe5209a5b81c1443f6c48bd1bf67c3f8eb425dfb1010748",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 135,
+      "hasStructuralAnalysis": true
+    },
+    "docs/internal/understand-anything.md": {
+      "filePath": "docs/internal/understand-anything.md",
+      "contentHash": "b09b25d2f82edbcb0363a35ab47c1004c14bdb52a7536a8754bbc73a3fff3275",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 113,
+      "hasStructuralAnalysis": true
+    },
+    "docs/oauth/token-exchange-SOL-150070/architecture-plan.md": {
+      "filePath": "docs/oauth/token-exchange-SOL-150070/architecture-plan.md",
+      "contentHash": "33b685887e3e9b879bc754b49ee329dca2399b067f035d729ae47b11389be5ff",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1373,
+      "hasStructuralAnalysis": true
+    },
+    "docs/sam-integration.md": {
+      "filePath": "docs/sam-integration.md",
+      "contentHash": "2b537b8aced7130c96d215afcb253a9d6cd5a29da9b5cdcf85e19de883226a76",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 107,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-05-20-client-auth-mode.md": {
+      "filePath": "docs/superpowers/plans/2026-05-20-client-auth-mode.md",
+      "contentHash": "a73b94c30f1522bdfc2300f2d670d3520d12187766f01df490b6bd81623309fa",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2167,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-05-21-pr62-review-fixes.md": {
+      "filePath": "docs/superpowers/plans/2026-05-21-pr62-review-fixes.md",
+      "contentHash": "97e285fa10f0d9f5edfc1aaf05f2fd045a2e099d8668ca8be8676a84316e1913",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 649,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-05-25-broker-alias-contract.md": {
+      "filePath": "docs/superpowers/plans/2026-05-25-broker-alias-contract.md",
+      "contentHash": "ed4c73de0b5741ae934b38f6fe3adb1fd50377d2e3b812f91a4a73255a3ef697",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 777,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-05-27-sol-149606-tool-invocation-identity-audit.md": {
+      "filePath": "docs/superpowers/plans/2026-05-27-sol-149606-tool-invocation-identity-audit.md",
+      "contentHash": "b6a55b25c939eee94f6a875d78135cc08b9ac605e9a67a471ec265c50a096c5d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 796,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-06-14-sol-150070-implementation-decisions.md": {
+      "filePath": "docs/superpowers/plans/2026-06-14-sol-150070-implementation-decisions.md",
+      "contentHash": "b63f3667c1244dfe775942b1c6a5ba181f141aac17374f050aaca57175f5e324",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 246,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-06-26-obs-story1-story7.md": {
+      "filePath": "docs/superpowers/plans/2026-06-26-obs-story1-story7.md",
+      "contentHash": "3343702f692c2c3a1adb5f4cfab57310145c6412c1027bc98a3aa1670ae0d9be",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 49,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-06-29-sol-150860-docs-gaps.md": {
+      "filePath": "docs/superpowers/plans/2026-06-29-sol-150860-docs-gaps.md",
+      "contentHash": "71d6c5ba4bd4bb11a09b1b51b83479d43c38658c960d89dbe9af7c75081900c6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 84,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md": {
+      "filePath": "docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md",
+      "contentHash": "8e2b32a864b2c4a151e14943598fb1157b286791183273aac7cd985cb95cda45",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 335,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/oauth-token-exchange/SOL-150796-T2-config-schema.md": {
+      "filePath": "docs/superpowers/plans/oauth-token-exchange/SOL-150796-T2-config-schema.md",
+      "contentHash": "9fbbc0f03b8e71404626b38392494937bffb0e8ccf0dd6a76d9e981a4581e2e5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 952,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-05-20-client-auth-mode-design.md": {
+      "filePath": "docs/superpowers/specs/2026-05-20-client-auth-mode-design.md",
+      "contentHash": "621cff93e14a3877895ec8831cfc88dd1ef35f12f4239721c91ae6c978e6dd40",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 281,
+      "hasStructuralAnalysis": true
+    },
+    "docs/tools-reference.md": {
+      "filePath": "docs/tools-reference.md",
+      "contentHash": "9e91e581f1c7311635b43b638a38e83835c06f7aa0dbcb2186cf45bb02d930a4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 960,
+      "hasStructuralAnalysis": true
+    },
+    "docs/user-guide.md": {
+      "filePath": "docs/user-guide.md",
+      "contentHash": "d5e09c1e292414c83bce3c477681e3e17a49d652655af9e192528408be34d069",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 280,
+      "hasStructuralAnalysis": true
+    },
+    "fixit-notes.md": {
+      "filePath": "fixit-notes.md",
+      "contentHash": "c675d2a5a0aa8a03ed1a0943b2a7a40776ba50521ce06f38d7420262e2d4192e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "go.mod": {
+      "filePath": "go.mod",
+      "contentHash": "dc754cc1456efb932d45bc61495584d802fe2225aedc7b6b41736f8a8976d262",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 43,
+      "hasStructuralAnalysis": false
+    },
+    "go.sum": {
+      "filePath": "go.sum",
+      "contentHash": "a5cb21c91bcd203d89be312bdd4d4221cb342cff6cbfe7714ee172f5438a08cb",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 97,
+      "hasStructuralAnalysis": false
     },
     "internal/.gitkeep": {
       "filePath": "internal/.gitkeep",
@@ -3363,9 +4117,19 @@
       "totalLines": 24,
       "hasStructuralAnalysis": true
     },
+    "internal/composite/definitions/tools.yaml": {
+      "filePath": "internal/composite/definitions/tools.yaml",
+      "contentHash": "640f4e31cf3ba29a3b3d8294e6eb8dc330f5d81f24801c2a1dccb0fa11820020",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1172,
+      "hasStructuralAnalysis": true
+    },
     "internal/composite/executor.go": {
       "filePath": "internal/composite/executor.go",
-      "contentHash": "9042f6fad0f58235bbb2ca9d74f0dac996b3af3aeb2181d39f6072f8aca6237f",
+      "contentHash": "416e10bfe5fc8b851dfdd66f59f515aa523aaced54f69c23a8097679e2afd25d",
       "functions": [
         {
           "name": "NewCompositeExecutor",
@@ -3564,7 +4328,7 @@
           ],
           "returnType": "(map[string]any, error)",
           "exported": false,
-          "lineCount": 58
+          "lineCount": 68
         },
         {
           "name": "ApplyResultStrategy",
@@ -3719,7 +4483,94 @@
         "ResolveArgs",
         "ApplyResultStrategy"
       ],
-      "totalLines": 749,
+      "totalLines": 759,
+      "hasStructuralAnalysis": true
+    },
+    "internal/composite/executor_bridge_test.go": {
+      "filePath": "internal/composite/executor_bridge_test.go",
+      "contentHash": "dc0352ec4181b3a0ef5372ae0b74d33cdd6f89557fc0a4567645c2ea31dc5c85",
+      "functions": [
+        {
+          "name": "listBridgesTool",
+          "params": [],
+          "returnType": "CompositeTool",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "getBridgeStatusTool",
+          "params": [],
+          "returnType": "CompositeTool",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "makeBridgeItems",
+          "params": [
+            "n"
+          ],
+          "returnType": "[]any",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "TestExecute_ListBridges_SinglePage",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 35
+        },
+        {
+          "name": "TestExecute_ListBridges_TruncatesAtMaxResults",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 28
+        },
+        {
+          "name": "TestExecute_GetBridgeStatus_CompoundPathParams",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 32
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "context",
+          "specifiers": [
+            "context"
+          ]
+        },
+        {
+          "source": "fmt",
+          "specifiers": [
+            "fmt"
+          ]
+        },
+        {
+          "source": "sync",
+          "specifiers": [
+            "sync"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        }
+      ],
+      "exports": [
+        "TestExecute_ListBridges_SinglePage",
+        "TestExecute_ListBridges_TruncatesAtMaxResults",
+        "TestExecute_GetBridgeStatus_CompoundPathParams"
+      ],
+      "totalLines": 189,
       "hasStructuralAnalysis": true
     },
     "internal/composite/executor_client_test.go": {
@@ -4355,7 +5206,7 @@
     },
     "internal/composite/executor_helpers_test.go": {
       "filePath": "internal/composite/executor_helpers_test.go",
-      "contentHash": "af5a821613b008aacb4906bfe104d94b4993af1a4b3350c95699ad10eb8549d5",
+      "contentHash": "115848d6e9f58689876e277fa9562fa1fea68a7c7d31e1451f54ec6438faef45",
       "functions": [
         {
           "name": "newMockClient",
@@ -4380,7 +5231,7 @@
           "params": [],
           "returnType": "map[string]*sempv2.Operation",
           "exported": false,
-          "lineCount": 200
+          "lineCount": 215
         },
         {
           "name": "newSeqMockClient",
@@ -4530,7 +5381,7 @@
         "Execute",
         "Execute"
       ],
-      "totalLines": 351,
+      "totalLines": 366,
       "hasStructuralAnalysis": true
     },
     "internal/composite/executor_queue_test.go": {
@@ -5029,7 +5880,7 @@
     },
     "internal/composite/executor_vpn_test.go": {
       "filePath": "internal/composite/executor_vpn_test.go",
-      "contentHash": "adc78da9670d99893c2ca13748dbf03328ae85687b0fa9527445fa905eac9f52",
+      "contentHash": "f90a3d8ed8011b75e4ecc75b96f58b2e62beafa9fdecf2e33c70146d2328dcdb",
       "functions": [
         {
           "name": "getVPNStatusTool",
@@ -5183,7 +6034,7 @@
             "t"
           ],
           "exported": true,
-          "lineCount": 39
+          "lineCount": 40
         },
         {
           "name": "TestExecute_UpdateMessageVPN_BodyExcludesPathParam",
@@ -5281,7 +6132,7 @@
         "TestExecute_DeleteMessageVPN_NoBodyConstructed",
         "TestExecute_DeleteMessageVPN_SEMPError"
       ],
-      "totalLines": 726,
+      "totalLines": 727,
       "hasStructuralAnalysis": true
     },
     "internal/composite/loader.go": {
@@ -5374,6 +6225,49 @@
       "totalLines": 210,
       "hasStructuralAnalysis": true
     },
+    "internal/composite/loader_bridge_test.go": {
+      "filePath": "internal/composite/loader_bridge_test.go",
+      "contentHash": "31723b75d824f795881d32414f5457939bb974be4bae12b015fffe9c9821ed02",
+      "functions": [
+        {
+          "name": "TestLoadTools_ListBridges",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 69
+        },
+        {
+          "name": "TestLoadTools_GetBridgeStatus",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 76
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "testing/fstest",
+          "specifiers": [
+            "fstest"
+          ]
+        }
+      ],
+      "exports": [
+        "TestLoadTools_ListBridges",
+        "TestLoadTools_GetBridgeStatus"
+      ],
+      "totalLines": 174,
+      "hasStructuralAnalysis": true
+    },
     "internal/composite/loader_client_test.go": {
       "filePath": "internal/composite/loader_client_test.go",
       "contentHash": "a2564dab21296dc4a026bda6b04276142fdb8e04067d713e7435bf3ec028a3c3",
@@ -5451,6 +6345,46 @@
         "TestLoadTools_ClearClientStats"
       ],
       "totalLines": 366,
+      "hasStructuralAnalysis": true
+    },
+    "internal/composite/loader_cross_reference_test.go": {
+      "filePath": "internal/composite/loader_cross_reference_test.go",
+      "contentHash": "27018ec05998924292c5ca3fe381e90298685ad4dcd460286d4cec40dbe64d99",
+      "functions": [
+        {
+          "name": "TestListTools_ReferenceTheirDetailTool",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 34
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "strings",
+          "specifiers": [
+            "strings"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/composite/definitions",
+          "specifiers": [
+            "definitions"
+          ]
+        }
+      ],
+      "exports": [
+        "TestListTools_ReferenceTheirDetailTool"
+      ],
+      "totalLines": 64,
       "hasStructuralAnalysis": true
     },
     "internal/composite/loader_fanout_test.go": {
@@ -6238,6 +7172,174 @@
         "TestGetRdpStatus_ValidateTool"
       ],
       "totalLines": 354,
+      "hasStructuralAnalysis": true
+    },
+    "internal/composite/postprocess/handlers/list_bridges.go": {
+      "filePath": "internal/composite/postprocess/handlers/list_bridges.go",
+      "contentHash": "5e71da3d43f121ee66ae206b7091b6ffb82200973a215848a80a46ad354e2545",
+      "functions": [
+        {
+          "name": "init",
+          "params": [],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "ListBridges",
+          "params": [
+            "stepResults"
+          ],
+          "returnType": "(map[string]any, error)",
+          "exported": true,
+          "lineCount": 52
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "fmt",
+          "specifiers": [
+            "fmt"
+          ]
+        },
+        {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/composite/postprocess",
+          "specifiers": [
+            "postprocess"
+          ]
+        }
+      ],
+      "exports": [
+        "ListBridges"
+      ],
+      "totalLines": 139,
+      "hasStructuralAnalysis": true
+    },
+    "internal/composite/postprocess/handlers/list_bridges_test.go": {
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "contentHash": "b24a4f31fb9817d71d8f2e3864681ac5ca173c1d44cded3b59f607c59a1ca611",
+      "functions": [
+        {
+          "name": "bridge",
+          "params": [
+            "enabled",
+            "inboundState",
+            "outboundState",
+            "inboundFailureReason"
+          ],
+          "returnType": "map[string]any",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "TestListBridges_Counts",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 33
+        },
+        {
+          "name": "TestListBridges_OutboundOnlyFailure",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 17
+        },
+        {
+          "name": "TestListBridges_OutboundOnlyFailureWithStaleInboundReason",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 18
+        },
+        {
+          "name": "TestListBridges_UnidirectionalNotApplicableIsHealthy",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 13
+        },
+        {
+          "name": "TestListBridges_TruncationSurfaced",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 28
+        },
+        {
+          "name": "TestListBridges_Empty",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "TestListBridges_Errors",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 31
+        },
+        {
+          "name": "TestListBridges_MissingField",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 37
+        },
+        {
+          "name": "TestListBridges_NilField",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 15
+        },
+        {
+          "name": "TestListBridges_SkippedOmittedWhenZero",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 11
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "strings",
+          "specifiers": [
+            "strings"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        }
+      ],
+      "exports": [
+        "TestListBridges_Counts",
+        "TestListBridges_OutboundOnlyFailure",
+        "TestListBridges_OutboundOnlyFailureWithStaleInboundReason",
+        "TestListBridges_UnidirectionalNotApplicableIsHealthy",
+        "TestListBridges_TruncationSurfaced",
+        "TestListBridges_Empty",
+        "TestListBridges_Errors",
+        "TestListBridges_MissingField",
+        "TestListBridges_NilField",
+        "TestListBridges_SkippedOmittedWhenZero"
+      ],
+      "totalLines": 293,
       "hasStructuralAnalysis": true
     },
     "internal/composite/postprocess/handlers/list_queue_discards.go": {
@@ -7487,7 +8589,7 @@
     },
     "internal/config/config.go": {
       "filePath": "internal/config/config.go",
-      "contentHash": "04f4d4f76fa1ba0fbe39aec8f14c265d385d88d7ea749260656ffac15b118ce3",
+      "contentHash": "6560711753317e183dbb4a17c6635fbd89e66cd244cb086e11ecbf46fcca6373",
       "functions": [
         {
           "name": "selectedMethod",
@@ -7508,7 +8610,7 @@
           "params": [],
           "returnType": "slog.Value",
           "exported": true,
-          "lineCount": 10
+          "lineCount": 15
         },
         {
           "name": "LogValue",
@@ -7729,7 +8831,7 @@
           ],
           "returnType": "[]error",
           "exported": false,
-          "lineCount": 62
+          "lineCount": 64
         },
         {
           "name": "validateBrokerClientAuth",
@@ -7909,10 +9011,11 @@
             "ClientID",
             "ClientAuth",
             "GrantType",
-            "AudienceParam"
+            "AudienceParam",
+            "CircuitBreaker"
           ],
           "exported": true,
-          "lineCount": 7
+          "lineCount": 8
         },
         {
           "name": "BrokerClientAuth",
@@ -8169,7 +9272,7 @@
         "OAuthPlaintextListenerAcknowledged",
         "ToolAuthorizationEnabled"
       ],
-      "totalLines": 1778,
+      "totalLines": 1789,
       "hasStructuralAnalysis": true
     },
     "internal/config/config_test.go": {
@@ -9283,6 +10386,170 @@
       "totalLines": 4072,
       "hasStructuralAnalysis": true
     },
+    "internal/config/idp_circuit_breaker.go": {
+      "filePath": "internal/config/idp_circuit_breaker.go",
+      "contentHash": "2606c0abf99e4792bfe867e072531cb341e62fa7bf5e15a694d98b9e30700764",
+      "functions": [
+        {
+          "name": "BreakerEnabled",
+          "params": [],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "validateIdPCircuitBreaker",
+          "params": [
+            "cb"
+          ],
+          "returnType": "[]error",
+          "exported": false,
+          "lineCount": 34
+        }
+      ],
+      "classes": [
+        {
+          "name": "IdPCircuitBreakerConfig",
+          "methods": [],
+          "properties": [
+            "Enabled",
+            "FailureRateWindow",
+            "MinimumRequests",
+            "FailureRateThresholdPercent",
+            "ConsecutiveFailureThreshold",
+            "OpenStateDuration",
+            "HalfOpenProbeRequests"
+          ],
+          "exported": true,
+          "lineCount": 13
+        }
+      ],
+      "imports": [
+        {
+          "source": "fmt",
+          "specifiers": [
+            "fmt"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        }
+      ],
+      "exports": [
+        "IdPCircuitBreakerConfig",
+        "BreakerEnabled"
+      ],
+      "totalLines": 121,
+      "hasStructuralAnalysis": true
+    },
+    "internal/config/idp_circuit_breaker_test.go": {
+      "filePath": "internal/config/idp_circuit_breaker_test.go",
+      "contentHash": "13c6dfaac77da2076789393136a721732890c320657946b71d48d5966136343c",
+      "functions": [
+        {
+          "name": "ptr",
+          "params": [
+            "v"
+          ],
+          "returnType": "*T",
+          "exported": false,
+          "lineCount": 1
+        },
+        {
+          "name": "silenceLogs",
+          "params": [
+            "t"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "TestLoadConfig_CircuitBreaker_ParsesFromYAML",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 36
+        },
+        {
+          "name": "TestLoadConfig_CircuitBreaker_OmittedBlockIsNil",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 10
+        },
+        {
+          "name": "TestLoadConfig_CircuitBreaker_BadValueRejected",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 52
+        },
+        {
+          "name": "TestBreakerEnabled",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 22
+        },
+        {
+          "name": "TestValidateBrokerCircuitBreaker",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 52
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "bytes",
+          "specifiers": [
+            "bytes"
+          ]
+        },
+        {
+          "source": "log/slog",
+          "specifiers": [
+            "slog"
+          ]
+        },
+        {
+          "source": "strings",
+          "specifiers": [
+            "strings"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        }
+      ],
+      "exports": [
+        "TestLoadConfig_CircuitBreaker_ParsesFromYAML",
+        "TestLoadConfig_CircuitBreaker_OmittedBlockIsNil",
+        "TestLoadConfig_CircuitBreaker_BadValueRejected",
+        "TestBreakerEnabled",
+        "TestValidateBrokerCircuitBreaker"
+      ],
+      "totalLines": 258,
+      "hasStructuralAnalysis": true
+    },
     "internal/config/observability.go": {
       "filePath": "internal/config/observability.go",
       "contentHash": "3e5abc2df2b18485affbef3ba0359b04bff3e5627846f3b792bbe75be484d427",
@@ -10004,6 +11271,309 @@
         "TestMain"
       ],
       "totalLines": 54,
+      "hasStructuralAnalysis": true
+    },
+    "internal/idpclient/retrying.go": {
+      "filePath": "internal/idpclient/retrying.go",
+      "contentHash": "80bcd85916562e83b282d668a974742cd2b6aac54c32ad9942bf9a5f4aa4c6f5",
+      "functions": [
+        {
+          "name": "NewRetryingHTTPClient",
+          "params": [
+            "retry"
+          ],
+          "returnType": "(*http.Client, error)",
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "checkRetry",
+          "params": [
+            "ctx",
+            "resp",
+            "err"
+          ],
+          "returnType": "(bool, error)",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "WithAttemptsCounter",
+          "params": [
+            "ctx"
+          ],
+          "returnType": "(context.Context, func() int)",
+          "exported": true,
+          "lineCount": 5
+        },
+        {
+          "name": "RoundTrip",
+          "params": [
+            "req"
+          ],
+          "returnType": "(*http.Response, error)",
+          "exported": true,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "RetryOptions",
+          "methods": [],
+          "properties": [
+            "MaxRetries",
+            "RetryWaitMin",
+            "RetryWaitMax"
+          ],
+          "exported": true,
+          "lineCount": 12
+        },
+        {
+          "name": "attemptsKey",
+          "methods": [],
+          "properties": [],
+          "exported": false,
+          "lineCount": 1
+        },
+        {
+          "name": "attemptsRecorder",
+          "methods": [
+            "RoundTrip"
+          ],
+          "properties": [
+            "inner"
+          ],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "imports": [
+        {
+          "source": "context",
+          "specifiers": [
+            "context"
+          ]
+        },
+        {
+          "source": "net/http",
+          "specifiers": [
+            "http"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        },
+        {
+          "source": "github.com/hashicorp/go-retryablehttp",
+          "specifiers": [
+            "go-retryablehttp"
+          ]
+        }
+      ],
+      "exports": [
+        "RetryOptions",
+        "NewRetryingHTTPClient",
+        "WithAttemptsCounter",
+        "RoundTrip"
+      ],
+      "totalLines": 162,
+      "hasStructuralAnalysis": true
+    },
+    "internal/idpclient/retrying_test.go": {
+      "filePath": "internal/idpclient/retrying_test.go",
+      "contentHash": "7210baf110465221d985945179a59606651c0fbd6c6a624bdf0441c48660406e",
+      "functions": [
+        {
+          "name": "testRetryOptions",
+          "params": [],
+          "returnType": "RetryOptions",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "countingHandler",
+          "params": [
+            "t",
+            "status",
+            "body",
+            "headers"
+          ],
+          "returnType": "(http.HandlerFunc, *atomic.Int32)",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "TestNewRetryingHTTPClient_RetriesOn5xx",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 31
+        },
+        {
+          "name": "TestNewRetryingHTTPClient_RetriesOn429",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 30
+        },
+        {
+          "name": "TestNewRetryingHTTPClient_NoRetryOn2xx",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 22
+        },
+        {
+          "name": "TestNewRetryingHTTPClient_NoRetryOn4xx",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 40
+        },
+        {
+          "name": "TestNewRetryingHTTPClient_RetriesRecover",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 32
+        },
+        {
+          "name": "TestNewRetryingHTTPClient_CtxCancelAbortsBackoff",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 45
+        },
+        {
+          "name": "TestNewRetryingHTTPClient_ConnectionErrorRetries",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 28
+        },
+        {
+          "name": "RoundTrip",
+          "params": [],
+          "returnType": "(*http.Response, error)",
+          "exported": true,
+          "lineCount": 4
+        },
+        {
+          "name": "roundTripAndClose",
+          "params": [
+            "t",
+            "rec",
+            "req"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "TestAttemptsRecorder_NilSafe",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 11
+        },
+        {
+          "name": "TestAttemptsRecorder_IncrementsWhenAttached",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 12
+        },
+        {
+          "name": "TestCheckRetry_Table",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 50
+        }
+      ],
+      "classes": [
+        {
+          "name": "stubRoundTripper",
+          "methods": [
+            "RoundTrip"
+          ],
+          "properties": [
+            "calls"
+          ],
+          "exported": false,
+          "lineCount": 1
+        }
+      ],
+      "imports": [
+        {
+          "source": "context",
+          "specifiers": [
+            "context"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "net/http",
+          "specifiers": [
+            "http"
+          ]
+        },
+        {
+          "source": "net/http/httptest",
+          "specifiers": [
+            "httptest"
+          ]
+        },
+        {
+          "source": "sync/atomic",
+          "specifiers": [
+            "atomic"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        }
+      ],
+      "exports": [
+        "TestNewRetryingHTTPClient_RetriesOn5xx",
+        "TestNewRetryingHTTPClient_RetriesOn429",
+        "TestNewRetryingHTTPClient_NoRetryOn2xx",
+        "TestNewRetryingHTTPClient_NoRetryOn4xx",
+        "TestNewRetryingHTTPClient_RetriesRecover",
+        "TestNewRetryingHTTPClient_CtxCancelAbortsBackoff",
+        "TestNewRetryingHTTPClient_ConnectionErrorRetries",
+        "RoundTrip",
+        "TestAttemptsRecorder_NilSafe",
+        "TestAttemptsRecorder_IncrementsWhenAttached",
+        "TestCheckRetry_Table"
+      ],
+      "totalLines": 433,
       "hasStructuralAnalysis": true
     },
     "internal/middleware/recovery/middleware.go": {
@@ -14730,7 +16300,7 @@
     },
     "internal/semp/resilience/retry.go": {
       "filePath": "internal/semp/resilience/retry.go",
-      "contentHash": "0ea6166992a3a148d3d72ba029f226d047a13d3c48ceade4870cdd9049b72d78",
+      "contentHash": "39eb13c1ec715647f8cb2f0576e6db22d5d14457aa1bf2ce754057e2f718234d",
       "functions": [
         {
           "name": "WithRetrySafe",
@@ -14768,7 +16338,7 @@
           ],
           "returnType": "(bool, error)",
           "exported": false,
-          "lineCount": 78
+          "lineCount": 95
         }
       ],
       "classes": [
@@ -14785,12 +16355,13 @@
           "properties": [
             "auth401Retried",
             "other5xxRetried",
+            "transientRetried",
             "method",
             "retrySafe",
             "needsReauth"
           ],
           "exported": false,
-          "lineCount": 7
+          "lineCount": 8
         },
         {
           "name": "retrySafeKey",
@@ -14812,6 +16383,12 @@
           "source": "context",
           "specifiers": [
             "context"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
           ]
         },
         {
@@ -14837,7 +16414,7 @@
         "WithRetrySafe",
         "OperationIDKey"
       ],
-      "totalLines": 150,
+      "totalLines": 186,
       "hasStructuralAnalysis": true
     },
     "internal/semp/resilience/retry_safe_test.go": {
@@ -14951,7 +16528,7 @@
     },
     "internal/semp/resilience/sender.go": {
       "filePath": "internal/semp/resilience/sender.go",
-      "contentHash": "a805100294d800de95bb9110594512a7ad98fc68ad29e12fa6c9b9a61381e4e8",
+      "contentHash": "6eab339db9fd2398e74361bd7f4abb5950ea21380cf191e01eaffa42d115612f",
       "functions": [
         {
           "name": "Error",
@@ -14988,7 +16565,7 @@
           ],
           "returnType": "(*http.Response, error)",
           "exported": true,
-          "lineCount": 74
+          "lineCount": 77
         },
         {
           "name": "Close",
@@ -15137,12 +16714,12 @@
         "Close",
         "Close"
       ],
-      "totalLines": 337,
+      "totalLines": 340,
       "hasStructuralAnalysis": true
     },
     "internal/semp/resilience/sender_test.go": {
       "filePath": "internal/semp/resilience/sender_test.go",
-      "contentHash": "f0bdc2c64c1773f11458fadecd6620a5b2f3b011438d958c6e45fe2a25d4221d",
+      "contentHash": "58c7ec38bc36dc2d5edde4dee9f5284769676a83168dc48961427bb08b824730",
       "functions": [
         {
           "name": "mustNewSafeCookieJar",
@@ -15419,6 +16996,14 @@
           ],
           "exported": true,
           "lineCount": 33
+        },
+        {
+          "name": "TestSender_Do_TransientError_CappedRetries",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 39
         },
         {
           "name": "TestSender_Retry_500_RetriesOnce",
@@ -15698,6 +17283,7 @@
         "TestSender_Retry_429_RetriesWithBackoff",
         "TestSender_Retry_503_RetriesWithBackoff",
         "TestSender_Retry_429_ExhaustsRetries",
+        "TestSender_Do_TransientError_CappedRetries",
         "TestSender_Retry_500_RetriesOnce",
         "TestSender_Retry_502_RetriesOnce",
         "TestSender_Retry_500_SucceedsOnRetry",
@@ -15714,7 +17300,7 @@
         "TestSenderDo_SemaphoreWaitRespectsContextCancel",
         "TestNew_PanicsOnNilSemaphore"
       ],
-      "totalLines": 1453,
+      "totalLines": 1500,
       "hasStructuralAnalysis": true
     },
     "internal/semp/resilience/transport.go": {
@@ -16780,7 +18366,7 @@
     },
     "internal/semp/sempv2/client.go": {
       "filePath": "internal/semp/sempv2/client.go",
-      "contentHash": "a8ca2e235c6f942fd534394f26d08d17f021b932b17d7fa22d159b727e55fcac",
+      "contentHash": "819eff5b2f9047e055fb1a5764a544955958e77895045083f5a7f4aeec96f96f",
       "functions": [
         {
           "name": "Error",
@@ -16834,7 +18420,7 @@
           ],
           "returnType": "(string, error)",
           "exported": false,
-          "lineCount": 21
+          "lineCount": 30
         },
         {
           "name": "unfilledPlaceholders",
@@ -17060,12 +18646,12 @@
         "NewHTTPClient",
         "Execute"
       ],
-      "totalLines": 409,
+      "totalLines": 418,
       "hasStructuralAnalysis": true
     },
     "internal/semp/sempv2/client_test.go": {
       "filePath": "internal/semp/sempv2/client_test.go",
-      "contentHash": "5c89b24cde338b9732321b8f6acaff7f171268d661ef1c96ecf51c6e3b31449f",
+      "contentHash": "a6b3a0d065ea0a8c0426b4e04cb95c854fad5e3441ba9d50d61ed6baa8b108bb",
       "functions": [
         {
           "name": "newTestClient",
@@ -17125,6 +18711,14 @@
           ],
           "exported": true,
           "lineCount": 20
+        },
+        {
+          "name": "TestClient_Execute_RejectsUnsafePathParam",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 63
         },
         {
           "name": "TestClient_Execute_PathParams",
@@ -17436,6 +19030,7 @@
         "TestClient_Execute_MissingPathParam_ReturnsError",
         "TestClient_Execute_MissingPathParam_DeduplicatedInError",
         "TestClient_Execute_AllPathParamsProvided_NoError",
+        "TestClient_Execute_RejectsUnsafePathParam",
         "TestClient_Execute_PathParams",
         "TestClient_Execute_QueryParams",
         "TestClient_Execute_QueryParams_ArrayCSVRawCommas",
@@ -17461,7 +19056,7 @@
         "TestClient_TransportPool_ReusesConnections",
         "TestClient_TLSWiring"
       ],
-      "totalLines": 1115,
+      "totalLines": 1186,
       "hasStructuralAnalysis": true
     },
     "internal/semp/sempv2/correlation_test.go": {
@@ -17680,7 +19275,7 @@
     },
     "internal/semp/sempv2/operation.go": {
       "filePath": "internal/semp/sempv2/operation.go",
-      "contentHash": "c315dd4a994b0f3976d86e64cdf1ca306a58c1657d572e3ad08782e90f0000f7",
+      "contentHash": "5e9f798aee2f6ca6f050669db9a36a6c630880f871c924cf9fdbb2421ee9047a",
       "functions": [
         {
           "name": "ParseSpecs",
@@ -17689,7 +19284,7 @@
           ],
           "returnType": "(map[string]*Operation, error)",
           "exported": true,
-          "lineCount": 72
+          "lineCount": 73
         },
         {
           "name": "deriveSpecType",
@@ -17732,7 +19327,8 @@
             "Path",
             "Parameters",
             "Description",
-            "BodyFields"
+            "BodyFields",
+            "SchemaVersion"
           ],
           "exported": true,
           "lineCount": 9
@@ -17782,12 +19378,12 @@
         "Parameter",
         "ParseSpecs"
       ],
-      "totalLines": 230,
+      "totalLines": 231,
       "hasStructuralAnalysis": true
     },
     "internal/semp/sempv2/operation_test.go": {
       "filePath": "internal/semp/sempv2/operation_test.go",
-      "contentHash": "1a189863be1cc0c31948a71792df59259e1c10f2bee4f9647a6a1408379690aa",
+      "contentHash": "4f26d0014227d7627532b61b597dd7e2deed7ca9a055315be3411e180b36af6b",
       "functions": [
         {
           "name": "TestParseSpecs_OperationCount",
@@ -17811,7 +19407,7 @@
             "t"
           ],
           "exported": true,
-          "lineCount": 29
+          "lineCount": 34
         },
         {
           "name": "TestParseSpecs_RefParametersResolved",
@@ -17900,7 +19496,7 @@
         "TestParseSpecs_NoDuplicateKeys",
         "TestParseSpecs_SpecTypeDerivation"
       ],
-      "totalLines": 222,
+      "totalLines": 227,
       "hasStructuralAnalysis": true
     },
     "internal/semp/sempv2/specs/embed.go": {
@@ -17918,6 +19514,589 @@
       ],
       "exports": [],
       "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/circuitbreaker.go": {
+      "filePath": "internal/tokenexchange/circuitbreaker.go",
+      "contentHash": "4f11498212a8cc22f7cf42d27a058330749f48bd3bb1ef14f876d8fc4ace1094",
+      "functions": [
+        {
+          "name": "newTokenExchangeCircuitBreaker",
+          "params": [
+            "cfg"
+          ],
+          "returnType": "*gobreaker.CircuitBreaker[*Token]",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "newReadyToTrip",
+          "params": [
+            "cfg"
+          ],
+          "returnType": "func(gobreaker.Counts) bool",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "logBreakerStateChange",
+          "params": [
+            "name",
+            "from",
+            "to"
+          ],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "isBreakerExcluded",
+          "params": [
+            "err"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "isBreakerSuccess",
+          "params": [
+            "err"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "isBreakerFailure",
+          "params": [
+            "err"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "failureClassOf",
+          "params": [
+            "err"
+          ],
+          "returnType": "FailureClass",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "context",
+          "specifiers": [
+            "context"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "log/slog",
+          "specifiers": [
+            "slog"
+          ]
+        },
+        {
+          "source": "github.com/sony/gobreaker/v2",
+          "specifiers": [
+            "v2"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 171,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/circuitbreaker_config.go": {
+      "filePath": "internal/tokenexchange/circuitbreaker_config.go",
+      "contentHash": "367213bdd77d0e6e2fd83e21e3db9a80f7e58723098d08d28a989fc7582296ad",
+      "functions": [
+        {
+          "name": "DefaultCircuitBreakerConfig",
+          "params": [],
+          "returnType": "CircuitBreakerConfig",
+          "exported": true,
+          "lineCount": 10
+        },
+        {
+          "name": "Validate",
+          "params": [],
+          "returnType": "error",
+          "exported": true,
+          "lineCount": 31
+        }
+      ],
+      "classes": [
+        {
+          "name": "CircuitBreakerConfig",
+          "methods": [
+            "Validate"
+          ],
+          "properties": [
+            "FailureRateWindow",
+            "MinimumRequests",
+            "FailureRateThresholdPercent",
+            "ConsecutiveFailureThreshold",
+            "OpenStateDuration",
+            "HalfOpenProbeRequests"
+          ],
+          "exported": true,
+          "lineCount": 33
+        }
+      ],
+      "imports": [
+        {
+          "source": "fmt",
+          "specifiers": [
+            "fmt"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        },
+        {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/config",
+          "specifiers": [
+            "config"
+          ]
+        }
+      ],
+      "exports": [
+        "CircuitBreakerConfig",
+        "DefaultCircuitBreakerConfig",
+        "Validate"
+      ],
+      "totalLines": 115,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/circuitbreaker_config_test.go": {
+      "filePath": "internal/tokenexchange/circuitbreaker_config_test.go",
+      "contentHash": "6ac2524ed9079a960ebab499cfd50e5912d03d42f340f1dddea11a0f1fe8b99e",
+      "functions": [
+        {
+          "name": "TestDefaultCircuitBreakerConfig_Values",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 15
+        },
+        {
+          "name": "TestDefaultCircuitBreakerConfig_Validates",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "TestDefaultCircuitBreakerConfig_ReturnsFreshValue",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "TestCircuitBreakerConfig_Validate",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 55
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        },
+        {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/config",
+          "specifiers": [
+            "config"
+          ]
+        }
+      ],
+      "exports": [
+        "TestDefaultCircuitBreakerConfig_Values",
+        "TestDefaultCircuitBreakerConfig_Validates",
+        "TestDefaultCircuitBreakerConfig_ReturnsFreshValue",
+        "TestCircuitBreakerConfig_Validate"
+      ],
+      "totalLines": 121,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/circuitbreaker_exchange_test.go": {
+      "filePath": "internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "contentHash": "d6a4b312066b32220efe87948a4229cc0b0beaac822b3436d9c53a27207ce4d0",
+      "functions": [
+        {
+          "name": "fastTripBreakerConfig",
+          "params": [],
+          "returnType": "CircuitBreakerConfig",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "newBreakerTestExchangerPlain",
+          "params": [
+            "t",
+            "serverURL",
+            "cbCfg"
+          ],
+          "returnType": "*Exchanger",
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "newBreakerTestExchanger",
+          "params": [
+            "t",
+            "serverURL",
+            "cbCfg"
+          ],
+          "returnType": "*Exchanger",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "TestBreaker_OneLogicalOperationCountsOnce",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 31
+        },
+        {
+          "name": "TestBreaker_RateLimitExcludedNotCounted",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 27
+        },
+        {
+          "name": "TestBreaker_ConfigFaultExcludedNotCounted",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 38
+        },
+        {
+          "name": "TestBreaker_OpenStateFailsFast",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 30
+        },
+        {
+          "name": "TestBreaker_OpenStateErrorIsTransientAndEnriched",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 33
+        },
+        {
+          "name": "TestBreaker_DisabledCallsIdPAndRetries",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "TestBreaker_SingleflightBurstCountsOnce",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 39
+        },
+        {
+          "name": "TestBreaker_ConcurrentDistinctKeysCountExactlyOncePerCall",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 69
+        },
+        {
+          "name": "recoveryBreakerConfig",
+          "params": [],
+          "returnType": "CircuitBreakerConfig",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "waitForBreakerState",
+          "params": [
+            "t",
+            "cb",
+            "want"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "inputWithSubject",
+          "params": [
+            "s"
+          ],
+          "returnType": "ExchangeInput",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "TestBreaker_RecoveryClosesAfterConsecutiveProbeSuccesses",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 69
+        },
+        {
+          "name": "TestBreaker_HalfOpenProbeFailureReopens",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 50
+        },
+        {
+          "name": "TestBreaker_HalfOpenRejectsBeyondProbeBudget",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 75
+        },
+        {
+          "name": "TestBreaker_HalfOpenExcludedProbeRefundsSlot",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 58
+        },
+        {
+          "name": "TestBreaker_OpenBreakerRejectsStampedeCleanly",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 72
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "context",
+          "specifiers": [
+            "context"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "fmt",
+          "specifiers": [
+            "fmt"
+          ]
+        },
+        {
+          "source": "net/http",
+          "specifiers": [
+            "http"
+          ]
+        },
+        {
+          "source": "net/http/httptest",
+          "specifiers": [
+            "httptest"
+          ]
+        },
+        {
+          "source": "sync",
+          "specifiers": [
+            "sync"
+          ]
+        },
+        {
+          "source": "sync/atomic",
+          "specifiers": [
+            "atomic"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        },
+        {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/idpclient",
+          "specifiers": [
+            "idpclient"
+          ]
+        },
+        {
+          "source": "github.com/sony/gobreaker/v2",
+          "specifiers": [
+            "v2"
+          ]
+        }
+      ],
+      "exports": [
+        "TestBreaker_OneLogicalOperationCountsOnce",
+        "TestBreaker_RateLimitExcludedNotCounted",
+        "TestBreaker_ConfigFaultExcludedNotCounted",
+        "TestBreaker_OpenStateFailsFast",
+        "TestBreaker_OpenStateErrorIsTransientAndEnriched",
+        "TestBreaker_DisabledCallsIdPAndRetries",
+        "TestBreaker_SingleflightBurstCountsOnce",
+        "TestBreaker_ConcurrentDistinctKeysCountExactlyOncePerCall",
+        "TestBreaker_RecoveryClosesAfterConsecutiveProbeSuccesses",
+        "TestBreaker_HalfOpenProbeFailureReopens",
+        "TestBreaker_HalfOpenRejectsBeyondProbeBudget",
+        "TestBreaker_HalfOpenExcludedProbeRefundsSlot",
+        "TestBreaker_OpenBreakerRejectsStampedeCleanly"
+      ],
+      "totalLines": 849,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/circuitbreaker_test.go": {
+      "filePath": "internal/tokenexchange/circuitbreaker_test.go",
+      "contentHash": "c3e38ccfba468d438d04f923559e4596afb02d6cb60c1d97caf5a5229b3aea39",
+      "functions": [
+        {
+          "name": "exhaustedWith",
+          "params": [
+            "class"
+          ],
+          "returnType": "*ExchangeError",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "rawWith",
+          "params": [
+            "class"
+          ],
+          "returnType": "*ExchangeError",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "TestIsBreakerFailure",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 40
+        },
+        {
+          "name": "TestIsBreakerExcluded",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 35
+        },
+        {
+          "name": "TestIsBreakerSuccess",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 23
+        },
+        {
+          "name": "TestNewReadyToTrip",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 138
+        },
+        {
+          "name": "TestBreakerClassification_ExcludedNeverCounted",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 21
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "context",
+          "specifiers": [
+            "context"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "github.com/sony/gobreaker/v2",
+          "specifiers": [
+            "v2"
+          ]
+        }
+      ],
+      "exports": [
+        "TestIsBreakerFailure",
+        "TestIsBreakerExcluded",
+        "TestIsBreakerSuccess",
+        "TestNewReadyToTrip",
+        "TestBreakerClassification_ExcludedNeverCounted"
+      ],
+      "totalLines": 311,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/dedup_key.go": {
@@ -18097,9 +20276,102 @@
       "totalLines": 106,
       "hasStructuralAnalysis": true
     },
+    "internal/tokenexchange/defaults.go": {
+      "filePath": "internal/tokenexchange/defaults.go",
+      "contentHash": "48553e25308aebbd7c7d7967023520b0193bd801624a45675a15b46830a0463c",
+      "functions": [
+        {
+          "name": "ComputeChainDeadline",
+          "params": [
+            "override",
+            "perAttempt",
+            "retryWaitMax",
+            "maxRetries"
+          ],
+          "returnType": "time.Duration",
+          "exported": true,
+          "lineCount": 12
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        }
+      ],
+      "exports": [
+        "ComputeChainDeadline"
+      ],
+      "totalLines": 137,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/defaults_test.go": {
+      "filePath": "internal/tokenexchange/defaults_test.go",
+      "contentHash": "e555bcd32f2b0ff069a7737472a8672093a77811bab91911b3d58ebe859bc08f",
+      "functions": [
+        {
+          "name": "TestComputeChainDeadline_FormulaAcrossInputs",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 52
+        },
+        {
+          "name": "TestComputeChainDeadline_OverrideWins",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 25
+        },
+        {
+          "name": "TestComputeChainDeadline_ZeroOrNegativeOverrideUsesFormula",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 12
+        },
+        {
+          "name": "TestDefaults_PinShippedValues",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 14
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        }
+      ],
+      "exports": [
+        "TestComputeChainDeadline_FormulaAcrossInputs",
+        "TestComputeChainDeadline_OverrideWins",
+        "TestComputeChainDeadline_ZeroOrNegativeOverrideUsesFormula",
+        "TestDefaults_PinShippedValues"
+      ],
+      "totalLines": 144,
+      "hasStructuralAnalysis": true
+    },
     "internal/tokenexchange/errors.go": {
       "filePath": "internal/tokenexchange/errors.go",
-      "contentHash": "0885b2865427e5db65b223ea45301aae802b68e3c1308e693397b83e2b870108",
+      "contentHash": "2899380264bfa46bb38b2e28649df934b6c663cb825f5ca9808022f75833d1e9",
       "functions": [
         {
           "name": "Error",
@@ -18116,11 +20388,20 @@
           "lineCount": 1
         },
         {
+          "name": "AgentMessage",
+          "params": [
+            "brokerAlias"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 10
+        },
+        {
           "name": "LogAttrs",
           "params": [],
           "returnType": "[]slog.Attr",
           "exported": true,
-          "lineCount": 19
+          "lineCount": 28
         }
       ],
       "classes": [
@@ -18129,6 +20410,7 @@
           "methods": [
             "Error",
             "Unwrap",
+            "AgentMessage",
             "LogAttrs"
           ],
           "properties": [
@@ -18138,13 +20420,26 @@
             "BrokerAlias",
             "Audience",
             "HTTPStatus",
+            "FailureClass",
             "Elapsed"
           ],
           "exported": true,
-          "lineCount": 9
+          "lineCount": 13
         }
       ],
       "imports": [
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "fmt",
+          "specifiers": [
+            "fmt"
+          ]
+        },
         {
           "source": "log/slog",
           "specifiers": [
@@ -18162,14 +20457,88 @@
         "ExchangeError",
         "Error",
         "Unwrap",
+        "AgentMessage",
         "LogAttrs"
       ],
-      "totalLines": 75,
+      "totalLines": 108,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/errors_test.go": {
+      "filePath": "internal/tokenexchange/errors_test.go",
+      "contentHash": "55ee13ad293c7e9072fc21b2e7b6d9518821cb4ad188ce1869b57ea51e121274",
+      "functions": [
+        {
+          "name": "TestAgentMessage_TransientSentinels",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "TestAgentMessage_PermanentSentinels",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 23
+        },
+        {
+          "name": "TestAgentMessage_NeverLeaksInternalDetail",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 29
+        },
+        {
+          "name": "TestExchangeError_NeverContainsSecrets",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 37
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "strings",
+          "specifiers": [
+            "strings"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        }
+      ],
+      "exports": [
+        "TestAgentMessage_TransientSentinels",
+        "TestAgentMessage_PermanentSentinels",
+        "TestAgentMessage_NeverLeaksInternalDetail",
+        "TestExchangeError_NeverContainsSecrets"
+      ],
+      "totalLines": 163,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/exchange.go": {
       "filePath": "internal/tokenexchange/exchange.go",
-      "contentHash": "fc67a059c8b3f16859ed12e9511924c8074b1375a778fa399f76e7a972b0baa0",
+      "contentHash": "113baf8e7e16df4878a8f9027dc61498105e7266f9b176a4a99fb1f69551525b",
       "functions": [
         {
           "name": "Exchange",
@@ -18179,7 +20548,36 @@
           ],
           "returnType": "(*Token, error)",
           "exported": true,
-          "lineCount": 81
+          "lineCount": 65
+        },
+        {
+          "name": "runProtectedExchange",
+          "params": [
+            "key",
+            "input"
+          ],
+          "returnType": "(*Token, error)",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "runExchangeOnce",
+          "params": [
+            "key",
+            "input"
+          ],
+          "returnType": "(*Token, error)",
+          "exported": false,
+          "lineCount": 39
+        },
+        {
+          "name": "mapCircuitOpen",
+          "params": [
+            "err"
+          ],
+          "returnType": "error",
+          "exported": false,
+          "lineCount": 9
         },
         {
           "name": "Close",
@@ -18198,6 +20596,18 @@
           "lineCount": 9
         },
         {
+          "name": "classifyRetryOutcome",
+          "params": [
+            "ctx",
+            "err",
+            "attempts",
+            "brokerAlias"
+          ],
+          "returnType": "error",
+          "exported": false,
+          "lineCount": 49
+        },
+        {
           "name": "doExchange",
           "params": [
             "ctx",
@@ -18205,7 +20615,7 @@
           ],
           "returnType": "(*Token, error)",
           "exported": false,
-          "lineCount": 22
+          "lineCount": 23
         }
       ],
       "classes": [],
@@ -18235,9 +20645,21 @@
           ]
         },
         {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/idpclient",
+          "specifiers": [
+            "idpclient"
+          ]
+        },
+        {
           "source": "github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache",
           "specifiers": [
             "cache"
+          ]
+        },
+        {
+          "source": "github.com/sony/gobreaker/v2",
+          "specifiers": [
+            "v2"
           ]
         }
       ],
@@ -18246,12 +20668,12 @@
         "Close",
         "Invalidate"
       ],
-      "totalLines": 155,
+      "totalLines": 288,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/exchange_test.go": {
       "filePath": "internal/tokenexchange/exchange_test.go",
-      "contentHash": "99147f86419044e1d128f06e5da78976b4a92bdf2fc5876a495b2f4fbfb37ba1",
+      "contentHash": "564914fd5bc4caf7fc3d12e3eb47579002e0dbfc5c3f5093401194b45286397b",
       "functions": [
         {
           "name": "newTestExchanger",
@@ -18368,12 +20790,12 @@
           "lineCount": 21
         },
         {
-          "name": "TestDoExchange_BuildRequestFailureWrapsAsTransport",
+          "name": "TestDoExchange_BuildRequestFailureClassifiesAsRequestBuild",
           "params": [
             "t"
           ],
           "exported": true,
-          "lineCount": 24
+          "lineCount": 27
         },
         {
           "name": "TestDoExchange_HTTPFailureWithCancelledContextReturnsContextError",
@@ -18487,12 +20909,12 @@
           "lineCount": 51
         },
         {
-          "name": "TestExchange_UnknownGrantTypeReturnsTransportError",
+          "name": "TestExchange_UnknownGrantTypeReturnsRequestBuildError",
           "params": [
             "t"
           ],
           "exported": true,
-          "lineCount": 29
+          "lineCount": 32
         },
         {
           "name": "TestExchange_SingleflightSharesErrors",
@@ -18604,6 +21026,102 @@
           ],
           "exported": true,
           "lineCount": 40
+        },
+        {
+          "name": "newRetryingTestExchanger",
+          "params": [
+            "t",
+            "serverURL"
+          ],
+          "returnType": "*Exchanger",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "newRetryingTestExchangerWithChain",
+          "params": [
+            "t",
+            "serverURL",
+            "chainDeadline"
+          ],
+          "returnType": "*Exchanger",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "buildRetryingTestExchanger",
+          "params": [
+            "t",
+            "serverURL",
+            "chainDeadline"
+          ],
+          "returnType": "*Exchanger",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "TestExchange_RetriesExhaustedOn5xx",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 36
+        },
+        {
+          "name": "TestExchange_RetriesExhaustedOn429",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 35
+        },
+        {
+          "name": "TestExchange_RetryRecoversNoExhaustion",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "TestExchange_ConnectionErrorRetriesExhausted",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 27
+        },
+        {
+          "name": "TestExchange_RejectedNotRewrapped",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 18
+        },
+        {
+          "name": "TestClassifyRetryOutcome_ZeroAttemptsPassthrough",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 13
+        },
+        {
+          "name": "TestClassifyRetryOutcome_DeadlineMidRetryRewrapped",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 30
+        },
+        {
+          "name": "TestExchange_ChainDeadlineFiresMidRetry",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 34
         }
       ],
       "classes": [
@@ -18729,6 +21247,12 @@
           ]
         },
         {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/idpclient",
+          "specifiers": [
+            "idpclient"
+          ]
+        },
+        {
           "source": "github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache",
           "specifiers": [
             "cache"
@@ -18752,7 +21276,7 @@
         "TestExchange_ContextDeadlineExceededReturnsDeadlineError",
         "TestExchange_TransportErrorReturned",
         "TestExchange_RejectedErrorReturned",
-        "TestDoExchange_BuildRequestFailureWrapsAsTransport",
+        "TestDoExchange_BuildRequestFailureClassifiesAsRequestBuild",
         "TestDoExchange_HTTPFailureWithCancelledContextReturnsContextError",
         "TestDoExchange_HTTPFailureWithoutContextErrorReturnsTransport",
         "TestDoExchange_PassesNowFuncToParseIdPResponse",
@@ -18765,7 +21289,7 @@
         "TestExchange_ContextErrorNotLogged",
         "TestExchange_InvalidResponseError",
         "TestExchange_RequestBodyContainsExpectedFields",
-        "TestExchange_UnknownGrantTypeReturnsTransportError",
+        "TestExchange_UnknownGrantTypeReturnsRequestBuildError",
         "TestExchange_SingleflightSharesErrors",
         "TestExchange_ResponseFieldsPreserved",
         "TestExchange_FourxxWithOAuthError",
@@ -18777,14 +21301,22 @@
         "Put",
         "Delete",
         "Close",
-        "TestExchange_SingleflightWinnerOnlyWritesCache"
+        "TestExchange_SingleflightWinnerOnlyWritesCache",
+        "TestExchange_RetriesExhaustedOn5xx",
+        "TestExchange_RetriesExhaustedOn429",
+        "TestExchange_RetryRecoversNoExhaustion",
+        "TestExchange_ConnectionErrorRetriesExhausted",
+        "TestExchange_RejectedNotRewrapped",
+        "TestClassifyRetryOutcome_ZeroAttemptsPassthrough",
+        "TestClassifyRetryOutcome_DeadlineMidRetryRewrapped",
+        "TestExchange_ChainDeadlineFiresMidRetry"
       ],
-      "totalLines": 1388,
+      "totalLines": 1736,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/exchanger.go": {
       "filePath": "internal/tokenexchange/exchanger.go",
-      "contentHash": "a67716a698e9f144094eb08885ab41243e6415a8dde3621fd71a9a4b6b44d02c",
+      "contentHash": "e662dea59f162818b079f55447adda89c4d080c6cddc32e99fd69fa13ccb1828",
       "functions": [
         {
           "name": "New",
@@ -18793,7 +21325,7 @@
           ],
           "returnType": "(*Exchanger, error)",
           "exported": true,
-          "lineCount": 20
+          "lineCount": 43
         }
       ],
       "classes": [
@@ -18808,13 +21340,14 @@
             "grantType",
             "audienceParam",
             "httpClient",
-            "exchangeTimeout",
+            "chainDeadline",
             "cache",
             "group",
-            "nowFunc"
+            "nowFunc",
+            "breaker"
           ],
           "exported": true,
-          "lineCount": 13
+          "lineCount": 22
         }
       ],
       "imports": [
@@ -18837,15 +21370,15 @@
           ]
         },
         {
-          "source": "github.com/SolaceDev/solace-broker-mcp/internal/defaults",
-          "specifiers": [
-            "defaults"
-          ]
-        },
-        {
           "source": "github.com/SolaceDev/solace-broker-mcp/internal/oauth/cache",
           "specifiers": [
             "cache"
+          ]
+        },
+        {
+          "source": "github.com/sony/gobreaker/v2",
+          "specifiers": [
+            "v2"
           ]
         },
         {
@@ -18859,7 +21392,7 @@
         "Exchanger",
         "New"
       ],
-      "totalLines": 78,
+      "totalLines": 110,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/exchanger_test.go": {
@@ -18944,9 +21477,158 @@
       "totalLines": 125,
       "hasStructuralAnalysis": true
     },
+    "internal/tokenexchange/failure_class.go": {
+      "filePath": "internal/tokenexchange/failure_class.go",
+      "contentHash": "465252082651625df7b9dea37178a797112bcc94b7d8a87ec7c6ed0d2f7a8437",
+      "functions": [
+        {
+          "name": "String",
+          "params": [],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 16
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "String"
+      ],
+      "totalLines": 67,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/failure_class_test.go": {
+      "filePath": "internal/tokenexchange/failure_class_test.go",
+      "contentHash": "0a7411da9c7d5b144cc427d816afa54fedcfc266d16c40937d5ebaba40b62880",
+      "functions": [
+        {
+          "name": "TestFailureClass_String",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 17
+        },
+        {
+          "name": "TestParseIdPResponse_FailureClassPerStatus",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 44
+        },
+        {
+          "name": "TestParseIdPResponse_FailureClassBodyRead",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 25
+        },
+        {
+          "name": "TestDoExchange_FailureClassNetwork",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 24
+        },
+        {
+          "name": "TestExchangeError_LogAttrsIncludesFailureClass",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 15
+        },
+        {
+          "name": "TestExchangeError_LogAttrsBreakerState",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 21
+        },
+        {
+          "name": "TestClassifyRetryOutcome_DeadlinePathClassifiesAsNetwork",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 37
+        },
+        {
+          "name": "hasLogAttr",
+          "params": [
+            "attrs",
+            "key",
+            "val"
+          ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "context",
+          "specifiers": [
+            "context"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "log/slog",
+          "specifiers": [
+            "slog"
+          ]
+        },
+        {
+          "source": "net/http",
+          "specifiers": [
+            "http"
+          ]
+        },
+        {
+          "source": "net/http/httptest",
+          "specifiers": [
+            "httptest"
+          ]
+        },
+        {
+          "source": "strings",
+          "specifiers": [
+            "strings"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        }
+      ],
+      "exports": [
+        "TestFailureClass_String",
+        "TestParseIdPResponse_FailureClassPerStatus",
+        "TestParseIdPResponse_FailureClassBodyRead",
+        "TestDoExchange_FailureClassNetwork",
+        "TestExchangeError_LogAttrsIncludesFailureClass",
+        "TestExchangeError_LogAttrsBreakerState",
+        "TestClassifyRetryOutcome_DeadlinePathClassifiesAsNetwork"
+      ],
+      "totalLines": 255,
+      "hasStructuralAnalysis": true
+    },
     "internal/tokenexchange/from_config.go": {
       "filePath": "internal/tokenexchange/from_config.go",
-      "contentHash": "438676aff91464772a89a6f042ba8db60423ee33a4a45ef6f6a374972075abdc",
+      "contentHash": "bf3c1d5eff848985110cf322a349f7278e04fca2dc8c10b316a076b2c92c4f13",
       "functions": [
         {
           "name": "FromConfig",
@@ -18957,7 +21639,16 @@
           ],
           "returnType": "(*Exchanger, error)",
           "exported": true,
-          "lineCount": 31
+          "lineCount": 38
+        },
+        {
+          "name": "resolveCircuitBreakerConfig",
+          "params": [
+            "cb"
+          ],
+          "returnType": "*CircuitBreakerConfig",
+          "exported": false,
+          "lineCount": 30
         },
         {
           "name": "resolveClientAuth",
@@ -18996,6 +21687,12 @@
           ]
         },
         {
+          "source": "log/slog",
+          "specifiers": [
+            "slog"
+          ]
+        },
+        {
           "source": "net/http",
           "specifiers": [
             "http"
@@ -19017,7 +21714,92 @@
       "exports": [
         "FromConfig"
       ],
-      "totalLines": 106,
+      "totalLines": 149,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/from_config_breaker_test.go": {
+      "filePath": "internal/tokenexchange/from_config_breaker_test.go",
+      "contentHash": "6cc8351e0d56da03f3a1e7dbea15853092684b1d27b96293537655e29ee3c494",
+      "functions": [
+        {
+          "name": "ptr",
+          "params": [
+            "v"
+          ],
+          "returnType": "*T",
+          "exported": false,
+          "lineCount": 1
+        },
+        {
+          "name": "TestResolveCircuitBreakerConfig_NilUsesDefaults",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 10
+        },
+        {
+          "name": "TestResolveCircuitBreakerConfig_DisabledReturnsNil",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "TestResolveCircuitBreakerConfig_EnabledTrueUsesDefaults",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "TestResolveCircuitBreakerConfig_PartialOverlay",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 17
+        },
+        {
+          "name": "TestResolveCircuitBreakerConfig_FullOverlay",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 22
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        },
+        {
+          "source": "time",
+          "specifiers": [
+            "time"
+          ]
+        },
+        {
+          "source": "github.com/SolaceDev/solace-broker-mcp/internal/config",
+          "specifiers": [
+            "config"
+          ]
+        }
+      ],
+      "exports": [
+        "TestResolveCircuitBreakerConfig_NilUsesDefaults",
+        "TestResolveCircuitBreakerConfig_DisabledReturnsNil",
+        "TestResolveCircuitBreakerConfig_EnabledTrueUsesDefaults",
+        "TestResolveCircuitBreakerConfig_PartialOverlay",
+        "TestResolveCircuitBreakerConfig_FullOverlay"
+      ],
+      "totalLines": 103,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/from_config_test.go": {
@@ -19500,7 +22282,7 @@
     },
     "internal/tokenexchange/response.go": {
       "filePath": "internal/tokenexchange/response.go",
-      "contentHash": "b628e401799766816a5585abd150855d1d66a8d1bdae1867c3897d2e848d1948",
+      "contentHash": "e8c41692d8effbf643db2645163a6af7db47011c531acefaaaa10fa593c2e99e",
       "functions": [
         {
           "name": "parseIdPResponse",
@@ -19510,7 +22292,7 @@
           ],
           "returnType": "(*Token, error)",
           "exported": false,
-          "lineCount": 32
+          "lineCount": 48
         },
         {
           "name": "parseSuccessBody",
@@ -19616,12 +22398,12 @@
         }
       ],
       "exports": [],
-      "totalLines": 190,
+      "totalLines": 210,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/response_test.go": {
       "filePath": "internal/tokenexchange/response_test.go",
-      "contentHash": "24b75593f44c26ac9483470d2967e25f03107f9aa2120cca7fdc63f21467bdec",
+      "contentHash": "7cc017b2809d6f74859ccd838766a23a2924c6934f13b8982df37ec47ee02091",
       "functions": [
         {
           "name": "Read",
@@ -19792,12 +22574,12 @@
           "lineCount": 30
         },
         {
-          "name": "TestParseIdPResponse_FourxxNonOAuthBodyReturnsExchangeTransport",
+          "name": "TestParseIdPResponse_FourxxNonOAuthBodyReturnsInvalidResponse",
           "params": [
             "t"
           ],
           "exported": true,
-          "lineCount": 27
+          "lineCount": 30
         },
         {
           "name": "TestParseIdPResponse_ThreexxAndFivexxReturnExchangeTransport",
@@ -19805,15 +22587,15 @@
             "t"
           ],
           "exported": true,
-          "lineCount": 43
+          "lineCount": 44
         },
         {
-          "name": "TestClassifyClientError_OversizedErrorCodeReturnsTransport",
+          "name": "TestClassifyClientError_OversizedErrorCodeReturnsInvalidResponse",
           "params": [
             "t"
           ],
           "exported": true,
-          "lineCount": 37
+          "lineCount": 40
         },
         {
           "name": "TestClassifyClientError_ErrorDescriptionNotInMessage",
@@ -19856,12 +22638,12 @@
           "lineCount": 24
         },
         {
-          "name": "TestClassifyClientError_ExplicitEmptyErrorFieldRoutesToTransport",
+          "name": "TestClassifyClientError_ExplicitEmptyErrorFieldRoutesToInvalidResponse",
           "params": [
             "t"
           ],
           "exported": true,
-          "lineCount": 12
+          "lineCount": 15
         },
         {
           "name": "TestParseSuccessBody_UnknownFieldsSilentlyIgnored",
@@ -19971,23 +22753,114 @@
         "TestParseSuccessBody_ExpiresInOverflowGuard",
         "TestParseSuccessBody_TokenConstructionAndExpiresAt",
         "TestParseIdPResponse_FourxxOAuthErrorReturnsExchangeRejected",
-        "TestParseIdPResponse_FourxxNonOAuthBodyReturnsExchangeTransport",
+        "TestParseIdPResponse_FourxxNonOAuthBodyReturnsInvalidResponse",
         "TestParseIdPResponse_ThreexxAndFivexxReturnExchangeTransport",
-        "TestClassifyClientError_OversizedErrorCodeReturnsTransport",
+        "TestClassifyClientError_OversizedErrorCodeReturnsInvalidResponse",
         "TestClassifyClientError_ErrorDescriptionNotInMessage",
         "TestParseIdPResponse_HappyPath",
         "TestParseSuccessBody_ShortLivedTokenReturnsNonErrorTokenWithPastExpiresAt",
         "TestParseIdPResponse_OversizedBodySurfacesAsInvalidResponseNotTransport",
         "TestParseSuccessBody_NullBodyTriggersAccessTokenMissingError",
-        "TestClassifyClientError_ExplicitEmptyErrorFieldRoutesToTransport",
+        "TestClassifyClientError_ExplicitEmptyErrorFieldRoutesToInvalidResponse",
         "TestParseSuccessBody_UnknownFieldsSilentlyIgnored"
       ],
-      "totalLines": 974,
+      "totalLines": 994,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/transport_error.go": {
+      "filePath": "internal/tokenexchange/transport_error.go",
+      "contentHash": "f1792e6efb24e7ce0664b890dbf41d17b764946e8c26e37d9f1d295aa7ab49f6",
+      "functions": [
+        {
+          "name": "classifyTransportError",
+          "params": [
+            "err"
+          ],
+          "returnType": "FailureClass",
+          "exported": false,
+          "lineCount": 23
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "crypto/x509",
+          "specifiers": [
+            "x509"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "net",
+          "specifiers": [
+            "net"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 57,
+      "hasStructuralAnalysis": true
+    },
+    "internal/tokenexchange/transport_error_test.go": {
+      "filePath": "internal/tokenexchange/transport_error_test.go",
+      "contentHash": "4d0c6bc8c13a11ecaa2021ffe4da666efb3fb4a755bd6ef40e3446a8e7224d7b",
+      "functions": [
+        {
+          "name": "TestClassifyTransportError",
+          "params": [
+            "t"
+          ],
+          "exported": true,
+          "lineCount": 57
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "crypto/x509",
+          "specifiers": [
+            "x509"
+          ]
+        },
+        {
+          "source": "errors",
+          "specifiers": [
+            "errors"
+          ]
+        },
+        {
+          "source": "fmt",
+          "specifiers": [
+            "fmt"
+          ]
+        },
+        {
+          "source": "net",
+          "specifiers": [
+            "net"
+          ]
+        },
+        {
+          "source": "testing",
+          "specifiers": [
+            "testing"
+          ]
+        }
+      ],
+      "exports": [
+        "TestClassifyTransportError"
+      ],
+      "totalLines": 88,
       "hasStructuralAnalysis": true
     },
     "internal/tokenexchange/types.go": {
       "filePath": "internal/tokenexchange/types.go",
-      "contentHash": "b03c110206b7d0f31afc923af8166b94557acdb9056e18d2bfb00424dbd55972",
+      "contentHash": "be83948b5513d15786a08723f732a71fa738829a7a2faf4beb09a078ebee0247",
       "functions": [
         {
           "name": "String",
@@ -20069,10 +22942,12 @@
             "GrantType",
             "AudienceParam",
             "HTTPClient",
-            "Cache"
+            "Cache",
+            "ChainDeadline",
+            "CircuitBreaker"
           ],
           "exported": true,
-          "lineCount": 24
+          "lineCount": 39
         },
         {
           "name": "ExchangeInput",
@@ -20156,7 +23031,7 @@
         "GoString",
         "LogValue"
       ],
-      "totalLines": 242,
+      "totalLines": 284,
       "hasStructuralAnalysis": true
     },
     "internal/tools/authorization.go": {
@@ -21214,7 +24089,7 @@
     },
     "internal/tools/errors.go": {
       "filePath": "internal/tools/errors.go",
-      "contentHash": "34d79b57a33db131e59b321a56e97ff1d55cd73873b256f5041ca9c8a21475b5",
+      "contentHash": "1727bc74ae3882572e70a44457d1a4b92b72ae065c39f347a6cf352bb1c09dd8",
       "functions": [
         {
           "name": "buildErrorResult",
@@ -21253,15 +24128,6 @@
           "returnType": "string",
           "exported": false,
           "lineCount": 16
-        },
-        {
-          "name": "buildExchangeErrorMessage",
-          "params": [
-            "err"
-          ],
-          "returnType": "string",
-          "exported": false,
-          "lineCount": 14
         },
         {
           "name": "isRetryable",
@@ -21345,12 +24211,12 @@
         }
       ],
       "exports": [],
-      "totalLines": 342,
+      "totalLines": 327,
       "hasStructuralAnalysis": true
     },
     "internal/tools/errors_test.go": {
       "filePath": "internal/tools/errors_test.go",
-      "contentHash": "242472461f61dfaba560bdb928c48ed1ee27b927a0fb6734252f2f37302663a7",
+      "contentHash": "924e81e6249ac2017984a628285e77f070bd6d5699faaf821d1306d3e9e4d499",
       "functions": [
         {
           "name": "TestSanitizeBrokerText",
@@ -21366,7 +24232,7 @@
             "t"
           ],
           "exported": true,
-          "lineCount": 50
+          "lineCount": 57
         },
         {
           "name": "TestBuildSEMPv2Message",
@@ -21390,7 +24256,7 @@
             "t"
           ],
           "exported": true,
-          "lineCount": 111
+          "lineCount": 128
         },
         {
           "name": "TestBuildErrorResult_ExchangeError_StructuredFields",
@@ -21399,22 +24265,6 @@
           ],
           "exported": true,
           "lineCount": 49
-        },
-        {
-          "name": "TestBuildExchangeErrorMessage",
-          "params": [
-            "t"
-          ],
-          "exported": true,
-          "lineCount": 41
-        },
-        {
-          "name": "TestExchangeError_NeverContainsSecrets",
-          "params": [
-            "t"
-          ],
-          "exported": true,
-          "lineCount": 34
         }
       ],
       "classes": [],
@@ -21438,21 +24288,9 @@
           ]
         },
         {
-          "source": "strings",
-          "specifiers": [
-            "strings"
-          ]
-        },
-        {
           "source": "testing",
           "specifiers": [
             "testing"
-          ]
-        },
-        {
-          "source": "time",
-          "specifiers": [
-            "time"
           ]
         },
         {
@@ -21486,11 +24324,9 @@
         "TestBuildSEMPv2Message",
         "TestBuildSEMPv1Message",
         "TestBuildErrorMessage",
-        "TestBuildErrorResult_ExchangeError_StructuredFields",
-        "TestBuildExchangeErrorMessage",
-        "TestExchangeError_NeverContainsSecrets"
+        "TestBuildErrorResult_ExchangeError_StructuredFields"
       ],
-      "totalLines": 431,
+      "totalLines": 380,
       "hasStructuralAnalysis": true
     },
     "internal/tools/identity.go": {
@@ -22938,6 +25774,16 @@
       "totalLines": 55,
       "hasStructuralAnalysis": true
     },
+    "internal/tools/queuemetrics/testdata/show_queue_detail.xml": {
+      "filePath": "internal/tools/queuemetrics/testdata/show_queue_detail.xml",
+      "contentHash": "cfa3b7a5f30dd6dac466f6702a14458637f7dbbbb230841b84f34b7df60f324e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 25,
+      "hasStructuralAnalysis": false
+    },
     "internal/tools/register.go": {
       "filePath": "internal/tools/register.go",
       "contentHash": "d3702ece8e2b0d48866e9f9001afb3c3c2211cec0d89d2a38c98dba5e09aa336",
@@ -24136,6 +26982,66 @@
       "totalLines": 72,
       "hasStructuralAnalysis": true
     },
+    "internal/tools/sempv1/brokerstatus/testdata/show_hardware_details_appliance.xml": {
+      "filePath": "internal/tools/sempv1/brokerstatus/testdata/show_hardware_details_appliance.xml",
+      "contentHash": "554000de472a88046c9dd2b2660e908d76a00653f519b6b4af90fd209c66bab1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 226,
+      "hasStructuralAnalysis": false
+    },
+    "internal/tools/sempv1/brokerstatus/testdata/show_memory.xml": {
+      "filePath": "internal/tools/sempv1/brokerstatus/testdata/show_memory.xml",
+      "contentHash": "37990bd69ea6d3ed6797ce7020e3d6046e1ef3d67daa321ede3d50ead3a2e5c3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 125,
+      "hasStructuralAnalysis": false
+    },
+    "internal/tools/sempv1/brokerstatus/testdata/show_message_spool_detail.xml": {
+      "filePath": "internal/tools/sempv1/brokerstatus/testdata/show_message_spool_detail.xml",
+      "contentHash": "30b040225029c2328386f950548726933c2c67db21ef99d232a233aedab3eafa",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 185,
+      "hasStructuralAnalysis": false
+    },
+    "internal/tools/sempv1/brokerstatus/testdata/show_system.xml": {
+      "filePath": "internal/tools/sempv1/brokerstatus/testdata/show_system.xml",
+      "contentHash": "08a3d75b70f0d93319e7ecece767457d67dd23f611eb53904b39119408fae49e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": false
+    },
+    "internal/tools/sempv1/brokerstatus/testdata/show_version.xml": {
+      "filePath": "internal/tools/sempv1/brokerstatus/testdata/show_version.xml",
+      "contentHash": "ffaec6211574913c60d95be9aa8a4bdc456c663212cdacbcd6e413bbca0652ad",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 51,
+      "hasStructuralAnalysis": false
+    },
+    "internal/tools/sempv1/brokerstatus/testdata/show_version_appliance.xml": {
+      "filePath": "internal/tools/sempv1/brokerstatus/testdata/show_version_appliance.xml",
+      "contentHash": "b08b6a813241bfd6e93346c9e7010f2aa1ec2ae88f7ef7c5629afcb168724414",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 52,
+      "hasStructuralAnalysis": false
+    },
     "internal/tools/sempv1/brokerstatus/version_response.go": {
       "filePath": "internal/tools/sempv1/brokerstatus/version_response.go",
       "contentHash": "0ed9bde520a145bac75c41a9bc787db8a4495f97510ffbda335d3f8960be90bb",
@@ -24832,6 +27738,36 @@
       "totalLines": 99,
       "hasStructuralAnalysis": true
     },
+    "internal/tools/sempv1/discardstats/testdata/show_message_spool_stats.xml": {
+      "filePath": "internal/tools/sempv1/discardstats/testdata/show_message_spool_stats.xml",
+      "contentHash": "031010e733bb7684f0447ee2c89113c33d6d89c81cf45edbf2b4695b79943647",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 141,
+      "hasStructuralAnalysis": false
+    },
+    "internal/tools/sempv1/discardstats/testdata/show_message_vpn_default_stats.xml": {
+      "filePath": "internal/tools/sempv1/discardstats/testdata/show_message_vpn_default_stats.xml",
+      "contentHash": "0db4dbd658312af39efba0c47abc3437d789340d84074370876d748895381d48",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 183,
+      "hasStructuralAnalysis": false
+    },
+    "internal/tools/sempv1/discardstats/testdata/show_stats_client.xml": {
+      "filePath": "internal/tools/sempv1/discardstats/testdata/show_stats_client.xml",
+      "contentHash": "7d1c9e71f5b702bb4e3c3c17fc91f5cc51ad28bac90f14a1ad13256094efc5ca",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 127,
+      "hasStructuralAnalysis": false
+    },
     "internal/tools/sempv1/discardstats/vpn_stats_response.go": {
       "filePath": "internal/tools/sempv1/discardstats/vpn_stats_response.go",
       "contentHash": "524c864ff199cc9b22124a178462eee16b0073d8598a6fcf91e3d317f7d1fa3d",
@@ -25344,6 +28280,16 @@
       "totalLines": 127,
       "hasStructuralAnalysis": true
     },
+    "internal/tools/sempv1/redundancy/testdata/show_redundancy_standalone.xml": {
+      "filePath": "internal/tools/sempv1/redundancy/testdata/show_redundancy_standalone.xml",
+      "contentHash": "8ffe2235239f53413e0ed501a8e80a470fe38f8e4bd3a0e65dc391b6fac5a2b5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 71,
+      "hasStructuralAnalysis": false
+    },
     "internal/tools/types.go": {
       "filePath": "internal/tools/types.go",
       "contentHash": "179398140c0601b74f400d3fd3e8d7153e024c18c9aeaca9efd805c2854a5f61",
@@ -25645,6 +28591,36 @@
         "Version"
       ],
       "totalLines": 12,
+      "hasStructuralAnalysis": true
+    },
+    "sweep-notes.md": {
+      "filePath": "sweep-notes.md",
+      "contentHash": "a7f6c5fb10deee1c520a1d87463aa6055e0d98324fb886e921a5a26eeaf5fe8b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 83,
+      "hasStructuralAnalysis": true
+    },
+    "watch-for-prs-notes.md": {
+      "filePath": "watch-for-prs-notes.md",
+      "contentHash": "4749e49548abe1bcab85022f2874678528943e23d735cc543098600c3ce24447",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 19,
+      "hasStructuralAnalysis": true
+    },
+    "watch-my-prs-notes.md": {
+      "filePath": "watch-my-prs-notes.md",
+      "contentHash": "01b9ed788b3e12db0b10612d31b69fa5ddb88fa4194567832040c3a8c05c7b48",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 131,
       "hasStructuralAnalysis": true
     }
   }

--- a/.ua/knowledge-graph.json
+++ b/.ua/knowledge-graph.json
@@ -3,43 +3,27 @@
   "project": {
     "name": "solace-broker-mcp",
     "languages": [
-      "go",
-      "markdown",
-      "yaml",
-      "json",
-      "xml",
+      "csv",
       "dockerfile",
-      "makefile"
+      "go",
+      "json",
+      "makefile",
+      "markdown",
+      "mod",
+      "shell",
+      "sum",
+      "xml",
+      "yaml"
     ],
     "frameworks": [
       "Docker",
-      "GitHub Actions",
-      "MCP Go SDK",
-      "kin-openapi",
-      "go-oidc"
+      "GitHub Actions"
     ],
-    "description": "A Go HTTP MCP server exposing Solace event broker management and monitoring to AI assistants over SEMP v1/v2.",
-    "analyzedAt": "2026-07-21T16:48:49Z",
-    "gitCommitHash": "c1f193ea253213b0d4019e829217170cdd416473"
+    "description": "An HTTP MCP (Model Context Protocol) server, written in Go, that exposes Solace event broker management and monitoring to AI assistants via SEMP v1 and v2 APIs. It provides 35 tools (19 read-only monitoring tools plus 16 optional write/action tools gated off by default), handling authentication, rate limiting, retries, and response formatting. Note: this project has over 100 source files; consider scoping analysis to a subdirectory for faster results.",
+    "analyzedAt": "2026-07-23T17:52:29Z",
+    "gitCommitHash": "c4955e9172cf021b9640e932f9f05c1800cd88f6"
   },
   "nodes": [
-    {
-      "id": "file:cmd/server/main.go",
-      "type": "file",
-      "name": "main.go",
-      "filePath": "cmd/server/main.go",
-      "summary": "Application entry point: parses config, wires observability/auth/token-exchange middleware, builds the MCP HTTP endpoint and health mux, and manages graceful startup and drain/shutdown.",
-      "tags": [
-        "entry-point",
-        "server",
-        "bootstrap",
-        "http",
-        "lifecycle",
-        "tested"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Large main() orchestrates the full startup graph; uses slog with a secret-redacting handler and signal-driven graceful drain."
-    },
     {
       "id": "file:internal/banner/banner.go",
       "type": "file",
@@ -100,23 +84,6 @@
       "languageNotes": "Uses go:embed to bundle YAML tool definitions into the compiled binary."
     },
     {
-      "id": "file:internal/composite/executor.go",
-      "type": "file",
-      "name": "executor.go",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Core composite tool execution engine: resolves templated args, groups steps into batches, runs fan-out and paginated SEMPv2 fetches, and applies result strategies.",
-      "tags": [
-        "service",
-        "composite",
-        "executor",
-        "pagination",
-        "fan-out",
-        "tested"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Central engine with a CompositeExecutor type driving multi-step SEMPv2 calls, Go text/template arg resolution, and cursor-based pagination."
-    },
-    {
       "id": "file:internal/composite/executor_client_test.go",
       "type": "file",
       "name": "executor_client_test.go",
@@ -156,19 +123,6 @@
       "complexity": "complex"
     },
     {
-      "id": "file:internal/composite/executor_helpers_test.go",
-      "type": "file",
-      "name": "executor_helpers_test.go",
-      "filePath": "internal/composite/executor_helpers_test.go",
-      "summary": "Tests executor helper functions and shared test fixtures.",
-      "tags": [
-        "test",
-        "composite",
-        "helpers"
-      ],
-      "complexity": "complex"
-    },
-    {
       "id": "file:internal/composite/executor_queue_test.go",
       "type": "file",
       "name": "executor_queue_test.go",
@@ -193,159 +147,6 @@
         "rdp"
       ],
       "complexity": "complex"
-    },
-    {
-      "id": "function:cmd/server/main.go:main",
-      "type": "function",
-      "name": "main",
-      "filePath": "cmd/server/main.go",
-      "summary": "Startup orchestrator: loads config, initializes observability, auth, and token exchange, registers tools, builds the HTTP server, and runs the graceful drain/shutdown loop.",
-      "tags": [
-        "entry-point",
-        "bootstrap",
-        "lifecycle"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        510,
-        878
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:buildMux",
-      "type": "function",
-      "name": "buildMux",
-      "filePath": "cmd/server/main.go",
-      "summary": "Constructs the HTTP request multiplexer wiring health/readiness and MCP endpoints.",
-      "tags": [
-        "http",
-        "routing",
-        "setup"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        111,
-        137
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:healthConfigFromFile",
-      "type": "function",
-      "name": "healthConfigFromFile",
-      "filePath": "cmd/server/main.go",
-      "summary": "Loads health-check configuration from the config file into a healthConfig value.",
-      "tags": [
-        "config",
-        "health",
-        "loader"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        167,
-        196
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:startServer",
-      "type": "function",
-      "name": "startServer",
-      "filePath": "cmd/server/main.go",
-      "summary": "Starts the HTTP server, using TLS when cert/key files are provided.",
-      "tags": [
-        "http",
-        "server",
-        "tls"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        259,
-        279
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:drainAndShutdown",
-      "type": "function",
-      "name": "drainAndShutdown",
-      "filePath": "cmd/server/main.go",
-      "summary": "Coordinates readiness draining then graceful shutdown with a configurable delay and force signal.",
-      "tags": [
-        "lifecycle",
-        "shutdown",
-        "graceful"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        312,
-        329
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:gracefulShutdown",
-      "type": "function",
-      "name": "gracefulShutdown",
-      "filePath": "cmd/server/main.go",
-      "summary": "Attempts a timeout-bounded graceful server shutdown, falling back to force close.",
-      "tags": [
-        "lifecycle",
-        "shutdown"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        390,
-        410
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:newTokenExchanger",
-      "type": "function",
-      "name": "newTokenExchanger",
-      "filePath": "cmd/server/main.go",
-      "summary": "Builds the OAuth token exchanger from OAuth configuration for two-hop identity propagation.",
-      "tags": [
-        "auth",
-        "oauth",
-        "token-exchange",
-        "factory"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        451,
-        478
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:newSlogHandler",
-      "type": "function",
-      "name": "newSlogHandler",
-      "filePath": "cmd/server/main.go",
-      "summary": "Creates the structured slog handler at the configured level with secret redaction.",
-      "tags": [
-        "logging",
-        "security",
-        "factory"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        86,
-        102
-      ]
-    },
-    {
-      "id": "function:cmd/server/main.go:redactSecretAttr",
-      "type": "function",
-      "name": "redactSecretAttr",
-      "filePath": "cmd/server/main.go",
-      "summary": "slog ReplaceAttr hook that redacts attributes marked as secret from log output.",
-      "tags": [
-        "logging",
-        "security",
-        "validation"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        65,
-        74
-      ]
     },
     {
       "id": "function:internal/banner/banner.go:LogStartupAuthMode",
@@ -501,172 +302,6 @@
       ]
     },
     {
-      "id": "class:internal/composite/executor.go:CompositeExecutor",
-      "type": "class",
-      "name": "CompositeExecutor",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Executor type that runs a composite tool's steps against a SEMPv2 client, handling batching, fan-out, and pagination.",
-      "tags": [
-        "service",
-        "composite",
-        "executor"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        63,
-        73
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:NewCompositeExecutor",
-      "type": "function",
-      "name": "NewCompositeExecutor",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Constructs a CompositeExecutor bound to the supplied SEMPv2 operations set.",
-      "tags": [
-        "factory",
-        "composite"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        81,
-        86
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:Execute",
-      "type": "function",
-      "name": "Execute",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Runs all steps of a composite tool for the given params and returns the assembled result.",
-      "tags": [
-        "composite",
-        "executor",
-        "orchestration"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        94,
-        124
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:GroupStepsIntoBatches",
-      "type": "function",
-      "name": "GroupStepsIntoBatches",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Groups tool steps into execution batches based on inter-step dependencies.",
-      "tags": [
-        "composite",
-        "planning"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        129,
-        154
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:fetchFanOut",
-      "type": "function",
-      "name": "fetchFanOut",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Executes a fan-out step, issuing one SEMP call per resolved item and collecting results.",
-      "tags": [
-        "composite",
-        "fan-out",
-        "semp"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        235,
-        342
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:fetchPaginated",
-      "type": "function",
-      "name": "fetchPaginated",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Executes a paginated SEMPv2 fetch, following next-page cursors until results are exhausted or capped.",
-      "tags": [
-        "composite",
-        "pagination",
-        "semp"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        378,
-        472
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:constructRequestBody",
-      "type": "function",
-      "name": "constructRequestBody",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Builds the SEMP request body for a step from its operation spec, resolved args, and params.",
-      "tags": [
-        "composite",
-        "semp",
-        "serialization"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        659,
-        716
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:ResolveArgs",
-      "type": "function",
-      "name": "ResolveArgs",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Resolves templated step arguments against the current execution context.",
-      "tags": [
-        "composite",
-        "templating"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        599,
-        617
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:ApplyResultStrategy",
-      "type": "function",
-      "name": "ApplyResultStrategy",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Combines per-step results into the final tool output according to the result strategy.",
-      "tags": [
-        "composite",
-        "aggregation"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        723,
-        738
-      ]
-    },
-    {
-      "id": "function:internal/composite/executor.go:resolveMaxResults",
-      "type": "function",
-      "name": "resolveMaxResults",
-      "filePath": "internal/composite/executor.go",
-      "summary": "Determines the effective max-results cap for a paginated fetch from params and defaults.",
-      "tags": [
-        "composite",
-        "pagination",
-        "validation"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        484,
-        510
-      ]
-    },
-    {
       "id": "file:internal/composite/executor_topic_endpoint_test.go",
       "type": "file",
       "name": "executor_topic_endpoint_test.go",
@@ -678,19 +313,6 @@
         "topic-endpoint"
       ],
       "complexity": "moderate"
-    },
-    {
-      "id": "file:internal/composite/executor_vpn_test.go",
-      "type": "file",
-      "name": "executor_vpn_test.go",
-      "filePath": "internal/composite/executor_vpn_test.go",
-      "summary": "Tests composite executor behavior for VPN tools.",
-      "tags": [
-        "test",
-        "composite",
-        "vpn"
-      ],
-      "complexity": "complex"
     },
     {
       "id": "file:internal/composite/loader.go",
@@ -1358,36 +980,6 @@
       "complexity": "moderate"
     },
     {
-      "id": "file:internal/semp/sempv2/operation.go",
-      "type": "file",
-      "name": "operation.go",
-      "filePath": "internal/semp/sempv2/operation.go",
-      "summary": "Defines the Operation and Parameter types and ParseSpecs, which reads embedded Swagger 2.0 specs and extracts every SEMPv2 operation keyed by specType/operationId.",
-      "tags": [
-        "data-model",
-        "openapi",
-        "parser",
-        "sempv2",
-        "tested"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Uses getkin/kin-openapi openapi2 to resolve $ref parameters and derive spec type from basePath."
-    },
-    {
-      "id": "file:internal/semp/sempv2/operation_test.go",
-      "type": "file",
-      "name": "operation_test.go",
-      "filePath": "internal/semp/sempv2/operation_test.go",
-      "summary": "Tests ParseSpecs against embedded specs: operation counts, field extraction, $ref parameter resolution, no ghost/duplicate keys, basePath inclusion, and spec-type derivation.",
-      "tags": [
-        "test",
-        "openapi",
-        "parser",
-        "sempv2"
-      ],
-      "complexity": "complex"
-    },
-    {
       "id": "file:internal/semp/sempv2/specs/embed.go",
       "type": "file",
       "name": "embed.go",
@@ -1615,91 +1207,6 @@
         "middleware"
       ],
       "complexity": "simple"
-    },
-    {
-      "id": "class:internal/semp/sempv2/operation.go:Operation",
-      "type": "class",
-      "name": "Operation",
-      "filePath": "internal/semp/sempv2/operation.go",
-      "lineRange": [
-        17,
-        25
-      ],
-      "summary": "Represents a single SEMPv2 API endpoint parsed from an OpenAPI spec: method, path template, parameters, description, and body fields.",
-      "tags": [
-        "data-model",
-        "openapi",
-        "sempv2"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:internal/semp/sempv2/operation.go:Parameter",
-      "type": "class",
-      "name": "Parameter",
-      "filePath": "internal/semp/sempv2/operation.go",
-      "lineRange": [
-        28,
-        34
-      ],
-      "summary": "Describes a single SEMPv2 operation parameter: name, location, type, required flag, and description.",
-      "tags": [
-        "data-model",
-        "openapi",
-        "sempv2"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:internal/semp/sempv2/operation.go:ParseSpecs",
-      "type": "function",
-      "name": "ParseSpecs",
-      "filePath": "internal/semp/sempv2/operation.go",
-      "lineRange": [
-        57,
-        128
-      ],
-      "summary": "Reads all embedded Swagger 2.0 specs and extracts every operation into a map keyed by specType/operationId, disambiguating shared operationIds across specs.",
-      "tags": [
-        "openapi",
-        "parser",
-        "sempv2"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:internal/semp/sempv2/operation.go:extractParameters",
-      "type": "function",
-      "name": "extractParameters",
-      "filePath": "internal/semp/sempv2/operation.go",
-      "lineRange": [
-        151,
-        183
-      ],
-      "summary": "Extracts and resolves an operation's parameters, following $ref into shared parameter definitions.",
-      "tags": [
-        "openapi",
-        "parser",
-        "sempv2"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/semp/sempv2/operation.go:extractBodyFields",
-      "type": "function",
-      "name": "extractBodyFields",
-      "filePath": "internal/semp/sempv2/operation.go",
-      "lineRange": [
-        192,
-        229
-      ],
-      "summary": "Resolves the set of attribute names an operation's request body accepts from its schema definitions.",
-      "tags": [
-        "openapi",
-        "parser",
-        "sempv2"
-      ],
-      "complexity": "moderate"
     },
     {
       "id": "class:internal/tools/composite_handler.go:CompositeToolHandler",
@@ -2607,34 +2114,6 @@
       "complexity": "complex"
     },
     {
-      "id": "file:internal/tools/errors.go",
-      "type": "file",
-      "name": "errors.go",
-      "filePath": "internal/tools/errors.go",
-      "summary": "Translates SEMP and token-exchange errors into agent-safe MCP results: maps broker error codes to hints, sanitizes broker text, decides retryability, and builds protocol-specific messages without leaking internal detail.",
-      "tags": [
-        "error-handling",
-        "security",
-        "semp",
-        "translation",
-        "tested"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "file:internal/tools/errors_test.go",
-      "type": "file",
-      "name": "errors_test.go",
-      "filePath": "internal/tools/errors_test.go",
-      "summary": "Tests error translation: broker-text sanitization, retryability, SEMPv1/v2 and exchange message building, and that exchange errors never leak secrets.",
-      "tags": [
-        "test",
-        "error-handling",
-        "security"
-      ],
-      "complexity": "complex"
-    },
-    {
       "id": "function:internal/semp/sempv1/xml_util.go:Escape",
       "type": "function",
       "name": "Escape",
@@ -2698,106 +2177,6 @@
       "lineRange": [
         164,
         219
-      ]
-    },
-    {
-      "id": "function:internal/tools/errors.go:buildErrorResult",
-      "type": "function",
-      "name": "buildErrorResult",
-      "filePath": "internal/tools/errors.go",
-      "summary": "Builds the agent-facing MCP error result from a SEMP or exchange error, choosing message, retryability and structured fields while withholding internal detail.",
-      "tags": [
-        "error-handling",
-        "security",
-        "translation"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        104,
-        158
-      ]
-    },
-    {
-      "id": "function:internal/tools/errors.go:buildErrorMessage",
-      "type": "function",
-      "name": "buildErrorMessage",
-      "filePath": "internal/tools/errors.go",
-      "summary": "Selects the caller-facing message for an error, mapping broker error codes to generic hints and masking 500-class internal detail.",
-      "tags": [
-        "error-handling",
-        "security",
-        "translation"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        173,
-        226
-      ]
-    },
-    {
-      "id": "function:internal/tools/errors.go:buildSEMPv1Message",
-      "type": "function",
-      "name": "buildSEMPv1Message",
-      "filePath": "internal/tools/errors.go",
-      "summary": "Constructs the agent-facing message for a SEMPv1 error, sanitizing broker text.",
-      "tags": [
-        "error-handling",
-        "security",
-        "semp"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        238,
-        273
-      ]
-    },
-    {
-      "id": "function:internal/tools/errors.go:buildSEMPv2Message",
-      "type": "function",
-      "name": "buildSEMPv2Message",
-      "filePath": "internal/tools/errors.go",
-      "summary": "Constructs the agent-facing message for a SEMPv2 error, sanitizing broker text.",
-      "tags": [
-        "error-handling",
-        "security",
-        "semp"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        275,
-        290
-      ]
-    },
-    {
-      "id": "function:internal/tools/errors.go:buildExchangeErrorMessage",
-      "type": "function",
-      "name": "buildExchangeErrorMessage",
-      "filePath": "internal/tools/errors.go",
-      "summary": "Constructs an agent-facing message for a token-exchange failure that never contains secrets.",
-      "tags": [
-        "error-handling",
-        "security"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        292,
-        305
-      ]
-    },
-    {
-      "id": "function:internal/tools/errors.go:isRetryable",
-      "type": "function",
-      "name": "isRetryable",
-      "filePath": "internal/tools/errors.go",
-      "summary": "Decides whether an error represents a transient condition the caller should retry.",
-      "tags": [
-        "error-handling",
-        "resilience"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        312,
-        329
       ]
     },
     {
@@ -3932,227 +3311,6 @@
       ]
     },
     {
-      "id": "file:internal/tokenexchange/errors.go",
-      "type": "file",
-      "name": "errors.go",
-      "filePath": "internal/tokenexchange/errors.go",
-      "summary": "Structured ExchangeError type classifying token-exchange failures (transport, rejected, invalid-response) with sanitized slog attributes for observability.",
-      "tags": [
-        "token-exchange",
-        "error-handling",
-        "logging"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:internal/tokenexchange/errors.go:ExchangeError",
-      "type": "class",
-      "name": "ExchangeError",
-      "filePath": "internal/tokenexchange/errors.go",
-      "summary": "Structured token-exchange error classifying transport, rejected, and invalid-response failures with an underlying cause.",
-      "tags": [
-        "token-exchange",
-        "error-handling"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        40,
-        48
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/errors.go:LogAttrs",
-      "type": "function",
-      "name": "LogAttrs",
-      "filePath": "internal/tokenexchange/errors.go",
-      "summary": "Emits sanitized slog attributes describing the exchange failure for observability.",
-      "tags": [
-        "logging",
-        "error-handling"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        56,
-        74
-      ]
-    },
-    {
-      "id": "file:internal/tokenexchange/exchange.go",
-      "type": "file",
-      "name": "exchange.go",
-      "filePath": "internal/tokenexchange/exchange.go",
-      "summary": "Core RFC 8693 exchange flow: serves cache hits, coalesces concurrent misses via singleflight keyed on the dedup hash, calls the IdP, caches results, and maps context/transport errors precisely.",
-      "tags": [
-        "token-exchange",
-        "oauth",
-        "concurrency",
-        "caching",
-        "tested"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Uses golang.org/x/sync/singleflight to collapse duplicate in-flight exchanges per deduplication key."
-    },
-    {
-      "id": "function:internal/tokenexchange/exchange.go:Exchange",
-      "type": "function",
-      "name": "Exchange",
-      "filePath": "internal/tokenexchange/exchange.go",
-      "summary": "Serves a fresh cached token or coalesces concurrent misses via singleflight, calling the IdP once per deduplication key and caching the result.",
-      "tags": [
-        "token-exchange",
-        "concurrency",
-        "caching"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        30,
-        110
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/exchange.go:doExchange",
-      "type": "function",
-      "name": "doExchange",
-      "filePath": "internal/tokenexchange/exchange.go",
-      "summary": "Performs a single IdP round trip: builds the request, sends it, parses the response, and maps context versus transport errors.",
-      "tags": [
-        "token-exchange",
-        "http",
-        "error-handling"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        133,
-        154
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/exchange.go:Invalidate",
-      "type": "function",
-      "name": "Invalidate",
-      "filePath": "internal/tokenexchange/exchange.go",
-      "summary": "Evicts a cached exchanged token by deduplication key so the next Exchange re-fetches.",
-      "tags": [
-        "token-exchange",
-        "caching"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        123,
-        131
-      ]
-    },
-    {
-      "id": "file:internal/tokenexchange/exchanger.go",
-      "type": "file",
-      "name": "exchanger.go",
-      "filePath": "internal/tokenexchange/exchanger.go",
-      "summary": "Defines the Exchanger process-singleton holding deployment-global protocol state and its validating New constructor (rejects nil HTTP client or cache).",
-      "tags": [
-        "token-exchange",
-        "factory",
-        "singleton",
-        "tested"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:internal/tokenexchange/exchanger.go:Exchanger",
-      "type": "class",
-      "name": "Exchanger",
-      "filePath": "internal/tokenexchange/exchanger.go",
-      "summary": "Process-singleton holding deployment-global token-exchange protocol state (IdP endpoint, client credentials, grant type, cache).",
-      "tags": [
-        "token-exchange",
-        "singleton"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        34,
-        46
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/exchanger.go:New",
-      "type": "function",
-      "name": "New",
-      "filePath": "internal/tokenexchange/exchanger.go",
-      "summary": "Validating constructor for an Exchanger; rejects a nil HTTP client or nil cache.",
-      "tags": [
-        "factory",
-        "token-exchange",
-        "validation"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        58,
-        77
-      ]
-    },
-    {
-      "id": "file:internal/tokenexchange/from_config.go",
-      "type": "file",
-      "name": "from_config.go",
-      "filePath": "internal/tokenexchange/from_config.go",
-      "summary": "Builds an Exchanger from broker OAuth configuration, resolving client-auth method, grant type, and audience-parameter wire format into validated protocol parameters.",
-      "tags": [
-        "token-exchange",
-        "configuration",
-        "factory",
-        "tested"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/tokenexchange/from_config.go:FromConfig",
-      "type": "function",
-      "name": "FromConfig",
-      "filePath": "internal/tokenexchange/from_config.go",
-      "summary": "Builds an Exchanger from broker OAuth configuration, resolving client-auth, grant type, and audience-param format into validated Params.",
-      "tags": [
-        "factory",
-        "configuration",
-        "token-exchange"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        36,
-        66
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/from_config.go:resolveClientAuth",
-      "type": "function",
-      "name": "resolveClientAuth",
-      "filePath": "internal/tokenexchange/from_config.go",
-      "summary": "Maps configured client authentication method to the internal client-auth mode.",
-      "tags": [
-        "configuration",
-        "token-exchange"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        72,
-        83
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/from_config.go:resolveAudienceParam",
-      "type": "function",
-      "name": "resolveAudienceParam",
-      "filePath": "internal/tokenexchange/from_config.go",
-      "summary": "Maps configured audience wire format to the internal audience-parameter mode.",
-      "tags": [
-        "configuration",
-        "token-exchange"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        94,
-        105
-      ]
-    },
-    {
       "id": "file:internal/tokenexchange/request.go",
       "type": "file",
       "name": "request.go",
@@ -4217,148 +3375,6 @@
       ]
     },
     {
-      "id": "file:internal/tokenexchange/response.go",
-      "type": "file",
-      "name": "response.go",
-      "filePath": "internal/tokenexchange/response.go",
-      "summary": "Parses and validates IdP token-exchange responses: enforces JSON content type, caps body size, validates required fields and token type, computes expiry, and classifies 4xx OAuth errors versus transport failures.",
-      "tags": [
-        "token-exchange",
-        "parsing",
-        "http",
-        "validation",
-        "tested"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/tokenexchange/response.go:parseIdPResponse",
-      "type": "function",
-      "name": "parseIdPResponse",
-      "filePath": "internal/tokenexchange/response.go",
-      "summary": "Top-level response dispatcher: enforces content type, caps body size, and routes success versus 3xx/4xx/5xx error handling.",
-      "tags": [
-        "parsing",
-        "http",
-        "validation"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        54,
-        85
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/response.go:parseSuccessBody",
-      "type": "function",
-      "name": "parseSuccessBody",
-      "filePath": "internal/tokenexchange/response.go",
-      "summary": "Validates a success response's required fields, token type, and expires_in, then constructs a Token with computed expiry.",
-      "tags": [
-        "parsing",
-        "validation"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        87,
-        141
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/response.go:classifyClientError",
-      "type": "function",
-      "name": "classifyClientError",
-      "filePath": "internal/tokenexchange/response.go",
-      "summary": "Classifies a 4xx body as an OAuth rejection versus a transport error, guarding oversized error codes.",
-      "tags": [
-        "parsing",
-        "error-handling"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        167,
-        189
-      ]
-    },
-    {
-      "id": "function:internal/tokenexchange/response.go:responseMediaType",
-      "type": "function",
-      "name": "responseMediaType",
-      "filePath": "internal/tokenexchange/response.go",
-      "summary": "Extracts and lowercases the response media type, stripping parameters.",
-      "tags": [
-        "parsing",
-        "http"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        143,
-        153
-      ]
-    },
-    {
-      "id": "file:internal/tokenexchange/types.go",
-      "type": "file",
-      "name": "types.go",
-      "filePath": "internal/tokenexchange/types.go",
-      "summary": "Package-level type definitions for token exchange (Params, ExchangeInput, Token) with LogValuer implementations that keep secrets out of logs; documents the Exchanger singleton contract.",
-      "tags": [
-        "token-exchange",
-        "data-model",
-        "type-definition"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:internal/tokenexchange/types.go:Params",
-      "type": "class",
-      "name": "Params",
-      "filePath": "internal/tokenexchange/types.go",
-      "summary": "Deployment-global exchange parameters (IdP endpoint, client credentials, grant type, audience format) with a secret-safe LogValuer.",
-      "tags": [
-        "data-model",
-        "token-exchange",
-        "type-definition"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        103,
-        126
-      ]
-    },
-    {
-      "id": "class:internal/tokenexchange/types.go:ExchangeInput",
-      "type": "class",
-      "name": "ExchangeInput",
-      "filePath": "internal/tokenexchange/types.go",
-      "summary": "Per-request exchange inputs (subject token, broker alias, audience) with a LogValuer that hides the token.",
-      "tags": [
-        "data-model",
-        "token-exchange"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        159,
-        170
-      ]
-    },
-    {
-      "id": "class:internal/tokenexchange/types.go:Token",
-      "type": "class",
-      "name": "Token",
-      "filePath": "internal/tokenexchange/types.go",
-      "summary": "An exchanged access token with its type and computed expiry, redacted in logs.",
-      "tags": [
-        "data-model",
-        "token-exchange"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        195,
-        198
-      ]
-    },
-    {
       "id": "file:internal/tokenexchange/dedup_key_test.go",
       "type": "file",
       "name": "dedup_key_test.go",
@@ -4370,20 +3386,6 @@
         "security"
       ],
       "complexity": "simple"
-    },
-    {
-      "id": "file:internal/tokenexchange/exchange_test.go",
-      "type": "file",
-      "name": "exchange_test.go",
-      "filePath": "internal/tokenexchange/exchange_test.go",
-      "summary": "Extensive tests for the exchange flow: singleflight deduplication, per-key concurrency, cache hit/miss, context/deadline error mapping, IdP error classification, and secret-safe debug logging.",
-      "tags": [
-        "test",
-        "token-exchange",
-        "concurrency",
-        "caching"
-      ],
-      "complexity": "complex"
     },
     {
       "id": "file:internal/tokenexchange/exchanger_test.go",
@@ -4409,20 +3411,6 @@
         "token-exchange",
         "http",
         "rfc8693"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "file:internal/tokenexchange/response_test.go",
-      "type": "file",
-      "name": "response_test.go",
-      "filePath": "internal/tokenexchange/response_test.go",
-      "summary": "Tests for IdP response parsing: body always closed, 1 MiB size cap, content-type guards, token-type validation, expiry computation, and 3xx/4xx/5xx error classification.",
-      "tags": [
-        "test",
-        "token-exchange",
-        "parsing",
-        "validation"
       ],
       "complexity": "complex"
     },
@@ -4748,22 +3736,6 @@
       ]
     },
     {
-      "id": "file:internal/semp/resilience/retry.go",
-      "type": "file",
-      "name": "retry.go",
-      "filePath": "internal/semp/resilience/retry.go",
-      "summary": "Retry decision engine: context helpers for marking retry-safe operations and checkRetry, which classifies HTTP responses/errors into retry-or-not decisions with backoff state.",
-      "tags": [
-        "resilience",
-        "retry",
-        "middleware",
-        "decision-logic",
-        "tested"
-      ],
-      "complexity": "moderate",
-      "languageNotes": "Uses context.Context value keys (unexported key types) to thread per-request retry state."
-    },
-    {
       "id": "file:internal/semp/resilience/retry_safe_test.go",
       "type": "file",
       "name": "retry_safe_test.go",
@@ -4788,138 +3760,6 @@
         "rate-limiting"
       ],
       "complexity": "simple"
-    },
-    {
-      "id": "file:internal/semp/resilience/sender.go",
-      "type": "file",
-      "name": "sender.go",
-      "filePath": "internal/semp/resilience/sender.go",
-      "summary": "Core resilient HTTP sender: applies per-broker concurrency limits, per-attempt timeouts, an overall retry-chain deadline, authentication, and retry/backoff, returning a typed RetriesExhaustedError when attempts are exhausted.",
-      "tags": [
-        "resilience",
-        "retry",
-        "http",
-        "service",
-        "rate-limiting",
-        "tested"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Central engine of the transport layer; coordinates semaphore, authenticator, retry policy, and body lifecycle."
-    },
-    {
-      "id": "function:internal/semp/resilience/retry.go:checkRetry",
-      "type": "function",
-      "name": "checkRetry",
-      "filePath": "internal/semp/resilience/retry.go",
-      "summary": "Classifies an HTTP response or transport error into a retry decision, honoring retry-safe marking, status codes, auth-failure handling, and backoff state.",
-      "tags": [
-        "retry",
-        "decision-logic",
-        "resilience"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        72,
-        149
-      ]
-    },
-    {
-      "id": "class:internal/semp/resilience/sender.go:Sender",
-      "type": "class",
-      "name": "Sender",
-      "filePath": "internal/semp/resilience/sender.go",
-      "summary": "Resilient HTTP sender coordinating concurrency limiting, authentication, per-attempt timeouts, and retry/backoff for SEMP requests.",
-      "tags": [
-        "resilience",
-        "http",
-        "service"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        42,
-        50
-      ]
-    },
-    {
-      "id": "class:internal/semp/resilience/sender.go:RetriesExhaustedError",
-      "type": "class",
-      "name": "RetriesExhaustedError",
-      "filePath": "internal/semp/resilience/sender.go",
-      "summary": "Typed error returned when all retry attempts are exhausted, wrapping the last underlying error.",
-      "tags": [
-        "error-handling",
-        "resilience"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        19,
-        23
-      ]
-    },
-    {
-      "id": "function:internal/semp/resilience/sender.go:New",
-      "type": "function",
-      "name": "New",
-      "filePath": "internal/semp/resilience/sender.go",
-      "summary": "Builds a Sender from an HTTP client, SEMP config, authenticator, broker URL, and semaphore, wiring retry policy and timeouts; panics on a nil semaphore.",
-      "tags": [
-        "factory",
-        "resilience",
-        "service"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        67,
-        153
-      ]
-    },
-    {
-      "id": "function:internal/semp/resilience/sender.go:Do",
-      "type": "function",
-      "name": "Do",
-      "filePath": "internal/semp/resilience/sender.go",
-      "summary": "Executes a request through the resilience pipeline: acquires the semaphore, applies timeouts and the retry-chain deadline, authenticates, and drives retries.",
-      "tags": [
-        "resilience",
-        "http",
-        "retry"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        159,
-        232
-      ]
-    },
-    {
-      "id": "function:internal/semp/resilience/sender.go:errorHandler",
-      "type": "function",
-      "name": "errorHandler",
-      "filePath": "internal/semp/resilience/sender.go",
-      "summary": "Retry hook that inspects responses/errors, closes bodies on exhaustion, and produces a RetriesExhaustedError when the attempt budget is spent.",
-      "tags": [
-        "resilience",
-        "error-handling",
-        "resource-cleanup"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        284,
-        336
-      ]
-    },
-    {
-      "id": "file:internal/semp/resilience/sender_test.go",
-      "type": "file",
-      "name": "sender_test.go",
-      "filePath": "internal/semp/resilience/sender_test.go",
-      "summary": "Extensive Sender test suite covering retry-chain deadlines, rate limiting, per-auth-mode 401 handling, 429/5xx backoff, no-retry cases for non-idempotent methods, and semaphore enforcement.",
-      "tags": [
-        "test",
-        "resilience",
-        "retry",
-        "concurrency"
-      ],
-      "complexity": "complex"
     },
     {
       "id": "file:internal/semp/resilience/transport.go",
@@ -5095,187 +3935,6 @@
         "correlation"
       ],
       "complexity": "moderate"
-    },
-    {
-      "id": "file:internal/semp/sempv2/client.go",
-      "type": "file",
-      "name": "client.go",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "SEMPv2 client that builds REST URLs from templated operations, encodes path/query params (including CSV arrays), issues requests via the resilient sender, and parses structured SEMP error bodies.",
-      "tags": [
-        "api-handler",
-        "sempv2",
-        "rest",
-        "service",
-        "secure-logging",
-        "tested"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Implements slog.LogValuer for credential redaction; buildRequest and buildURL handle SEMPv2 operation templating."
-    },
-    {
-      "id": "file:internal/semp/sempv2/client_test.go",
-      "type": "file",
-      "name": "client_test.go",
-      "filePath": "internal/semp/sempv2/client_test.go",
-      "summary": "Comprehensive SEMPv2 client tests: path/query param encoding, CSV array handling, auth modes, SEMP error parsing, path encoding, transport pooling, timeouts, and TLS wiring.",
-      "tags": [
-        "test",
-        "sempv2",
-        "rest"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "class:internal/semp/sempv2/client.go:Client",
-      "type": "class",
-      "name": "Client",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Interface abstracting SEMPv2 operation execution for consumers that should not depend on the HTTP implementation.",
-      "tags": [
-        "interface",
-        "sempv2",
-        "contract"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        25,
-        27
-      ]
-    },
-    {
-      "id": "class:internal/semp/sempv2/client.go:HTTPClient",
-      "type": "class",
-      "name": "HTTPClient",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "SEMPv2 REST client implementation that builds URLs from templated operations, issues requests via the resilient sender, and redacts credentials from logs.",
-      "tags": [
-        "api-handler",
-        "sempv2",
-        "rest",
-        "secure-logging"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        63,
-        67
-      ]
-    },
-    {
-      "id": "class:internal/semp/sempv2/client.go:SEMPError",
-      "type": "class",
-      "name": "SEMPError",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Typed error representing a parsed SEMPv2 error response, carrying operation, status code, and SEMP meta fields.",
-      "tags": [
-        "error-handling",
-        "sempv2"
-      ],
-      "complexity": "simple",
-      "lineRange": [
-        39,
-        46
-      ]
-    },
-    {
-      "id": "function:internal/semp/sempv2/client.go:NewHTTPClient",
-      "type": "function",
-      "name": "NewHTTPClient",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Constructs a SEMPv2 HTTPClient, wiring the tuned transport, semaphore, authenticator, and cookie jar.",
-      "tags": [
-        "factory",
-        "sempv2"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        98,
-        124
-      ]
-    },
-    {
-      "id": "function:internal/semp/sempv2/client.go:Execute",
-      "type": "function",
-      "name": "Execute",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Builds the request URL and body from a templated SEMPv2 operation and arguments, sends it, and parses the response or SEMP error.",
-      "tags": [
-        "api-handler",
-        "sempv2",
-        "rest"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        134,
-        182
-      ]
-    },
-    {
-      "id": "function:internal/semp/sempv2/client.go:buildURL",
-      "type": "function",
-      "name": "buildURL",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Substitutes path parameters into a SEMPv2 operation template and validates that no placeholders remain unfilled.",
-      "tags": [
-        "sempv2",
-        "url-building"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        189,
-        209
-      ]
-    },
-    {
-      "id": "function:internal/semp/sempv2/client.go:buildRequest",
-      "type": "function",
-      "name": "buildRequest",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Assembles the HTTP request for a SEMPv2 operation: method, URL, query params (including CSV arrays), headers, and optional JSON body.",
-      "tags": [
-        "sempv2",
-        "rest",
-        "serialization"
-      ],
-      "complexity": "complex",
-      "lineRange": [
-        238,
-        307
-      ]
-    },
-    {
-      "id": "function:internal/semp/sempv2/client.go:encodeCSVQueryParam",
-      "type": "function",
-      "name": "encodeCSVQueryParam",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Encodes an array-valued query parameter as a trimmed, empty-dropped comma-separated string for SEMPv2 requests.",
-      "tags": [
-        "sempv2",
-        "serialization",
-        "query-params"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        314,
-        337
-      ]
-    },
-    {
-      "id": "function:internal/semp/sempv2/client.go:parseSEMPError",
-      "type": "function",
-      "name": "parseSEMPError",
-      "filePath": "internal/semp/sempv2/client.go",
-      "summary": "Parses a SEMPv2 error response body into a structured SEMPError, tolerating malformed or partial meta.",
-      "tags": [
-        "sempv2",
-        "error-handling",
-        "parsing"
-      ],
-      "complexity": "moderate",
-      "lineRange": [
-        385,
-        408
-      ]
     },
     {
       "id": "file:internal/semp/sempv2/correlation_test.go",
@@ -5465,23 +4124,6 @@
       "complexity": "complex"
     },
     {
-      "id": "file:internal/config/config.go",
-      "type": "file",
-      "name": "config.go",
-      "filePath": "internal/config/config.go",
-      "summary": "Central configuration model and loader: parses YAML/env, validates brokers, OAuth, and tool-authorization settings for the MCP server.",
-      "tags": [
-        "config",
-        "configuration",
-        "validation",
-        "oauth",
-        "broker",
-        "tested"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Large config surface with per-section validation and slog.LogValuer implementations to redact secrets."
-    },
-    {
       "id": "function:internal/auth/middleware.go:NewAuthMiddleware",
       "type": "function",
       "name": "NewAuthMiddleware",
@@ -5634,190 +4276,6 @@
         "security"
       ],
       "complexity": "moderate"
-    },
-    {
-      "id": "class:internal/config/config.go:ServerConfig",
-      "type": "class",
-      "name": "ServerConfig",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        44,
-        94
-      ],
-      "summary": "Top-level server configuration aggregating brokers, auth, listeners, and observability settings.",
-      "tags": [
-        "config",
-        "data-model",
-        "configuration"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:internal/config/config.go:BrokerConfig",
-      "type": "class",
-      "name": "BrokerConfig",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        375,
-        380
-      ],
-      "summary": "Configuration for a single Solace broker connection including SEMP and auth settings.",
-      "tags": [
-        "config",
-        "broker",
-        "data-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:internal/config/config.go:AuthConfig",
-      "type": "class",
-      "name": "AuthConfig",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        414,
-        425
-      ],
-      "summary": "MCP client authentication configuration (static token or OAuth/OIDC).",
-      "tags": [
-        "config",
-        "authentication",
-        "data-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:internal/config/config.go:ToolAuthorizationConfig",
-      "type": "class",
-      "name": "ToolAuthorizationConfig",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        338,
-        343
-      ],
-      "summary": "Configuration controlling group-based tool authorization.",
-      "tags": [
-        "config",
-        "tool-authorization",
-        "data-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:internal/config/config.go:Load",
-      "type": "function",
-      "name": "Load",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        531,
-        557
-      ],
-      "summary": "Loads configuration from the default path, applying env overrides and validation.",
-      "tags": [
-        "config",
-        "loader",
-        "entry-point"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/config/config.go:LoadConfig",
-      "type": "function",
-      "name": "LoadConfig",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        586,
-        639
-      ],
-      "summary": "Reads and parses a config file, applies defaults and env overrides, then validates the result.",
-      "tags": [
-        "config",
-        "loader",
-        "validation"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/config/config.go:validate",
-      "type": "function",
-      "name": "validate",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        931,
-        1152
-      ],
-      "summary": "Validates the fully-assembled configuration across all sections, returning aggregated errors.",
-      "tags": [
-        "config",
-        "validation"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:internal/config/config.go:applyDefaults",
-      "type": "function",
-      "name": "applyDefaults",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        642,
-        706
-      ],
-      "summary": "Applies default values to unset configuration fields after loading.",
-      "tags": [
-        "config",
-        "defaults"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/config/config.go:validateToolAuthorization",
-      "type": "function",
-      "name": "validateToolAuthorization",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        1189,
-        1264
-      ],
-      "summary": "Validates the tool-authorization configuration section.",
-      "tags": [
-        "config",
-        "tool-authorization",
-        "validation"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/config/config.go:validateBroker",
-      "type": "function",
-      "name": "validateBroker",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        1297,
-        1375
-      ],
-      "summary": "Validates a single broker configuration entry.",
-      "tags": [
-        "config",
-        "broker",
-        "validation"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:internal/config/config.go:ToolAuthorizationEnabled",
-      "type": "function",
-      "name": "ToolAuthorizationEnabled",
-      "filePath": "internal/config/config.go",
-      "lineRange": [
-        1763,
-        1777
-      ],
-      "summary": "Reports whether tool authorization is enabled in the current configuration.",
-      "tags": [
-        "config",
-        "tool-authorization"
-      ],
-      "complexity": "simple"
     },
     {
       "id": "file:internal/config/config_test.go",
@@ -6729,21 +5187,6 @@
       "languageNotes": "Reusable workflow (workflow_call) with minimal least-privilege token permissions; E2E jobs bring brokers up/down with docker compose and dump logs on failure."
     },
     {
-      "id": "pipeline:.github/workflows/ci-pr.yaml",
-      "type": "pipeline",
-      "name": "ci-pr.yaml",
-      "filePath": ".github/workflows/ci-pr.yaml",
-      "summary": "Pull-request CI trigger that runs the shared FOSSA software-composition-analysis scan-and-guard workflow, with concurrency cancellation per PR number.",
-      "tags": [
-        "ci-cd",
-        "infrastructure",
-        "security",
-        "pull-request"
-      ],
-      "complexity": "simple",
-      "languageNotes": "Delegates to a pinned SolaceDev reusable workflow; uses concurrency group with cancel-in-progress to supersede stale runs."
-    },
-    {
       "id": "pipeline:.github/workflows/fossa-scan.yaml",
       "type": "pipeline",
       "name": "fossa-scan.yaml",
@@ -6772,22 +5215,6 @@
       ],
       "complexity": "moderate",
       "languageNotes": "Costs API credits per run so is deliberately workflow_dispatch-only; binds dispatch inputs to env vars to avoid GitHub script-injection patterns."
-    },
-    {
-      "id": "pipeline:.github/workflows/release.yml",
-      "type": "pipeline",
-      "name": "release.yml",
-      "filePath": ".github/workflows/release.yml",
-      "summary": "Release workflow triggered on v* tags: reruns the build-and-test suite, runs FOSSA, cross-compiles Go binaries for linux/darwin amd64/arm64, builds and pushes a multi-arch Docker image to GHCR, then publishes a GitHub Release with archives and checksums.",
-      "tags": [
-        "ci-cd",
-        "deployment",
-        "release",
-        "containerization",
-        "build-system"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Uses a build matrix for cross-platform Go binaries and docker buildx for multi-arch images; release job fans in on binaries, docker, and FOSSA."
     },
     {
       "id": "pipeline:.github/workflows/transition_on_merge.yaml",
@@ -7010,20 +5437,6 @@
       "complexity": "simple"
     },
     {
-      "id": "config:.claude/settings.json",
-      "type": "config",
-      "name": "settings.json",
-      "filePath": ".claude/settings.json",
-      "summary": "Project-level Claude Code settings enabling the understand-anything plugin for the repository.",
-      "tags": [
-        "configuration",
-        "claude-code",
-        "plugin",
-        "tooling"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "config:.fossa.yml",
       "type": "config",
       "name": ".fossa.yml",
@@ -7048,34 +5461,6 @@
         "linting",
         "build-system",
         "golang"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "document:CHANGELOG.md",
-      "type": "document",
-      "name": "CHANGELOG.md",
-      "filePath": "CHANGELOG.md",
-      "summary": "Keep-a-Changelog release history from 0.0.1 through 0.5.0 plus an Unreleased section, grouping changes under Added/Changed/Removed/Fixed/Security with versioning and release-process notes.",
-      "tags": [
-        "documentation",
-        "changelog",
-        "release",
-        "versioning"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "document:CLAUDE.md",
-      "type": "document",
-      "name": "CLAUDE.md",
-      "filePath": "CLAUDE.md",
-      "summary": "Project instructions for Claude Code covering the build/test/e2e commands, how to add a tool (composite YAML vs native Go), kebab-case tool naming, and the pre-commit log-security check.",
-      "tags": [
-        "documentation",
-        "development",
-        "conventions",
-        "entry-point"
       ],
       "complexity": "simple"
     },
@@ -7209,34 +5594,6 @@
       "complexity": "simple"
     },
     {
-      "id": "document:README.md",
-      "type": "document",
-      "name": "README.md",
-      "filePath": "README.md",
-      "summary": "Primary project documentation covering overview, features, architecture, the tool catalog, prerequisites, quickstart/binary/Docker deployment, client connection (Claude Code, SAM), development setup, CI, security, and disclaimer.",
-      "tags": [
-        "documentation",
-        "entry-point",
-        "overview",
-        "deployment"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "document:RELEASING.md",
-      "type": "document",
-      "name": "RELEASING.md",
-      "filePath": "RELEASING.md",
-      "summary": "Release engineering guide describing SemVer versioning, distribution pointers, release gates, the implemented cut/runbook/rollback process, and planned DORA metrics.",
-      "tags": [
-        "documentation",
-        "release",
-        "process",
-        "versioning"
-      ],
-      "complexity": "moderate"
-    },
-    {
       "id": "document:THIRD_PARTY_LICENSES.md",
       "type": "document",
       "name": "THIRD_PARTY_LICENSES.md",
@@ -7290,34 +5647,6 @@
         "scratch"
       ],
       "complexity": "simple"
-    },
-    {
-      "id": "config:go.mod",
-      "type": "config",
-      "name": "go.mod",
-      "filePath": "go.mod",
-      "summary": "Go module definition declaring the module path, Go version, and direct/indirect dependency requirements for the MCP server.",
-      "tags": [
-        "configuration",
-        "dependencies",
-        "golang",
-        "build-system"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "config:go.sum",
-      "type": "config",
-      "name": "go.sum",
-      "filePath": "go.sum",
-      "summary": "Cryptographic checksums pinning the exact versions of all Go module dependencies for reproducible, verifiable builds.",
-      "tags": [
-        "configuration",
-        "dependencies",
-        "golang",
-        "security"
-      ],
-      "complexity": "moderate"
     },
     {
       "id": "document:sweep-notes.md",
@@ -7527,7 +5856,7 @@
       "type": "config",
       "name": "configmap.yaml",
       "filePath": "deploy/kubernetes/configmap.yaml",
-      "summary": "Kubernetes ConfigMap holding the MCP server's config.yaml — port, OAuth client auth, SEMP tuning, and broker connection settings with ${VAR} credential references resolved from the Secret at runtime.",
+      "summary": "Kubernetes ConfigMap holding the MCP server's config.yaml \u2014 port, OAuth client auth, SEMP tuning, and broker connection settings with ${VAR} credential references resolved from the Secret at runtime.",
       "tags": [
         "configuration",
         "infrastructure",
@@ -7641,34 +5970,6 @@
       "complexity": "moderate"
     },
     {
-      "id": "document:docs/tools-reference.md",
-      "type": "document",
-      "name": "tools-reference.md",
-      "filePath": "docs/tools-reference.md",
-      "summary": "Comprehensive reference for every MCP tool the server exposes, grouped by category (discovery, broker status, replication, VPNs, queues, clients, RDPs, discards, action tools, and management).",
-      "tags": [
-        "documentation",
-        "reference",
-        "tools",
-        "api-schema"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "document:docs/user-guide.md",
-      "type": "document",
-      "name": "user-guide.md",
-      "filePath": "docs/user-guide.md",
-      "summary": "End-user guide covering prerequisites, limitations, quick start, tools reference, recommended environments, deployment targets, and troubleshooting including health-check endpoints.",
-      "tags": [
-        "documentation",
-        "entry-point",
-        "user-guide",
-        "getting-started"
-      ],
-      "complexity": "complex"
-    },
-    {
       "id": "document:docs/internal/architecture.md",
       "type": "document",
       "name": "architecture.md",
@@ -7741,21 +6042,6 @@
         "backlog",
         "tracking",
         "gaps"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "document:docs/internal/understand-anything.md",
-      "type": "document",
-      "name": "understand-anything.md",
-      "filePath": "docs/internal/understand-anything.md",
-      "summary": "Quick-start guide for the Understand-Anything knowledge graph tooling, explaining how to view the graph, regenerate or update it as a maintainer, and what artifacts are committed versus generated.",
-      "tags": [
-        "documentation",
-        "tooling",
-        "knowledge-graph",
-        "getting-started",
-        "onboarding"
       ],
       "complexity": "moderate"
     },
@@ -7913,54 +6199,6 @@
         "planning"
       ],
       "complexity": "moderate"
-    },
-    {
-      "id": "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-action-extended.json",
-      "type": "schema",
-      "name": "semp-v2-swagger-private-action-extended.json",
-      "filePath": "internal/semp/sempv2/specs/semp-v2-swagger-private-action-extended.json",
-      "summary": "SEMP v2 Swagger 2.0 spec for the private Action API (basePath /SEMP/v2/__private_action__), defining 123 action endpoints and 192 object definitions used to drive imperative broker operations.",
-      "tags": [
-        "schema-definition",
-        "api-schema",
-        "sempv2",
-        "swagger",
-        "action"
-      ],
-      "complexity": "complex",
-      "languageNotes": "OpenAPI/Swagger 2.0 spec; the smallest of the three private SEMP surfaces, scoped to action (POST-style) operations."
-    },
-    {
-      "id": "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-config-extended.json",
-      "type": "schema",
-      "name": "semp-v2-swagger-private-config-extended.json",
-      "filePath": "internal/semp/sempv2/specs/semp-v2-swagger-private-config-extended.json",
-      "summary": "SEMP v2 Swagger 2.0 spec for the private Config API (basePath /SEMP/v2/__private_config__), defining 195 configuration endpoints and 475 object definitions for creating and modifying broker configuration.",
-      "tags": [
-        "schema-definition",
-        "api-schema",
-        "sempv2",
-        "swagger",
-        "config"
-      ],
-      "complexity": "complex",
-      "languageNotes": "OpenAPI/Swagger 2.0 spec; the config surface exposes full CRUD over broker objects such as VPNs, queues, and clients."
-    },
-    {
-      "id": "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-monitor-extended.json",
-      "type": "schema",
-      "name": "semp-v2-swagger-private-monitor-extended.json",
-      "filePath": "internal/semp/sempv2/specs/semp-v2-swagger-private-monitor-extended.json",
-      "summary": "SEMP v2 Swagger 2.0 spec for the private Monitor API (basePath /SEMP/v2/__private_monitor__), defining 256 read-only monitoring endpoints and 860 object definitions for observing broker state and statistics.",
-      "tags": [
-        "schema-definition",
-        "api-schema",
-        "sempv2",
-        "swagger",
-        "monitor"
-      ],
-      "complexity": "complex",
-      "languageNotes": "OpenAPI/Swagger 2.0 spec; the largest of the three surfaces, providing read-only status and metrics endpoints."
     },
     {
       "id": "config:internal/tools/sempv1/brokerstatus/testdata/show_hardware_details_appliance.xml",
@@ -8295,22 +6533,6 @@
       "complexity": "simple"
     },
     {
-      "id": "config:internal/composite/definitions/tools.yaml",
-      "type": "config",
-      "name": "tools.yaml",
-      "filePath": "internal/composite/definitions/tools.yaml",
-      "summary": "Embedded YAML definitions for composite MCP tools, declaring multi-step SEMPv2 calls, templates, and pagination for the broker monitoring/management tools exposed by the server.",
-      "tags": [
-        "configuration",
-        "tool-definition",
-        "composite",
-        "semp",
-        "mcp"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Embedded at build time; declarative tool definitions that avoid native Go handlers for most SEMPv2 tools."
-    },
-    {
       "id": "file:internal/observability/schema/version.go",
       "type": "file",
       "name": "version.go",
@@ -8533,73 +6755,3836 @@
         "io"
       ],
       "complexity": "simple"
+    },
+    {
+      "id": "file:internal/tools/errors.go",
+      "type": "file",
+      "name": "errors.go",
+      "filePath": "internal/tools/errors.go",
+      "summary": "Builds sanitized, user-facing error results and messages for MCP tool calls, mapping SEMPv1/SEMPv2/token-exchange errors to hints and a retryable flag, and redacting broker hostnames and IP addresses from error text.",
+      "tags": [
+        "error-handling",
+        "sanitization",
+        "tool",
+        "serialization",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses errors.As/errors.Is type-switching over wrapped error chains and precompiled regexps to scrub host/IP details."
+    },
+    {
+      "id": "function:internal/tools/errors.go:buildErrorResult",
+      "type": "function",
+      "name": "buildErrorResult",
+      "filePath": "internal/tools/errors.go",
+      "lineRange": [
+        104,
+        158
+      ],
+      "summary": "Constructs a structured MCP error result from an error, attaching a hint, a retryable flag, and broker-specific structured fields for token-exchange failures.",
+      "tags": [
+        "error-handling",
+        "factory",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors.go:buildErrorMessage",
+      "type": "function",
+      "name": "buildErrorMessage",
+      "filePath": "internal/tools/errors.go",
+      "lineRange": [
+        173,
+        226
+      ],
+      "summary": "Produces a sanitized human-readable error message, dispatching on the underlying error type (token-exchange, SEMPv1, SEMPv2) to build the appropriate text.",
+      "tags": [
+        "error-handling",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors.go:buildSEMPv1Message",
+      "type": "function",
+      "name": "buildSEMPv1Message",
+      "filePath": "internal/tools/errors.go",
+      "lineRange": [
+        238,
+        273
+      ],
+      "summary": "Formats a SEMPv1-specific error message, incorporating sanitized broker text.",
+      "tags": [
+        "error-handling",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors.go:buildSEMPv2Message",
+      "type": "function",
+      "name": "buildSEMPv2Message",
+      "filePath": "internal/tools/errors.go",
+      "lineRange": [
+        275,
+        290
+      ],
+      "summary": "Formats a SEMPv2-specific error message, incorporating sanitized broker text.",
+      "tags": [
+        "error-handling",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tools/errors.go:isRetryable",
+      "type": "function",
+      "name": "isRetryable",
+      "filePath": "internal/tools/errors.go",
+      "lineRange": [
+        297,
+        314
+      ],
+      "summary": "Determines whether an error is retryable by inspecting resilience, SEMPv1, and SEMPv2 error types in the wrapped chain.",
+      "tags": [
+        "error-handling",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tools/errors_test.go",
+      "type": "file",
+      "name": "errors_test.go",
+      "filePath": "internal/tools/errors_test.go",
+      "summary": "Unit tests covering broker-text sanitization, error retryability classification, SEMPv1/SEMPv2 message formatting, and structured error-result fields for token-exchange failures.",
+      "tags": [
+        "test",
+        "error-handling",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/tools/errors_test.go:TestSanitizeBrokerText",
+      "type": "function",
+      "name": "TestSanitizeBrokerText",
+      "filePath": "internal/tools/errors_test.go",
+      "lineRange": [
+        29,
+        69
+      ],
+      "summary": "Table-driven test verifying broker hostname and IPv4/IPv6 redaction in sanitizeBrokerText.",
+      "tags": [
+        "test",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors_test.go:TestIsRetryable",
+      "type": "function",
+      "name": "TestIsRetryable",
+      "filePath": "internal/tools/errors_test.go",
+      "lineRange": [
+        71,
+        127
+      ],
+      "summary": "Table-driven test asserting retryability classification across resilience, SEMPv1, SEMPv2, and plain errors.",
+      "tags": [
+        "test",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors_test.go:TestBuildSEMPv2Message",
+      "type": "function",
+      "name": "TestBuildSEMPv2Message",
+      "filePath": "internal/tools/errors_test.go",
+      "lineRange": [
+        129,
+        158
+      ],
+      "summary": "Verifies SEMPv2 error message formatting and broker-text sanitization.",
+      "tags": [
+        "test",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors_test.go:TestBuildSEMPv1Message",
+      "type": "function",
+      "name": "TestBuildSEMPv1Message",
+      "filePath": "internal/tools/errors_test.go",
+      "lineRange": [
+        160,
+        196
+      ],
+      "summary": "Verifies SEMPv1 error message formatting and broker-text sanitization.",
+      "tags": [
+        "test",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors_test.go:TestBuildErrorMessage",
+      "type": "function",
+      "name": "TestBuildErrorMessage",
+      "filePath": "internal/tools/errors_test.go",
+      "lineRange": [
+        198,
+        325
+      ],
+      "summary": "Exercises buildErrorMessage across error types, checking sanitized output and hint selection.",
+      "tags": [
+        "test",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tools/errors_test.go:TestBuildErrorResult_ExchangeError_StructuredFields",
+      "type": "function",
+      "name": "TestBuildErrorResult_ExchangeError_StructuredFields",
+      "filePath": "internal/tools/errors_test.go",
+      "lineRange": [
+        327,
+        375
+      ],
+      "summary": "Asserts that token-exchange errors produce the expected structured fields in the error result.",
+      "tags": [
+        "test",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/semp/resilience/retry.go",
+      "type": "file",
+      "name": "retry.go",
+      "filePath": "internal/semp/resilience/retry.go",
+      "summary": "Retry-decision logic for the resilient HTTP sender: context helpers marking requests retry-safe and the CheckRetry policy that bounds retries per failure class (401 re-auth, 5xx, 429/503 backoff, transient/connection errors).",
+      "tags": [
+        "retry",
+        "resilience",
+        "http-client",
+        "policy",
+        "context",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses unexported context key structs to carry per-request retry state through the retryablehttp callback chain."
+    },
+    {
+      "id": "function:internal/semp/resilience/retry.go:WithRetrySafe",
+      "type": "function",
+      "name": "WithRetrySafe",
+      "filePath": "internal/semp/resilience/retry.go",
+      "lineRange": [
+        56,
+        58
+      ],
+      "summary": "Returns a context marking the request as safe to retry, e.g. read-only SEMPv1 show commands that travel over POST.",
+      "tags": [
+        "retry",
+        "context",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/resilience/retry.go:checkRetry",
+      "type": "function",
+      "name": "checkRetry",
+      "filePath": "internal/semp/resilience/retry.go",
+      "lineRange": [
+        91,
+        185
+      ],
+      "summary": "retryablehttp CheckRetry callback deciding whether to retry a response, capping retries per failure class and handling 401 re-auth, 5xx, and transient/connection errors.",
+      "tags": [
+        "retry",
+        "policy",
+        "http-client",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:internal/semp/resilience/sender.go",
+      "type": "file",
+      "name": "sender.go",
+      "filePath": "internal/semp/resilience/sender.go",
+      "summary": "Resilient HTTP sender wrapping go-retryablehttp with per-broker rate limiting, semaphore-bounded concurrency, authenticator-driven 401 re-auth, and overall retry-chain deadline bounding.",
+      "tags": [
+        "resilience",
+        "http-client",
+        "retry",
+        "rate-limiting",
+        "service",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:internal/semp/resilience/sender.go:RetriesExhaustedError",
+      "type": "class",
+      "name": "RetriesExhaustedError",
+      "filePath": "internal/semp/resilience/sender.go",
+      "lineRange": [
+        19,
+        23
+      ],
+      "summary": "Typed error returned when all retry attempts are exhausted, carrying the last status code, attempt count, and wrapped cause.",
+      "tags": [
+        "error-handling",
+        "type-definition",
+        "resilience"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/semp/resilience/sender.go:Sender",
+      "type": "class",
+      "name": "Sender",
+      "filePath": "internal/semp/resilience/sender.go",
+      "lineRange": [
+        42,
+        50
+      ],
+      "summary": "Per-broker resilient HTTP sender coordinating retries, rate limiting, a concurrency semaphore, and authentication.",
+      "tags": [
+        "resilience",
+        "http-client",
+        "service",
+        "retry"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/resilience/sender.go:New",
+      "type": "function",
+      "name": "New",
+      "filePath": "internal/semp/resilience/sender.go",
+      "lineRange": [
+        67,
+        153
+      ],
+      "summary": "Constructs a Sender, wiring the retryablehttp client (CheckRetry/ErrorHandler/PrepareRetry callbacks), rate limiter, and semaphore; panics on nil authenticator or semaphore.",
+      "tags": [
+        "factory",
+        "constructor",
+        "resilience",
+        "http-client"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/resilience/sender.go:Do",
+      "type": "function",
+      "name": "Do",
+      "filePath": "internal/semp/resilience/sender.go",
+      "lineRange": [
+        159,
+        235
+      ],
+      "summary": "Sends an HTTP request through the per-broker rate limiter and retry client, enforcing context cancellation and the overall retry-chain deadline.",
+      "tags": [
+        "http-client",
+        "retry",
+        "rate-limiting",
+        "resilience"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/resilience/sender.go:errorHandler",
+      "type": "function",
+      "name": "errorHandler",
+      "filePath": "internal/semp/resilience/sender.go",
+      "lineRange": [
+        287,
+        339
+      ],
+      "summary": "retryablehttp ErrorHandler producing a typed RetriesExhaustedError from the final response or transport error once retries are exhausted.",
+      "tags": [
+        "error-handling",
+        "retry",
+        "resilience"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/semp/resilience/sender_test.go",
+      "type": "file",
+      "name": "sender_test.go",
+      "filePath": "internal/semp/resilience/sender_test.go",
+      "summary": "Extensive unit tests for the resilient Sender covering retry policy per status class, rate limiting, per-broker semaphore enforcement, 401 re-auth behavior, and deadline bounding.",
+      "tags": [
+        "test",
+        "resilience",
+        "retry",
+        "http-client"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:internal/semp/sempv2/client.go",
+      "type": "file",
+      "name": "client.go",
+      "filePath": "internal/semp/sempv2/client.go",
+      "summary": "SEMPv2 HTTP client that builds and executes broker management/monitoring operations: URL/path templating, CSV query-param encoding, request construction, auth, and typed SEMP error parsing.",
+      "tags": [
+        "http-client",
+        "api-handler",
+        "sempv2",
+        "serialization",
+        "service",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements slog.LogValuer (LogValue) to emit structured, redaction-safe log fields for the client."
+    },
+    {
+      "id": "class:internal/semp/sempv2/client.go:Client",
+      "type": "class",
+      "name": "Client",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        25,
+        27
+      ],
+      "summary": "Public interface for executing a SEMPv2 operation against a broker.",
+      "tags": [
+        "type-definition",
+        "api-handler",
+        "sempv2"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/semp/sempv2/client.go:SEMPError",
+      "type": "class",
+      "name": "SEMPError",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        39,
+        46
+      ],
+      "summary": "Typed error capturing a SEMPv2 error response (operation, status, SEMP code/status, description, body) with a formatted Error message.",
+      "tags": [
+        "error-handling",
+        "type-definition",
+        "sempv2"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/semp/sempv2/client.go:HTTPClient",
+      "type": "class",
+      "name": "HTTPClient",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        63,
+        67
+      ],
+      "summary": "Concrete SEMPv2 client holding the resilient sender, base URL, and authenticator; builds URLs/requests, executes operations, and exposes structured log values.",
+      "tags": [
+        "http-client",
+        "api-handler",
+        "sempv2",
+        "service"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/sempv2/client.go:NewHTTPClient",
+      "type": "function",
+      "name": "NewHTTPClient",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        98,
+        124
+      ],
+      "summary": "Constructs an HTTPClient from broker/SEMP config, semaphore, authenticator, and cookie jar, building the base URL and resilient sender.",
+      "tags": [
+        "factory",
+        "constructor",
+        "http-client",
+        "sempv2"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/client.go:Execute",
+      "type": "function",
+      "name": "Execute",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        134,
+        182
+      ],
+      "summary": "Executes a SEMPv2 operation: builds URL and request, applies auth and correlation headers, sends via the resilient Sender, and parses the response or SEMP error.",
+      "tags": [
+        "api-handler",
+        "http-client",
+        "sempv2",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/sempv2/client.go:buildURL",
+      "type": "function",
+      "name": "buildURL",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        189,
+        218
+      ],
+      "summary": "Builds the request URL for an operation by substituting path parameters into the templated path and validating that all placeholders are filled.",
+      "tags": [
+        "url-building",
+        "sempv2",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/client.go:unfilledPlaceholders",
+      "type": "function",
+      "name": "unfilledPlaceholders",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        223,
+        243
+      ],
+      "summary": "Scans a templated path for unsubstituted placeholders, returning de-duplicated missing parameter names.",
+      "tags": [
+        "validation",
+        "url-building",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/client.go:buildRequest",
+      "type": "function",
+      "name": "buildRequest",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        247,
+        316
+      ],
+      "summary": "Constructs the HTTP request for a SEMPv2 operation, encoding query parameters (including CSV arrays), request body, and headers.",
+      "tags": [
+        "http-client",
+        "serialization",
+        "sempv2",
+        "request-building"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/sempv2/client.go:encodeCSVQueryParam",
+      "type": "function",
+      "name": "encodeCSVQueryParam",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        323,
+        346
+      ],
+      "summary": "Encodes an array-valued query parameter into a trimmed, empty-dropped CSV string.",
+      "tags": [
+        "serialization",
+        "query-params",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/client.go:parseSEMPError",
+      "type": "function",
+      "name": "parseSEMPError",
+      "filePath": "internal/semp/sempv2/client.go",
+      "lineRange": [
+        394,
+        417
+      ],
+      "summary": "Parses a SEMPv2 error response body into a typed SEMPError, tolerating malformed or partial metadata.",
+      "tags": [
+        "error-handling",
+        "deserialization",
+        "sempv2"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/semp/sempv2/client_test.go",
+      "type": "file",
+      "name": "client_test.go",
+      "filePath": "internal/semp/sempv2/client_test.go",
+      "summary": "Comprehensive unit tests for the SEMPv2 HTTPClient covering path/query encoding, request bodies, auth modes, SEMP error parsing, TLS wiring, transport pooling, and timeouts.",
+      "tags": [
+        "test",
+        "http-client",
+        "sempv2",
+        "api-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:cmd/server/main.go",
+      "type": "file",
+      "name": "main.go",
+      "filePath": "cmd/server/main.go",
+      "summary": "Server entry point that bootstraps configuration, broker pool, tool manager, OAuth token exchange, authorization, observability, and the HTTP MCP server with graceful shutdown.",
+      "tags": [
+        "entry-point",
+        "bootstrap",
+        "http-server",
+        "lifecycle",
+        "mcp-server",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Large main() orchestrates dependency wiring; helper functions isolate mux construction, TLS listener startup, and signal-driven drain/shutdown."
+    },
+    {
+      "id": "function:cmd/server/main.go:redactSecretAttr",
+      "type": "function",
+      "name": "redactSecretAttr",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        65,
+        74
+      ],
+      "summary": "slog ReplaceAttr hook that redacts attribute values whose key names look like secrets.",
+      "tags": [
+        "logging",
+        "security",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:newSlogHandler",
+      "type": "function",
+      "name": "newSlogHandler",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        86,
+        102
+      ],
+      "summary": "Builds the structured JSON slog handler with secret redaction and optional correlation-id enrichment.",
+      "tags": [
+        "logging",
+        "observability",
+        "factory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:buildMux",
+      "type": "function",
+      "name": "buildMux",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        111,
+        137
+      ],
+      "summary": "Constructs the HTTP ServeMux wiring liveness, health, and readiness probe endpoints.",
+      "tags": [
+        "http-server",
+        "health",
+        "routing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:healthConfigFromFile",
+      "type": "function",
+      "name": "healthConfigFromFile",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        167,
+        196
+      ],
+      "summary": "Reads optional health-probe port and scheme configuration from a YAML file.",
+      "tags": [
+        "config",
+        "health",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:limitRequestBody",
+      "type": "function",
+      "name": "limitRequestBody",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        221,
+        230
+      ],
+      "summary": "HTTP middleware that caps request body size using http.MaxBytesReader.",
+      "tags": [
+        "middleware",
+        "http-server",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:startServer",
+      "type": "function",
+      "name": "startServer",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        259,
+        279
+      ],
+      "summary": "Launches the HTTP(S) listener in a goroutine, reporting fatal errors on a channel.",
+      "tags": [
+        "http-server",
+        "lifecycle",
+        "concurrency"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:drainAndShutdown",
+      "type": "function",
+      "name": "drainAndShutdown",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        312,
+        329
+      ],
+      "summary": "Marks readiness as draining, waits a drain delay, then gracefully shuts down or force-closes on a second signal.",
+      "tags": [
+        "lifecycle",
+        "shutdown",
+        "http-server"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:gracefulShutdown",
+      "type": "function",
+      "name": "gracefulShutdown",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        390,
+        410
+      ],
+      "summary": "Attempts graceful server shutdown within a timeout, force-closing the server on failure.",
+      "tags": [
+        "lifecycle",
+        "shutdown",
+        "http-server"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:newTokenExchanger",
+      "type": "function",
+      "name": "newTokenExchanger",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        456,
+        494
+      ],
+      "summary": "Builds the OAuth token exchanger with a retrying HTTP client and token cache from configuration.",
+      "tags": [
+        "oauth",
+        "token-exchange",
+        "factory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:cmd/server/main.go:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        526,
+        894
+      ],
+      "summary": "Server entry point wiring config, broker pool, tools, auth, token exchange, observability, and signal-driven lifecycle.",
+      "tags": [
+        "entry-point",
+        "bootstrap",
+        "lifecycle"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:cmd/server/main.go:shutdowner",
+      "type": "class",
+      "name": "shutdowner",
+      "filePath": "cmd/server/main.go",
+      "lineRange": [
+        363,
+        366
+      ],
+      "summary": "Interface abstracting Shutdown and Close, letting shutdown helpers accept either the real server or a test double.",
+      "tags": [
+        "interface",
+        "lifecycle",
+        "abstraction"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "type": "file",
+      "name": "list_bridges_test.go",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "summary": "Unit tests for the ListBridges post-process handler covering counts, failure-state classification, truncation, empty/error inputs, and missing/nil field handling.",
+      "tags": [
+        "test",
+        "unit-test",
+        "post-processing",
+        "bridges"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_Counts",
+      "type": "function",
+      "name": "TestListBridges_Counts",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        32,
+        64
+      ],
+      "summary": "Verifies aggregate up/down and directional counts across a mix of bridge states.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_OutboundOnlyFailure",
+      "type": "function",
+      "name": "TestListBridges_OutboundOnlyFailure",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        69,
+        85
+      ],
+      "summary": "Checks a bridge with only an outbound failure is classified as down.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_OutboundOnlyFailureWithStaleInboundReason",
+      "type": "function",
+      "name": "TestListBridges_OutboundOnlyFailureWithStaleInboundReason",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        94,
+        111
+      ],
+      "summary": "Ensures a stale inbound failure reason does not misclassify an outbound-only failure.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_UnidirectionalNotApplicableIsHealthy",
+      "type": "function",
+      "name": "TestListBridges_UnidirectionalNotApplicableIsHealthy",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        116,
+        128
+      ],
+      "summary": "Confirms a not-applicable direction on a unidirectional bridge counts as healthy.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_TruncationSurfaced",
+      "type": "function",
+      "name": "TestListBridges_TruncationSurfaced",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        130,
+        157
+      ],
+      "summary": "Asserts truncation of the bridge list is surfaced in the result.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_Empty",
+      "type": "function",
+      "name": "TestListBridges_Empty",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        162,
+        187
+      ],
+      "summary": "Handles an empty bridge list without error.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_Errors",
+      "type": "function",
+      "name": "TestListBridges_Errors",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        189,
+        219
+      ],
+      "summary": "Validates error propagation for malformed inputs.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_MissingField",
+      "type": "function",
+      "name": "TestListBridges_MissingField",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        224,
+        260
+      ],
+      "summary": "Handles bridges with missing fields gracefully.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_NilField",
+      "type": "function",
+      "name": "TestListBridges_NilField",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        264,
+        278
+      ],
+      "summary": "Handles nil field values in bridge data.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_SkippedOmittedWhenZero",
+      "type": "function",
+      "name": "TestListBridges_SkippedOmittedWhenZero",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges_test.go",
+      "lineRange": [
+        282,
+        292
+      ],
+      "summary": "Ensures the skipped count is omitted from output when zero.",
+      "tags": [
+        "test",
+        "unit-test",
+        "bridges"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:internal/idpclient/retrying.go",
+      "type": "file",
+      "name": "retrying.go",
+      "filePath": "internal/idpclient/retrying.go",
+      "summary": "Wraps an HTTP client with automatic retry and exponential backoff (via retryablehttp) for IdP calls, retrying on 5xx and 429 while honoring context cancellation, plus an attempt counter for observability.",
+      "tags": [
+        "http-client",
+        "retry",
+        "resilience",
+        "idp",
+        "observability",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses a context key and a RoundTripper wrapper (attemptsRecorder) to count retry attempts without changing the client interface."
+    },
+    {
+      "id": "function:internal/idpclient/retrying.go:NewRetryingHTTPClient",
+      "type": "function",
+      "name": "NewRetryingHTTPClient",
+      "filePath": "internal/idpclient/retrying.go",
+      "lineRange": [
+        72,
+        97
+      ],
+      "summary": "Builds an HTTP client with retry/backoff on 5xx and 429 responses using retryablehttp.",
+      "tags": [
+        "http-client",
+        "retry",
+        "factory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying.go:checkRetry",
+      "type": "function",
+      "name": "checkRetry",
+      "filePath": "internal/idpclient/retrying.go",
+      "lineRange": [
+        102,
+        122
+      ],
+      "summary": "Retry policy deciding whether a response or error warrants another attempt, aborting on context cancellation.",
+      "tags": [
+        "retry",
+        "resilience",
+        "policy"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying.go:WithAttemptsCounter",
+      "type": "function",
+      "name": "WithAttemptsCounter",
+      "filePath": "internal/idpclient/retrying.go",
+      "lineRange": [
+        142,
+        146
+      ],
+      "summary": "Attaches a retry-attempt counter to a context for later inspection.",
+      "tags": [
+        "observability",
+        "context",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying.go:RoundTrip",
+      "type": "function",
+      "name": "RoundTrip",
+      "filePath": "internal/idpclient/retrying.go",
+      "lineRange": [
+        156,
+        161
+      ],
+      "summary": "attemptsRecorder RoundTripper that increments the context attempt counter per request.",
+      "tags": [
+        "http-client",
+        "observability",
+        "middleware"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/idpclient/retrying.go:RetryOptions",
+      "type": "class",
+      "name": "RetryOptions",
+      "filePath": "internal/idpclient/retrying.go",
+      "lineRange": [
+        34,
+        45
+      ],
+      "summary": "Configuration struct for maximum retries and minimum/maximum backoff wait durations.",
+      "tags": [
+        "type-definition",
+        "config",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:internal/idpclient/retrying_test.go",
+      "type": "file",
+      "name": "retrying_test.go",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "summary": "Unit tests for the retrying HTTP client verifying retry behavior on 5xx/429, no-retry on 2xx/4xx, recovery, context-cancellation backoff abort, connection-error retries, and the attempts-counter RoundTripper.",
+      "tags": [
+        "test",
+        "unit-test",
+        "http-client",
+        "retry"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_RetriesOn5xx",
+      "type": "function",
+      "name": "TestNewRetryingHTTPClient_RetriesOn5xx",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        65,
+        95
+      ],
+      "summary": "Verifies the client retries on 5xx responses up to the configured maximum.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_RetriesOn429",
+      "type": "function",
+      "name": "TestNewRetryingHTTPClient_RetriesOn429",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        105,
+        134
+      ],
+      "summary": "Verifies the client retries on HTTP 429 Too Many Requests.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_NoRetryOn2xx",
+      "type": "function",
+      "name": "TestNewRetryingHTTPClient_NoRetryOn2xx",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        138,
+        159
+      ],
+      "summary": "Confirms no retry occurs for successful 2xx responses.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_NoRetryOn4xx",
+      "type": "function",
+      "name": "TestNewRetryingHTTPClient_NoRetryOn4xx",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        167,
+        206
+      ],
+      "summary": "Confirms 4xx client errors (other than 429) are not retried.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_RetriesRecover",
+      "type": "function",
+      "name": "TestNewRetryingHTTPClient_RetriesRecover",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        210,
+        241
+      ],
+      "summary": "Checks a request succeeds after transient failures recover.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_CtxCancelAbortsBackoff",
+      "type": "function",
+      "name": "TestNewRetryingHTTPClient_CtxCancelAbortsBackoff",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        247,
+        291
+      ],
+      "summary": "Ensures context cancellation aborts pending backoff without further attempts.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_ConnectionErrorRetries",
+      "type": "function",
+      "name": "TestNewRetryingHTTPClient_ConnectionErrorRetries",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        296,
+        323
+      ],
+      "summary": "Verifies connection errors trigger retries.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestAttemptsRecorder_NilSafe",
+      "type": "function",
+      "name": "TestAttemptsRecorder_NilSafe",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        351,
+        361
+      ],
+      "summary": "Ensures the attempts recorder is safe when no counter is attached to the context.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestAttemptsRecorder_IncrementsWhenAttached",
+      "type": "function",
+      "name": "TestAttemptsRecorder_IncrementsWhenAttached",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        366,
+        377
+      ],
+      "summary": "Verifies the attempt counter increments when attached to the context.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/idpclient/retrying_test.go:TestCheckRetry_Table",
+      "type": "function",
+      "name": "TestCheckRetry_Table",
+      "filePath": "internal/idpclient/retrying_test.go",
+      "lineRange": [
+        382,
+        431
+      ],
+      "summary": "Table-driven tests for the checkRetry policy across status codes, errors, and cancellation.",
+      "tags": [
+        "test",
+        "unit-test",
+        "retry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "file",
+      "name": "circuitbreaker.go",
+      "filePath": "internal/tokenexchange/circuitbreaker.go",
+      "summary": "Builds and tunes the process-wide gobreaker circuit breaker guarding IdP token exchange, and classifies each error as a breaker success, failure, or excluded outcome (rate limits and config faults never count against the failure rate).",
+      "tags": [
+        "circuit-breaker",
+        "resilience",
+        "token-exchange",
+        "error-handling",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the generic gobreaker/v2 CircuitBreaker[*Token]; failure classification funnels through errors.Is/errors.As on the ExchangeError chain."
+    },
+    {
+      "id": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "file",
+      "name": "circuitbreaker_exchange_test.go",
+      "filePath": "internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "summary": "Integration tests exercising the circuit breaker through the real Exchange path: one-logical-operation counting, singleflight collapse, open/half-open/recovery transitions, and stampede rejection against httptest IdP servers.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "integration",
+        "resilience",
+        "concurrency"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "file",
+      "name": "circuitbreaker_test.go",
+      "filePath": "internal/tokenexchange/circuitbreaker_test.go",
+      "summary": "Unit tests for the breaker classification helpers (isBreakerFailure, isBreakerExcluded, isBreakerSuccess) and the newReadyToTrip trip predicate, verifying excluded classes are never counted.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "unit-test",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:internal/tokenexchange/defaults.go",
+      "type": "file",
+      "name": "defaults.go",
+      "filePath": "internal/tokenexchange/defaults.go",
+      "summary": "Package-local retry timing knobs (per-attempt timeout, retry count, backoff bounds) and ComputeChainDeadline, which derives the overall chain deadline from those defaults or an operator override.",
+      "tags": [
+        "configuration",
+        "retry",
+        "defaults",
+        "token-exchange",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/defaults_test.go",
+      "type": "file",
+      "name": "defaults_test.go",
+      "filePath": "internal/tokenexchange/defaults_test.go",
+      "summary": "Tests for ComputeChainDeadline across input combinations and override precedence, plus a pin test locking the shipped default timing values.",
+      "tags": [
+        "test",
+        "retry",
+        "defaults",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/errors.go",
+      "type": "file",
+      "name": "errors.go",
+      "filePath": "internal/tokenexchange/errors.go",
+      "summary": "Defines ExchangeError, the structured error carrying diagnostic context (endpoint, broker, audience, HTTP status, elapsed) through the wrapping chain while guaranteeing log-safe, secret-free messages.",
+      "tags": [
+        "error-handling",
+        "type-definition",
+        "logging",
+        "security",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Implements Error/Unwrap for errors.Is compatibility and LogAttrs for structured slog output; mirrors the sempv1.Error / sempv2.SEMPError pattern."
+    },
+    {
+      "id": "file:internal/tokenexchange/errors_test.go",
+      "type": "file",
+      "name": "errors_test.go",
+      "filePath": "internal/tokenexchange/errors_test.go",
+      "summary": "Tests that ExchangeError's agent-facing messages map correctly to transient vs permanent sentinels and never leak internal detail, tokens, or secrets.",
+      "tags": [
+        "test",
+        "error-handling",
+        "security",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/exchange.go",
+      "type": "file",
+      "name": "exchange.go",
+      "filePath": "internal/tokenexchange/exchange.go",
+      "summary": "Core RFC 8693 token-exchange flow: cache-first lookup, singleflight deduplication of concurrent identical requests, circuit-breaker-protected IdP round-trip, and retry-outcome classification into structured ExchangeErrors.",
+      "tags": [
+        "token-exchange",
+        "oauth",
+        "caching",
+        "resilience",
+        "api-handler",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Combines golang.org/x/sync/singleflight, gobreaker, and a token cache; context cancellation/deadline errors are distinguished from transport failures."
+    },
+    {
+      "id": "file:internal/tokenexchange/exchange_test.go",
+      "type": "file",
+      "name": "exchange_test.go",
+      "filePath": "internal/tokenexchange/exchange_test.go",
+      "summary": "Exhaustive test suite for the Exchange path: happy path, singleflight dedup and concurrency, cache hit/miss/invalidate, retry exhaustion and recovery, chain-deadline behavior, and secret-free logging.",
+      "tags": [
+        "test",
+        "token-exchange",
+        "oauth",
+        "concurrency",
+        "caching"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:internal/tokenexchange/exchanger.go",
+      "type": "file",
+      "name": "exchanger.go",
+      "filePath": "internal/tokenexchange/exchanger.go",
+      "summary": "Declares the immutable, process-wide Exchanger struct and its New constructor that wires the token URL, client credentials, HTTP client, cache, singleflight group, and circuit breaker together.",
+      "tags": [
+        "token-exchange",
+        "factory",
+        "singleton",
+        "oauth",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Enforces a write-once invariant: all fields set in New() and never mutated, enabling lock-free concurrent reads verified by the race detector."
+    },
+    {
+      "id": "file:internal/tokenexchange/failure_class.go",
+      "type": "file",
+      "name": "failure_class.go",
+      "filePath": "internal/tokenexchange/failure_class.go",
+      "summary": "Defines the FailureClass enum that distinguishes transport sub-causes (network, upstream 5xx, rate-limited, body-read, config) sharing the ErrExchangeTransport sentinel, so the breaker can exclude rate limits and config faults.",
+      "tags": [
+        "type-definition",
+        "error-handling",
+        "circuit-breaker",
+        "enum",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "file",
+      "name": "failure_class_test.go",
+      "filePath": "internal/tokenexchange/failure_class_test.go",
+      "summary": "Tests FailureClass.String, per-status classification from IdP responses, network/body-read classification, and that LogAttrs surfaces the failure class and breaker state.",
+      "tags": [
+        "test",
+        "error-handling",
+        "circuit-breaker",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker.go:newTokenExchangeCircuitBreaker",
+      "type": "function",
+      "name": "newTokenExchangeCircuitBreaker",
+      "filePath": "internal/tokenexchange/circuitbreaker.go",
+      "lineRange": [
+        34,
+        46
+      ],
+      "summary": "Constructs the process-wide gobreaker.CircuitBreaker[*Token] from CircuitBreakerConfig, deriving the bucket period from the failure-rate window and wiring the trip predicate and state-change logger.",
+      "tags": [
+        "circuit-breaker",
+        "factory",
+        "resilience"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker.go:newReadyToTrip",
+      "type": "function",
+      "name": "newReadyToTrip",
+      "filePath": "internal/tokenexchange/circuitbreaker.go",
+      "lineRange": [
+        62,
+        77
+      ],
+      "summary": "Returns the ReadyToTrip predicate that opens the breaker once minimum request volume and the configured failure-rate threshold are both met.",
+      "tags": [
+        "circuit-breaker",
+        "resilience",
+        "policy"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker.go:isBreakerExcluded",
+      "type": "function",
+      "name": "isBreakerExcluded",
+      "filePath": "internal/tokenexchange/circuitbreaker.go",
+      "lineRange": [
+        107,
+        134
+      ],
+      "summary": "Reports whether an error is excluded from the breaker's failure accounting \u2014 context cancellation/deadline, rate limits, and config faults are not availability failures.",
+      "tags": [
+        "circuit-breaker",
+        "error-handling",
+        "classification"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker.go:isBreakerFailure",
+      "type": "function",
+      "name": "isBreakerFailure",
+      "filePath": "internal/tokenexchange/circuitbreaker.go",
+      "lineRange": [
+        148,
+        158
+      ],
+      "summary": "Decides whether an error counts as a breaker failure by inspecting its FailureClass, excluding rate-limited and config sub-causes.",
+      "tags": [
+        "circuit-breaker",
+        "error-handling",
+        "classification"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/defaults.go:ComputeChainDeadline",
+      "type": "function",
+      "name": "ComputeChainDeadline",
+      "filePath": "internal/tokenexchange/defaults.go",
+      "lineRange": [
+        125,
+        136
+      ],
+      "summary": "Derives the overall retry-chain deadline from an operator override or, when unset/invalid, from the per-attempt timeout, max backoff, and retry count.",
+      "tags": [
+        "retry",
+        "configuration",
+        "timing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/tokenexchange/errors.go:ExchangeError",
+      "type": "class",
+      "name": "ExchangeError",
+      "filePath": "internal/tokenexchange/errors.go",
+      "lineRange": [
+        43,
+        55
+      ],
+      "summary": "Structured token-exchange error carrying a sentinel plus diagnostic fields (endpoint, broker alias, audience, HTTP status, failure class, elapsed) through the wrapping chain for safe, structured logging.",
+      "tags": [
+        "error-handling",
+        "type-definition",
+        "logging",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/errors.go:AgentMessage",
+      "type": "function",
+      "name": "AgentMessage",
+      "filePath": "internal/tokenexchange/errors.go",
+      "lineRange": [
+        66,
+        75
+      ],
+      "summary": "Produces the human/agent-facing message for an ExchangeError, mapping the sentinel to guidance without leaking tokens, secrets, or IdP error descriptions.",
+      "tags": [
+        "error-handling",
+        "security",
+        "messaging"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/errors.go:LogAttrs",
+      "type": "function",
+      "name": "LogAttrs",
+      "filePath": "internal/tokenexchange/errors.go",
+      "lineRange": [
+        80,
+        107
+      ],
+      "summary": "Emits the structured slog attributes (endpoint, broker, audience, HTTP status, failure class, breaker state, elapsed) for a single per-invocation error log line.",
+      "tags": [
+        "logging",
+        "error-handling",
+        "observability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/exchange.go:Exchange",
+      "type": "function",
+      "name": "Exchange",
+      "filePath": "internal/tokenexchange/exchange.go",
+      "lineRange": [
+        32,
+        96
+      ],
+      "summary": "Performs an RFC 8693 token exchange: serves from cache on hit, otherwise collapses concurrent identical requests via singleflight into one breaker-protected IdP round-trip and caches the result.",
+      "tags": [
+        "token-exchange",
+        "oauth",
+        "caching",
+        "api-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/tokenexchange/exchange.go:runExchangeOnce",
+      "type": "function",
+      "name": "runExchangeOnce",
+      "filePath": "internal/tokenexchange/exchange.go",
+      "lineRange": [
+        119,
+        157
+      ],
+      "summary": "Executes a single deduplicated exchange attempt inside the circuit breaker, storing a successful token in the cache and mapping breaker-open into a transient error.",
+      "tags": [
+        "token-exchange",
+        "resilience",
+        "caching"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/exchange.go:Invalidate",
+      "type": "function",
+      "name": "Invalidate",
+      "filePath": "internal/tokenexchange/exchange.go",
+      "lineRange": [
+        184,
+        192
+      ],
+      "summary": "Removes the cached token for a given subject-token/broker pair so the next Exchange forces a fresh IdP round-trip.",
+      "tags": [
+        "token-exchange",
+        "caching",
+        "invalidation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/exchange.go:classifyRetryOutcome",
+      "type": "function",
+      "name": "classifyRetryOutcome",
+      "filePath": "internal/tokenexchange/exchange.go",
+      "lineRange": [
+        215,
+        263
+      ],
+      "summary": "Interprets the result of a retrying HTTP exchange, distinguishing context cancellation/deadline, retries-exhausted, and other transport failures into the appropriate structured ExchangeError.",
+      "tags": [
+        "retry",
+        "error-handling",
+        "classification"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/exchange.go:doExchange",
+      "type": "function",
+      "name": "doExchange",
+      "filePath": "internal/tokenexchange/exchange.go",
+      "lineRange": [
+        265,
+        287
+      ],
+      "summary": "Builds and sends the token-exchange HTTP request to the IdP, then parses the response into a Token or a classified failure.",
+      "tags": [
+        "token-exchange",
+        "http",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:internal/tokenexchange/exchanger.go:Exchanger",
+      "type": "class",
+      "name": "Exchanger",
+      "filePath": "internal/tokenexchange/exchanger.go",
+      "lineRange": [
+        34,
+        55
+      ],
+      "summary": "Immutable, process-wide token exchanger holding the IdP endpoint, client credentials, grant/audience config, HTTP client, cache, singleflight group, and circuit breaker; all fields are write-once for lock-free concurrent use.",
+      "tags": [
+        "token-exchange",
+        "singleton",
+        "type-definition",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/exchanger.go:New",
+      "type": "function",
+      "name": "New",
+      "filePath": "internal/tokenexchange/exchanger.go",
+      "lineRange": [
+        67,
+        109
+      ],
+      "summary": "Validates parameters and constructs an Exchanger, wiring the HTTP client, token cache, singleflight group, and circuit breaker into a single immutable instance.",
+      "tags": [
+        "token-exchange",
+        "factory",
+        "constructor"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/failure_class.go:String",
+      "type": "function",
+      "name": "String",
+      "filePath": "internal/tokenexchange/failure_class.go",
+      "lineRange": [
+        51,
+        66
+      ],
+      "summary": "Renders a FailureClass value as its stable string label for logging and diagnostics.",
+      "tags": [
+        "error-handling",
+        "logging",
+        "enum"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:internal/tokenexchange/response.go",
+      "type": "file",
+      "name": "response.go",
+      "filePath": "internal/tokenexchange/response.go",
+      "summary": "Parses and classifies the IdP's HTTP response to an RFC 8693 token exchange, mapping 2xx/4xx/5xx outcomes and body shapes to a *Token or one of the ExchangeError sentinels. Caps the body at 1 MiB and guards against non-JSON (proxy/SSO-intercepted) responses.",
+      "tags": [
+        "token-exchange",
+        "oauth",
+        "serialization",
+        "validation",
+        "http-response",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Deliberately ignores RFC 6749 error_description to avoid logging IdP-echoed unsafe content."
+    },
+    {
+      "id": "function:internal/tokenexchange/response.go:parseIdPResponse",
+      "type": "function",
+      "name": "parseIdPResponse",
+      "filePath": "internal/tokenexchange/response.go",
+      "lineRange": [
+        58,
+        105
+      ],
+      "summary": "Top-level response classifier: enforces the body-size cap and Content-Type guard, then routes 2xx to parseSuccessBody, 4xx to classifyClientError, and 3xx/5xx/429 to ErrExchangeTransport. Always closes the response body.",
+      "tags": [
+        "token-exchange",
+        "http-response",
+        "error-classification",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/response.go:parseSuccessBody",
+      "type": "function",
+      "name": "parseSuccessBody",
+      "filePath": "internal/tokenexchange/response.go",
+      "lineRange": [
+        107,
+        161
+      ],
+      "summary": "Unmarshals an RFC 8693 success body, validating required fields (access_token, bearer token_type, issued_token_type) and expires_in bounds, then builds a *Token with a skew-adjusted ExpiresAt.",
+      "tags": [
+        "token-exchange",
+        "serialization",
+        "validation",
+        "oauth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/response.go:responseMediaType",
+      "type": "function",
+      "name": "responseMediaType",
+      "filePath": "internal/tokenexchange/response.go",
+      "lineRange": [
+        163,
+        173
+      ],
+      "summary": "Extracts the bare media type from the response Content-Type header via mime.ParseMediaType, stripping parameters so the JSON guard compares cleanly.",
+      "tags": [
+        "token-exchange",
+        "http-response",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/response.go:classifyClientError",
+      "type": "function",
+      "name": "classifyClientError",
+      "filePath": "internal/tokenexchange/response.go",
+      "lineRange": [
+        187,
+        209
+      ],
+      "summary": "Classifies a 4xx body: an OAuth-shaped error JSON becomes ErrExchangeRejected (wrapping a bounded error code), anything else becomes ErrInvalidResponse to flag possible proxy/WAF interception.",
+      "tags": [
+        "token-exchange",
+        "error-classification",
+        "oauth",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/response_test.go",
+      "type": "file",
+      "name": "response_test.go",
+      "filePath": "internal/tokenexchange/response_test.go",
+      "summary": "Exhaustive table and parallel tests for the IdP response parser: body-always-closed guarantees, 1 MiB size cap, Content-Type guards, success-body field validation, expires_in overflow, and 4xx/5xx classification into the correct sentinels.",
+      "tags": [
+        "test",
+        "token-exchange",
+        "oauth",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:internal/tokenexchange/transport_error.go",
+      "type": "file",
+      "name": "transport_error.go",
+      "filePath": "internal/tokenexchange/transport_error.go",
+      "summary": "Classifies a transport-level error from httpClient.Do into a FailureClass, separating permanent operator misconfiguration (bad TLS trust/hostname, NXDOMAIN) which is excluded from the circuit breaker, from transient network faults which count against it.",
+      "tags": [
+        "token-exchange",
+        "error-classification",
+        "circuit-breaker",
+        "networking",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses errors.As against x509 and net.DNSError types; DNS timeout is deliberately kept in the network class while NXDOMAIN is treated as config."
+    },
+    {
+      "id": "function:internal/tokenexchange/transport_error.go:classifyTransportError",
+      "type": "function",
+      "name": "classifyTransportError",
+      "filePath": "internal/tokenexchange/transport_error.go",
+      "lineRange": [
+        34,
+        56
+      ],
+      "summary": "Maps a Go error from httpClient.Do to FailureClassConfig for TLS/certificate/hostname failures and NXDOMAIN, or FailureClassNetwork for all other transient faults so one operator typo cannot trip the shared breaker for every tenant.",
+      "tags": [
+        "token-exchange",
+        "error-classification",
+        "circuit-breaker",
+        "networking"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "file",
+      "name": "transport_error_test.go",
+      "filePath": "internal/tokenexchange/transport_error_test.go",
+      "summary": "Table-driven tests for classifyTransportError, asserting that TLS trust/hostname errors and NXDOMAIN map to the config class while connection and timeout faults map to the network class.",
+      "tags": [
+        "test",
+        "token-exchange",
+        "error-classification",
+        "circuit-breaker"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/types.go",
+      "type": "file",
+      "name": "types.go",
+      "filePath": "internal/tokenexchange/types.go",
+      "summary": "Core types and sentinel errors for the RFC 8693 token exchange package: the ClientAuthMethod/AudienceFormat/GrantType enums, the Params and ExchangeInput inputs, the Token result, and the ExchangeError sentinels callers classify by errors.Is.",
+      "tags": [
+        "token-exchange",
+        "oauth",
+        "type-definition",
+        "data-model"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Every credential-bearing struct implements String/GoString/LogValue to redact secrets from fmt and slog, mirroring cache.CachedCredential."
+    },
+    {
+      "id": "class:internal/tokenexchange/types.go:Params",
+      "type": "class",
+      "name": "Params",
+      "filePath": "internal/tokenexchange/types.go",
+      "lineRange": [
+        104,
+        142
+      ],
+      "summary": "Construction-time inputs to New: IdP endpoint, client credentials/auth method, grant type, audience wire format, HTTP client, token cache, chain deadline, and optional circuit-breaker config. Redacts ClientSecret through its String/LogValue implementations.",
+      "tags": [
+        "token-exchange",
+        "oauth",
+        "data-model",
+        "configuration",
+        "secure-logging"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:internal/tokenexchange/types.go:ExchangeInput",
+      "type": "class",
+      "name": "ExchangeInput",
+      "filePath": "internal/tokenexchange/types.go",
+      "lineRange": [
+        175,
+        186
+      ],
+      "summary": "Per-call inputs to Exchange: the inbound subject-token JWT, the broker alias logging label, and the per-broker audience value. Redacts SubjectToken from all fmt/slog output.",
+      "tags": [
+        "token-exchange",
+        "oauth",
+        "data-model",
+        "secure-logging"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/tokenexchange/types.go:Token",
+      "type": "class",
+      "name": "Token",
+      "filePath": "internal/tokenexchange/types.go",
+      "lineRange": [
+        211,
+        214
+      ],
+      "summary": "Result of a successful exchange: the exchanged bearer token value and a skew-adjusted ExpiresAt use-by instant. Redacts Value from all fmt/slog output.",
+      "tags": [
+        "token-exchange",
+        "oauth",
+        "data-model",
+        "secure-logging"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:internal/composite/executor.go",
+      "type": "file",
+      "name": "executor.go",
+      "filePath": "internal/composite/executor.go",
+      "summary": "Core engine that executes composite (multi-step) tool definitions against a SEMPv2 client, handling dependency-ordered batching, fan-out, pagination, argument templating, request-body construction, and result aggregation.",
+      "tags": [
+        "service",
+        "composite",
+        "orchestration",
+        "semp",
+        "pagination",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses Go text/template with panic recovery and concurrent batch execution via the safego wrapper."
+    },
+    {
+      "id": "file:internal/composite/executor_bridge_test.go",
+      "type": "file",
+      "name": "executor_bridge_test.go",
+      "filePath": "internal/composite/executor_bridge_test.go",
+      "summary": "Tests the composite executor against bridge tools, covering single-page listing, maxResults truncation, and compound path-parameter resolution for bridge status.",
+      "tags": [
+        "test",
+        "composite",
+        "bridge",
+        "semp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/composite/executor_helpers_test.go",
+      "type": "file",
+      "name": "executor_helpers_test.go",
+      "filePath": "internal/composite/executor_helpers_test.go",
+      "summary": "Shared test scaffolding for the composite executor suite: mock SEMPv2 clients (fixed, sequential, arg-capturing), sample tool operation definitions, and pagination result helpers.",
+      "tags": [
+        "test",
+        "test-fixtures",
+        "mock",
+        "composite"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Defines multiple mock client structs each satisfying the SEMPv2 client interface's Execute method."
+    },
+    {
+      "id": "file:internal/composite/executor_vpn_test.go",
+      "type": "file",
+      "name": "executor_vpn_test.go",
+      "filePath": "internal/composite/executor_vpn_test.go",
+      "summary": "End-to-end tests of the composite executor across Message VPN tools, covering status/list/rates/replication reads and create/update/delete writes including body construction, field-collision rejection, and SEMP error handling.",
+      "tags": [
+        "test",
+        "composite",
+        "message-vpn",
+        "semp",
+        "crud"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:internal/composite/loader_bridge_test.go",
+      "type": "file",
+      "name": "loader_bridge_test.go",
+      "filePath": "internal/composite/loader_bridge_test.go",
+      "summary": "Verifies the composite tool loader correctly parses and materializes the list-bridges and get-bridge-status tool definitions from embedded YAML.",
+      "tags": [
+        "test",
+        "loader",
+        "bridge",
+        "composite"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/composite/loader_cross_reference_test.go",
+      "type": "file",
+      "name": "loader_cross_reference_test.go",
+      "filePath": "internal/composite/loader_cross_reference_test.go",
+      "summary": "Guards that every list-style composite tool references a corresponding detail tool, keeping the embedded tool definitions cross-referentially consistent.",
+      "tags": [
+        "test",
+        "loader",
+        "validation",
+        "composite"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/composite/executor.go:CompositeExecutor",
+      "type": "class",
+      "name": "CompositeExecutor",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        63,
+        73
+      ],
+      "summary": "The composite tool execution engine, holding the SEMPv2 operation map and driving step batching, fan-out, pagination, and result strategy application.",
+      "tags": [
+        "service",
+        "composite",
+        "orchestration",
+        "engine"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/composite/executor.go:NewCompositeExecutor",
+      "type": "function",
+      "name": "NewCompositeExecutor",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        81,
+        86
+      ],
+      "summary": "Factory that constructs a CompositeExecutor from a map of SEMPv2 operations.",
+      "tags": [
+        "factory",
+        "constructor",
+        "composite"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/executor.go:Execute",
+      "type": "function",
+      "name": "Execute",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        94,
+        124
+      ],
+      "summary": "Entry point that runs a composite tool's steps in dependency-ordered batches against the client and applies the configured result strategy to produce the final output.",
+      "tags": [
+        "entry-point",
+        "orchestration",
+        "composite",
+        "semp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/composite/executor.go:GroupStepsIntoBatches",
+      "type": "function",
+      "name": "GroupStepsIntoBatches",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        129,
+        154
+      ],
+      "summary": "Groups tool steps into sequential execution batches based on inter-step data dependencies so independent steps can run concurrently.",
+      "tags": [
+        "scheduling",
+        "dependency-graph",
+        "composite"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/composite/executor.go:runSingle",
+      "type": "function",
+      "name": "runSingle",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        181,
+        208
+      ],
+      "summary": "Executes a single non-fan-out step, resolving its templated args and invoking the SEMPv2 client once.",
+      "tags": [
+        "execution",
+        "composite",
+        "semp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/composite/executor.go:fetchFanOut",
+      "type": "function",
+      "name": "fetchFanOut",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        235,
+        342
+      ],
+      "summary": "Executes a fan-out step, issuing one SEMPv2 call per item resolved from a prior step's results and collecting the per-item responses.",
+      "tags": [
+        "execution",
+        "fan-out",
+        "composite",
+        "semp"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/composite/executor.go:fetchPaginated",
+      "type": "function",
+      "name": "fetchPaginated",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        378,
+        472
+      ],
+      "summary": "Executes a paginated SEMPv2 fetch, following nextPageUri cursors and accumulating data items until the resolved maxResults limit is reached.",
+      "tags": [
+        "execution",
+        "pagination",
+        "composite",
+        "semp"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/composite/executor.go:resolveMaxResults",
+      "type": "function",
+      "name": "resolveMaxResults",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        484,
+        510
+      ],
+      "summary": "Resolves the effective maxResults limit for a paginated step from tool params, applying defaults and bounds.",
+      "tags": [
+        "pagination",
+        "validation",
+        "composite"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/composite/executor.go:extractNextPageURI",
+      "type": "function",
+      "name": "extractNextPageURI",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        525,
+        536
+      ],
+      "summary": "Extracts the SEMPv2 pagination cursor URI from a response's metadata block.",
+      "tags": [
+        "pagination",
+        "parsing",
+        "composite"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/executor.go:executeBatch",
+      "type": "function",
+      "name": "executeBatch",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        562,
+        592
+      ],
+      "summary": "Runs all steps in a batch concurrently via safego and collects their individual step results.",
+      "tags": [
+        "concurrency",
+        "execution",
+        "composite"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/composite/executor.go:ResolveArgs",
+      "type": "function",
+      "name": "ResolveArgs",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        599,
+        617
+      ],
+      "summary": "Resolves templated argument strings for a step against the current execution context, producing concrete SEMP call arguments.",
+      "tags": [
+        "templating",
+        "composite",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/composite/executor.go:safeTemplateExecute",
+      "type": "function",
+      "name": "safeTemplateExecute",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        622,
+        635
+      ],
+      "summary": "Executes a Go text/template with panic recovery, converting any template failure into a returned error.",
+      "tags": [
+        "templating",
+        "error-handling",
+        "composite"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/composite/executor.go:constructRequestBody",
+      "type": "function",
+      "name": "constructRequestBody",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        659,
+        726
+      ],
+      "summary": "Builds a SEMPv2 request body from the operation spec and resolved args, rejecting path-parameter collisions and unknown body fields.",
+      "tags": [
+        "serialization",
+        "validation",
+        "composite",
+        "semp"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/composite/executor.go:ApplyResultStrategy",
+      "type": "function",
+      "name": "ApplyResultStrategy",
+      "filePath": "internal/composite/executor.go",
+      "lineRange": [
+        733,
+        748
+      ],
+      "summary": "Combines per-step results into the tool's final output according to the configured result strategy (collect or post-process).",
+      "tags": [
+        "aggregation",
+        "composite",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "type": "file",
+      "name": "list_bridges.go",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges.go",
+      "summary": "Post-process handler that reshapes raw SEMPv2 bridge step results into a normalized list-bridges tool response, extracting bridge name, VPN, direction, and enabled state. Self-registers with the postprocess registry via init().",
+      "tags": [
+        "post-processor",
+        "api-handler",
+        "serialization",
+        "bridges",
+        "composite",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses an init() side-effect to register the handler by name, the plugin-style registry pattern used across the composite postprocess package."
+    },
+    {
+      "id": "function:internal/composite/postprocess/handlers/list_bridges.go:ListBridges",
+      "type": "function",
+      "name": "ListBridges",
+      "filePath": "internal/composite/postprocess/handlers/list_bridges.go",
+      "lineRange": [
+        87,
+        138
+      ],
+      "summary": "Transforms the raw step results for the list-bridges tool into a structured slice of bridge summaries, pulling scalar fields via boolField/stringField helpers.",
+      "tags": [
+        "post-processor",
+        "serialization",
+        "transform",
+        "bridges"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/semp/sempv2/operation.go",
+      "type": "file",
+      "name": "operation.go",
+      "filePath": "internal/semp/sempv2/operation.go",
+      "summary": "Parses the embedded SEMPv2 OpenAPI spec files into a flat map of Operation definitions, resolving $ref parameters and extracting request-body fields for use by the composite executor.",
+      "tags": [
+        "schema-parsing",
+        "openapi",
+        "data-model",
+        "sempv2",
+        "spec",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Consumes an fs.FS abstraction so specs can be sourced from the embedded filesystem or a test fixture; derives operation type from the spec base path."
+    },
+    {
+      "id": "class:internal/semp/sempv2/operation.go:Operation",
+      "type": "class",
+      "name": "Operation",
+      "filePath": "internal/semp/sempv2/operation.go",
+      "lineRange": [
+        17,
+        25
+      ],
+      "summary": "Struct describing a single SEMPv2 operation: HTTP method, path, parameters, body fields, description, and schema version.",
+      "tags": [
+        "data-model",
+        "type-definition",
+        "sempv2",
+        "openapi"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/semp/sempv2/operation.go:Parameter",
+      "type": "class",
+      "name": "Parameter",
+      "filePath": "internal/semp/sempv2/operation.go",
+      "lineRange": [
+        28,
+        34
+      ],
+      "summary": "Struct describing one SEMPv2 operation parameter: name, location (in), type, required flag, and description.",
+      "tags": [
+        "data-model",
+        "type-definition",
+        "sempv2",
+        "openapi"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "function",
+      "name": "ParseSpecs",
+      "filePath": "internal/semp/sempv2/operation.go",
+      "lineRange": [
+        57,
+        129
+      ],
+      "summary": "Reads every .json spec in the given filesystem, unmarshals each as an OpenAPI document, and builds a keyed map of Operation definitions including resolved parameters and body fields.",
+      "tags": [
+        "schema-parsing",
+        "openapi",
+        "factory",
+        "sempv2"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation.go:deriveSpecType",
+      "type": "function",
+      "name": "deriveSpecType",
+      "filePath": "internal/semp/sempv2/operation.go",
+      "lineRange": [
+        133,
+        146
+      ],
+      "summary": "Derives the spec type (e.g. config vs monitor) from a spec file's base path by splitting and trimming the filename.",
+      "tags": [
+        "parsing",
+        "utility",
+        "sempv2"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation.go:extractParameters",
+      "type": "function",
+      "name": "extractParameters",
+      "filePath": "internal/semp/sempv2/operation.go",
+      "lineRange": [
+        152,
+        184
+      ],
+      "summary": "Extracts an operation's parameters, resolving shared/$ref parameter references against the spec's shared parameter set.",
+      "tags": [
+        "schema-parsing",
+        "openapi",
+        "ref-resolution",
+        "sempv2"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation.go:extractBodyFields",
+      "type": "function",
+      "name": "extractBodyFields",
+      "filePath": "internal/semp/sempv2/operation.go",
+      "lineRange": [
+        193,
+        230
+      ],
+      "summary": "Extracts request-body field definitions for an operation, resolving schema definitions and shared parameter references.",
+      "tags": [
+        "schema-parsing",
+        "openapi",
+        "ref-resolution",
+        "sempv2"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/semp/sempv2/operation_test.go",
+      "type": "file",
+      "name": "operation_test.go",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "summary": "Unit tests for ParseSpecs covering operation counts, field extraction, $ref parameter resolution, ghost/duplicate-key prevention, base-path inclusion, and spec-type derivation.",
+      "tags": [
+        "test",
+        "schema-parsing",
+        "sempv2",
+        "openapi"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_OperationCount",
+      "type": "function",
+      "name": "TestParseSpecs_OperationCount",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        11,
+        22
+      ],
+      "summary": "Verifies ParseSpecs returns a non-empty operation map from the embedded specs.",
+      "tags": [
+        "test",
+        "sempv2",
+        "schema-parsing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_OperationFields",
+      "type": "function",
+      "name": "TestParseSpecs_OperationFields",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        24,
+        67
+      ],
+      "summary": "Asserts the parsed fields of a known operation: method, path prefix, description, and parameter set.",
+      "tags": [
+        "test",
+        "sempv2",
+        "schema-parsing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_BodyFields",
+      "type": "function",
+      "name": "TestParseSpecs_BodyFields",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        69,
+        102
+      ],
+      "summary": "Verifies request-body fields are extracted correctly for a mutating operation.",
+      "tags": [
+        "test",
+        "sempv2",
+        "schema-parsing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_RefParametersResolved",
+      "type": "function",
+      "name": "TestParseSpecs_RefParametersResolved",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        104,
+        128
+      ],
+      "summary": "Confirms $ref-based shared parameters are resolved into concrete Parameter entries.",
+      "tags": [
+        "test",
+        "sempv2",
+        "ref-resolution"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_NoGhostParameters",
+      "type": "function",
+      "name": "TestParseSpecs_NoGhostParameters",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        130,
+        147
+      ],
+      "summary": "Ensures no unresolved/ghost parameters leak into the parsed operations.",
+      "tags": [
+        "test",
+        "sempv2",
+        "ref-resolution"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_MonitorOperationsPresent",
+      "type": "function",
+      "name": "TestParseSpecs_MonitorOperationsPresent",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        149,
+        160
+      ],
+      "summary": "Checks that monitor-type operations are present in the parsed spec map.",
+      "tags": [
+        "test",
+        "sempv2",
+        "schema-parsing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_PathIncludesBasePath",
+      "type": "function",
+      "name": "TestParseSpecs_PathIncludesBasePath",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        162,
+        177
+      ],
+      "summary": "Verifies operation paths are prefixed with the spec's base path.",
+      "tags": [
+        "test",
+        "sempv2",
+        "schema-parsing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_NoDuplicateKeys",
+      "type": "function",
+      "name": "TestParseSpecs_NoDuplicateKeys",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        179,
+        194
+      ],
+      "summary": "Ensures the parsed operation map contains no duplicate operation keys.",
+      "tags": [
+        "test",
+        "sempv2",
+        "schema-parsing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_SpecTypeDerivation",
+      "type": "function",
+      "name": "TestParseSpecs_SpecTypeDerivation",
+      "filePath": "internal/semp/sempv2/operation_test.go",
+      "lineRange": [
+        196,
+        226
+      ],
+      "summary": "Exercises spec-type derivation from base paths across config and monitor specs.",
+      "tags": [
+        "test",
+        "sempv2",
+        "parsing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/config/config.go",
+      "type": "file",
+      "name": "config.go",
+      "filePath": "internal/config/config.go",
+      "summary": "Central configuration loader and validator for the MCP server: parses YAML with env-var substitution, applies defaults and env overrides, and validates brokers, OAuth, TLS, and tool-authorization settings.",
+      "tags": [
+        "configuration",
+        "validation",
+        "yaml",
+        "data-model",
+        "secure-logging",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Config structs implement slog.LogValuer (LogValue methods) to redact secrets and sanitize URLs in structured logs."
+    },
+    {
+      "id": "function:internal/config/config.go:Load",
+      "type": "function",
+      "name": "Load",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        540,
+        566
+      ],
+      "summary": "Resolves the config file path from env/defaults and delegates to LoadConfig, returning the loaded ServerConfig.",
+      "tags": [
+        "config",
+        "entry-point",
+        "loader"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:LoadConfig",
+      "type": "function",
+      "name": "LoadConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        595,
+        648
+      ],
+      "summary": "Reads a YAML config file, substitutes env vars, decodes into the config struct, applies defaults and env overrides, then validates.",
+      "tags": [
+        "config",
+        "loader",
+        "yaml",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validate",
+      "type": "function",
+      "name": "validate",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        940,
+        1161
+      ],
+      "summary": "Core validation routine aggregating all config checks (brokers, ports, listen address, OAuth, TLS, tool authorization) into a joined error.",
+      "tags": [
+        "validation",
+        "config",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:internal/config/config.go:applyDefaults",
+      "type": "function",
+      "name": "applyDefaults",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        651,
+        715
+      ],
+      "summary": "Applies default values to unset config fields (log level, SEMP tuning, tool authorization, observability).",
+      "tags": [
+        "config",
+        "defaults"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:loadEnvFile",
+      "type": "function",
+      "name": "loadEnvFile",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        725,
+        759
+      ],
+      "summary": "Loads key=value pairs from an optional .env file alongside the config without overriding already-set environment variables.",
+      "tags": [
+        "config",
+        "env",
+        "loader"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validateAndCanonicalizeBrokers",
+      "type": "function",
+      "name": "validateAndCanonicalizeBrokers",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        807,
+        867
+      ],
+      "summary": "Validates broker aliases, lowercases and canonicalizes them, and detects duplicate alias collisions.",
+      "tags": [
+        "validation",
+        "brokers",
+        "canonicalization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:substituteEnvVars",
+      "type": "function",
+      "name": "substituteEnvVars",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        875,
+        900
+      ],
+      "summary": "Substitutes ${VAR} references in the raw YAML with environment values, skipping comments and collecting missing-variable errors.",
+      "tags": [
+        "config",
+        "env",
+        "substitution"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validateToolAuthorization",
+      "type": "function",
+      "name": "validateToolAuthorization",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1198,
+        1273
+      ],
+      "summary": "Validates the tool-authorization block: enabled flag, groups claim name, and access-level group mappings.",
+      "tags": [
+        "validation",
+        "authorization",
+        "config"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validateBroker",
+      "type": "function",
+      "name": "validateBroker",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1306,
+        1384
+      ],
+      "summary": "Validates a single broker's URL, alias, and auth mode, enforcing production-mode constraints.",
+      "tags": [
+        "validation",
+        "brokers",
+        "auth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validateBrokerOAuthConfig",
+      "type": "function",
+      "name": "validateBrokerOAuthConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1406,
+        1469
+      ],
+      "summary": "Validates the hop-2 broker OAuth configuration: token URL, client ID, grant type, client auth, and circuit breaker.",
+      "tags": [
+        "validation",
+        "oauth",
+        "config"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validateBrokerClientAuth",
+      "type": "function",
+      "name": "validateBrokerClientAuth",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1484,
+        1508
+      ],
+      "summary": "Validates that exactly one broker OAuth client-authentication method is configured and delegates to secret validation.",
+      "tags": [
+        "validation",
+        "oauth",
+        "auth"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validateClientSecretAuth",
+      "type": "function",
+      "name": "validateClientSecretAuth",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1513,
+        1531
+      ],
+      "summary": "Validates a client-secret-based OAuth auth method, ensuring the secret is present.",
+      "tags": [
+        "validation",
+        "oauth",
+        "secret"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/config.go:applyEnvOverrides",
+      "type": "function",
+      "name": "applyEnvOverrides",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1691,
+        1718
+      ],
+      "summary": "Applies environment-variable overrides for port and observability plus unreleased-feature gating.",
+      "tags": [
+        "config",
+        "env",
+        "override"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:validateBrokerURL",
+      "type": "function",
+      "name": "validateBrokerURL",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1614,
+        1634
+      ],
+      "summary": "Parses and validates a broker URL, requiring HTTPS in production and returning sanitized error messages.",
+      "tags": [
+        "validation",
+        "url",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:Hop2OAuthActive",
+      "type": "function",
+      "name": "Hop2OAuthActive",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        314,
+        327
+      ],
+      "summary": "Reports whether hop-2 broker OAuth is active given the unreleased-feature gate and configuration.",
+      "tags": [
+        "config",
+        "oauth",
+        "feature-flag"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/config.go:ToolAuthorizationEnabled",
+      "type": "function",
+      "name": "ToolAuthorizationEnabled",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1774,
+        1788
+      ],
+      "summary": "Reports whether tool authorization is effectively enabled, combining the feature gate and config flag.",
+      "tags": [
+        "config",
+        "authorization",
+        "feature-flag"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/config.go:selectedMethod",
+      "type": "function",
+      "name": "selectedMethod",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        171,
+        191
+      ],
+      "summary": "Determines the single selected broker OAuth client-auth method, erroring if zero or multiple are set.",
+      "tags": [
+        "config",
+        "oauth",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:splitYAMLComment",
+      "type": "function",
+      "name": "splitYAMLComment",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        912,
+        934
+      ],
+      "summary": "Splits a YAML line into code and trailing-comment segments so env substitution skips commented text.",
+      "tags": [
+        "parsing",
+        "yaml",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/config.go:applyToolAuthorizationDefaults",
+      "type": "function",
+      "name": "applyToolAuthorizationDefaults",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1181,
+        1193
+      ],
+      "summary": "Applies default access-level group and groups-claim settings when tool authorization is enabled.",
+      "tags": [
+        "config",
+        "defaults",
+        "authorization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/config.go:validateHop1Hop2Alignment",
+      "type": "function",
+      "name": "validateHop1Hop2Alignment",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1288,
+        1301
+      ],
+      "summary": "Ensures hop-1 and hop-2 broker OAuth counts align, erroring on misconfiguration.",
+      "tags": [
+        "validation",
+        "oauth",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/config.go:envBool",
+      "type": "function",
+      "name": "envBool",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        1677,
+        1689
+      ],
+      "summary": "Parses a boolean environment variable with a default, warning on invalid values.",
+      "tags": [
+        "config",
+        "env",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:ServerConfig",
+      "type": "class",
+      "name": "ServerConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        44,
+        94
+      ],
+      "summary": "Top-level server configuration aggregating brokers, SEMP tuning, TLS, MCP client auth, broker OAuth, observability, and feature toggles.",
+      "tags": [
+        "data-model",
+        "config",
+        "type-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:internal/config/config.go:BrokerOAuthConfig",
+      "type": "class",
+      "name": "BrokerOAuthConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        107,
+        114
+      ],
+      "summary": "Configuration for hop-2 broker OAuth (token URL, client ID, grant type, audience param, client auth, circuit breaker).",
+      "tags": [
+        "data-model",
+        "oauth",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:BrokerClientAuth",
+      "type": "class",
+      "name": "BrokerClientAuth",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        135,
+        138
+      ],
+      "summary": "Broker OAuth client-authentication settings supporting client_secret_basic and client_secret_post methods.",
+      "tags": [
+        "data-model",
+        "oauth",
+        "auth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:ClientSecretAuth",
+      "type": "class",
+      "name": "ClientSecretAuth",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        145,
+        147
+      ],
+      "summary": "Holds a client secret for OAuth client authentication, redacted in structured logs.",
+      "tags": [
+        "data-model",
+        "secret",
+        "oauth"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:MCPClientAuthConfig",
+      "type": "class",
+      "name": "MCPClientAuthConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        329,
+        342
+      ],
+      "summary": "MCP client authentication config (issuer, audience, dev token, resource URL, mode, tool authorization).",
+      "tags": [
+        "data-model",
+        "auth",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:ToolAuthorizationConfig",
+      "type": "class",
+      "name": "ToolAuthorizationConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        347,
+        352
+      ],
+      "summary": "Tool-authorization config mapping access-level groups via a configurable groups claim.",
+      "tags": [
+        "data-model",
+        "authorization",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:BrokerConfig",
+      "type": "class",
+      "name": "BrokerConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        384,
+        389
+      ],
+      "summary": "Configuration for a single broker (URL, insecure-TLS skip, auth, display name).",
+      "tags": [
+        "data-model",
+        "brokers",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:AuthConfig",
+      "type": "class",
+      "name": "AuthConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        423,
+        434
+      ],
+      "summary": "Broker authentication config (mode, username, password, token, audience) with secrets redacted in logs.",
+      "tags": [
+        "data-model",
+        "auth",
+        "secret"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:internal/config/config.go:SEMPConfig",
+      "type": "class",
+      "name": "SEMPConfig",
+      "filePath": "internal/config/config.go",
+      "lineRange": [
+        493,
+        500
+      ],
+      "summary": "SEMP client tuning parameters (per-broker concurrency, request timeout, retry counts and intervals).",
+      "tags": [
+        "data-model",
+        "config",
+        "semp"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:internal/config/idp_circuit_breaker.go",
+      "type": "file",
+      "name": "idp_circuit_breaker.go",
+      "filePath": "internal/config/idp_circuit_breaker.go",
+      "summary": "Defines the IdP circuit-breaker configuration struct and its validation, protecting the token endpoint from cascading failures.",
+      "tags": [
+        "configuration",
+        "circuit-breaker",
+        "resilience",
+        "validation",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:internal/config/idp_circuit_breaker.go:IdPCircuitBreakerConfig",
+      "type": "class",
+      "name": "IdPCircuitBreakerConfig",
+      "filePath": "internal/config/idp_circuit_breaker.go",
+      "lineRange": [
+        33,
+        45
+      ],
+      "summary": "Circuit-breaker settings for the IdP token endpoint (failure-rate window, minimum requests, thresholds, open-state duration, half-open probes).",
+      "tags": [
+        "data-model",
+        "circuit-breaker",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/idp_circuit_breaker.go:BreakerEnabled",
+      "type": "function",
+      "name": "BreakerEnabled",
+      "filePath": "internal/config/idp_circuit_breaker.go",
+      "lineRange": [
+        75,
+        80
+      ],
+      "summary": "Reports whether the circuit breaker is enabled, defaulting to disabled when the config is nil or unset.",
+      "tags": [
+        "circuit-breaker",
+        "config",
+        "accessor"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/idp_circuit_breaker.go:validateIdPCircuitBreaker",
+      "type": "function",
+      "name": "validateIdPCircuitBreaker",
+      "filePath": "internal/config/idp_circuit_breaker.go",
+      "lineRange": [
+        87,
+        120
+      ],
+      "summary": "Validates circuit-breaker fields, collecting errors for out-of-range thresholds, windows, and probe counts.",
+      "tags": [
+        "validation",
+        "circuit-breaker",
+        "config"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "file",
+      "name": "idp_circuit_breaker_test.go",
+      "filePath": "internal/config/idp_circuit_breaker_test.go",
+      "summary": "Unit tests for IdP circuit-breaker config parsing from YAML, the BreakerEnabled accessor, and field validation.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "config",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/idp_circuit_breaker_test.go:TestLoadConfig_CircuitBreaker_ParsesFromYAML",
+      "type": "function",
+      "name": "TestLoadConfig_CircuitBreaker_ParsesFromYAML",
+      "filePath": "internal/config/idp_circuit_breaker_test.go",
+      "lineRange": [
+        67,
+        102
+      ],
+      "summary": "Verifies circuit-breaker settings are parsed correctly from a YAML config file.",
+      "tags": [
+        "test",
+        "config",
+        "yaml"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/idp_circuit_breaker_test.go:TestLoadConfig_CircuitBreaker_OmittedBlockIsNil",
+      "type": "function",
+      "name": "TestLoadConfig_CircuitBreaker_OmittedBlockIsNil",
+      "filePath": "internal/config/idp_circuit_breaker_test.go",
+      "lineRange": [
+        107,
+        116
+      ],
+      "summary": "Verifies an omitted circuit-breaker block leaves the config nil rather than defaulted.",
+      "tags": [
+        "test",
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/config/idp_circuit_breaker_test.go:TestLoadConfig_CircuitBreaker_BadValueRejected",
+      "type": "function",
+      "name": "TestLoadConfig_CircuitBreaker_BadValueRejected",
+      "filePath": "internal/config/idp_circuit_breaker_test.go",
+      "lineRange": [
+        124,
+        175
+      ],
+      "summary": "Table-driven test asserting invalid circuit-breaker values are rejected with clear error messages.",
+      "tags": [
+        "test",
+        "validation",
+        "config"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/idp_circuit_breaker_test.go:TestBreakerEnabled",
+      "type": "function",
+      "name": "TestBreakerEnabled",
+      "filePath": "internal/config/idp_circuit_breaker_test.go",
+      "lineRange": [
+        180,
+        201
+      ],
+      "summary": "Table-driven test of the BreakerEnabled accessor across nil, enabled, and disabled states.",
+      "tags": [
+        "test",
+        "circuit-breaker"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/config/idp_circuit_breaker_test.go:TestValidateBrokerCircuitBreaker",
+      "type": "function",
+      "name": "TestValidateBrokerCircuitBreaker",
+      "filePath": "internal/config/idp_circuit_breaker_test.go",
+      "lineRange": [
+        206,
+        257
+      ],
+      "summary": "Table-driven test of validateIdPCircuitBreaker across valid and invalid configurations.",
+      "tags": [
+        "test",
+        "validation",
+        "circuit-breaker"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "file",
+      "name": "circuitbreaker_config.go",
+      "filePath": "internal/tokenexchange/circuitbreaker_config.go",
+      "summary": "Defines the operator-facing CircuitBreakerConfig struct, its production-safe defaults, and validation for the token-exchange IdP circuit breaker, translating conceptual window/threshold fields onto the underlying gobreaker implementation.",
+      "tags": [
+        "config",
+        "circuit-breaker",
+        "validation",
+        "resilience",
+        "type-definition",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Defaults are exposed via a constructor function rather than a package var so each caller gets a fresh, non-shared value."
+    },
+    {
+      "id": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "file",
+      "name": "circuitbreaker_config_test.go",
+      "filePath": "internal/tokenexchange/circuitbreaker_config_test.go",
+      "summary": "Table-driven unit tests covering the circuit breaker defaults values, their validity, fresh-value semantics, and field-by-field Validate rejection cases.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "validation",
+        "table-driven"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:internal/tokenexchange/from_config.go",
+      "type": "file",
+      "name": "from_config.go",
+      "filePath": "internal/tokenexchange/from_config.go",
+      "summary": "Builds a token-exchange Exchanger from the validated broker_oauth config block, resolving client auth method, grant type, audience parameter, and circuit breaker overlay into the typed Params the constructor expects.",
+      "tags": [
+        "factory",
+        "config",
+        "oauth",
+        "token-exchange",
+        "circuit-breaker",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Circuit breaker resolution overlays only operator-set pointer fields onto shipped defaults; a nil result signals an operator-disabled breaker."
+    },
+    {
+      "id": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "file",
+      "name": "from_config_breaker_test.go",
+      "filePath": "internal/tokenexchange/from_config_breaker_test.go",
+      "summary": "Unit tests for resolveCircuitBreakerConfig covering nil/omitted defaults, explicit disable, enabled-true defaults, and partial and full operator field overlays.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "config",
+        "token-exchange"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:internal/tokenexchange/circuitbreaker_config.go:CircuitBreakerConfig",
+      "type": "class",
+      "name": "CircuitBreakerConfig",
+      "filePath": "internal/tokenexchange/circuitbreaker_config.go",
+      "lineRange": [
+        33,
+        65
+      ],
+      "summary": "Struct holding the conceptual circuit breaker tuning parameters: failure-rate window, minimum requests, failure-rate threshold, consecutive-failure threshold, open-state duration, and half-open probe count.",
+      "tags": [
+        "type-definition",
+        "circuit-breaker",
+        "config",
+        "resilience"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker_config.go:DefaultCircuitBreakerConfig",
+      "type": "function",
+      "name": "DefaultCircuitBreakerConfig",
+      "filePath": "internal/tokenexchange/circuitbreaker_config.go",
+      "lineRange": [
+        70,
+        79
+      ],
+      "summary": "Returns the production-safe default CircuitBreakerConfig by value so each caller receives a fresh copy that cannot mutate shared defaults.",
+      "tags": [
+        "factory",
+        "circuit-breaker",
+        "defaults"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker_config.go:Validate",
+      "type": "function",
+      "name": "Validate",
+      "filePath": "internal/tokenexchange/circuitbreaker_config.go",
+      "lineRange": [
+        84,
+        114
+      ],
+      "summary": "Validates a CircuitBreakerConfig, returning descriptive errors for out-of-range window, request, threshold, and duration fields.",
+      "tags": [
+        "validation",
+        "circuit-breaker",
+        "error-handling"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker_config_test.go:TestDefaultCircuitBreakerConfig_Values",
+      "type": "function",
+      "name": "TestDefaultCircuitBreakerConfig_Values",
+      "filePath": "internal/tokenexchange/circuitbreaker_config_test.go",
+      "lineRange": [
+        27,
+        41
+      ],
+      "summary": "Asserts the concrete field values returned by DefaultCircuitBreakerConfig match the documented production defaults.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "defaults"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/circuitbreaker_config_test.go:TestCircuitBreakerConfig_Validate",
+      "type": "function",
+      "name": "TestCircuitBreakerConfig_Validate",
+      "filePath": "internal/tokenexchange/circuitbreaker_config_test.go",
+      "lineRange": [
+        66,
+        120
+      ],
+      "summary": "Table-driven test mutating individual fields of a valid config to confirm Validate accepts the baseline and rejects each invalid field variation.",
+      "tags": [
+        "test",
+        "validation",
+        "circuit-breaker",
+        "table-driven"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/from_config.go:FromConfig",
+      "type": "function",
+      "name": "FromConfig",
+      "filePath": "internal/tokenexchange/from_config.go",
+      "lineRange": [
+        37,
+        74
+      ],
+      "summary": "Constructs an Exchanger from a validated BrokerOAuthConfig, HTTP client, and token cache by resolving auth method, grant type, audience parameter, and breaker config into typed Params.",
+      "tags": [
+        "factory",
+        "config",
+        "oauth",
+        "token-exchange"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/from_config.go:resolveCircuitBreakerConfig",
+      "type": "function",
+      "name": "resolveCircuitBreakerConfig",
+      "filePath": "internal/tokenexchange/from_config.go",
+      "lineRange": [
+        80,
+        109
+      ],
+      "summary": "Overlays operator-set circuit breaker fields onto the shipped defaults, returning nil (and warning) when the operator explicitly disabled the breaker.",
+      "tags": [
+        "config",
+        "circuit-breaker",
+        "defaults",
+        "overlay"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:internal/tokenexchange/from_config.go:resolveClientAuth",
+      "type": "function",
+      "name": "resolveClientAuth",
+      "filePath": "internal/tokenexchange/from_config.go",
+      "lineRange": [
+        115,
+        126
+      ],
+      "summary": "Determines the client auth method and extracts the secret from the exactly-one populated client-auth sub-block, treating ambiguous states as programming errors.",
+      "tags": [
+        "oauth",
+        "validation",
+        "config",
+        "authentication"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/from_config.go:resolveAudienceParam",
+      "type": "function",
+      "name": "resolveAudienceParam",
+      "filePath": "internal/tokenexchange/from_config.go",
+      "lineRange": [
+        137,
+        148
+      ],
+      "summary": "Maps the YAML audience_parameter_name string to the typed AudienceFormat enum, rejecting schema-accepted-but-unimplemented and unsupported values.",
+      "tags": [
+        "config",
+        "validation",
+        "oauth",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/from_config_breaker_test.go:TestResolveCircuitBreakerConfig_PartialOverlay",
+      "type": "function",
+      "name": "TestResolveCircuitBreakerConfig_PartialOverlay",
+      "filePath": "internal/tokenexchange/from_config_breaker_test.go",
+      "lineRange": [
+        61,
+        77
+      ],
+      "summary": "Verifies that setting only some operator fields overlays those onto the defaults while leaving the remaining fields at their default values.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "config",
+        "overlay"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:internal/tokenexchange/from_config_breaker_test.go:TestResolveCircuitBreakerConfig_FullOverlay",
+      "type": "function",
+      "name": "TestResolveCircuitBreakerConfig_FullOverlay",
+      "filePath": "internal/tokenexchange/from_config_breaker_test.go",
+      "lineRange": [
+        81,
+        102
+      ],
+      "summary": "Verifies that setting every operator field fully replaces all default circuit breaker values in the resolved config.",
+      "tags": [
+        "test",
+        "circuit-breaker",
+        "config",
+        "overlay"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/ci-pr.yaml",
+      "type": "pipeline",
+      "name": "ci-pr.yaml",
+      "filePath": ".github/workflows/ci-pr.yaml",
+      "summary": "Pull-request CI workflow that runs a FOSSA software-composition scan (via the shared SolaceDev reusable workflow) and an advisory CHANGELOG-updated check on every opened, synchronized, or reopened PR.",
+      "tags": [
+        "ci-cd",
+        "infrastructure",
+        "security",
+        "changelog",
+        "pull-request"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses a concurrency group keyed on the PR number with cancel-in-progress to supersede stale runs, and delegates SCA scanning to a pinned reusable workflow."
+    },
+    {
+      "id": "pipeline:.github/workflows/release.yml",
+      "type": "pipeline",
+      "name": "release.yml",
+      "filePath": ".github/workflows/release.yml",
+      "summary": "Tag-triggered release pipeline (on v* tags) that runs the build-and-test suite, verifies and extracts CHANGELOG release notes, cross-compiles Go binaries for linux/darwin amd64+arm64, builds and pushes a multi-arch Docker image to GHCR, and publishes a GitHub Release with archives and checksums.",
+      "tags": [
+        "ci-cd",
+        "deployment",
+        "release",
+        "containerization",
+        "infrastructure"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Fails fast on a missing CHANGELOG block before publishing, uses a build matrix for cross-platform Go binaries, and pushes multi-arch (amd64/arm64) images via docker buildx with GHA cache."
+    },
+    {
+      "id": "config:.claude/settings.json",
+      "type": "config",
+      "name": "settings.json",
+      "filePath": ".claude/settings.json",
+      "summary": "Claude Code harness configuration registering a PreToolUse hook that runs the changelog-reminder script before every Bash tool invocation.",
+      "tags": [
+        "configuration",
+        "claude-code",
+        "hooks",
+        "development"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses the $CLAUDE_PROJECT_DIR variable to resolve the hook command path relative to the project root."
+    },
+    {
+      "id": "document:README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "README.md",
+      "summary": "Primary project documentation for the Solace Broker MCP server, covering overview, features, architecture, tool catalog, prerequisites, quickstart (binary/go install/Docker), configuration, development setup, and CI/contributing/security sections.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "overview",
+        "quickstart",
+        "configuration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:CHANGELOG.md",
+      "type": "document",
+      "name": "CHANGELOG.md",
+      "filePath": "CHANGELOG.md",
+      "summary": "Keep-a-Changelog history tracking releases from 0.0.1 through 0.5.0 plus an Unreleased section, grouped by Added/Changed/Removed/Fixed/Security, with versioning and release-process notes.",
+      "tags": [
+        "documentation",
+        "changelog",
+        "release",
+        "versioning"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:RELEASING.md",
+      "type": "document",
+      "name": "RELEASING.md",
+      "filePath": "RELEASING.md",
+      "summary": "Release engineering guide describing SemVer versioning, distribution pointers, release gates, the cut-a-release runbook, rollback procedure, and planned DORA metrics.",
+      "tags": [
+        "documentation",
+        "release",
+        "ci-cd",
+        "runbook"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:CLAUDE.md",
+      "type": "document",
+      "name": "CLAUDE.md",
+      "filePath": "CLAUDE.md",
+      "summary": "Contributor and agent guidance for the repository, documenting build/test commands, how to add a tool (composite YAML vs native Go), kebab-case tool naming, secure-logging checks, and changelog requirements before opening a PR.",
+      "tags": [
+        "documentation",
+        "development",
+        "conventions",
+        "contributing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:go.mod",
+      "type": "config",
+      "name": "go.mod",
+      "filePath": "go.mod",
+      "summary": "Go module manifest declaring the module path github.com/SolaceDev/solace-broker-mcp, Go 1.25, and direct/indirect dependencies including the MCP Go SDK, kin-openapi, go-oidc, gobreaker, and otter cache.",
+      "tags": [
+        "configuration",
+        "go-module",
+        "dependencies",
+        "build-system"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses multiple require blocks to separate direct dependencies from indirect (// indirect) transitive dependencies."
+    },
+    {
+      "id": "config:go.sum",
+      "type": "config",
+      "name": "go.sum",
+      "filePath": "go.sum",
+      "summary": "Go dependency checksum lockfile recording cryptographic hashes for all module versions resolved by go.mod, ensuring reproducible and verifiable builds.",
+      "tags": [
+        "configuration",
+        "go-module",
+        "dependencies",
+        "lockfile",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.github/scripts/changelog-check.sh",
+      "type": "file",
+      "name": "changelog-check.sh",
+      "filePath": ".github/scripts/changelog-check.sh",
+      "summary": "CI advisory gate that warns when a PR changes production surface without a corresponding CHANGELOG [Unreleased] entry; supports a no-changelog label escape hatch and a blocking mode via CHANGELOG_GATE_MODE.",
+      "tags": [
+        "ci-cd",
+        "changelog",
+        "git",
+        "validation",
+        "shell-script"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses a merge-base diff (not two-dot) to isolate the PR's own changes, and awk to slice the [Unreleased] section from CHANGELOG.md at two refs for comparison."
+    },
+    {
+      "id": "function:.github/scripts/changelog-check.sh:extract_unreleased",
+      "type": "function",
+      "name": "extract_unreleased",
+      "filePath": ".github/scripts/changelog-check.sh",
+      "lineRange": [
+        59,
+        67
+      ],
+      "summary": "Returns the CHANGELOG.md [Unreleased] section content at a given git ref via awk, stopping at the next version header and yielding empty output when the file or section is absent.",
+      "tags": [
+        "utility",
+        "git",
+        "parsing",
+        "changelog"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.github/scripts/extract-release-notes.sh",
+      "type": "file",
+      "name": "extract-release-notes.sh",
+      "filePath": ".github/scripts/extract-release-notes.sh",
+      "summary": "Release-time gate that extracts the CHANGELOG.md block for a v-prefixed tag into a release-notes file, failing the release when no dated section exists for the version.",
+      "tags": [
+        "ci-cd",
+        "release",
+        "changelog",
+        "parsing",
+        "shell-script"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Strips the v prefix from the tag and escapes dots in the version before matching the bare '## [x.y.z]' heading with awk."
+    },
+    {
+      "id": "file:.github/scripts/production-surface.sh",
+      "type": "file",
+      "name": "production-surface.sh",
+      "filePath": ".github/scripts/production-surface.sh",
+      "summary": "Sourced-only definitions of the single-source-of-truth regexes (SURFACE_RE, SURFACE_TEST_EXCLUDE) identifying production-surface paths whose change requires a CHANGELOG entry, shared across the CI gate, reminder hook, and cut-release skill.",
+      "tags": [
+        "ci-cd",
+        "configuration",
+        "changelog",
+        "shell-script"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/tools-reference.md",
+      "type": "document",
+      "name": "tools-reference.md",
+      "filePath": "docs/tools-reference.md",
+      "summary": "Comprehensive reference for every MCP tool the server exposes, grouped by domain (discovery, broker status, replication, VPNs, queues, clients, RDPs, bridges, discards, action tools, and Config API management), documenting parameters, output envelopes, and error conventions.",
+      "tags": [
+        "documentation",
+        "api-schema",
+        "reference",
+        "tools"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Large reference doc with 52 headings; per-tool sections follow a consistent parameter/output/error template."
+    },
+    {
+      "id": "document:docs/user-guide.md",
+      "type": "document",
+      "name": "user-guide.md",
+      "filePath": "docs/user-guide.md",
+      "summary": "Getting-started and operations guide covering prerequisites, deployment, connecting an MCP client, example queries, a domain-grouped tool overview, recommended environments, and troubleshooting.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "user-guide",
+        "troubleshooting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/internal/understand-anything.md",
+      "type": "document",
+      "name": "understand-anything.md",
+      "filePath": "docs/internal/understand-anything.md",
+      "summary": "Quick-start guide for the Understand Anything knowledge-graph tool: a two-tier walkthrough covering how to view the committed `.ua/` graph (Node-only, read-only) and how maintainers regenerate or update it via the Claude Code plugin, plus notes on token cost, code-privacy boundaries, and which files are committed versus gitignored.",
+      "tags": [
+        "documentation",
+        "tooling",
+        "knowledge-graph",
+        "developer-guide",
+        "onboarding"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Markdown guide organized into decision-table plus tiered sections; references the /understand Claude Code skill workflow and the .ua/ committed-graph layout."
+    },
+    {
+      "id": "file:.claude/hooks/changelog-reminder.sh",
+      "type": "file",
+      "name": "changelog-reminder.sh",
+      "filePath": ".claude/hooks/changelog-reminder.sh",
+      "summary": "Claude Code PreToolUse Bash hook that injects a non-blocking reminder to update CHANGELOG.md [Unreleased] when a branch changes production surface (internal/config, internal/tools, tools.yaml) before running gh pr create/edit. Sources the shared production-surface.sh matcher and mirrors the CI changelog gate without ever blocking.",
+      "tags": [
+        "hook",
+        "ci-cd",
+        "changelog",
+        "automation",
+        "shell"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses set -euo pipefail with `|| true` guards around git show to stay non-blocking, and an awk range extractor to isolate the [Unreleased] changelog section."
+    },
+    {
+      "id": "document:.claude/skills/cut-release/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": ".claude/skills/cut-release/SKILL.md",
+      "summary": "Cut-release skill playbook documenting the end-to-end release workflow in five phases: prepare the CHANGELOG, open the prepare-release PR, watch for merge, cut the release via a guarded auto-tag, and report/hand off. Serves as the operator-facing instructions for the /cut-release command.",
+      "tags": [
+        "documentation",
+        "release",
+        "ci-cd",
+        "changelog",
+        "runbook"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:internal/composite/definitions/tools.yaml",
+      "type": "config",
+      "name": "tools.yaml",
+      "filePath": "internal/composite/definitions/tools.yaml",
+      "summary": "Embedded composite tool definitions declaring 30 MCP tools over Solace SEMP \u2014 monitoring/read tools (get-rdp-status, get-vpn-status, list-queues, get-message-rates, get-replication-status) and management/write tools (create/update/delete for message-VPNs, queues, topic-endpoints, RDPs, plus disconnect-client and stats-clearing). Each entry specifies description, parameters, and the multi-step SEMPv2 call templates that back the tool.",
+      "tags": [
+        "configuration",
+        "mcp-tools",
+        "api-schema",
+        "semp",
+        "tool-definition"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Leading comment block codifies tool-description guidelines for LLM tool selection; the `broker` parameter is intentionally absent from every tool since it is auto-injected at registration."
     }
   ],
   "edges": [
     {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:main",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:buildMux",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:healthConfigFromFile",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:startServer",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:drainAndShutdown",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:gracefulShutdown",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:newTokenExchanger",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:newSlogHandler",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "function:cmd/server/main.go:redactSecretAttr",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:internal/banner/banner.go",
       "target": "function:internal/banner/banner.go:LogStartupAuthMode",
       "type": "contains",
@@ -8724,118 +10709,6 @@
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "class:internal/composite/executor.go:CompositeExecutor",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "class:internal/composite/executor.go:CompositeExecutor",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:NewCompositeExecutor",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:NewCompositeExecutor",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:Execute",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:Execute",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:GroupStepsIntoBatches",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:GroupStepsIntoBatches",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:fetchFanOut",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:fetchPaginated",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:constructRequestBody",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:ResolveArgs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:ResolveArgs",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:ApplyResultStrategy",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:ApplyResultStrategy",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "function:internal/composite/executor.go:resolveMaxResults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
     },
     {
       "source": "file:cmd/server/main.go",
@@ -8951,13 +10824,6 @@
     },
     {
       "source": "file:cmd/server/main.go",
-      "target": "file:internal/composite/executor.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
       "target": "file:internal/composite/executor_client_test.go",
       "type": "imports",
       "direction": "forward",
@@ -8979,13 +10845,6 @@
     },
     {
       "source": "file:cmd/server/main.go",
-      "target": "file:internal/composite/executor_helpers_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
       "target": "file:internal/composite/executor_queue_test.go",
       "type": "imports",
       "direction": "forward",
@@ -9001,13 +10860,6 @@
     {
       "source": "file:cmd/server/main.go",
       "target": "file:internal/composite/executor_topic_endpoint_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/composite/executor_vpn_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -9162,13 +11014,6 @@
     {
       "source": "file:cmd/server/main.go",
       "target": "file:internal/composite/result_strategy_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/config/config.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -9385,20 +11230,6 @@
     },
     {
       "source": "file:cmd/server/main.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -9407,20 +11238,6 @@
     {
       "source": "file:cmd/server/main.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/semp/sempv2/operation.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -9448,42 +11265,7 @@
     },
     {
       "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/errors.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/exchange.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/exchange_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/exchanger.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
       "target": "file:internal/tokenexchange/exchanger_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/from_config.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -9505,27 +11287,6 @@
     {
       "source": "file:cmd/server/main.go",
       "target": "file:internal/tokenexchange/request_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/response.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/response_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tokenexchange/types.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -9575,20 +11336,6 @@
     {
       "source": "file:cmd/server/main.go",
       "target": "file:internal/tools/correlation_meta_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tools/errors.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:cmd/server/main.go",
-      "target": "file:internal/tools/errors_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -9882,20 +11629,6 @@
     },
     {
       "source": "file:internal/composite/executor.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -9904,20 +11637,6 @@
     {
       "source": "file:internal/composite/executor.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "file:internal/semp/sempv2/operation.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -10050,20 +11769,6 @@
     },
     {
       "source": "file:internal/composite/executor_helpers_test.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_helpers_test.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_helpers_test.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -10072,20 +11777,6 @@
     {
       "source": "file:internal/composite/executor_helpers_test.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_helpers_test.go",
-      "target": "file:internal/semp/sempv2/operation.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_helpers_test.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -10204,13 +11895,6 @@
     },
     {
       "source": "file:internal/composite/executor.go",
-      "target": "file:internal/composite/executor_helpers_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "file:internal/composite/executor.go",
       "target": "file:internal/composite/executor_queue_test.go",
       "type": "tested_by",
       "direction": "forward",
@@ -10226,13 +11910,6 @@
     {
       "source": "file:internal/composite/executor.go",
       "target": "file:internal/composite/executor_topic_endpoint_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "file:internal/composite/executor.go",
-      "target": "file:internal/composite/executor_vpn_test.go",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5
@@ -10309,20 +11986,6 @@
     },
     {
       "source": "file:internal/composite/executor_vpn_test.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_vpn_test.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_vpn_test.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -10331,20 +11994,6 @@
     {
       "source": "file:internal/composite/executor_vpn_test.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_vpn_test.go",
-      "target": "file:internal/semp/sempv2/operation.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/composite/executor_vpn_test.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -10784,62 +12433,6 @@
       "weight": 1
     },
     {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "class:internal/semp/sempv2/operation.go:Operation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "class:internal/semp/sempv2/operation.go:Operation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "class:internal/semp/sempv2/operation.go:Parameter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "class:internal/semp/sempv2/operation.go:Parameter",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "function:internal/semp/sempv2/operation.go:extractParameters",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
-      "target": "function:internal/semp/sempv2/operation.go:extractBodyFields",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:internal/tools/composite_handler.go",
       "target": "class:internal/tools/composite_handler.go:CompositeToolHandler",
       "type": "contains",
@@ -11163,20 +12756,6 @@
     },
     {
       "source": "file:internal/semp/sempv2/operation_test.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation_test.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation_test.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -11185,13 +12764,6 @@
     {
       "source": "file:internal/semp/sempv2/operation_test.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation_test.go",
-      "target": "file:internal/semp/sempv2/operation.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -11996,13 +13568,6 @@
     },
     {
       "source": "file:internal/semp/sempv2/operation.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "file:internal/semp/sempv2/operation.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
       "type": "tested_by",
       "direction": "forward",
@@ -12373,48 +13938,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:internal/tools/errors.go",
-      "target": "function:internal/tools/errors.go:buildErrorResult",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "function:internal/tools/errors.go:buildErrorMessage",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "function:internal/tools/errors.go:buildSEMPv1Message",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "function:internal/tools/errors.go:buildSEMPv2Message",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "function:internal/tools/errors.go:buildExchangeErrorMessage",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "function:internal/tools/errors.go:isRetryable",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:internal/tools/authorization.go",
       "target": "file:internal/authz/authz.go",
       "type": "imports",
@@ -12563,13 +14086,6 @@
     },
     {
       "source": "file:internal/tools/errors.go",
-      "target": "file:internal/semp/resilience/retry.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
       "target": "file:internal/semp/resilience/retry_safe_test.go",
       "type": "imports",
       "direction": "forward",
@@ -12578,20 +14094,6 @@
     {
       "source": "file:internal/tools/errors.go",
       "target": "file:internal/semp/resilience/semaphore.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/semp/resilience/sender.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/semp/resilience/sender_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -12689,20 +14191,6 @@
     },
     {
       "source": "file:internal/tools/errors.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -12711,20 +14199,6 @@
     {
       "source": "file:internal/tools/errors.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/semp/sempv2/operation.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -12745,42 +14219,7 @@
     },
     {
       "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/errors.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/exchange.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/exchange_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/exchanger.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
       "target": "file:internal/tokenexchange/exchanger_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/from_config.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -12802,27 +14241,6 @@
     {
       "source": "file:internal/tools/errors.go",
       "target": "file:internal/tokenexchange/request_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/response.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/response_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tokenexchange/types.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -12864,13 +14282,6 @@
     },
     {
       "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/semp/resilience/retry.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
       "target": "file:internal/semp/resilience/retry_safe_test.go",
       "type": "imports",
       "direction": "forward",
@@ -12879,20 +14290,6 @@
     {
       "source": "file:internal/tools/errors_test.go",
       "target": "file:internal/semp/resilience/semaphore.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/semp/resilience/sender.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/semp/resilience/sender_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -12990,20 +14387,6 @@
     },
     {
       "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -13012,20 +14395,6 @@
     {
       "source": "file:internal/tools/errors_test.go",
       "target": "file:internal/semp/sempv2/error_truncate_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/semp/sempv2/operation.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -13046,42 +14415,7 @@
     },
     {
       "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/errors.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/exchange.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/exchange_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/exchanger.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
       "target": "file:internal/tokenexchange/exchanger_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/from_config.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -13108,27 +14442,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/response.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/response_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tools/errors_test.go",
-      "target": "file:internal/tokenexchange/types.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:internal/semp/sempv1/xml_util.go",
       "target": "file:internal/semp/sempv1/xml_util_test.go",
       "type": "tested_by",
@@ -13138,13 +14451,6 @@
     {
       "source": "file:internal/tools/authorization.go",
       "target": "file:internal/tools/authorization_validate_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "file:internal/tools/errors.go",
-      "target": "file:internal/tools/errors_test.go",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5
@@ -15992,125 +17298,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:internal/tokenexchange/errors.go",
-      "target": "class:internal/tokenexchange/errors.go:ExchangeError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/errors.go",
-      "target": "class:internal/tokenexchange/errors.go:ExchangeError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/errors.go",
-      "target": "function:internal/tokenexchange/errors.go:LogAttrs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/errors.go",
-      "target": "function:internal/tokenexchange/errors.go:LogAttrs",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/exchange.go",
-      "target": "function:internal/tokenexchange/exchange.go:Exchange",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/exchange.go",
-      "target": "function:internal/tokenexchange/exchange.go:Exchange",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/exchange.go",
-      "target": "function:internal/tokenexchange/exchange.go:doExchange",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/exchange.go",
-      "target": "function:internal/tokenexchange/exchange.go:Invalidate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/exchange.go",
-      "target": "function:internal/tokenexchange/exchange.go:Invalidate",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/exchanger.go",
-      "target": "class:internal/tokenexchange/exchanger.go:Exchanger",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/exchanger.go",
-      "target": "class:internal/tokenexchange/exchanger.go:Exchanger",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/exchanger.go",
-      "target": "function:internal/tokenexchange/exchanger.go:New",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/exchanger.go",
-      "target": "function:internal/tokenexchange/exchanger.go:New",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/from_config.go",
-      "target": "function:internal/tokenexchange/from_config.go:FromConfig",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/from_config.go",
-      "target": "function:internal/tokenexchange/from_config.go:FromConfig",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/from_config.go",
-      "target": "function:internal/tokenexchange/from_config.go:resolveClientAuth",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/from_config.go",
-      "target": "function:internal/tokenexchange/from_config.go:resolveAudienceParam",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:internal/tokenexchange/request.go",
       "target": "function:internal/tokenexchange/request.go:buildIdPRequest",
       "type": "contains",
@@ -16130,76 +17317,6 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/response.go",
-      "target": "function:internal/tokenexchange/response.go:parseIdPResponse",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/response.go",
-      "target": "function:internal/tokenexchange/response.go:parseSuccessBody",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/response.go",
-      "target": "function:internal/tokenexchange/response.go:classifyClientError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/response.go",
-      "target": "function:internal/tokenexchange/response.go:responseMediaType",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/types.go",
-      "target": "class:internal/tokenexchange/types.go:Params",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/types.go",
-      "target": "class:internal/tokenexchange/types.go:Params",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/types.go",
-      "target": "class:internal/tokenexchange/types.go:ExchangeInput",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/types.go",
-      "target": "class:internal/tokenexchange/types.go:ExchangeInput",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/tokenexchange/types.go",
-      "target": "class:internal/tokenexchange/types.go:Token",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/tokenexchange/types.go",
-      "target": "class:internal/tokenexchange/types.go:Token",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "file:internal/semp/pool.go",
@@ -16574,13 +17691,6 @@
     },
     {
       "source": "file:internal/tokenexchange/from_config.go",
-      "target": "file:internal/config/config.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/tokenexchange/from_config.go",
       "target": "file:internal/config/config_test.go",
       "type": "imports",
       "direction": "forward",
@@ -16685,13 +17795,6 @@
       "weight": 0.5
     },
     {
-      "source": "file:internal/tokenexchange/exchange.go",
-      "target": "file:internal/tokenexchange/exchange_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
       "source": "file:internal/tokenexchange/exchanger.go",
       "target": "file:internal/tokenexchange/exchanger_test.go",
       "type": "tested_by",
@@ -16706,43 +17809,8 @@
       "weight": 0.5
     },
     {
-      "source": "file:internal/tokenexchange/response.go",
-      "target": "file:internal/tokenexchange/response_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "function:internal/tokenexchange/exchange.go:Exchange",
-      "target": "function:internal/tokenexchange/exchange.go:doExchange",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "function:internal/tokenexchange/exchange.go:doExchange",
       "target": "function:internal/tokenexchange/request.go:buildIdPRequest",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:internal/tokenexchange/exchange.go:doExchange",
-      "target": "function:internal/tokenexchange/response.go:parseIdPResponse",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:internal/tokenexchange/response.go:parseIdPResponse",
-      "target": "function:internal/tokenexchange/response.go:parseSuccessBody",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:internal/tokenexchange/response.go:parseIdPResponse",
-      "target": "function:internal/tokenexchange/response.go:classifyClientError",
       "type": "calls",
       "direction": "forward",
       "weight": 0.8
@@ -16757,27 +17825,6 @@
     {
       "source": "function:internal/tokenexchange/request.go:buildIdPRequest",
       "target": "function:internal/tokenexchange/request.go:setAudience",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:internal/tokenexchange/from_config.go:FromConfig",
-      "target": "function:internal/tokenexchange/exchanger.go:New",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:internal/tokenexchange/from_config.go:FromConfig",
-      "target": "function:internal/tokenexchange/from_config.go:resolveClientAuth",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:internal/tokenexchange/from_config.go:FromConfig",
-      "target": "function:internal/tokenexchange/from_config.go:resolveAudienceParam",
       "type": "calls",
       "direction": "forward",
       "weight": 0.8
@@ -17427,85 +18474,8 @@
       "weight": 0.5
     },
     {
-      "source": "file:internal/semp/resilience/retry.go",
-      "target": "function:internal/semp/resilience/retry.go:checkRetry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "class:internal/semp/resilience/sender.go:Sender",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "class:internal/semp/resilience/sender.go:Sender",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "class:internal/semp/resilience/sender.go:RetriesExhaustedError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "class:internal/semp/resilience/sender.go:RetriesExhaustedError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "function:internal/semp/resilience/sender.go:New",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "function:internal/semp/resilience/sender.go:New",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "function:internal/semp/resilience/sender.go:Do",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "function:internal/semp/resilience/sender.go:Do",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "function:internal/semp/resilience/sender.go:errorHandler",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:internal/semp/resilience/semaphore.go",
       "target": "file:internal/defaults/defaults.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "file:internal/config/config.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -17593,13 +18563,6 @@
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/resilience/sender.go",
-      "target": "file:internal/semp/resilience/sender_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
     },
     {
       "source": "file:internal/semp/resilience/sender.go",
@@ -17698,13 +18661,6 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
-    },
-    {
-      "source": "file:internal/semp/resilience/sender_test.go",
-      "target": "file:internal/config/config.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:internal/semp/resilience/sender_test.go",
@@ -18111,104 +19067,6 @@
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "class:internal/semp/sempv2/client.go:Client",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "class:internal/semp/sempv2/client.go:Client",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "class:internal/semp/sempv2/client.go:HTTPClient",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "class:internal/semp/sempv2/client.go:HTTPClient",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "class:internal/semp/sempv2/client.go:SEMPError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "class:internal/semp/sempv2/client.go:SEMPError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:NewHTTPClient",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:NewHTTPClient",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:Execute",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:Execute",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:buildURL",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:buildRequest",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:encodeCSVQueryParam",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "function:internal/semp/sempv2/client.go:parseSEMPError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
     },
     {
       "source": "file:internal/semp/sempv1/client_test.go",
@@ -18625,13 +19483,6 @@
     },
     {
       "source": "file:internal/semp/sempv2/client.go",
-      "target": "file:internal/config/config.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
       "target": "file:internal/config/config_test.go",
       "type": "imports",
       "direction": "forward",
@@ -18779,13 +19630,6 @@
     },
     {
       "source": "file:internal/semp/sempv2/client.go",
-      "target": "file:internal/semp/resilience/retry.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
       "target": "file:internal/semp/resilience/retry_safe_test.go",
       "type": "imports",
       "direction": "forward",
@@ -18794,20 +19638,6 @@
     {
       "source": "file:internal/semp/sempv2/client.go",
       "target": "file:internal/semp/resilience/semaphore.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "file:internal/semp/resilience/sender.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "file:internal/semp/resilience/sender_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -18829,13 +19659,6 @@
     {
       "source": "file:internal/semp/sempv2/client.go",
       "target": "file:internal/version/version.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client_test.go",
-      "target": "file:internal/config/config.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -18968,13 +19791,6 @@
     },
     {
       "source": "file:internal/semp/sempv2/client_test.go",
-      "target": "file:internal/semp/resilience/retry.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client_test.go",
       "target": "file:internal/semp/resilience/retry_safe_test.go",
       "type": "imports",
       "direction": "forward",
@@ -18983,20 +19799,6 @@
     {
       "source": "file:internal/semp/sempv2/client_test.go",
       "target": "file:internal/semp/resilience/semaphore.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client_test.go",
-      "target": "file:internal/semp/resilience/sender.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client_test.go",
-      "target": "file:internal/semp/resilience/sender_test.go",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -19017,13 +19819,6 @@
     },
     {
       "source": "file:internal/semp/sempv2/client_test.go",
-      "target": "file:internal/semp/sempv2/client.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client_test.go",
       "target": "file:internal/semp/sempv2/correlation_test.go",
       "type": "imports",
       "direction": "forward",
@@ -19035,27 +19830,6 @@
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client_test.go",
-      "target": "file:internal/semp/sempv2/operation.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client_test.go",
-      "target": "file:internal/semp/sempv2/operation_test.go",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:internal/semp/sempv2/client.go",
-      "target": "file:internal/semp/sempv2/client_test.go",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5
     },
     {
       "source": "file:internal/semp/sempv2/client.go",
@@ -19704,132 +20478,6 @@
     {
       "source": "file:internal/authz/authz.go",
       "target": "function:internal/authz/authz.go:Authorize",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:ServerConfig",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:ServerConfig",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:BrokerConfig",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:BrokerConfig",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:AuthConfig",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:AuthConfig",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:ToolAuthorizationConfig",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "class:internal/config/config.go:ToolAuthorizationConfig",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:Load",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:Load",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:LoadConfig",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:LoadConfig",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:validate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:applyDefaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:validateToolAuthorization",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:validateBroker",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:ToolAuthorizationEnabled",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:internal/config/config.go",
-      "target": "function:internal/config/config.go:ToolAuthorizationEnabled",
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
@@ -22089,20 +22737,6 @@
       "weight": 0.5
     },
     {
-      "source": "document:README.md",
-      "target": "document:CHANGELOG.md",
-      "type": "related",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "document:RELEASING.md",
-      "target": "document:CHANGELOG.md",
-      "type": "related",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
       "source": "document:DISCLAIMERS.md",
       "target": "document:THIRD_PARTY_LICENSES.md",
       "type": "related",
@@ -22136,13 +22770,6 @@
       "type": "related",
       "direction": "forward",
       "weight": 0.5
-    },
-    {
-      "source": "config:go.sum",
-      "target": "config:go.mod",
-      "type": "depends_on",
-      "direction": "forward",
-      "weight": 0.6
     },
     {
       "source": "document:.github/CONTRIBUTING.md",
@@ -22192,13 +22819,6 @@
       "type": "serves",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "document:docs/user-guide.md",
-      "target": "document:docs/tools-reference.md",
-      "type": "related",
-      "direction": "forward",
-      "weight": 0.5
     },
     {
       "source": "document:docs/user-guide.md",
@@ -22308,20 +22928,6 @@
     {
       "source": "document:docs/superpowers/plans/2026-06-14-sol-150070-implementation-decisions.md",
       "target": "document:docs/superpowers/plans/2026-05-20-client-auth-mode.md",
-      "type": "related",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-config-extended.json",
-      "target": "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-monitor-extended.json",
-      "type": "related",
-      "direction": "forward",
-      "weight": 0.5
-    },
-    {
-      "source": "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-action-extended.json",
-      "target": "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-config-extended.json",
       "type": "related",
       "direction": "forward",
       "weight": 0.5
@@ -22556,15 +23162,4489 @@
       "direction": "forward",
       "weight": 0.5,
       "description": "Path-based pairing (deterministic)"
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "function:internal/tools/errors.go:buildErrorResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "function:internal/tools/errors.go:buildErrorMessage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "function:internal/tools/errors.go:buildSEMPv1Message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "function:internal/tools/errors.go:buildSEMPv2Message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "function:internal/tools/errors.go:isRetryable",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/semp/resilience/retry.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/semp/resilience/sender.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/semp/resilience/sender_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/errors.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/exchange.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/exchanger.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/from_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/response.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/response_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tokenexchange/types.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors.go",
+      "target": "file:internal/tools/errors_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestSanitizeBrokerText",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestSanitizeBrokerText",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestIsRetryable",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestIsRetryable",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildSEMPv2Message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildSEMPv2Message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildSEMPv1Message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildSEMPv1Message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildErrorMessage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildErrorMessage",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildErrorResult_ExchangeError_StructuredFields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "function:internal/tools/errors_test.go:TestBuildErrorResult_ExchangeError_StructuredFields",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/semp/resilience/retry.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/semp/resilience/sender.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/semp/resilience/sender_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/errors.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/exchange.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/exchanger.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/from_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/response.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/response_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tools/errors_test.go",
+      "target": "file:internal/tokenexchange/types.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:internal/tools/errors_test.go:TestIsRetryable",
+      "target": "function:internal/tools/errors.go:isRetryable",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/tools/errors_test.go:TestBuildSEMPv2Message",
+      "target": "function:internal/tools/errors.go:buildSEMPv2Message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/tools/errors_test.go:TestBuildSEMPv1Message",
+      "target": "function:internal/tools/errors.go:buildSEMPv1Message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/tools/errors_test.go:TestBuildErrorMessage",
+      "target": "function:internal/tools/errors.go:buildErrorMessage",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/tools/errors_test.go:TestBuildErrorResult_ExchangeError_StructuredFields",
+      "target": "function:internal/tools/errors.go:buildErrorResult",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/resilience/sender_test.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/resilience/sender_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/resilience/sender_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/resilience/retry.go",
+      "target": "function:internal/semp/resilience/retry.go:WithRetrySafe",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/resilience/retry.go",
+      "target": "function:internal/semp/resilience/retry.go:checkRetry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "class:internal/semp/resilience/sender.go:RetriesExhaustedError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "class:internal/semp/resilience/sender.go:Sender",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "function:internal/semp/resilience/sender.go:New",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "function:internal/semp/resilience/sender.go:Do",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "function:internal/semp/resilience/sender.go:errorHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/resilience/retry.go",
+      "target": "function:internal/semp/resilience/retry.go:WithRetrySafe",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "class:internal/semp/resilience/sender.go:RetriesExhaustedError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "class:internal/semp/resilience/sender.go:Sender",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "function:internal/semp/resilience/sender.go:New",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "function:internal/semp/resilience/sender.go:Do",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/resilience/sender.go",
+      "target": "file:internal/semp/resilience/sender_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/semp/resilience/retry.go",
+      "target": "file:internal/semp/resilience/sender_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "file:internal/semp/resilience/retry.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "file:internal/semp/resilience/sender.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "file:internal/semp/resilience/sender_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/semp/resilience/retry.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/semp/resilience/sender.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/semp/resilience/sender_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client_test.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "class:internal/semp/sempv2/client.go:Client",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "class:internal/semp/sempv2/client.go:SEMPError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "class:internal/semp/sempv2/client.go:HTTPClient",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:NewHTTPClient",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:Execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:buildURL",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:unfilledPlaceholders",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:buildRequest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:encodeCSVQueryParam",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:parseSEMPError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "class:internal/semp/sempv2/client.go:Client",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "class:internal/semp/sempv2/client.go:SEMPError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "class:internal/semp/sempv2/client.go:HTTPClient",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:NewHTTPClient",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "function:internal/semp/sempv2/client.go:Execute",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/client.go:Execute",
+      "target": "function:internal/semp/resilience/sender.go:Do",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/client.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:redactSecretAttr",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:newSlogHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:buildMux",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:healthConfigFromFile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:limitRequestBody",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:startServer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:drainAndShutdown",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:gracefulShutdown",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:newTokenExchanger",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "function:cmd/server/main.go:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "class:cmd/server/main.go:shutdowner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/executor.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/executor_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/executor_helpers_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/executor_vpn_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/loader_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/loader_cross_reference_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/idpclient/retrying.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/idpclient/retrying_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/errors.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/exchange.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/exchanger.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/from_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/response.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/response_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tokenexchange/types.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tools/errors.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:cmd/server/main.go",
+      "target": "file:internal/tools/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:cmd/server/main.go:main",
+      "target": "function:internal/tools/manager.go:NewToolManagerFromComposite",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cmd/server/main.go:main",
+      "target": "function:internal/semp/pool.go:NewBrokerPool",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_Counts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_OutboundOnlyFailure",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_OutboundOnlyFailureWithStaleInboundReason",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_UnidirectionalNotApplicableIsHealthy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_TruncationSurfaced",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_Empty",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_Errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_MissingField",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_NilField",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges_test.go:TestListBridges_SkippedOmittedWhenZero",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "target": "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test \u2192 production)"
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "function:internal/idpclient/retrying.go:NewRetryingHTTPClient",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "function:internal/idpclient/retrying.go:NewRetryingHTTPClient",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "function:internal/idpclient/retrying.go:checkRetry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "function:internal/idpclient/retrying.go:WithAttemptsCounter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "function:internal/idpclient/retrying.go:WithAttemptsCounter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "function:internal/idpclient/retrying.go:RoundTrip",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "function:internal/idpclient/retrying.go:RoundTrip",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "class:internal/idpclient/retrying.go:RetryOptions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "class:internal/idpclient/retrying.go:RetryOptions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_RetriesOn5xx",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_RetriesOn429",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_NoRetryOn2xx",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_NoRetryOn4xx",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_RetriesRecover",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_CtxCancelAbortsBackoff",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestNewRetryingHTTPClient_ConnectionErrorRetries",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestAttemptsRecorder_NilSafe",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestAttemptsRecorder_IncrementsWhenAttached",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying_test.go",
+      "target": "function:internal/idpclient/retrying_test.go:TestCheckRetry_Table",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/idpclient/retrying.go",
+      "target": "file:internal/idpclient/retrying_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test \u2192 production)"
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker.go",
+      "target": "function:internal/tokenexchange/circuitbreaker.go:newTokenExchangeCircuitBreaker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker.go",
+      "target": "function:internal/tokenexchange/circuitbreaker.go:newReadyToTrip",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker.go",
+      "target": "function:internal/tokenexchange/circuitbreaker.go:isBreakerExcluded",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker.go",
+      "target": "function:internal/tokenexchange/circuitbreaker.go:isBreakerFailure",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/defaults.go",
+      "target": "function:internal/tokenexchange/defaults.go:ComputeChainDeadline",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/errors.go",
+      "target": "class:internal/tokenexchange/errors.go:ExchangeError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/errors.go",
+      "target": "function:internal/tokenexchange/errors.go:AgentMessage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/errors.go",
+      "target": "function:internal/tokenexchange/errors.go:LogAttrs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "function:internal/tokenexchange/exchange.go:Exchange",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "function:internal/tokenexchange/exchange.go:runExchangeOnce",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "function:internal/tokenexchange/exchange.go:Invalidate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "function:internal/tokenexchange/exchange.go:classifyRetryOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "function:internal/tokenexchange/exchange.go:doExchange",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/exchanger.go",
+      "target": "class:internal/tokenexchange/exchanger.go:Exchanger",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/exchanger.go",
+      "target": "function:internal/tokenexchange/exchanger.go:New",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/failure_class.go",
+      "target": "function:internal/tokenexchange/failure_class.go:String",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/defaults.go",
+      "target": "function:internal/tokenexchange/defaults.go:ComputeChainDeadline",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/errors.go",
+      "target": "class:internal/tokenexchange/errors.go:ExchangeError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/errors.go",
+      "target": "function:internal/tokenexchange/errors.go:AgentMessage",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/errors.go",
+      "target": "function:internal/tokenexchange/errors.go:LogAttrs",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "function:internal/tokenexchange/exchange.go:Exchange",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "function:internal/tokenexchange/exchange.go:Invalidate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/exchanger.go",
+      "target": "class:internal/tokenexchange/exchanger.go:Exchanger",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/exchanger.go",
+      "target": "function:internal/tokenexchange/exchanger.go:New",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/failure_class.go",
+      "target": "function:internal/tokenexchange/failure_class.go:String",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/tokenexchange/circuitbreaker.go:newTokenExchangeCircuitBreaker",
+      "target": "function:internal/tokenexchange/circuitbreaker.go:newReadyToTrip",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "target": "file:internal/idpclient/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "target": "file:internal/idpclient/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "target": "file:internal/idpclient/main_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "target": "file:internal/idpclient/retrying.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "target": "file:internal/idpclient/retrying_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "file:internal/idpclient/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "file:internal/idpclient/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "file:internal/idpclient/main_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "file:internal/idpclient/retrying.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "file:internal/idpclient/retrying_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange_test.go",
+      "target": "file:internal/idpclient/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange_test.go",
+      "target": "file:internal/idpclient/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange_test.go",
+      "target": "file:internal/idpclient/main_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange_test.go",
+      "target": "file:internal/idpclient/retrying.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange_test.go",
+      "target": "file:internal/idpclient/retrying_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "file:internal/tokenexchange/exchange_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/exchange.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/defaults.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/errors.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/failure_class.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/response.go",
+      "target": "function:internal/tokenexchange/response.go:parseIdPResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/response.go",
+      "target": "function:internal/tokenexchange/response.go:parseSuccessBody",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/response.go",
+      "target": "function:internal/tokenexchange/response.go:responseMediaType",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/response.go",
+      "target": "function:internal/tokenexchange/response.go:classifyClientError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/transport_error.go",
+      "target": "function:internal/tokenexchange/transport_error.go:classifyTransportError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/types.go",
+      "target": "class:internal/tokenexchange/types.go:Params",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/types.go",
+      "target": "class:internal/tokenexchange/types.go:ExchangeInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/types.go",
+      "target": "class:internal/tokenexchange/types.go:Token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/types.go",
+      "target": "class:internal/tokenexchange/types.go:Params",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/types.go",
+      "target": "class:internal/tokenexchange/types.go:ExchangeInput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/types.go",
+      "target": "class:internal/tokenexchange/types.go:Token",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/response.go",
+      "target": "file:internal/tokenexchange/response_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/transport_error.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_helpers_test.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_helpers_test.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_helpers_test.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_helpers_test.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_vpn_test.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_vpn_test.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_vpn_test.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor_vpn_test.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/loader_cross_reference_test.go",
+      "target": "file:internal/composite/definitions/embed.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "class:internal/composite/executor.go:CompositeExecutor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:NewCompositeExecutor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:Execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:GroupStepsIntoBatches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:runSingle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:fetchFanOut",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:fetchPaginated",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:resolveMaxResults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:extractNextPageURI",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:executeBatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:ResolveArgs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:safeTemplateExecute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:constructRequestBody",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:ApplyResultStrategy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "class:internal/composite/executor.go:CompositeExecutor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:NewCompositeExecutor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:Execute",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:GroupStepsIntoBatches",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:ResolveArgs",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "function:internal/composite/executor.go:ApplyResultStrategy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:internal/composite/executor.go:CompositeExecutor",
+      "target": "function:internal/composite/executor.go:Execute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "class:internal/composite/executor.go:CompositeExecutor",
+      "target": "function:internal/composite/executor.go:runSingle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "class:internal/composite/executor.go:CompositeExecutor",
+      "target": "function:internal/composite/executor.go:fetchFanOut",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "class:internal/composite/executor.go:CompositeExecutor",
+      "target": "function:internal/composite/executor.go:fetchPaginated",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "class:internal/composite/executor.go:CompositeExecutor",
+      "target": "function:internal/composite/executor.go:executeBatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "class:internal/composite/executor.go:CompositeExecutor",
+      "target": "function:internal/composite/executor.go:constructRequestBody",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "file:internal/composite/executor_bridge_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "file:internal/composite/executor_helpers_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/composite/executor.go",
+      "target": "file:internal/composite/executor_vpn_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/composite/loader.go",
+      "target": "file:internal/composite/loader_bridge_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/composite/loader.go",
+      "target": "file:internal/composite/loader_cross_reference_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "target": "file:internal/composite/postprocess/postprocess.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "target": "file:internal/composite/postprocess/postprocess_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges.go:ListBridges",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "target": "function:internal/composite/postprocess/handlers/list_bridges.go:ListBridges",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/composite/postprocess/handlers/list_bridges.go",
+      "target": "function:internal/composite/postprocess/postprocess.go:Register",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "function:internal/semp/sempv2/operation.go:deriveSpecType",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "function:internal/semp/sempv2/operation.go:extractParameters",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "function:internal/semp/sempv2/operation.go:extractBodyFields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "class:internal/semp/sempv2/operation.go:Operation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "class:internal/semp/sempv2/operation.go:Parameter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "class:internal/semp/sempv2/operation.go:Operation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "class:internal/semp/sempv2/operation.go:Parameter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "target": "function:internal/semp/sempv2/operation.go:deriveSpecType",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "target": "function:internal/semp/sempv2/operation.go:extractParameters",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "target": "function:internal/semp/sempv2/operation.go:extractBodyFields",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "file:internal/semp/sempv2/client.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "file:internal/semp/sempv2/client_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "file:internal/semp/sempv2/operation.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation.go",
+      "target": "file:internal/semp/sempv2/operation_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_OperationCount",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_OperationFields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_BodyFields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_RefParametersResolved",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_NoGhostParameters",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_MonitorOperationsPresent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_PathIncludesBasePath",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_NoDuplicateKeys",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/semp/sempv2/operation_test.go",
+      "target": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_SpecTypeDerivation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_OperationCount",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_OperationFields",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_BodyFields",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_RefParametersResolved",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_NoGhostParameters",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_MonitorOperationsPresent",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_PathIncludesBasePath",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_NoDuplicateKeys",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/semp/sempv2/operation_test.go:TestParseSpecs_SpecTypeDerivation",
+      "target": "function:internal/semp/sempv2/operation.go:ParseSpecs",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:Load",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:LoadConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:applyDefaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:loadEnvFile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateAndCanonicalizeBrokers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:substituteEnvVars",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateToolAuthorization",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateBroker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateBrokerOAuthConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateBrokerClientAuth",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateClientSecretAuth",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:applyEnvOverrides",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateBrokerURL",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:Hop2OAuthActive",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:ToolAuthorizationEnabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:selectedMethod",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:splitYAMLComment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:applyToolAuthorizationDefaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:validateHop1Hop2Alignment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:envBool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:ServerConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:BrokerOAuthConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:BrokerClientAuth",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:ClientSecretAuth",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:MCPClientAuthConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:ToolAuthorizationConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:BrokerConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:AuthConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:SEMPConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:Load",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:LoadConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:Hop2OAuthActive",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "function:internal/config/config.go:ToolAuthorizationEnabled",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:ServerConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:BrokerOAuthConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:BrokerClientAuth",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:ClientSecretAuth",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:MCPClientAuthConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:ToolAuthorizationConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:BrokerConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:AuthConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "class:internal/config/config.go:SEMPConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/config/config.go:validate",
+      "target": "function:internal/banner/banner.go:LogOAuthNotSupported",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/config/config.go:validate",
+      "target": "function:internal/banner/banner.go:LogHop2WithoutHop1",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:internal/config/config.go:validateBrokerOAuthConfig",
+      "target": "function:internal/config/idp_circuit_breaker.go:validateIdPCircuitBreaker",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker.go",
+      "target": "class:internal/config/idp_circuit_breaker.go:IdPCircuitBreakerConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker.go",
+      "target": "function:internal/config/idp_circuit_breaker.go:BreakerEnabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker.go",
+      "target": "function:internal/config/idp_circuit_breaker.go:validateIdPCircuitBreaker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker.go",
+      "target": "class:internal/config/idp_circuit_breaker.go:IdPCircuitBreakerConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker.go",
+      "target": "function:internal/config/idp_circuit_breaker.go:BreakerEnabled",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker_test.go",
+      "target": "function:internal/config/idp_circuit_breaker_test.go:TestLoadConfig_CircuitBreaker_ParsesFromYAML",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker_test.go",
+      "target": "function:internal/config/idp_circuit_breaker_test.go:TestLoadConfig_CircuitBreaker_OmittedBlockIsNil",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker_test.go",
+      "target": "function:internal/config/idp_circuit_breaker_test.go:TestLoadConfig_CircuitBreaker_BadValueRejected",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker_test.go",
+      "target": "function:internal/config/idp_circuit_breaker_test.go:TestBreakerEnabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker_test.go",
+      "target": "function:internal/config/idp_circuit_breaker_test.go:TestValidateBrokerCircuitBreaker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/config/idp_circuit_breaker.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/config/config.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "class:internal/tokenexchange/circuitbreaker_config.go:CircuitBreakerConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "function:internal/tokenexchange/circuitbreaker_config.go:DefaultCircuitBreakerConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "function:internal/tokenexchange/circuitbreaker_config.go:Validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "class:internal/tokenexchange/circuitbreaker_config.go:CircuitBreakerConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "function:internal/tokenexchange/circuitbreaker_config.go:DefaultCircuitBreakerConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "function:internal/tokenexchange/circuitbreaker_config.go:Validate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "function:internal/tokenexchange/circuitbreaker_config_test.go:TestDefaultCircuitBreakerConfig_Values",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "function:internal/tokenexchange/circuitbreaker_config_test.go:TestCircuitBreakerConfig_Validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "function:internal/tokenexchange/from_config.go:FromConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "function:internal/tokenexchange/from_config.go:resolveCircuitBreakerConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "function:internal/tokenexchange/from_config.go:resolveClientAuth",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "function:internal/tokenexchange/from_config.go:resolveAudienceParam",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "function:internal/tokenexchange/from_config.go:FromConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "function:internal/tokenexchange/from_config_breaker_test.go:TestResolveCircuitBreakerConfig_PartialOverlay",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "function:internal/tokenexchange/from_config_breaker_test.go:TestResolveCircuitBreakerConfig_FullOverlay",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "function:internal/tokenexchange/from_config.go:resolveCircuitBreakerConfig",
+      "target": "function:internal/tokenexchange/circuitbreaker_config.go:DefaultCircuitBreakerConfig",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/observability.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/observability_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/tool_authorization_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "target": "file:internal/config/yaml_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/observability.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/observability_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/tool_authorization_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "target": "file:internal/config/yaml_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/observability.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/observability_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/tool_authorization_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "target": "file:internal/config/yaml_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "document:RELEASING.md",
+      "target": "document:CHANGELOG.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "document:CHANGELOG.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "document:RELEASING.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:go.sum",
+      "target": "config:go.mod",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:.github/scripts/changelog-check.sh",
+      "target": "function:.github/scripts/changelog-check.sh:extract_unreleased",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:.github/scripts/changelog-check.sh",
+      "target": "file:.github/scripts/production-surface.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:docs/user-guide.md",
+      "target": "document:docs/tools-reference.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:.claude/hooks/changelog-reminder.sh",
+      "target": "config:internal/composite/definitions/tools.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:cmd/server/panic_recovery_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:cmd/server/panic_recovery_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:cmd/server/startup_banner_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:cmd/server/startup_banner_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:cmd/server/tool_policy_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:cmd/server/tool_policy_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/auth/middleware.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/auth/middleware.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/auth/middleware.go",
+      "target": "file:internal/idpclient/retrying.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/auth/middleware.go",
+      "target": "file:internal/idpclient/retrying_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/auth/middleware_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/auth/middleware_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/authz/authz.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/authz/authz.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/authz/authz_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/authz/authz_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/composite/result_strategy_test.go",
+      "target": "file:internal/composite/executor_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/composite/result_strategy_test.go",
+      "target": "file:internal/composite/loader_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/composite/result_strategy_test.go",
+      "target": "file:internal/composite/loader_cross_reference_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/audit/audit.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/audit/audit.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/audit/audit_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/audit/audit_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/correlation/correlation.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/correlation/correlation.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/correlation/correlation_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/correlation/correlation_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/health/health.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/health/health.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/health/health_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/health/health_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/metrics/metrics.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/metrics/metrics.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/metrics/metrics_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/metrics/metrics_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/tracing/tracing.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/tracing/tracing.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/tracing/tracing_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/observability/tracing/tracing_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/auth/oauth_test.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/broker_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/pool_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/resilience/body_close_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/resilience/body_close_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/resilience/transport.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/resilience/transport.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/resilience/transport_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/resilience/transport_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv1/client.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv1/client.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv1/client_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv1/client_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv1/correlation_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv1/correlation_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv2/correlation_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/semp/sempv2/correlation_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tokenexchange/from_config_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization_audit_schema_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization_audit_schema_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization_validate_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/authorization_validate_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/composite_handler.go",
+      "target": "file:internal/composite/executor_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/composite_handler.go",
+      "target": "file:internal/composite/loader_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/composite_handler.go",
+      "target": "file:internal/composite/loader_cross_reference_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/composite_handler_test.go",
+      "target": "file:internal/composite/executor_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/composite_handler_test.go",
+      "target": "file:internal/composite/loader_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/composite_handler_test.go",
+      "target": "file:internal/composite/loader_cross_reference_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/composite/executor_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/composite/loader_bridge_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/composite/loader_cross_reference_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/circuitbreaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_config_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/circuitbreaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/defaults.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/defaults_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/errors_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/failure_class.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/failure_class_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/from_config_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/transport_error.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager.go",
+      "target": "file:internal/tokenexchange/transport_error_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager_test.go",
+      "target": "file:internal/config/idp_circuit_breaker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:internal/tools/manager_test.go",
+      "target": "file:internal/config/idp_circuit_breaker_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
     }
   ],
   "layers": [
     {
       "id": "layer:entry",
       "name": "Entry & Bootstrap",
-      "description": "Process entry point (cmd/server) that parses config and wires observability, auth, and token-exchange middleware into the MCP HTTP server with graceful startup and drain.",
+      "description": "Process entry point (cmd/server) that parses config and wires observability, auth, SEMP, and tools.",
       "nodeIds": [
-        "file:cmd/server/main.go",
         "file:cmd/server/correlation_wiring_test.go",
         "file:cmd/server/main_test.go",
         "file:cmd/server/panic_recovery_test.go",
@@ -22572,25 +27652,23 @@
         "file:cmd/server/startup_banner_test.go",
         "file:cmd/server/tool_policy_test.go",
         "file:cmd/server/body_limit_test.go",
-        "file:cmd/server/redact_test.go"
+        "file:cmd/server/redact_test.go",
+        "file:cmd/server/main.go"
       ]
     },
     {
       "id": "layer:tools",
       "name": "MCP Tools & Composite Engine",
-      "description": "MCP tools exposed to AI assistants: the YAML-driven composite engine plus native SEMPv1 Go handlers, registration, authorization, and validation.",
+      "description": "MCP tools exposed to AI assistants: the YAML-driven composite engine plus native tool handlers, including list-bridges postprocessing.",
       "nodeIds": [
         "file:internal/composite/definition.go",
         "file:internal/composite/definitions/embed.go",
-        "file:internal/composite/executor.go",
         "file:internal/composite/executor_client_test.go",
         "file:internal/composite/executor_fanout_test.go",
         "file:internal/composite/executor_framework_test.go",
-        "file:internal/composite/executor_helpers_test.go",
         "file:internal/composite/executor_queue_test.go",
         "file:internal/composite/executor_rdp_test.go",
         "file:internal/composite/executor_topic_endpoint_test.go",
-        "file:internal/composite/executor_vpn_test.go",
         "file:internal/composite/loader.go",
         "file:internal/composite/loader_client_test.go",
         "file:internal/composite/loader_fanout_test.go",
@@ -22640,8 +27718,6 @@
         "file:internal/tools/sempv1/redundancy/response_test.go",
         "file:internal/tools/authorization.go",
         "file:internal/tools/authorization_validate_test.go",
-        "file:internal/tools/errors.go",
-        "file:internal/tools/errors_test.go",
         "file:internal/tools/identity.go",
         "file:internal/tools/identity_test.go",
         "file:internal/tools/queuemetrics/handler.go",
@@ -22670,19 +27746,27 @@
         "config:internal/tools/sempv1/discardstats/testdata/show_message_spool_stats.xml",
         "config:internal/tools/sempv1/discardstats/testdata/show_message_vpn_default_stats.xml",
         "config:internal/tools/sempv1/discardstats/testdata/show_stats_client.xml",
-        "config:internal/composite/definitions/tools.yaml",
         "config:internal/tools/queuemetrics/testdata/show_queue_detail.xml",
-        "config:internal/tools/sempv1/redundancy/testdata/show_redundancy_standalone.xml"
+        "config:internal/tools/sempv1/redundancy/testdata/show_redundancy_standalone.xml",
+        "file:internal/tools/errors.go",
+        "file:internal/tools/errors_test.go",
+        "file:internal/composite/postprocess/handlers/list_bridges_test.go",
+        "file:internal/composite/executor.go",
+        "file:internal/composite/executor_bridge_test.go",
+        "file:internal/composite/executor_helpers_test.go",
+        "file:internal/composite/executor_vpn_test.go",
+        "file:internal/composite/loader_bridge_test.go",
+        "file:internal/composite/loader_cross_reference_test.go",
+        "file:internal/composite/postprocess/handlers/list_bridges.go",
+        "config:internal/composite/definitions/tools.yaml"
       ]
     },
     {
       "id": "layer:semp",
       "name": "SEMP Broker Client",
-      "description": "SEMPv1/SEMPv2 clients that talk to Solace brokers, including connection pooling, resilience/retry, auth, and correlation-header plumbing.",
+      "description": "SEMPv1/SEMPv2 clients that talk to Solace brokers, including connection pooling and resilience.",
       "nodeIds": [
         "file:internal/semp/sempv2/error_truncate_test.go",
-        "file:internal/semp/sempv2/operation.go",
-        "file:internal/semp/sempv2/operation_test.go",
         "file:internal/semp/sempv2/specs/embed.go",
         "file:internal/semp/sempv1/envelope.go",
         "file:internal/semp/sempv1/envelope_test.go",
@@ -22706,39 +27790,36 @@
         "file:internal/semp/resilience/cookiejar_test.go",
         "file:internal/semp/resilience/io.go",
         "file:internal/semp/resilience/io_test.go",
-        "file:internal/semp/resilience/retry.go",
         "file:internal/semp/resilience/retry_safe_test.go",
         "file:internal/semp/resilience/semaphore.go",
-        "file:internal/semp/resilience/sender.go",
-        "file:internal/semp/resilience/sender_test.go",
         "file:internal/semp/resilience/transport.go",
         "file:internal/semp/resilience/transport_test.go",
         "file:internal/semp/sempv1/client.go",
         "file:internal/semp/sempv1/client_test.go",
         "file:internal/semp/sempv1/correlation_test.go",
-        "file:internal/semp/sempv2/client.go",
-        "file:internal/semp/sempv2/client_test.go",
         "file:internal/semp/sempv2/correlation_test.go",
         "file:internal/semp/broker_test.go",
         "file:internal/semp/correlationhdr/correlationhdr.go",
         "file:internal/semp/correlationhdr/correlationhdr_test.go",
         "file:internal/semp/correlationhdr/span_internal_test.go",
         "file:internal/semp/pool_test.go",
-        "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-action-extended.json",
-        "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-config-extended.json",
-        "schema:internal/semp/sempv2/specs/semp-v2-swagger-private-monitor-extended.json"
+        "file:internal/semp/resilience/retry.go",
+        "file:internal/semp/resilience/sender.go",
+        "file:internal/semp/resilience/sender_test.go",
+        "file:internal/semp/sempv2/client.go",
+        "file:internal/semp/sempv2/client_test.go",
+        "file:internal/semp/sempv2/operation.go",
+        "file:internal/semp/sempv2/operation_test.go"
       ]
     },
     {
       "id": "layer:auth",
       "name": "Authentication & Authorization",
-      "description": "Request authentication and authorization: OAuth/OIDC verification, IdP client, token exchange, authz policy, and HTTP middleware.",
+      "description": "Request authentication and authorization: OAuth/OIDC verification, IdP client, authz policy, and RFC 8693 token exchange with circuit breaker.",
       "nodeIds": [
         "file:internal/idpclient/client.go",
         "file:internal/idpclient/client_test.go",
         "file:internal/idpclient/main_test.go",
-        "file:internal/middleware/recovery/middleware.go",
-        "file:internal/middleware/recovery/middleware_test.go",
         "file:internal/auth/claims.go",
         "file:internal/auth/errors.go",
         "file:internal/auth/principal.go",
@@ -22753,29 +27834,44 @@
         "file:internal/auth/raw_subject_token_test.go",
         "file:internal/oauth/cache/cache_test.go",
         "file:internal/tokenexchange/dedup_key.go",
-        "file:internal/tokenexchange/errors.go",
-        "file:internal/tokenexchange/exchange.go",
-        "file:internal/tokenexchange/exchanger.go",
-        "file:internal/tokenexchange/from_config.go",
         "file:internal/tokenexchange/request.go",
-        "file:internal/tokenexchange/response.go",
-        "file:internal/tokenexchange/types.go",
         "file:internal/tokenexchange/dedup_key_test.go",
-        "file:internal/tokenexchange/exchange_test.go",
         "file:internal/tokenexchange/exchanger_test.go",
         "file:internal/tokenexchange/request_test.go",
-        "file:internal/tokenexchange/response_test.go",
         "file:internal/auth/middleware.go",
         "file:internal/auth/middleware_test.go",
         "file:internal/authz/authz.go",
         "file:internal/authz/authz_test.go",
-        "file:internal/tokenexchange/from_config_test.go"
+        "file:internal/tokenexchange/from_config_test.go",
+        "file:internal/idpclient/retrying.go",
+        "file:internal/idpclient/retrying_test.go",
+        "file:internal/tokenexchange/circuitbreaker.go",
+        "file:internal/tokenexchange/circuitbreaker_exchange_test.go",
+        "file:internal/tokenexchange/circuitbreaker_test.go",
+        "file:internal/tokenexchange/defaults.go",
+        "file:internal/tokenexchange/defaults_test.go",
+        "file:internal/tokenexchange/errors.go",
+        "file:internal/tokenexchange/errors_test.go",
+        "file:internal/tokenexchange/exchange.go",
+        "file:internal/tokenexchange/exchange_test.go",
+        "file:internal/tokenexchange/exchanger.go",
+        "file:internal/tokenexchange/failure_class.go",
+        "file:internal/tokenexchange/failure_class_test.go",
+        "file:internal/tokenexchange/response.go",
+        "file:internal/tokenexchange/response_test.go",
+        "file:internal/tokenexchange/transport_error.go",
+        "file:internal/tokenexchange/transport_error_test.go",
+        "file:internal/tokenexchange/types.go",
+        "file:internal/tokenexchange/circuitbreaker_config.go",
+        "file:internal/tokenexchange/circuitbreaker_config_test.go",
+        "file:internal/tokenexchange/from_config.go",
+        "file:internal/tokenexchange/from_config_breaker_test.go"
       ]
     },
     {
       "id": "layer:observability",
       "name": "Observability",
-      "description": "Cross-cutting telemetry: request correlation, structured logging, health checks, metrics, tracing, and audit emission.",
+      "description": "Cross-cutting telemetry: request correlation, structured logging, health checks, metrics, and audit.",
       "nodeIds": [
         "file:internal/observability/logging/sanitize/sanitize.go",
         "file:internal/observability/logging/sanitize/sanitize_test.go",
@@ -22802,15 +27898,16 @@
     {
       "id": "layer:config",
       "name": "Configuration & Support",
-      "description": "Runtime configuration loading and small support packages (banner, version, defaults, safego) alongside build/lint/module config files.",
+      "description": "Runtime configuration loading (including IdP circuit-breaker config) and small support packages (banner, version, defaults, safego, panic-recovery middleware) plus project and dev-tooling config.",
       "nodeIds": [
         "file:internal/banner/banner.go",
         "file:internal/banner/banner_test.go",
+        "file:internal/middleware/recovery/middleware.go",
+        "file:internal/middleware/recovery/middleware_test.go",
         "file:internal/safego/safego.go",
         "file:internal/safego/safego_test.go",
         "file:internal/defaults/defaults.go",
         "file:internal/version/version.go",
-        "file:internal/config/config.go",
         "file:internal/config/config_test.go",
         "file:internal/config/observability.go",
         "file:internal/config/observability_test.go",
@@ -22818,38 +27915,34 @@
         "file:internal/config/yaml_error_test.go",
         "table:data:.claude/review-balance-history.tsv",
         "config:.claude/review-balance.json",
-        "config:.claude/settings.json",
-        "config:.fossa.yml",
-        "config:.golangci.yml",
         "config:broker-config.example.yaml",
+        "file:.ua/.understandignore",
+        "file:internal/.gitkeep",
+        "file:internal/config/config.go",
+        "file:internal/config/idp_circuit_breaker.go",
+        "file:internal/config/idp_circuit_breaker_test.go",
+        "config:.claude/settings.json",
         "config:go.mod",
         "config:go.sum",
-        "file:.ua/.understandignore",
-        "file:internal/.gitkeep"
+        "file:.claude/hooks/changelog-reminder.sh"
       ]
     },
     {
       "id": "layer:infrastructure",
       "name": "Infrastructure & CI/CD",
-      "description": "Container build (Dockerfile), Makefile, Kubernetes manifests, and GitHub Actions pipelines for build, test, release, and scanning.",
+      "description": "Container build, Makefile, Kubernetes manifests, repo/CI config, release scripts, and GitHub Actions pipelines.",
       "nodeIds": [
         "service:Dockerfile",
         "service:Dockerfile:builder",
         "service:Dockerfile:static-debian12",
         "config:.dockerignore",
         "pipeline:.github/workflows/build-and-test.yml",
-        "pipeline:.github/workflows/ci-pr.yaml",
         "pipeline:.github/workflows/fossa-scan.yaml",
         "pipeline:.github/workflows/llm-eval.yml",
-        "pipeline:.github/workflows/release.yml",
         "pipeline:.github/workflows/transition_on_merge.yaml",
+        "config:.fossa.yml",
+        "config:.golangci.yml",
         "pipeline:Makefile",
-        "document:.github/ADMIN_SETUP.md",
-        "document:.github/CODE_OF_CONDUCT.md",
-        "document:.github/CONTRIBUTING.md",
-        "document:.github/OPEN_SOURCE_STATUS.md",
-        "document:.github/PULL_REQUEST_TEMPLATE.md",
-        "document:.github/SECURITY.md",
         "config:.github/renovate.json",
         "config:.github/workflow-config.json",
         "config:.github/ISSUE_TEMPLATE/bug_report.yml",
@@ -22859,38 +27952,42 @@
         "service:deploy/kubernetes/deployment.yaml",
         "config:deploy/kubernetes/secret.yaml",
         "service:deploy/kubernetes/service.yaml",
-        "file:.github/CODEOWNERS"
+        "file:.github/CODEOWNERS",
+        "pipeline:.github/workflows/ci-pr.yaml",
+        "pipeline:.github/workflows/release.yml",
+        "file:.github/scripts/changelog-check.sh",
+        "file:.github/scripts/extract-release-notes.sh",
+        "file:.github/scripts/production-surface.sh"
       ]
     },
     {
       "id": "layer:documentation",
       "name": "Documentation",
-      "description": "Project and internal documentation: README, examples, tool reference, architecture/design docs, changelog, and license notices.",
+      "description": "Project and internal documentation: README, examples, tool reference, architecture and design docs, and dev-skill guides.",
       "nodeIds": [
-        "document:CHANGELOG.md",
-        "document:CLAUDE.md",
         "document:DISCLAIMERS.md",
         "document:EXAMPLES.md",
-        "document:README.md",
-        "document:RELEASING.md",
         "document:THIRD_PARTY_LICENSES.md",
         "document:TOOLS.md",
         "document:fixit-notes.md",
         "document:sweep-notes.md",
         "document:watch-for-prs-notes.md",
         "document:watch-my-prs-notes.md",
+        "document:.github/ADMIN_SETUP.md",
+        "document:.github/CODE_OF_CONDUCT.md",
+        "document:.github/CONTRIBUTING.md",
+        "document:.github/OPEN_SOURCE_STATUS.md",
+        "document:.github/PULL_REQUEST_TEMPLATE.md",
+        "document:.github/SECURITY.md",
         "document:docs/authentication.md",
         "document:docs/configuration.md",
         "document:docs/examples.md",
         "document:docs/sam-integration.md",
-        "document:docs/tools-reference.md",
-        "document:docs/user-guide.md",
         "document:docs/internal/architecture.md",
         "document:docs/internal/e2e-testing.md",
         "document:docs/internal/packaging-release.md",
         "document:docs/internal/secure-logging-rules.md",
         "document:docs/internal/todo-gaps.md",
-        "document:docs/internal/understand-anything.md",
         "document:docs/internal/semp/get-broker-status-curated-fields.md",
         "document:docs/internal/semp/get-discard-stats-curated-fields.md",
         "document:docs/internal/semp/sempv1-client-design.md",
@@ -22908,15 +28005,23 @@
         "document:docs/oauth/token-exchange-SOL-150070/architecture-plan.md",
         "document:docs/superpowers/plans/oauth-token-exchange/2026-06-21-SOL-150797-T3-raw-subject-token.md",
         "document:docs/superpowers/plans/oauth-token-exchange/SOL-150796-T2-config-schema.md",
-        "document:docs/superpowers/specs/2026-05-20-client-auth-mode-design.md"
+        "document:docs/superpowers/specs/2026-05-20-client-auth-mode-design.md",
+        "document:README.md",
+        "document:CHANGELOG.md",
+        "document:RELEASING.md",
+        "document:CLAUDE.md",
+        "document:docs/tools-reference.md",
+        "document:docs/user-guide.md",
+        "document:docs/internal/understand-anything.md",
+        "document:.claude/skills/cut-release/SKILL.md"
       ]
     }
   ],
   "tour": [
     {
       "order": 1,
-      "title": "What This Project Is",
-      "description": "Start with the README to understand the mission: a Go MCP server that exposes Solace event broker monitoring and management to AI assistants over SEMP v1/v2. The architecture doc goes a level deeper, laying out the package structure, the two-hop inbound auth model, the read vs. write/action request flows, and the concurrency story for multiple users and brokers. Together these give you the map for the code tour that follows.",
+      "title": "Project Overview",
+      "description": "Start with the README to understand what this project is: a Go MCP server that exposes Solace broker monitoring and management to AI assistants over the SEMP v1/v2 protocols. It covers the feature set, the tool catalog, quickstart paths (binary, go install, Docker), and how configuration works. The internal architecture doc goes a level deeper, laying out the layers and data flow the rest of this tour walks through.",
       "nodeIds": [
         "document:README.md",
         "document:docs/internal/architecture.md"
@@ -22925,111 +28030,140 @@
     {
       "order": 2,
       "title": "Application Entry Point",
-      "description": "cmd/server/main.go is where the process comes alive. It parses configuration, wires the observability, auth, and token-exchange middleware, builds the MCP HTTP endpoint plus a health mux, and manages graceful startup and drain/shutdown. This one file has by far the highest fan-out in the codebase, so reading it is the fastest way to see how every subsystem connects.",
+      "description": "cmd/server/main.go is where the process comes to life and the single place that wires every subsystem together. It bootstraps configuration, builds the per-broker SEMP client pool, constructs the tool manager, sets up OAuth token exchange and authorization, initializes observability, and starts the HTTP MCP server with graceful shutdown. Reading this file gives you the whole runtime skeleton before you dive into any one layer.",
       "nodeIds": [
         "file:cmd/server/main.go"
       ],
-      "languageLesson": "Go convention puts the runnable binary under cmd/<name>/main.go. A single large main() acts as the composition root, constructing dependencies explicitly and passing them down rather than using globals. Note the signal-driven graceful drain via os/signal and context cancellation."
+      "languageLesson": "Go bootstraps run through func main() in package main. Dependencies are wired explicitly by hand here rather than through a DI framework, and graceful shutdown is coordinated with context.Context and signal.NotifyContext so in-flight requests drain before exit."
     },
     {
       "order": 3,
-      "title": "Configuration Model",
-      "description": "Before anything can run, config must be loaded and validated. internal/config/config.go is the central model and loader: it parses YAML and environment variables and validates brokers, OAuth, and tool-authorization settings, while observability.go covers the logging, tracing, and correlation knobs. These files rank at the very top of the fan-in ranking, meaning almost every other package depends on the shapes defined here.",
+      "title": "Tool Registration and Dispatch",
+      "description": "These two files turn broker capabilities into MCP tools the AI can call. register.go wraps each handler with panic recovery and correlation-ID stamping, auto-injects the broker parameter into every tool schema, gates write tools, and registers the built-in list-brokers tool. manager.go is the request path at runtime: it validates parameters, resolves the target broker connection, routes the call to the right handler, and emits secure structured logs with broker-error classification.",
       "nodeIds": [
-        "file:internal/config/config.go",
-        "file:internal/config/observability.go"
+        "file:internal/tools/register.go",
+        "file:internal/tools/manager.go"
       ]
     },
     {
       "order": 4,
-      "title": "Tool Manager and Registration",
-      "description": "This is the heart of the request path. ToolManager (manager.go) validates parameters, resolves the target broker connection, routes each MCP tool call to its registered handler, and emits structured, secure logs with broker-error classification. register.go wraps every handler with panic recovery and correlation-ID stamping, gates write tools, and registers the built-in list-brokers tool. errors.go standardizes how broker failures become MCP responses.",
+      "title": "The Composite Engine",
+      "description": "Most tools are not hand-written Go; they are declared in tools.yaml and driven by the composite engine, which is the heart of this project. definition.go is the Go struct schema for a YAML tool (parameters, steps, result strategy), loader.go reads the embedded definitions and validates their structure, and executor.go runs them against a SEMPv2 client with dependency-ordered batching, fan-out, pagination, and argument templating. This declarative approach is why adding a monitoring tool usually means editing YAML, not writing code.",
       "nodeIds": [
-        "file:internal/tools/manager.go",
-        "file:internal/tools/register.go",
-        "file:internal/tools/errors.go"
+        "file:internal/composite/definition.go",
+        "file:internal/composite/loader.go",
+        "file:internal/composite/executor.go",
+        "config:internal/composite/definitions/tools.yaml"
       ],
-      "languageLesson": "register.go injects the broker parameter into every tool's JSON schema at registration time, so no handler declares it manually. This is a decorator-style pattern in Go: handlers are wrapped in successive middleware closures (panic recovery, correlation stamping, write-gating) before being registered."
+      "languageLesson": "The tools.yaml file is compiled into the binary with go:embed (see definitions/embed.go), so a single static executable ships all tool definitions with no external files to deploy."
     },
     {
       "order": 5,
-      "title": "Composite Engine (YAML Tools)",
-      "description": "Most tools are declared in YAML rather than written in Go. The executor is the composite execution engine: it resolves templated args, groups steps into batches, runs fan-out and paginated SEMPv2 fetches, and applies result strategies. loader.go reads the embedded tool definitions and validates their structure, fan-out references, and post-process handler wiring, while postprocess.go is the registry of named Go transformers applied to step results. This is the primary mechanism for adding new tools.",
+      "title": "Postprocessing and Bridge Monitoring",
+      "description": "Raw SEMPv2 responses are verbose, so the composite engine runs named Go postprocessors to reshape step results into clean tool outputs. postprocess.go is the registry, and it validates at startup that each handler's required fields match the SEMP step's select clause. list_bridges.go is a recent addition powering the new list-bridges and get-bridge-status tools: it normalizes raw bridge results into name, VPN, direction, and enabled state, self-registering via an init() function so the engine discovers it automatically.",
       "nodeIds": [
-        "file:internal/composite/executor.go",
-        "file:internal/composite/loader.go",
-        "file:internal/composite/postprocess/postprocess.go"
+        "file:internal/composite/postprocess/postprocess.go",
+        "file:internal/composite/postprocess/handlers/list_bridges.go"
       ],
-      "languageLesson": "Tool definitions are compiled into the binary with Go's embed package (//go:embed), so there are no external files to ship at runtime. Post-processors register themselves into a name-keyed map, a registry pattern that keeps the executor decoupled from individual tool logic."
+      "languageLesson": "Go's init() functions run automatically at package load. Handlers use them to self-register into a central registry, so importing the package is enough to make a postprocessor available, no explicit wiring needed."
     },
     {
       "order": 6,
-      "title": "Per-Broker Client Assembly",
-      "description": "Building on the tool layer, requests ultimately need a broker connection. broker.go assembles a per-broker client, wiring the tuned HTTP transport, cookie jar, authenticator (basic/bearer/oauth), and both the SEMPv1 and SEMPv2 protocol clients from configuration. pool.go is a thread-safe cache that lazily constructs and reuses those clients per broker alias, which is what lets one stateless server serve many brokers concurrently.",
+      "title": "Native SEMPv1 Tools",
+      "description": "A few tools need logic the YAML engine cannot express, mainly SEMPv1's legacy XML parsing. get-broker-status is the canonical example: its handler executes SEMPv1 show commands, decodes the XML envelope, and conditionally gathers appliance hardware status. Compare this native Go handler with the YAML-driven tools from Step 4 to understand when each mechanism is the right choice.",
       "nodeIds": [
-        "file:internal/semp/broker.go",
-        "file:internal/semp/pool.go"
-      ],
-      "languageLesson": "pool.go distinguishes an unknown broker alias from a client-construction failure using a sentinel error (a package-level error value compared with errors.Is). This is idiomatic Go for letting callers branch on a specific failure mode without string matching."
+        "file:internal/tools/sempv1/brokerstatus/handler.go"
+      ]
     },
     {
       "order": 7,
-      "title": "SEMPv2 Client (Modern REST)",
-      "description": "The SEMPv2 client is the modern path used by the composite engine. It builds REST URLs from templated operations, encodes path and query parameters (including CSV arrays), issues requests through a resilient sender with retry handling, and parses structured SEMP error bodies into typed errors. operation.go defines the operation descriptors that the executor from Step 5 templates against.",
+      "title": "SEMP Client Pool",
+      "description": "Every tool ultimately talks to a broker, and this layer manages those connections. pool.go is a thread-safe pool that lazily builds and caches SEMPv1/v2 clients per broker alias, distinguishing an unknown alias from a construction failure via a sentinel error. broker.go assembles one broker's client, wiring the tuned HTTP transport, cookie jar, authenticator (basic/bearer/oauth), and both protocol clients from configuration. This is what the tool manager from Step 3 resolves against on each call.",
       "nodeIds": [
-        "file:internal/semp/sempv2/client.go",
-        "file:internal/semp/sempv2/operation.go"
+        "file:internal/semp/pool.go",
+        "file:internal/semp/broker.go"
       ]
     },
     {
       "order": 8,
-      "title": "SEMPv1 Client (Legacy XML)",
-      "description": "Some broker capabilities are only reachable over the legacy SEMPv1 XML-RPC protocol, which is why a handful of tools are native Go handlers instead of YAML. client.go posts legacy XML commands over the same resilient sender, validates input, classifies show vs. config commands, and deliberately excludes credentials from logs. envelope.go defines the <rpc-reply> structs and parseReply, which surfaces execute-result errors from the broker's response.",
+      "title": "SEMP Protocol Clients and Resilience",
+      "description": "These are the two protocol dialects the server speaks to Solace brokers. sempv2/client.go builds and executes modern management/monitoring operations with URL templating, query-param encoding, and typed error parsing, while sempv1/client.go posts legacy XML RPC commands and classifies show versus config commands. Both ride on transport.go, a tuned http.Transport with granular timeouts, per-host connection caps, and TLS verification derived from configuration, keeping broker calls robust under load.",
       "nodeIds": [
+        "file:internal/semp/sempv2/client.go",
         "file:internal/semp/sempv1/client.go",
-        "file:internal/semp/sempv1/envelope.go"
-      ],
-      "languageLesson": "Go's encoding/xml maps struct fields to XML via tags (xml:\"rpc-reply\"). The envelope structs mirror the broker's nested reply shape so a single Unmarshal populates the whole tree, and error detection becomes a matter of inspecting decoded fields rather than parsing text."
-    },
-    {
-      "order": 9,
-      "title": "Two-Hop Auth and Token Exchange",
-      "description": "The server never passes a user's inbound token straight through to the broker. exchange.go implements the RFC 8693 token-exchange flow: it serves cache hits, coalesces concurrent misses, calls the IdP, and maps context and transport errors precisely so the broker remains the authorization authority. cache.go defines the token cache contract (intentionally silent, no logs or metrics), and principal.go carries the authenticated identity across the request via a context key.",
-      "nodeIds": [
-        "file:internal/tokenexchange/exchange.go",
-        "file:internal/oauth/cache/cache.go",
-        "file:internal/auth/principal.go"
-      ],
-      "languageLesson": "Concurrent cache misses for the same token are collapsed with golang.org/x/sync/singleflight, keyed on a dedup hash, so a burst of identical requests triggers exactly one IdP call. Identity is threaded through request scope using context.WithValue plus an unexported key type, the standard Go way to avoid key collisions."
-    },
-    {
-      "order": 10,
-      "title": "Observability and Secure Logging",
-      "description": "Cutting across every layer is correlation and log hygiene. The correlation package decides when to propagate correlation IDs and installs a slog handler that stamps them onto every log line, giving each request a traceable identity. The sanitize package is a leaf dependency whose Claim function strips control, bidi, and format characters and caps length so IdP- or admin-controlled strings cannot forge log lines or spoof identities. This is why the project enforces secure-logging rules before every commit.",
-      "nodeIds": [
-        "file:internal/observability/correlation/sloghandler.go",
-        "file:internal/observability/correlation/correlation.go",
-        "file:internal/observability/logging/sanitize/sanitize.go"
-      ],
-      "languageLesson": "slog.Handler is an interface; wrapping one lets you enrich every record (here, injecting the correlation ID from context) without touching call sites. The sanitize package guards against CWE-117 log injection and CWE-1007 homograph spoofing, a reminder that any externally controlled string is untrusted at the logging boundary."
-    },
-    {
-      "order": 11,
-      "title": "How It's Tested End-to-End",
-      "description": "Unit tests live beside the code, but confidence comes from the E2E suites. This guide describes the shared test scaffold and how scenarios run against Dockerized Solace brokers, both as raw curl calls and through a Go MCP SDK agent driving the real tool surface. It explains the prerequisites, configuration, and CI integration, closing the loop between the tool definitions from earlier steps and verified broker behavior.",
-      "nodeIds": [
-        "document:docs/internal/e2e-testing.md"
+        "file:internal/semp/resilience/transport.go"
       ]
     },
     {
+      "order": 9,
+      "title": "Authentication and Authorization",
+      "description": "Before any tool runs, the request must be authenticated and authorized. middleware.go constructs static-token or OIDC token verifiers and publishes OAuth protected-resource metadata for MCP clients, establishing who the caller is. authz.go then maps the caller's groups to the set of MCP tools they may invoke and renders the allow/deny decision. Together they are the gate in front of the tool manager from Step 3.",
+      "nodeIds": [
+        "file:internal/auth/middleware.go",
+        "file:internal/authz/authz.go"
+      ]
+    },
+    {
+      "order": 10,
+      "title": "RFC 8693 Token Exchange",
+      "description": "When the broker is the authorization authority, the server exchanges the caller's token for a broker-scoped one using the RFC 8693 token-exchange flow. exchange.go is the core: cache-first lookup, singleflight deduplication of concurrent identical requests, a circuit-breaker-protected IdP round-trip, and retry-outcome classification. exchanger.go declares the immutable process-wide exchanger, and idpclient/client.go centralizes the shared HTTP client and TLS config used to reach identity providers. The design doc explains why token exchange, not passthrough, was chosen.",
+      "nodeIds": [
+        "file:internal/tokenexchange/exchange.go",
+        "file:internal/tokenexchange/exchanger.go",
+        "file:internal/idpclient/client.go",
+        "document:docs/oauth/token-exchange-SOL-150070/architecture-plan.md"
+      ],
+      "languageLesson": "Go's singleflight collapses concurrent identical calls into one in-flight request, so a burst of parallel tool calls needing the same token triggers a single IdP round-trip and shares the result."
+    },
+    {
+      "order": 11,
+      "title": "Token-Exchange Circuit Breaker",
+      "description": "A recent hardening addition protects the IdP token endpoint from cascading failures. circuitbreaker.go builds and tunes a process-wide gobreaker instance and, crucially, classifies each error as a breaker success, failure, or excluded outcome so that rate limits and config faults never trip the breaker. idp_circuit_breaker.go defines and validates the configuration knobs. This is what the exchange flow from Step 10 wraps its IdP round-trip in, so one struggling IdP cannot take the whole server down.",
+      "nodeIds": [
+        "file:internal/tokenexchange/circuitbreaker.go",
+        "file:internal/config/idp_circuit_breaker.go"
+      ],
+      "languageLesson": "A circuit breaker has three states: closed (calls flow), open (calls fail fast after too many failures), and half-open (a probe tests recovery). Excluding certain error classes from the failure count keeps expected faults like rate limits from tripping the breaker."
+    },
+    {
       "order": 12,
-      "title": "Containerization and CI/CD",
-      "description": "Finally, how the server ships. The Dockerfile is a two-stage build: it compiles a static CGO-free binary from ./cmd/server, then packages it into a minimal distroless nonroot image exposing port 9090 with a health check. The build-and-test workflow is the source of truth for CI, running lint, race-enabled tests, a FOSSA license scan, and five Dockerized E2E suites on every push. This is the production gate every change from Steps 2 through 11 must pass.",
+      "title": "Observability",
+      "description": "Cross-cutting telemetry threads through every request. correlation.go gates and drives correlation-ID propagation, so a single request can be traced across log lines and downstream SEMP calls (recall register.go stamps this ID in Step 3). health.go serves the /livez and /readyz probes that let Kubernetes know the process is alive and ready, with saturation-event emission behind a capability flag. These are the hooks the deployment layer relies on.",
+      "nodeIds": [
+        "file:internal/observability/correlation/correlation.go",
+        "file:internal/observability/health/health.go"
+      ]
+    },
+    {
+      "order": 13,
+      "title": "Configuration",
+      "description": "config.go is the central loader and validator that everything above depends on: it parses YAML with environment-variable substitution, applies defaults and env overrides, and validates brokers, OAuth, TLS, and tool-authorization settings before the server starts. The example config file shows the shape operators actually fill in, from broker connection details to auth mode. This is the single source of truth main.go reads at startup in Step 2.",
+      "nodeIds": [
+        "file:internal/config/config.go",
+        "config:broker-config.example.yaml"
+      ]
+    },
+    {
+      "order": 14,
+      "title": "Containerization and Deployment",
+      "description": "The Dockerfile packages the server into a container using a multi-stage build: a builder stage compiles the Go binary, and the final stage copies it onto a minimal static-debian image for a small, low-surface runtime. The Kubernetes manifests then deploy it: deployment.yaml manages replicas and wires in the liveness/readiness probes from Step 12, while service.yaml exposes the pods behind a stable DNS name.",
       "nodeIds": [
         "service:Dockerfile",
-        "pipeline:.github/workflows/build-and-test.yml"
+        "service:deploy/kubernetes/deployment.yaml",
+        "service:deploy/kubernetes/service.yaml"
       ],
-      "languageLesson": "Multi-stage Docker builds keep the toolchain in a builder stage and copy only the compiled binary into a tiny distroless runtime, so the shipped image contains no shell or package manager, shrinking both size and attack surface. Building CGO-free (CGO_ENABLED=0) yields a fully static binary that runs on a scratch-like base with no libc dependency."
+      "languageLesson": "Multi-stage Docker builds use multiple FROM statements. The builder stage carries the full Go toolchain, while the final stage ships only the compiled static binary on a distroless-style base, cutting image size and attack surface dramatically."
+    },
+    {
+      "order": 15,
+      "title": "Build and CI/CD Pipeline",
+      "description": "The capstone: how code gets built, verified, and released. The Makefile defines the local contract (build, vet, lint, race-enabled tests, E2E suites), and build-and-test.yml is the CI source of truth that runs the same checks plus E2E jobs on every change. release.yml drives the tagged release pipeline that produces the artifacts the deployment layer from Step 14 consumes. Together they close the loop from source to shipped binary.",
+      "nodeIds": [
+        "pipeline:Makefile",
+        "pipeline:.github/workflows/build-and-test.yml",
+        "pipeline:.github/workflows/release.yml"
+      ],
+      "languageLesson": "GitHub Actions workflows use on triggers to fire on pushes, PRs, or tags; jobs run in parallel while steps within a job run in sequence. A tag-triggered release workflow is a common pattern for cutting versioned artifacts."
     }
   ]
 }

--- a/.ua/meta.json
+++ b/.ua/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-07-21T16:50:07Z",
-  "gitCommitHash": "c1f193ea253213b0d4019e829217170cdd416473",
+  "lastAnalyzedAt": "2026-07-23T17:53:26Z",
+  "gitCommitHash": "c4955e9172cf021b9640e932f9f05c1800cd88f6",
   "version": "1.0.0",
-  "analyzedFiles": 206
+  "analyzedFiles": 317
 }


### PR DESCRIPTION
## What

Incremental refresh of the Understand-Anything knowledge graph (`.ua/`) from the last-analyzed commit `c1f193e` (2026-07-21) to HEAD `c4955e9` — 70 commits, 62 re-analyzed source files. Layers and the guided tour were rebuilt over the full node set.

## Why

The graph had drifted 70 commits behind, so the dashboard and `/understand-*` tooling no longer reflected the current architecture — most notably the new token-exchange circuit breaker and bridge monitoring tools.

## Notable additions now modeled

- `internal/tokenexchange/*` — RFC 8693 token exchange with the process-level **circuit breaker** (27 file nodes, folded into the Authentication & Authorization layer, now 49 nodes)
- `internal/config/idp_circuit_breaker*` — breaker config + validation
- `list-bridges` / `get-bridge-status` bridge monitoring tools (`list_bridges` handler)
- SEMP resilience retry/sender changes

## Scope decision: swagger specs excluded

Added `internal/semp/sempv2/specs/*.json` (~6.7MB of generated OpenAPI) to `.understandignore`. Each spec collapsed to a single low-value node and churns on every schema bump; `embed.go` still represents the package. This also cleared 3 orphaned nodes the 10.26.2 spec rename left behind.

## Result

| | Before | After |
|---|---|---|
| Nodes | 550 | 669 |
| Edges | 2002 | 2414 |
| Layers | 8 | 8 |
| Tour steps | 12 | 15 |

Data-only change under `.ua/` — no production surface touched, so no CHANGELOG entry required. Deterministic graph validation passed with 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)