### PR TITLE
SOL-152405: refresh the flip checklist against live repository state

### DIFF
--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -96,19 +96,27 @@ Confirm that landed, or expect broken links from day one.
 
 Navigate to: **Settings → Security → Code security and analysis**
 
-Current state, read from the repository API:
+Current state, read from the repository API on 2026-07-29. These settings change
+outside this file, so re-read before acting on the table rather than trusting it:
+
+```bash
+gh api repos/OWNER/REPO --jq '.security_and_analysis'
+```
 
 | Setting | Now | Action |
 |---------|-----|--------|
 | Dependabot alerts | On | None |
 | Dependabot security updates | On | None |
-| Secret scanning | **Off** | **Enable** |
-| Secret scanning push protection | **Off** | **Enable** |
+| Secret scanning | On | None |
+| Secret scanning push protection | On | None |
+| Secret scanning validity checks | On | None |
+| Secret scanning non-provider patterns | On | None |
 | CodeQL | Running - `Analyze (go)` passes on every PR | Confirm on the settings page |
 
-Enable both secret-scanning settings, not just the first. Alerts find credentials
-already committed; push protection rejects the next one before it lands. Both are
-free on public repositories.
+Both secret-scanning settings are already on, so there is nothing to enable here.
+Confirm rather than change: alerts find credentials already committed, push
+protection rejects the next one before it lands, and losing either is a
+regression. Both stay free on public repositories.
 
 On CodeQL: a check named `Analyze (go)` runs and passes on every PR, and its
 workflow path points at the code-scanning default setup. Against that, the
@@ -214,15 +222,21 @@ until both are registered — an unrequired check enforces nothing, the same tra
 
 Both strings are the jobs' `name:` values verbatim. They are plain jobs, not
 reusable-workflow calls, so each produces exactly one context with no ` / `
-suffix. Not yet confirmed against a live run of `dco.yaml`, because
-`pull_request_target` runs the base ref's copy and the workflow was not on `main`
-when this was written. Confirm both on the first PR after it merges:
-`gh api repos/OWNER/REPO/commits/<head-sha>/check-runs --jq '.check_runs[].name'`
+suffix. Confirmed against a live run: `dco.yaml` is on `main` and both contexts
+report on same-repo pull requests. Verified on PR #232 (`29fe3ab`) with
 
-**Rollout order: merge the PR first, then register these two.** Registering
-`DCO sign-off` while the workflow is absent from `main` deadlocks the PR that
-introduces it, because `pull_request_target` runs the base ref's workflows and the
-check cannot report.
+```bash
+gh api repos/OWNER/REPO/commits/<head-sha>/check-runs --jq '.check_runs[].name'
+```
+
+which returned `DCO sign-off` and `DCO check self-test` alongside the other nine,
+and returned bare `FOSSA Scan` as `skipped` — the trap described above, observed
+rather than inferred.
+
+Both are ready to register now. The workflow is on `main`, so the deadlock that
+would follow from registering `DCO sign-off` while `dco.yaml` was still absent
+(`pull_request_target` runs the base ref's workflows, so the check could not
+report) no longer applies.
 
 If *Require approval for all outside collaborators* is on (Settings → Actions →
 General), fork PR runs wait for a maintainer and their checks read **pending**
@@ -269,8 +283,8 @@ it. Verify `CHANGELOG updated`, `Analyze (go)`, and `FOSSA Scan / SCA Scan`
 against a real fork pull request before you treat any of them as a gate.
 
 **A third problem, and this one we create deliberately.** The GitHub Actions
-Permissions section below tells you to require approval for all external
-contributors. That holds the entire workflow run, not just one job, until a
+Permissions section below tells you to require approval for all outside
+collaborators. That holds the entire workflow run, not just one job, until a
 maintainer approves it.
 
 The consequence, in order: an external contributor opens their first pull request,
@@ -328,7 +342,7 @@ options, and the default on a public repo is the middle one:
 
 1. Require approval for first-time contributors who are new to GitHub
 2. **Require approval for first-time contributors** (the default)
-3. Require approval for all external contributors
+3. Require approval for all outside collaborators
 
 Choose option 3. GitHub defines the default as "only users who have never had a
 commit or pull request merged into this repository will require approval", so a
