### PR TITLE
SOL-152405: make ADMIN_SETUP.md accurate as the open-source flip checklist

### DIFF
--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -101,10 +101,12 @@ Enable both secret-scanning settings, not just the first. Alerts find credential
 already committed; push protection rejects the next one before it lands. Both are
 free on public repositories.
 
-On CodeQL: a check named `Analyze (go)` runs and passes on every PR, produced by
-the code-scanning default setup, while the repository API reports Code Security as
-disabled. Confirm which configuration is producing it on the settings page before
-relying on it, and re-check after the visibility change.
+On CodeQL: a check named `Analyze (go)` runs and passes on every PR, and its
+workflow path points at the code-scanning default setup. Against that, the
+repository API reports Code Security as disabled and the default-setup endpoint
+returns 403. Something is producing this check and we cannot say from the API
+which configuration owns it. Confirm on the settings page before relying on it,
+and re-check after the visibility change.
 
 **Dependency updates use Renovate, not Dependabot.**
 
@@ -196,9 +198,10 @@ Four more notes on the list:
   `pull_request` events). It blocks on findings that are new relative to the base
   branch, not on the full dependency inventory. That is what keeps `main` from
   entering an irregular state; do not read a green PR as a clean full scan.
-- `Analyze (go)` (CodeQL) is available and passes on every PR. Add it if you want
-  code scanning to block merges; it is not in the list above because that is a
-  policy call, not a correctness fix.
+- `Analyze (go)` (CodeQL) passes on every PR. Add it if you want code scanning to
+  block merges, after settling the configuration question in the Security Settings
+  section. It is not in the list above because that is a policy call, not a
+  correctness fix.
 - Do **not** require `run-pull-request-checks / *`. Those come from
   `transition_on_merge.yaml`, which runs on `pull_request: closed`, and the check
   name varies with the Jira key (e.g. `... Vault and JIRA Operations (SOL-152328)`).
@@ -215,14 +218,35 @@ both of which need a CI change. Tracked separately.
    triggered by a fork, so the reusable workflow finds an empty Vault URL and
    exits 1. It runs, and it goes red.
 
-What about the rest? Nobody has ever opened a fork pull request against this
-repository, so none of this is observed. `CHANGELOG updated` should be fine:
-`ci-pr.yaml` gives that job only `contents: read` and it reads no secrets.
-`Analyze (go)` comes from CodeQL default setup, which is expected to run but has
-not been seen against a fork here. Copilot review is inconsistent even on
-same-repo pull requests, so do not count on it either way.
+Nobody has ever opened a fork pull request against this repository, so nothing
+below is observed. `CHANGELOG updated` should be fine: `ci-pr.yaml` gives that job
+only `contents: read` and it reads no secrets. `Analyze (go)` appears to come from
+CodeQL default setup, which the Security Settings section asks you to confirm.
+Copilot review is inconsistent even on same-repo pull requests, so do not count on
+it. Verify `CHANGELOG updated`, `Analyze (go)`, and `FOSSA Scan / SCA Scan`
+against a real fork pull request before you treat any of them as a gate.
 
-Confirm all three against a real fork pull request before you rely on any of them.
+**A third problem, and this one we create deliberately.** The GitHub Actions
+Permissions section below tells you to require approval for all external
+contributors. That holds the entire workflow run, not just one job, until a
+maintainer approves it.
+
+The consequence, in order: an external contributor opens their first pull request,
+and **no checks run at all**. Not `FOSSA Scan / SCA Scan`, not `CHANGELOG updated`,
+not the seven that were already broken. Every required context sits pending and the
+pull request reads as stuck rather than as rejected or passing.
+
+That is expected, not broken. Maintainers need to know it, or the first community
+contribution gets triaged as a CI outage. Two things follow:
+
+- Watch the Actions tab for runs awaiting approval, not just the pull request page.
+- Tell the contributor you are waiting on an approval click, rather than leaving
+  them looking at a grey check.
+
+This also constrains the required-check list. Every context you require is a
+context that reports only after a human approves the run, so requiring more of
+them lengthens the stall rather than tightening the gate.
+
 Until the CI fix lands, merge community contributions by pushing the branch into
 this repository yourself.
 
@@ -270,6 +294,12 @@ contributor is exempt permanently once any one of their contributions merges. Th
 repository allows all actions and does not require SHA pinning
 (`allowed_actions: all`, `sha_pinning_required: false`), so until that tightens, a
 human should look at every external workflow run before it executes.
+
+This has a cost worth knowing: until a maintainer approves the run, **no checks
+report at all** on an external contributor's pull request, so it shows pending
+required contexts rather than a verdict. That is expected behavior, not a CI
+failure. The fork-pull-request warning at the end of the Branch Protection section
+explains what maintainers should do about it.
 
 ---
 
@@ -344,11 +374,15 @@ Navigate to: **Settings → General → Pull Requests**
 leave it. GitHub only restricts the "Update branch" button when the base branch
 does *not* require branches to be up to date; the setting lifts that restriction.
 `main-protection` sets `strict_required_status_checks_policy: true`, so the button
-is already offered on every stale pull request to `main`. Turn the setting on only
-if you later add a protected branch without the up-to-date requirement.
+is already offered on every stale pull request to `main`.
 
-Note that "Update branch" needs write access to the head branch either way, so a
-fork contributor never gets the button and has to rebase locally.
+Turn the setting on if you want the button on pull requests targeting other
+branches. `main-protection` applies to `~DEFAULT_BRANCH` only, so any pull request
+against a non-default base already lacks it today. Nobody is asking for that, so
+leaving the setting off is fine.
+
+"Update branch" needs write access to the head branch either way, so a fork
+contributor never gets the button and has to rebase locally.
 
 **Default commit messages.** Live values, which differ from the labels in the UI:
 

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -179,9 +179,9 @@ PRs #213, #216, and #217:
 
 ⚠️ **Do not select `FOSSA Scan`.** It looks like the right entry and is not. A
 check by that exact name comes from `build-and-test.yml`, where the job carries
-`if: github.event_name == 'push' && github.ref_name == <default branch>`, so on
-every pull request it reports **skipped**, and GitHub counts a skipped check as
-passing. Requiring `FOSSA Scan` therefore enforces nothing. The context that
+`if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch`,
+so on every pull request it reports **skipped**, and GitHub counts a skipped
+check as passing. Requiring `FOSSA Scan` therefore enforces nothing. The context that
 gates is `FOSSA Scan / SCA Scan`: the `ci-pr.yaml` caller job (`name: FOSSA Scan`)
 plus the inner job of the reusable workflow it calls (`name: "SCA Scan"`), which
 exits non-zero on findings because `.github/workflow-config.json` sets both FOSSA
@@ -259,8 +259,8 @@ Navigate to: **Settings → Actions → General → Workflow permissions**
 **Workflow permissions:**
 - ⚪ Read and write permissions (needed for release workflow to create releases).
   Currently set.
-- 🚨 **Allow GitHub Actions to create and approve pull requests: turn this OFF.
-  It is currently ON.** With a write `GITHUB_TOKEN` and a `main` ruleset that
+- 🚨 **Allow GitHub Actions to create and approve pull requests: turn this OFF.**
+  It is currently ON. With a write `GITHUB_TOKEN` and a `main` ruleset that
   needs exactly one approval and has an empty bypass list, a workflow can approve
   a pull request and satisfy the only human gate on `main`.
 

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -12,6 +12,11 @@ This document contains tasks that require **repository admin access**. These sho
 
 Navigate to: **Settings → General → About**
 