@@ -364,14 +378,17 @@ writing; re-check, do not assume.
   list.
 - ⬜ **"Allow GitHub Actions to create and approve pull requests" turned off.**
   Still on.
-- ⬜ **Fork pull request workflows set to require approval for all external
-  contributors.** The default is weaker; see the GitHub Actions Permissions
+- ⬜ **Fork pull request workflows set to require approval for all outside
+  collaborators.** The default is weaker; see the GitHub Actions Permissions
   section.
-- ⬜ **Secret scanning and push protection enabled.** Both still off.
-- ⬜ **A release cut that covers `main`.** v0.1.0 through v0.5.0 are already tagged
-  and published (v0.5.0 tagged 2026-07-09), so this is not about a first release
-  existing. `[Unreleased]` in `CHANGELOG.md` carries BREAKING entries, so v0.5.0
-  does not describe `main`. Cut one before the flip.
+- ✅ **Secret scanning and push protection enabled.** Both on, along with validity
+  checks and non-provider patterns. Confirm, do not re-enable; see Security Settings.
+- ⬜ **A release cut that covers `main`.** v0.1.0 through v0.6.0 are already tagged
+  and published (v0.6.0 tagged 2026-07-28), so this is not about a first release
+  existing. `main` is 8 commits ahead of v0.6.0 and `[Unreleased]` in
+  `CHANGELOG.md` carries entries, so v0.6.0 does not describe `main`. Cut one
+  before the flip. Re-check both facts rather than trusting the counts here:
+  `git rev-list --count v0.6.0..origin/main` and the `[Unreleased]` block.
 - ⬜ **`/discussions` links repointed** (see the Features section)
 
 **When ready:**

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -118,24 +118,28 @@ These settings must be configured by repository admin:
 - See: ADMIN_SETUP.md → "Branch Protection"
 
 ### 4. Security Features (5 minutes)
-- Enable secret scanning and secret-scanning push protection (both currently off)
-- Dependabot alerts and Dependabot security updates are already on
+- Secret scanning and secret-scanning push protection are already on, as are
+  validity checks and non-provider patterns. Confirm, do not re-enable
+- Dependabot alerts and Dependabot security updates are already on. Dependency
+  updates themselves run on Renovate (`.github/renovate.json`), not Dependabot;
+  do not create a `dependabot.yml`
 - CodeQL runs on every PR, but the repository API reports Code Security as
   disabled; confirm the configuration rather than assuming it
 - See: ADMIN_SETUP.md → "Security Settings"
 
 ### 5. Actions Settings (5 minutes)
 - Turn off "Allow GitHub Actions to create and approve pull requests" (currently on)
-- Set fork pull request workflows to require approval for all external contributors
+- Set fork pull request workflows to require approval for all outside collaborators
 - See: ADMIN_SETUP.md → "GitHub Actions Permissions"
 
 ### 6. Make Repository Public (5 minutes)
 **ONLY AFTER:**
 - Admin tasks above are complete
 - A release has been cut that covers what is on `main`. The newest release is
-  v0.5.0 (tagged 2026-07-09), and `[Unreleased]` in `CHANGELOG.md` carries BREAKING
-  entries, so v0.5.0 does **not** describe `main` today. Cut one before the flip
-  or the first thing a new user downloads is behind the code they are reading.
+  v0.6.0 (tagged 2026-07-28), and `main` has moved on since with `[Unreleased]`
+  entries in `CHANGELOG.md`, so v0.6.0 does **not** describe `main` today. Cut one
+  before the flip or the first thing a new user downloads is behind the code they
+  are reading.
 - See: ADMIN_SETUP.md → "Visibility Settings"
 
 **Total admin time**: ~45 minutes
@@ -145,9 +149,9 @@ These settings must be configured by repository admin:
 ## Open Source Maturity Progress
 
 This table is a historical record of PR #15 (2026-04-24), not current state. As of
-2026-07-27 the Security row overstates where we are: secret scanning and
-secret-scanning push protection are both off, and "Allow GitHub Actions to create
-and approve pull requests" is on. Do not cite the score below as go/no-go
+2026-07-29 one gap remains behind the Security row: "Allow GitHub Actions to
+create and approve pull requests" is still on. Secret scanning and its push
+protection have since been enabled. Do not cite the score below as go/no-go
 evidence without re-checking the live settings.
 
 | Category | Before PR #15 | After PR #15 | Target |
@@ -177,8 +181,8 @@ treating the 80% threshold as met.
 ### Immediate (Before Public Release)
 
 1. **Admin configures repository** - See ADMIN_SETUP.md (~45 minutes)
-2. **Cut a release** - `[Unreleased]` carries BREAKING entries, so v0.5.0 does not
-  describe `main`. See RELEASING.md.
+2. **Cut a release** - `[Unreleased]` carries entries, so v0.6.0 does not describe
+  `main`. See RELEASING.md.
 3. **Make repository public** - Settings → Danger Zone → Change visibility
 
 ### Post-Publication


### PR DESCRIPTION
## Why

PR #220 made `ADMIN_SETUP.md` accurate as of 2026-07-27. Three claims have gone stale in the two days since, and two of them instruct an admin to do the wrong thing. This closes out the last acceptance criterion on SOL-152405: *every remaining claim verified against repo and live repository state, including the pre-flip release item and the secret-scanning items.*

Docs only. No production surface, so no CHANGELOG entry (`.github/*.md` is outside `SURFACE_RE` in `.github/scripts/production-surface.sh`).

## What changed

**Secret scanning — the one that misleads.** The docs said secret scanning and push protection were both off and told the admin to enable them. The API now reports both on, plus validity checks and non-provider patterns. As written, the admin performs a no-op and a satisfied pre-flip item reads as an open blocker. Now says confirm rather than enable, with the read date and the `gh` command to re-read it.

**DCO confirmation is no longer deferred.** The doc said the two DCO contexts were "not yet confirmed against a live run" and told the admin to hold off registering them. `dco.yaml` landed in `7768d7f` and has run clean on four PRs. I ran the doc's own confirmation command against PR #232 (`29fe3ab`):

```
DCO check self-test        success
DCO sign-off              success
FOSSA Scan                skipped     ← the trap, now observed not inferred
FOSSA Scan / SCA Scan     success
lint build e2e-*          success
```

All 11 documented required contexts report as real check runs. Both DCO contexts are ready to register.

**Pre-flip release item.** Cited v0.5.0 and BREAKING entries. v0.6.0 was tagged 2026-07-28 and `[Unreleased]` now carries a Fixed entry. The item still stands (`main` is 8 commits past v0.6.0), but the versions and reasoning were wrong. Added the commands to re-derive both facts instead of trusting counts that drift.

**Fork-approval setting label.** The doc named the same radio button "all external contributors" in three places and "all outside collaborators" in two, including its own navigation path. An admin looks for that option by label. Now consistent. Prose uses of "external contributor" meaning a person are unchanged.

`OPEN_SOURCE_STATUS.md` carried the same three stale claims, so it gets the same corrections; leaving them would defeat the fix. Its dependency line also now names Renovate, since it previously mentioned only Dependabot.

## Verification

- `gh api repos/SolaceDev/solace-broker-mcp --jq '.security_and_analysis'` — both secret-scanning settings enabled
- `gh api .../commits/29fe3ab/check-runs` — all 11 contexts confirmed, bare `FOSSA Scan` skipped
- `git rev-list --count v0.6.0..origin/main` → 8
- `has_discussions: false` and `can_approve_pull_request_reviews: true` re-checked; existing text on both is correct and untouched

No Go or config files changed, so `make check` was not run.

## Out of scope

The `/discussions` links (SOL-152413, blocked on SOL-152428) and the Solace Community category remain open, as the doc already states.

## Separate finding

**SOL-150691** ("CI: run build/test/lint gates on pull_request so fork PRs are gated") is Closed/Done but its primary AC does not hold. At HEAD, `build-and-test.yml` still triggers on `push` + `workflow_call` only, and `ci-pr.yaml` never calls it, so a fork PR still gets no lint/build/e2e. It was closed 2026-07-02 from Needs Refinement with the comment "We already did this" and no PR reference. `ADMIN_SETUP.md:265-271` documents this gap as still open. Fork CI is in the SOL-152410 epic's definition of done — flagging rather than reopening.