+Description and topics already hold values, so these are edits, not blanks.
+Currently: description "Production MCP server for the Solace broker", topics
+`ai-agents`, `go`, `mcp`, `solace`, website unset. Replace them with the below, or
+decide deliberately to keep what is there.
+
 **Description** (appears at top of repo page):
 ```
 MCP (Model Context Protocol) server for Solace brokers - manage queues, topics, and configuration via Claude Code and other AI agents
@@ -65,11 +70,16 @@ second forum. This supersedes the earlier plan to open Discussions.
 - ✅ Preserve this repository (mark as important)
 - ✅ Sponsorships (if applicable)
 
-⚠️ **Before flipping public**: two files still link to `/discussions`, which 404s
-while Discussions is off — `.github/CONTRIBUTING.md:259` and
-`.github/ISSUE_TEMPLATE/config.yml:4`. Repointing them at the Solace Community
-category is tracked separately. Confirm it has landed, or expect broken links on
-the issue-template chooser from day one.
+⚠️ **Before flipping public**: three links still point at `/discussions`, which
+404s while Discussions is off.
+
+- `.github/CONTRIBUTING.md:49`
+- `.github/CONTRIBUTING.md:259`
+- `.github/ISSUE_TEMPLATE/config.yml:4` (the issue-template chooser)
+
+`.github/ISSUE_TEMPLATE/feature_request.yml:122` also says "issues and
+discussions" in prose. Repointing all of them at the Solace Community category is
+tracked separately. Confirm that landed, or expect broken links from day one.
 
 ---
 
@@ -113,8 +123,8 @@ excluded to prevent runaway PRs, and are bumped by hand.
 `main` is protected by two overlapping mechanisms. Both are live, and GitHub
 applies whichever is more restrictive:
 
-- **Ruleset `main-protection`** — carries the required status checks. Edit this one.
-- **Legacy branch protection rule** — requires 1 approval, with an empty
+- **Ruleset `main-protection`**: carries the required status checks. Edit this one.
+- **Legacy branch protection rule**: requires 1 approval, with an empty
   required-checks list.
 
 Put the checks on the ruleset. Adding them to the legacy rule instead leaves the
@@ -123,17 +133,27 @@ apart. Consider retiring the legacy rule once the ruleset covers everything it d
 
 Navigate to: **Settings → Rules → Rulesets → `main-protection`**
 
-**Pull request rule** (✅ = should be on):
-- ✅ Required approvals: **1** — already set
-- ✅ Dismiss stale approvals when new commits are pushed — already set
-- ✅ Require review from Code Owners — **not set yet**. `.github/CODEOWNERS` exists (`* @SolaceDev/dax-developers`), so this is available. Enabling it means every external contribution needs a dax-developers review.
-- ✅ Require conversation resolution before merging — **not set yet**
-- ⬜ Require signed commits (optional - DCO is sufficient)
+**Pull request rule.** ✅ = should be on.
+
+| Setting | Target | Live now |
+|---------|--------|----------|
+| Required approvals | ✅ 1 | Set |
+| Dismiss stale approvals on new commits | ✅ On | Set |
+| Require review from Code Owners | ✅ On | **Not set** |
+| Require conversation resolution before merging | ✅ On | **Not set** |
+| Require signed commits | ⬜ Optional (DCO is sufficient) | Not set |
+
+`.github/CODEOWNERS` exists (`* @SolaceDev/dax-developers`), so Code Owners review
+is available. Enabling it means every external contribution needs a dax-developers
+review.
 
 **Other rules:**
-- ✅ Restrict deletions — already set
-- ✅ Block force pushes — already set
-- ✅ Bypass list empty, so the rules apply to admins too — already set
+
+| Setting | Target | Live now |
+|---------|--------|----------|
+| Restrict deletions | ✅ On | Set |
+| Block force pushes | ✅ On | Set |
+| Bypass list empty, so rules apply to admins too | ✅ Empty | Empty |
 
 ### Required status checks
 
@@ -152,13 +172,13 @@ PRs #213, #216, and #217:
 | `e2e-monitoring` | `build-and-test.yml` | E2E suite (known flaky fixture; rerun the job before investigating) |
 | `e2e-management` | `build-and-test.yml` | E2E suite |
 | `e2e-action` | `build-and-test.yml` | E2E suite |
-| `FOSSA Scan / SCA Scan` | `ci-pr.yaml` job `fossa_scan` | Licensing policy and critical/high vulnerabilities |
+| `FOSSA Scan / SCA Scan` | `ci-pr.yaml` job `fossa_scan` | Licensing policy and critical/high vulnerabilities, diffed against the base branch |
 | `CHANGELOG updated` | `ci-pr.yaml` job `changelog` | Advisory today; see note below |
 
 ⚠️ **Do not select `FOSSA Scan`.** It looks like the right entry and is not. A
 check by that exact name comes from `build-and-test.yml`, where the job carries
 `if: github.event_name == 'push' && github.ref_name == <default branch>`, so on
-every pull request it reports **skipped** — and GitHub counts a skipped check as
+every pull request it reports **skipped**, and GitHub counts a skipped check as
 passing. Requiring `FOSSA Scan` therefore enforces nothing. The context that
 gates is `FOSSA Scan / SCA Scan`: the `ci-pr.yaml` caller job (`name: FOSSA Scan`)
 plus the inner job of the reusable workflow it calls (`name: "SCA Scan"`), which
@@ -166,12 +186,16 @@ exits non-zero on findings because `.github/workflow-config.json` sets both FOSS
 modes to `BLOCK`. Reusable-workflow jobs always surface as
 `<caller job name> / <inner job name>`, never as the caller name alone.
 
-Three more notes on the list:
+Four more notes on the list:
 
-- `CHANGELOG updated` cannot fail today — `ci-pr.yaml` sets
+- `CHANGELOG updated` cannot fail today. `ci-pr.yaml` sets
   `CHANGELOG_GATE_MODE: advisory`, so the script warns and exits 0. Requiring it
   makes the check's presence a merge precondition now, so flipping the mode to
   `blocking` later needs no ruleset change.
+- On a pull request, FOSSA runs in diff mode (`enable_diff_mode` is true for
+  `pull_request` events). It blocks on findings that are new relative to the base
+  branch, not on the full dependency inventory. That is what keeps `main` from
+  entering an irregular state; do not read a green PR as a clean full scan.
 - `Analyze (go)` (CodeQL) is available and passes on every PR. Add it if you want
   code scanning to block merges; it is not in the list above because that is a
   policy call, not a correctness fix.
@@ -179,14 +203,21 @@ Three more notes on the list:
   `transition_on_merge.yaml`, which runs on `pull_request: closed`, and the check
   name varies with the Jira key (e.g. `... Vault and JIRA Operations (SOL-152328)`).
 
-🚨 **Fork pull requests will block on these checks.**
-`build-and-test.yml` triggers on `push`, not `pull_request`. A fork contributor's
-push fires in their fork, so `lint`, `build`, and the five `e2e-*` checks never
-appear on the base repository's commit and the required contexts stay pending
-forever. Only `ci-pr.yaml` checks (`FOSSA Scan / SCA Scan`, `CHANGELOG updated`)
-run on fork PRs. Fixing this needs a CI change, tracked separately. Until it
-lands, expect to merge community contributions by pushing the branch into this
-repository yourself.
+🚨 **CI cannot currently green-light a fork pull request.** Two separate problems,
+both of which need a CI change. Tracked separately.
+
+1. **Seven checks never appear.** `build-and-test.yml` triggers on `push`, not
+   `pull_request`. A fork contributor's push fires in their fork, so `lint`,
+   `build`, and the five `e2e-*` checks never report on this repository's commit.
+   Those required contexts stay pending forever.
+2. **`FOSSA Scan / SCA Scan` fails.** `ci-pr.yaml` passes `use_vault: true` and
+   `secrets.VAULT_URL`. GitHub withholds secrets from `pull_request` runs
+   triggered by a fork, so the reusable workflow finds an empty Vault URL and
+   exits 1. It runs, and it goes red.
+
+`CHANGELOG updated`, `Analyze (go)`, and Copilot review do run normally on fork
+PRs. Until the CI fix lands, merge community contributions by pushing the branch
+into this repository yourself.
 
 ---
 
@@ -194,16 +225,30 @@ repository yourself.
 
 Navigate to: **Settings → Actions → General → Workflow permissions**
 
-**Recommended:**
-- ⚪ Read and write permissions (needed for release workflow to create releases)
-- ⬜ Allow GitHub Actions to create and approve pull requests — **leave off**. This
-  setting governs the Actions `GITHUB_TOKEN`. Renovate opens PRs with its own
-  GitHub App installation token, so it does not need this, and no workflow in this
-  repository opens or approves PRs.
+**Workflow permissions:**
+- ⚪ Read and write permissions (needed for release workflow to create releases).
+  Currently set.
+- 🚨 **Allow GitHub Actions to create and approve pull requests: turn this OFF.
+  It is currently ON.** Combined with a write `GITHUB_TOKEN` and a `main` ruleset
+  that needs exactly one approval and has an empty bypass list, a workflow can
+  approve a pull request and satisfy the only human gate on `main`. Nothing here
+  needs it: Renovate opens PRs with its own GitHub App installation token, and no
+  workflow in this repository opens or approves PRs.
 
 **Alternative (more restrictive):**
 - ⚪ Read repository contents and packages permissions
 - Manually grant write access to release workflow via repo secrets
+
+**Fork pull request workflows**
+
+Navigate to: **Settings → Actions → General → Fork pull request workflows from
+outside collaborators**
+
+Pick the approval posture before the repo goes public. The default on a public
+repo is "require approval for first-time contributors", which is the weakest of
+the three. This repository allows all actions and does not require SHA pinning, so
+"require approval for all outside collaborators" is the safer default until that
+changes.
 
 ---
 
@@ -213,18 +258,26 @@ Navigate to: **Settings → General → Danger Zone**
 
 The repository is currently **internal**, not private.
 
-**BEFORE making public, ensure:**
+**BEFORE making public.** ✅ = confirmed done. ⬜ = still open at the time of
+writing; re-check, do not assume.
+
 - ✅ All CRITICAL items resolved (LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md)
 - ✅ All HIGH items resolved (SECURITY.md, templates, CHANGELOG)
 - ✅ All secrets removed from git history (`git log --all -S "password"`)
 - ✅ `.gitignore` properly configured (`.env`, `broker-config.yaml`)
 - ✅ No sensitive data in issues or PRs
-- ✅ The latest release covers what is on `main`. Releases v0.1.0 through v0.5.0
-  are already tagged and published (v0.5.0 on 2026-07-10), so this is a question
-  of whether `[Unreleased]` in `CHANGELOG.md` warrants cutting another before the
-  flip, not whether a first release exists.
-- ✅ Required status checks corrected per the Branch Protection section above,
-  including the `FOSSA Scan / SCA Scan` swap
+- ⬜ **Required status checks corrected** per the Branch Protection section above,
+  including the `FOSSA Scan / SCA Scan` swap. The ruleset still holds the old
+  list.
+- ⬜ **"Allow GitHub Actions to create and approve pull requests" turned off.**
+  Still on.
+- ⬜ **Secret scanning and push protection enabled.** Both still off.
+- ⬜ **Decide whether to cut a release first.** v0.1.0 through v0.5.0 are already
+  tagged and published (v0.5.0 on 2026-07-10), so this is not about a first
+  release existing. `[Unreleased]` in `CHANGELOG.md` currently carries BREAKING
+  entries, so the public repo's newest release would not describe what is on
+  `main`.
+- ⬜ **`/discussions` links repointed** (see the Features section)
 
 **When ready:**
 1. Click **"Change visibility"**
@@ -291,7 +344,7 @@ Rulesets are the mechanism this repository already uses. Three are active:
 | Ruleset | What it does |
 |---------|--------------|
 | `main-protection` | PR review, required status checks, blocks force pushes and deletions. See [Branch Protection](#branch-protection). |
-| `Copilot review for default branch` | Requests a Copilot review on PRs to `main` |
+| `Copilot review for default branch` | Requests a Copilot review on PRs to `main`. **Also blocks force pushes and deletions**, so retiring it drops a second layer of that protection. |
 | `Code Quality Copilot review for default branch` | Copilot review including drafts and on every push |
 
 Configure `main-protection` per the Branch Protection section above. That section

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -2,7 +2,7 @@
 
 This document contains tasks that require **repository admin access**. These should be completed before or immediately after making the repository public.
 
-**Admin needed**: @andreaross or repository administrators
+**Admin needed**: @solace-aross or repository administrators
 
 ---
 
@@ -45,40 +45,31 @@ pubsub
 
 ---
 
-## Features (M2: GitHub Discussions)
+## Features (M2: Support Channels)
 
 Navigate to: **Settings → General → Features**
 
-**Enable:**
-- ✅ **Discussions** - Enable this feature
+**Do not enable GitHub Discussions.** Support runs on two channels so the
+conversation sits where Solace users already are, rather than splitting across a
+second forum. This supersedes the earlier plan to open Discussions.
+
+| Channel | Use for | Where |
+|---------|---------|-------|
+| GitHub Issues | Bug reports, feature requests | This repository |
+| Solace Community | Questions, ideas, general discussion | https://solace.community/ |
+| Private disclosure | Security vulnerabilities | `.github/SECURITY.md` |
+
+**Settings to set:**
+- ⬜ **Discussions** - leave OFF (currently off; keep it that way)
 - ✅ Issues (already enabled)
 - ✅ Preserve this repository (mark as important)
 - ✅ Sponsorships (if applicable)
 
-**After enabling Discussions**, create categories:
-
-1. Navigate to **Discussions → Categories** (⚙️ icon)
-2. Create these categories:
-
-| Category | Description | Format |
-|----------|-------------|--------|
-| **Announcements** | Release announcements and project updates | Announcement (maintainers only) |
-| **Q&A** | User questions and answers | Q&A (enable "Mark as answer") |
-| **Ideas** | Feature brainstorming and feedback | Open discussion |
-| **Show and Tell** | Community showcases and use cases | Open discussion |
-| **General** | Everything else | Open discussion |
-
-3. Pin a welcome post in Announcements:
-   ```markdown
-   # Welcome to Solace Broker MCP Server Discussions!
-
-   Use this space to:
-   - Ask questions (Q&A category)
-   - Share ideas for features (Ideas)
-   - Show off your integrations (Show and Tell)
-
-   For bug reports and feature requests, please use [Issues](../issues) instead.
-   ```
+⚠️ **Before flipping public**: two files still link to `/discussions`, which 404s
+while Discussions is off — `.github/CONTRIBUTING.md:259` and
+`.github/ISSUE_TEMPLATE/config.yml:4`. Repointing them at the Solace Community
+category is tracked separately. Confirm it has landed, or expect broken links on
+the issue-template chooser from day one.
 
 ---
 
@@ -86,59 +77,116 @@ Navigate to: **Settings → General → Features**
 
 Navigate to: **Settings → Security → Code security and analysis**
 
-**Enable:**
-- ✅ **Dependabot alerts** - Automatic vulnerability scanning for Go dependencies
-- ✅ **Dependabot security updates** - Auto-create PRs for security patches
-- ✅ **Secret scanning** - Detect accidentally committed credentials
-- ⚠️ **CodeQL analysis** (optional) - Advanced code scanning
-  - May be overkill for this project size
-  - Adds ~2-3 minutes to CI runs
-  - Recommend enabling if repo will be heavily used
+Current state, read from the repository API:
 
-**Configure Dependabot** (Settings → Security → Dependabot):
+| Setting | Now | Action |
+|---------|-----|--------|
+| Dependabot alerts | On | None |
+| Dependabot security updates | On | None |
+| Secret scanning | **Off** | **Enable** |
+| Secret scanning push protection | **Off** | **Enable** |
+| CodeQL | Running - `Analyze (go)` passes on every PR | Confirm on the settings page |
 
-Create `.github/dependabot.yml` (can be done in a PR, no admin needed):
-```yaml
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "andreaross"
-    labels:
-      - "dependencies"
-      - "automated"
-```
+Enable both secret-scanning settings, not just the first. Alerts find credentials
+already committed; push protection rejects the next one before it lands. Both are
+free on public repositories.
+
+On CodeQL: a check named `Analyze (go)` runs and passes on every PR, produced by
+the code-scanning default setup, while the repository API reports Code Security as
+disabled. Confirm which configuration is producing it on the settings page before
+relying on it, and re-check after the visibility change.
+
+**Dependency updates use Renovate, not Dependabot.**
+
+`.github/renovate.json` scopes Renovate to exactly one dependency: the pinned
+Claude Code CLI version in the LLM e2e harness. Go modules are deliberately
+excluded to prevent runaway PRs, and are bumped by hand.
+
+- Do **not** create `.github/dependabot.yml`. It would contradict that scoping.
+- Dependabot's role here is alerts and security-only updates. Those do not
+  conflict with Renovate and are already on.
 
 ---
 
-## Branch Protection Rules
+## Branch Protection
 
-Navigate to: **Settings → Branches → Branch protection rules → Add rule**
+`main` is protected by two overlapping mechanisms. Both are live, and GitHub
+applies whichever is more restrictive:
 
-**Branch name pattern**: `main`
+- **Ruleset `main-protection`** — carries the required status checks. Edit this one.
+- **Legacy branch protection rule** — requires 1 approval, with an empty
+  required-checks list.
 
-**Protect matching branches:**
-- ✅ **Require a pull request before merging**
-  - ✅ Require approvals: **1**
-  - ✅ Dismiss stale pull request approvals when new commits are pushed
-  - ⬜ Require review from Code Owners (enable if CODEOWNERS file added)
-- ✅ **Require status checks to pass before merging**
-  - ✅ Require branches to be up to date before merging
-  - Select required checks:
-    - `build`
-    - `lint`
-    - `e2e`
-    - `e2e-oauth`
-- ✅ **Require conversation resolution before merging**
-- ✅ **Do not allow bypassing the above settings** (enforces rules for admins too)
+Put the checks on the ruleset. Adding them to the legacy rule instead leaves the
+ruleset's stale list in force, and two lists to keep in sync is how they drift
+apart. Consider retiring the legacy rule once the ruleset covers everything it does.
+
+Navigate to: **Settings → Rules → Rulesets → `main-protection`**
+
+**Pull request rule** (✅ = should be on):
+- ✅ Required approvals: **1** — already set
+- ✅ Dismiss stale approvals when new commits are pushed — already set
+- ✅ Require review from Code Owners — **not set yet**. `.github/CODEOWNERS` exists (`* @SolaceDev/dax-developers`), so this is available. Enabling it means every external contribution needs a dax-developers review.
+- ✅ Require conversation resolution before merging — **not set yet**
 - ⬜ Require signed commits (optional - DCO is sufficient)
 
-**Rules applied to admins:**
-- ⬜ Allow admins to bypass (leave UNCHECKED - admins should follow same rules)
+**Other rules:**
+- ✅ Restrict deletions — already set
+- ✅ Block force pushes — already set
+- ✅ Bypass list empty, so the rules apply to admins too — already set
+
+### Required status checks
+
+**Require branches to be up to date before merging** is already on. The context
+list is not: it currently holds `lint`, `build`, and `FOSSA Scan`, the last of
+which enforces nothing (see the warning below). Replace it with the following.
+These names are what GitHub actually reports, confirmed against the check runs on
+PRs #213, #216, and #217:
+
+| Check | Source | Gates on |
+|-------|--------|----------|
+| `lint` | `build-and-test.yml` job `lint` | golangci-lint |
+| `build` | `build-and-test.yml` job `build` | build, vet, race tests |
+| `e2e-basic-mcp` | `build-and-test.yml` | E2E suite |
+| `e2e-oauth` | `build-and-test.yml` | E2E suite |
+| `e2e-monitoring` | `build-and-test.yml` | E2E suite (known flaky fixture; rerun the job before investigating) |
+| `e2e-management` | `build-and-test.yml` | E2E suite |
+| `e2e-action` | `build-and-test.yml` | E2E suite |
+| `FOSSA Scan / SCA Scan` | `ci-pr.yaml` job `fossa_scan` | Licensing policy and critical/high vulnerabilities |
+| `CHANGELOG updated` | `ci-pr.yaml` job `changelog` | Advisory today; see note below |
+
+⚠️ **Do not select `FOSSA Scan`.** It looks like the right entry and is not. A
+check by that exact name comes from `build-and-test.yml`, where the job carries
+`if: github.event_name == 'push' && github.ref_name == <default branch>`, so on
+every pull request it reports **skipped** — and GitHub counts a skipped check as
+passing. Requiring `FOSSA Scan` therefore enforces nothing. The context that
+gates is `FOSSA Scan / SCA Scan`: the `ci-pr.yaml` caller job (`name: FOSSA Scan`)
+plus the inner job of the reusable workflow it calls (`name: "SCA Scan"`), which
+exits non-zero on findings because `.github/workflow-config.json` sets both FOSSA
+modes to `BLOCK`. Reusable-workflow jobs always surface as
+`<caller job name> / <inner job name>`, never as the caller name alone.
+
+Three more notes on the list:
+
+- `CHANGELOG updated` cannot fail today — `ci-pr.yaml` sets
+  `CHANGELOG_GATE_MODE: advisory`, so the script warns and exits 0. Requiring it
+  makes the check's presence a merge precondition now, so flipping the mode to
+  `blocking` later needs no ruleset change.
+- `Analyze (go)` (CodeQL) is available and passes on every PR. Add it if you want
+  code scanning to block merges; it is not in the list above because that is a
+  policy call, not a correctness fix.
+- Do **not** require `run-pull-request-checks / *`. Those come from
+  `transition_on_merge.yaml`, which runs on `pull_request: closed`, and the check
+  name varies with the Jira key (e.g. `... Vault and JIRA Operations (SOL-152328)`).
+
+🚨 **Fork pull requests will block on these checks.**
+`build-and-test.yml` triggers on `push`, not `pull_request`. A fork contributor's
+push fires in their fork, so `lint`, `build`, and the five `e2e-*` checks never
+appear on the base repository's commit and the required contexts stay pending
+forever. Only `ci-pr.yaml` checks (`FOSSA Scan / SCA Scan`, `CHANGELOG updated`)
+run on fork PRs. Fixing this needs a CI change, tracked separately. Until it
+lands, expect to merge community contributions by pushing the branch into this
+repository yourself.
 
 ---
 
@@ -148,7 +196,10 @@ Navigate to: **Settings → Actions → General → Workflow permissions**
 
 **Recommended:**
 - ⚪ Read and write permissions (needed for release workflow to create releases)
-- ✅ Allow GitHub Actions to create and approve pull requests (for Dependabot)
+- ⬜ Allow GitHub Actions to create and approve pull requests — **leave off**. This
+  setting governs the Actions `GITHUB_TOKEN`. Renovate opens PRs with its own
+  GitHub App installation token, so it does not need this, and no workflow in this
+  repository opens or approves PRs.
 
 **Alternative (more restrictive):**
 - ⚪ Read repository contents and packages permissions
@@ -160,13 +211,20 @@ Navigate to: **Settings → Actions → General → Workflow permissions**
 
 Navigate to: **Settings → General → Danger Zone**
 
+The repository is currently **internal**, not private.
+
 **BEFORE making public, ensure:**
 - ✅ All CRITICAL items resolved (LICENSE, CONTRIBUTING.md, CODE_OF_CONDUCT.md)
 - ✅ All HIGH items resolved (SECURITY.md, templates, CHANGELOG)
 - ✅ All secrets removed from git history (`git log --all -S "password"`)
 - ✅ `.gitignore` properly configured (`.env`, `broker-config.yaml`)
-- ✅ No sensitive data in issues, PRs, or discussions
-- ✅ First release (v0.1.0) tagged and published
+- ✅ No sensitive data in issues or PRs
+- ✅ The latest release covers what is on `main`. Releases v0.1.0 through v0.5.0
+  are already tagged and published (v0.5.0 on 2026-07-10), so this is a question
+  of whether `[Unreleased]` in `CHANGELOG.md` warrants cutting another before the
+  flip, not whether a first release exists.
+- ✅ Required status checks corrected per the Branch Protection section above,
+  including the `FOSSA Scan / SCA Scan` swap
 
 **When ready:**
 1. Click **"Change visibility"**
@@ -224,20 +282,21 @@ If you want to host documentation via GitHub Pages:
 
 ---
 
-## Rulesets (Alternative to Branch Protection)
+## Rulesets
 
 Navigate to: **Settings → Rules → Rulesets**
 
-GitHub Rulesets are the new way to configure branch protection (more flexible than legacy rules). If available:
+Rulesets are the mechanism this repository already uses. Three are active:
 
-**Create ruleset**: "Protect main branch"
-- Target: `main` branch
-- Bypass: Nobody (or specific users/teams)
-- Rules:
-  - Require pull request with 1 approval
-  - Require status checks: build, lint, e2e, e2e-oauth
-  - Block force pushes
-  - Block deletions
+| Ruleset | What it does |
+|---------|--------------|
+| `main-protection` | PR review, required status checks, blocks force pushes and deletions. See [Branch Protection](#branch-protection). |
+| `Copilot review for default branch` | Requests a Copilot review on PRs to `main` |
+| `Code Quality Copilot review for default branch` | Copilot review including drafts and on every push |
+
+Configure `main-protection` per the Branch Protection section above. That section
+is the single source for the required-check names; do not maintain a second copy
+here.
 
 ---
 
@@ -251,7 +310,7 @@ After repository is made public:
 - [ ] Test PR template (create a test PR, then close it)
 - [ ] Verify SECURITY.md appears in Security tab
 - [ ] Submit to Go package indexes (if applicable)
-- [ ] Announce on Solace Community forum
+- [ ] Confirm the project's Solace Community category is live, then announce there
 - [ ] Share on relevant channels (Twitter, LinkedIn, etc.)
 - [ ] Add to MCP server registry (if one exists)
 
@@ -261,7 +320,8 @@ After repository is made public:
 
 **Weekly:**
 - Review open issues and PRs (target <7 days for first response)
-- Merge Dependabot security updates
+- Review Solace Community threads in the project's category
+- Triage Dependabot alerts and merge any security-update PRs
 - Check GitHub Insights for community health metrics
 
 **Monthly:**

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -215,11 +215,14 @@ both of which need a CI change. Tracked separately.
    triggered by a fork, so the reusable workflow finds an empty Vault URL and
    exits 1. It runs, and it goes red.
 
-`CHANGELOG updated` and `Analyze (go)` do run on fork PRs. The `changelog` job
-needs only `contents: read` and no secrets, and CodeQL analyzes
-`refs/pull/N/head`. Copilot review is inconsistent even on same-repo PRs, so do
-not count on it either way.
+What about the rest? Nobody has ever opened a fork pull request against this
+repository, so none of this is observed. `CHANGELOG updated` should be fine:
+`ci-pr.yaml` gives that job only `contents: read` and it reads no secrets.
+`Analyze (go)` comes from CodeQL default setup, which is expected to run but has
+not been seen against a fork here. Copilot review is inconsistent even on
+same-repo pull requests, so do not count on it either way.
 
+Confirm all three against a real fork pull request before you rely on any of them.
 Until the CI fix lands, merge community contributions by pushing the branch into
 this repository yourself.
 
@@ -261,11 +264,12 @@ options, and the default on a public repo is the middle one:
 2. **Require approval for first-time contributors** (the default)
 3. Require approval for all external contributors
 
-Choose option 3. Under the default, a contributor's workflow runs unreviewed from
-their second pull request onward. This repository allows all actions and does not
-require SHA pinning (`allowed_actions: all`, `sha_pinning_required: false`), so
-until that tightens, a human should look at every external workflow run before it
-executes.
+Choose option 3. GitHub defines the default as "only users who have never had a
+commit or pull request merged into this repository will require approval", so a
+contributor is exempt permanently once any one of their contributions merges. This
+repository allows all actions and does not require SHA pinning
+(`allowed_actions: all`, `sha_pinning_required: false`), so until that tightens, a
+human should look at every external workflow run before it executes.
 
 ---
 
@@ -334,12 +338,17 @@ Navigate to: **Settings → General → Pull Requests**
 | Allow squash merging | ✅ On | On |
 | Allow rebase merging | ✅ On | On |
 | Automatically delete head branches | ✅ On | On |
-| Always suggest updating pull request branches | ✅ On | **Off** |
+| Always suggest updating pull request branches | ⬜ No effect here | Off |
 
-Turn on "Always suggest updating pull request branches". `main-protection` requires
-branches to be up to date before merging, so without the suggestion a contributor
-hits a stale-branch block with no button offering to fix it. That is a poor first
-experience for someone outside the team who does not know the ruleset exists.
+"Always suggest updating pull request branches" changes nothing on `main`, so
+leave it. GitHub only restricts the "Update branch" button when the base branch
+does *not* require branches to be up to date; the setting lifts that restriction.
+`main-protection` sets `strict_required_status_checks_policy: true`, so the button
+is already offered on every stale pull request to `main`. Turn the setting on only
+if you later add a protected branch without the up-to-date requirement.
+
+Note that "Update branch" needs write access to the head branch either way, so a
+fork contributor never gets the button and has to rebase locally.
 
 **Default commit messages.** Live values, which differ from the labels in the UI:
 

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -336,7 +336,7 @@ writing; re-check, do not assume.
   section.
 - ⬜ **Secret scanning and push protection enabled.** Both still off.
 - ⬜ **A release cut that covers `main`.** v0.1.0 through v0.5.0 are already tagged
-  and published (v0.5.0 on 2026-07-10), so this is not about a first release
+  and published (v0.5.0 tagged 2026-07-09), so this is not about a first release
   existing. `[Unreleased]` in `CHANGELOG.md` carries BREAKING entries, so v0.5.0
   does not describe `main`. Cut one before the flip.
 - ⬜ **`/discussions` links repointed** (see the Features section)

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -73,13 +73,22 @@ second forum. This supersedes the earlier plan to open Discussions.
 ⚠️ **Before flipping public**: three links still point at `/discussions`, which
 404s while Discussions is off.
 
-- `.github/CONTRIBUTING.md:49`
-- `.github/CONTRIBUTING.md:259`
-- `.github/ISSUE_TEMPLATE/config.yml:4` (the issue-template chooser)
+Find them, rather than trusting a line number that will drift:
 
-`.github/ISSUE_TEMPLATE/feature_request.yml:122` also says "issues and
-discussions" in prose. Repointing all of them at the Solace Community category is
-tracked separately. Confirm that landed, or expect broken links from day one.
+```bash
+grep -rn '/discussions' .github/
+```
+
+At the time of writing that returns two links in `.github/CONTRIBUTING.md` and
+one in `.github/ISSUE_TEMPLATE/config.yml` (the issue-template chooser). This
+also mentions "issues and discussions" in prose, with no link to break:
+
+```bash
+grep -rn 'issues and discussions' .github/
+```
+
+Repointing all of them at the Solace Community category is tracked separately.
+Confirm that landed, or expect broken links from day one.
 
 ---
 

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -215,9 +215,13 @@ both of which need a CI change. Tracked separately.
    triggered by a fork, so the reusable workflow finds an empty Vault URL and
    exits 1. It runs, and it goes red.
 
-`CHANGELOG updated`, `Analyze (go)`, and Copilot review do run normally on fork
-PRs. Until the CI fix lands, merge community contributions by pushing the branch
-into this repository yourself.
+`CHANGELOG updated` and `Analyze (go)` do run on fork PRs. The `changelog` job
+needs only `contents: read` and no secrets, and CodeQL analyzes
+`refs/pull/N/head`. Copilot review is inconsistent even on same-repo PRs, so do
+not count on it either way.
+
+Until the CI fix lands, merge community contributions by pushing the branch into
+this repository yourself.
 
 ---
 
@@ -229,11 +233,17 @@ Navigate to: **Settings → Actions → General → Workflow permissions**
 - ⚪ Read and write permissions (needed for release workflow to create releases).
   Currently set.
 - 🚨 **Allow GitHub Actions to create and approve pull requests: turn this OFF.
-  It is currently ON.** Combined with a write `GITHUB_TOKEN` and a `main` ruleset
-  that needs exactly one approval and has an empty bypass list, a workflow can
-  approve a pull request and satisfy the only human gate on `main`. Nothing here
-  needs it: Renovate opens PRs with its own GitHub App installation token, and no
-  workflow in this repository opens or approves PRs.
+  It is currently ON.** With a write `GITHUB_TOKEN` and a `main` ruleset that
+  needs exactly one approval and has an empty bypass list, a workflow can approve
+  a pull request and satisfy the only human gate on `main`.
+
+  The exposure is not a fork contributor. On a public repo a fork PR's
+  `GITHUB_TOKEN` is read-only. It is a workflow running on a branch *inside* this
+  repository, and this repository allows all actions with no SHA pinning required
+  (see "Fork pull request workflows" below), so a compromised third-party action
+  inherits that ability. Nothing here needs the setting: Renovate opens PRs with
+  its own GitHub App installation token, and no workflow in this repository opens
+  or approves PRs.
 
 **Alternative (more restrictive):**
 - ⚪ Read repository contents and packages permissions
@@ -244,11 +254,18 @@ Navigate to: **Settings → Actions → General → Workflow permissions**
 Navigate to: **Settings → Actions → General → Fork pull request workflows from
 outside collaborators**
 
-Pick the approval posture before the repo goes public. The default on a public
-repo is "require approval for first-time contributors", which is the weakest of
-the three. This repository allows all actions and does not require SHA pinning, so
-"require approval for all outside collaborators" is the safer default until that
-changes.
+Pick the approval posture before the repo goes public. GitHub offers three
+options, and the default on a public repo is the middle one:
+
+1. Require approval for first-time contributors who are new to GitHub
+2. **Require approval for first-time contributors** (the default)
+3. Require approval for all external contributors
+
+Choose option 3. Under the default, a contributor's workflow runs unreviewed from
+their second pull request onward. This repository allows all actions and does not
+require SHA pinning (`allowed_actions: all`, `sha_pinning_required: false`), so
+until that tightens, a human should look at every external workflow run before it
+executes.
 
 ---
 
@@ -271,12 +288,14 @@ writing; re-check, do not assume.
   list.
 - ⬜ **"Allow GitHub Actions to create and approve pull requests" turned off.**
   Still on.
+- ⬜ **Fork pull request workflows set to require approval for all external
+  contributors.** The default is weaker; see the GitHub Actions Permissions
+  section.
 - ⬜ **Secret scanning and push protection enabled.** Both still off.
-- ⬜ **Decide whether to cut a release first.** v0.1.0 through v0.5.0 are already
-  tagged and published (v0.5.0 on 2026-07-10), so this is not about a first
-  release existing. `[Unreleased]` in `CHANGELOG.md` currently carries BREAKING
-  entries, so the public repo's newest release would not describe what is on
-  `main`.
+- ⬜ **A release cut that covers `main`.** v0.1.0 through v0.5.0 are already tagged
+  and published (v0.5.0 on 2026-07-10), so this is not about a first release
+  existing. `[Unreleased]` in `CHANGELOG.md` carries BREAKING entries, so v0.5.0
+  does not describe `main`. Cut one before the flip.
 - ⬜ **`/discussions` links repointed** (see the Features section)
 
 **When ready:**
@@ -309,16 +328,28 @@ Navigate to: **Settings → Collaborators and teams**
 
 Navigate to: **Settings → General → Pull Requests**
 
-**Recommended:**
-- ✅ Allow merge commits (default)
-- ✅ Allow squash merging (useful for cleaning up commit history)
-- ✅ Allow rebase merging
-- ✅ Always suggest updating pull request branches
-- ✅ Automatically delete head branches (keeps repo clean)
+| Setting | Target | Live now |
+|---------|--------|----------|
+| Allow merge commits | ✅ On | On |
+| Allow squash merging | ✅ On | On |
+| Allow rebase merging | ✅ On | On |
+| Automatically delete head branches | ✅ On | On |
+| Always suggest updating pull request branches | ✅ On | **Off** |
 
-**Default commit message:**
-- Squash: "Pull request title and description"
-- Merge: "Pull request title"
+Turn on "Always suggest updating pull request branches". `main-protection` requires
+branches to be up to date before merging, so without the suggestion a contributor
+hits a stale-branch block with no button offering to fix it. That is a poor first
+experience for someone outside the team who does not know the ruleset exists.
+
+**Default commit messages.** Live values, which differ from the labels in the UI:
+
+| Merge type | Title | Message |
+|------------|-------|---------|
+| Squash | `COMMIT_OR_PR_TITLE` | `COMMIT_MESSAGES` |
+| Merge | `MERGE_MESSAGE` | `PR_TITLE` |
+
+These are the defaults and no change is needed. They are recorded here so a future
+reader can tell a deliberate setting from drift.
 
 ---
 

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -154,9 +154,15 @@ evidence without re-checking the live settings.
 | Release Process | 1/5 ❌ | **4/5 ✅** | 5/5 |
 | Discoverability | 0/5 ❌ | **3/5 ⚠️** | 5/5 |
 
-**Overall Score**: 31/35 (89%) - **Growth Stage** ✅
+**Overall Score at the time of PR #15**: 31/35 (89%) - **Growth Stage** ✅
 
-**Target Achieved**: Yes! Exceeded 80% threshold for public release.
+**Target Achieved at the time of PR #15**: Yes! Exceeded 80% threshold for
+public release.
+
+Both lines describe 2026-04-24 and are not a current assessment. The Security
+row they include has since been overtaken by the live settings noted above, so
+the real figure today is lower. Re-score against the live settings before
+treating the 80% threshold as met.
 
 ---
 

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -113,23 +113,36 @@ These settings must be configured by repository admin:
 
 ### 4. Security Features (5 minutes)
 - Enable secret scanning and secret-scanning push protection (both currently off)
-- Turn off "Allow GitHub Actions to create and approve pull requests" (currently on)
 - Dependabot alerts and Dependabot security updates are already on
 - CodeQL runs on every PR, but the repository API reports Code Security as
   disabled; confirm the configuration rather than assuming it
 - See: ADMIN_SETUP.md → "Security Settings"
 
-### 5. Make Repository Public (5 minutes)
+### 5. Actions Settings (5 minutes)
+- Turn off "Allow GitHub Actions to create and approve pull requests" (currently on)
+- Set fork pull request workflows to require approval for all external contributors
+- See: ADMIN_SETUP.md → "GitHub Actions Permissions"
+
+### 6. Make Repository Public (5 minutes)
 **ONLY AFTER:**
 - Admin tasks above are complete
-- The latest release covers what is on `main` (v0.5.0 shipped 2026-07-10)
+- A release has been cut that covers what is on `main`. The newest release is
+  v0.5.0 (2026-07-10), and `[Unreleased]` in `CHANGELOG.md` carries BREAKING
+  entries, so v0.5.0 does **not** describe `main` today. Cut one before the flip
+  or the first thing a new user downloads is behind the code they are reading.
 - See: ADMIN_SETUP.md → "Visibility Settings"
 
-**Total admin time**: ~40 minutes
+**Total admin time**: ~45 minutes
 
 ---
 
 ## Open Source Maturity Progress
+
+This table is a historical record of PR #15 (2026-04-24), not current state. As of
+2026-07-27 the Security row overstates where we are: secret scanning and
+secret-scanning push protection are both off, and "Allow GitHub Actions to create
+and approve pull requests" is on. Do not cite the score below as go/no-go
+evidence without re-checking the live settings.
 
 | Category | Before PR #15 | After PR #15 | Target |
 |----------|---------------|--------------|--------|
@@ -151,8 +164,9 @@ These settings must be configured by repository admin:
 
 ### Immediate (Before Public Release)
 
-1. **Admin configures repository** - See ADMIN_SETUP.md (~40 minutes)
-2. **Cut a release if `[Unreleased]` warrants it** - See RELEASING.md
+1. **Admin configures repository** - See ADMIN_SETUP.md (~45 minutes)
+2. **Cut a release** - `[Unreleased]` carries BREAKING entries, so v0.5.0 does not
+  describe `main`. See RELEASING.md.
 3. **Make repository public** - Settings → Danger Zone → Change visibility
 
 ### Post-Publication

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -109,11 +109,14 @@ These settings must be configured by repository admin:
 - Require PR reviews before merge
 - Require CI checks to pass
 - Prevent force pushes to main
-- See: ADMIN_SETUP.md → "Branch Protection Rules"
+- See: ADMIN_SETUP.md → "Branch Protection"
 
 ### 4. Security Features (5 minutes)
 - Enable secret scanning and secret-scanning push protection (both currently off)
-- Dependabot alerts, Dependabot security updates, and CodeQL are already on
+- Turn off "Allow GitHub Actions to create and approve pull requests" (currently on)
+- Dependabot alerts and Dependabot security updates are already on
+- CodeQL runs on every PR, but the repository API reports Code Security as
+  disabled; confirm the configuration rather than assuming it
 - See: ADMIN_SETUP.md → "Security Settings"
 
 ### 5. Make Repository Public (5 minutes)
@@ -148,7 +151,7 @@ These settings must be configured by repository admin:
 
 ### Immediate (Before Public Release)
 
-1. **Admin configures repository** - See ADMIN_SETUP.md (~30 minutes)
+1. **Admin configures repository** - See ADMIN_SETUP.md (~40 minutes)
 2. **Cut a release if `[Unreleased]` warrants it** - See RELEASING.md
 3. **Make repository public** - Settings → Danger Zone → Change visibility
 

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -1,7 +1,8 @@
 # Open Source Readiness Status
 
-**Last Updated**: 2026-04-24
-**PR**: #15 (aross/SOL-149029-open-source-compliance)
+**Last Updated**: 2026-07-27
+**Originating PR**: #15 (aross/SOL-149029-open-source-compliance), merged
+**Last revised by**: SOL-152405 (support-channel decision, admin-checklist accuracy)
 
 ---
 
@@ -32,10 +33,15 @@ These items are **documented** but require repository admin to configure:
 - [ ] **M1: Repository Metadata** - See ADMIN_SETUP.md section "Repository Settings"
   - Description, topics, website URL
   - Admin needed to configure in Settings → General → About
-- [ ] **M2: GitHub Discussions** - See ADMIN_SETUP.md section "Features"
-  - Enable Discussions feature
-  - Create categories (Q&A, Ideas, Announcements, etc.)
-  - Admin needed to configure in Settings → General → Features
+- [ ] **M2: Support channels** - See ADMIN_SETUP.md section "Features"
+  - GitHub Discussions is **not** being enabled. Support runs on two channels:
+    GitHub Issues for bugs and features, and a dedicated Solace Community
+    (Discourse) category for questions and discussion. Vulnerabilities go through
+    private disclosure per SECURITY.md.
+  - This supersedes the earlier plan in this file to open Discussions.
+  - Remaining work: stand up the Solace Community category and repoint the
+    `/discussions` links in `.github/CONTRIBUTING.md` and
+    `.github/ISSUE_TEMPLATE/config.yml`. Tracked separately.
 - [x] **M3: README Badges** - Already added in first commit (build, license, Go version, CoC)
 
 ---
@@ -94,10 +100,9 @@ These settings must be configured by repository admin:
 - Topics for discoverability
 - See: ADMIN_SETUP.md → "Repository Settings"
 
-### 2. GitHub Discussions (15 minutes)
-- Enable Discussions feature
-- Create categories (Q&A, Ideas, Announcements)
-- Post welcome message
+### 2. Support channels (5 minutes)
+- Leave GitHub Discussions **off**
+- Confirm Issues is on
 - See: ADMIN_SETUP.md → "Features"
 
 ### 3. Branch Protection (10 minutes)
@@ -106,20 +111,18 @@ These settings must be configured by repository admin:
 - Prevent force pushes to main
 - See: ADMIN_SETUP.md → "Branch Protection Rules"
 
-### 4. Security Features (10 minutes)
-- Enable Dependabot alerts
-- Enable secret scanning
-- Optional: CodeQL analysis
+### 4. Security Features (5 minutes)
+- Enable secret scanning and secret-scanning push protection (both currently off)
+- Dependabot alerts, Dependabot security updates, and CodeQL are already on
 - See: ADMIN_SETUP.md → "Security Settings"
 
 ### 5. Make Repository Public (5 minutes)
 **ONLY AFTER:**
-- PR #15 is merged
 - Admin tasks above are complete
-- First release (v0.1.0) is created
+- The latest release covers what is on `main` (v0.5.0 shipped 2026-07-10)
 - See: ADMIN_SETUP.md → "Visibility Settings"
 
-**Total admin time**: ~1 hour
+**Total admin time**: ~40 minutes
 
 ---
 
@@ -145,22 +148,18 @@ These settings must be configured by repository admin:
 
 ### Immediate (Before Public Release)
 
-1. **Merge PR #15** - Get approval from reviewers
-2. **Admin configures repository** - See ADMIN_SETUP.md (requires ~1 hour)
-3. **Create v0.1.0 release** - See RELEASING.md (requires ~30 minutes)
-4. **Make repository public** - Settings → Danger Zone → Change visibility
+1. **Admin configures repository** - See ADMIN_SETUP.md (~30 minutes)
+2. **Cut a release if `[Unreleased]` warrants it** - See RELEASING.md
+3. **Make repository public** - Settings → Danger Zone → Change visibility
 
 ### Post-Publication
 
 1. **Monitor community health** - Track issue/PR response times
 2. **Announce release** - Solace Community, social media, internal channels
-3. **Enable Dependabot** - Automated dependency updates
-4. **Submit to registries** - MCP server registry (if exists), Go package indexes
+3. **Submit to registries** - MCP server registry (if exists), Go package indexes
 
 ### Future Enhancements
 
-- Add Dependabot configuration (`.github/dependabot.yml`)
-- Consider CODEOWNERS file for automatic reviewer assignment
 - Add more badges (coverage, downloads, stars)
 - Create GitHub Project board for roadmap visibility
 - Set up GitHub Sponsors (if applicable)

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -127,7 +127,7 @@ These settings must be configured by repository admin:
 **ONLY AFTER:**
 - Admin tasks above are complete
 - A release has been cut that covers what is on `main`. The newest release is
-  v0.5.0 (2026-07-10), and `[Unreleased]` in `CHANGELOG.md` carries BREAKING
+  v0.5.0 (tagged 2026-07-09), and `[Unreleased]` in `CHANGELOG.md` carries BREAKING
   entries, so v0.5.0 does **not** describe `main` today. Cut one before the flip
   or the first thing a new user downloads is behind the code they are reading.
 - See: ADMIN_SETUP.md → "Visibility Settings"


### PR DESCRIPTION
## Why

`.github/ADMIN_SETUP.md` is the checklist a repo admin follows to configure this repository and flip it public. All four open-source sign-offs are in, so it is on the critical path. It was wrong in ways that meant protective gates would not be enforced, and it told the admin to do something the team has since decided against.

Jira: [SOL-152405](https://sol-jira.atlassian.net/browse/SOL-152405)

## The one that matters

**FOSSA is not currently enforced on pull requests, despite engineering being told it is.**

In the go/no-go review Alex asked whether FOSSA gates at the PR level so `main` is never in an irregular state, and was told yes. It does not.

The live `main-protection` ruleset requires a context named `FOSSA Scan`. That check comes from `build-and-test.yml`, whose `fossa_scan` job carries `if: github.event_name == 'push' && github.ref_name == <default branch>`. On a pull request it reports **skipped**, and GitHub counts a skipped check as passing. So the required context is satisfied without any scan running.

The context that actually gates is **`FOSSA Scan / SCA Scan`**: the `ci-pr.yaml` caller job (`name: FOSSA Scan`) plus the inner job of the reusable workflow it calls (`name: "SCA Scan"`), which exits non-zero on findings because `.github/workflow-config.json` sets both FOSSA modes to `BLOCK`.

Evidence: `FOSSA Scan` is `skipped` on the head commit of PRs #213, #214, #216, #217. All four merged, with `bypass_actors: []`. That is direct proof the skipped check satisfied the requirement.

This PR only fixes the documentation. Applying it to the live ruleset is [SOL-152412](https://sol-jira.atlassian.net/browse/SOL-152412).

## How I determined the check names

Not by reading the YAML alone, because reusable-workflow jobs do not surface under the name the job id suggests. Four sources, cross-checked:

1. The workflow files, for job ids and `name:` overrides.
2. The Checks API on the head SHA of merged PRs #213, #216, #217, for the on-the-wire names.
3. The combined-status API, which surfaces the FOSSA commit statuses separately from the check runs.
4. The pinned upstream reusable workflow, whose inner job is `sca_scan` with `name: "SCA Scan"`, explaining the `FOSSA Scan / SCA Scan` form.

## The three briefed defects

| Defect | Fix |
|---|---|
| Required-checks list named `build`, `lint`, `e2e`, `e2e-oauth`, and repeated the same stale list in the Rulesets section. `e2e` is not a job. | Full correct list, in one place. Rulesets section now points at it instead of carrying a second copy. |
| Instructed enabling Discussions and creating four categories. | Replaced with the two-channel model: Issues for bugs and features, Solace Community for questions, private disclosure per SECURITY.md. `OPEN_SOURCE_STATUS.md` updated to match. |
| Told the admin to create `dependabot.yml` and to allow Actions to approve PRs "for Dependabot". | The repo uses Renovate. That setting governs the Actions `GITHUB_TOKEN`, not a GitHub App token, so Renovate does not need it. |

## Found in the accuracy pass

- **"Allow GitHub Actions to create and approve pull requests" is ON.** With a write `GITHUB_TOKEN` and a ruleset needing exactly one approval with an empty bypass list, a workflow can satisfy the only human gate on `main`. The exposure is a workflow on a branch inside this repo, not a fork contributor, since fork tokens are read-only. With `allowed_actions: all` and `sha_pinning_required: false`, a compromised third-party action inherits it.
- **Fork PRs cannot pass CI.** `build-and-test.yml` triggers on `push`, so seven checks never report on a fork PR. `FOSSA Scan / SCA Scan` runs and fails, because fork PRs get no secrets and the shared workflow exits 1 on an empty Vault URL. Documented as a warning; the CI fix is [SOL-152411](https://sol-jira.atlassian.net/browse/SOL-152411).
- Secret scanning and push protection are both off, not just the first.
- Branch protection pointed at the legacy UI. Both a legacy rule and a ruleset are live; the ruleset carries the checks.
- The pre-flip item asked for a v0.1.0 that shipped in April. Five releases exist. `[Unreleased]` carries BREAKING entries, so v0.5.0 does not describe `main`.
- The admin handle `@andreaross` resolves to an unrelated GitHub account with no access here. Corrected to `@solace-aross`.
- CODEOWNERS now exists, CodeQL already runs, three `/discussions` links will 404 on flip day, repository description and topics already hold values.

## Conflict warning

The DCO PR ([SOL-152402](https://sol-jira.atlassian.net/browse/SOL-152402)) adds its job to the same required-checks block. **Expect a merge conflict there.** Whichever of us merges second rebases. I deliberately did not add a DCO entry to the list.

## Verification

- `make check`: exit 0, 31 packages ok, 0 failures. Run after every round.
- `/check-logs` does not apply. It scans Go logging; this touches two Markdown files and no Go code.
- No CHANGELOG entry. `.github/scripts/production-surface.sh` scopes the `[Unreleased]` requirement to `internal/config/`, `internal/tools/`, and `internal/composite/definitions/tools.yaml`.
- Three rounds of skeptical Opus review, 24 findings, all resolved. Rounds 2 and 3 each caught errors the previous round's fixes had introduced, all of them causal claims about GitHub behavior written from memory. Every such claim in the final version is now backed by a cited primary source or a live API read.

## Out of scope

Configuring anything in the GitHub UI, standing up the Solace Community category, README support links, and the DCO check. All tracked under [SOL-152410](https://sol-jira.atlassian.net/browse/SOL-152410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## One dependency for the reviewer

Requiring approval for all external contributors (recommended in the Actions section) holds the **entire** workflow run until a maintainer approves. So on an external contributor's first PR, no check reports at all, including `FOSSA Scan / SCA Scan` and `CHANGELOG updated`. The PR reads as stuck.

That constrains how the required-check list gets configured, and it will apply to the DCO check too once it lands: it will be subject to the same approval delay.


[SOL-152405]: https://sol-jira.atlassian.net/browse/SOL-152405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOL-152412]: https://sol-jira.atlassian.net/browse/SOL-152412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