### PR TITLE
SOL-152411: let a fork pull request get a real CI verdict

### DIFF
--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -180,7 +180,9 @@ review.
 list is not: it currently holds `lint`, `build`, and `FOSSA Scan`, the last of
 which enforces nothing (see the warning below). Replace it with the following.
 These names are what GitHub actually reports, confirmed against the check runs on
-PRs #213, #216, and #217:
+PRs #213, #216, and #217 — except `SCA gate`, which SOL-152411 added and which has
+no live run behind it yet. Confirm that one against a real pull request before
+you rely on it:
 
 | Check | Source | Gates on |
 |-------|--------|----------|
@@ -191,21 +193,38 @@ PRs #213, #216, and #217:
 | `e2e-monitoring` | `build-and-test.yml` | E2E suite (known flaky fixture; rerun the job before investigating) |
 | `e2e-management` | `build-and-test.yml` | E2E suite |
 | `e2e-action` | `build-and-test.yml` | E2E suite |
-| `FOSSA Scan / SCA Scan` | `ci-pr.yaml` job `fossa_scan` | Licensing policy and critical/high vulnerabilities, diffed against the base branch |
+| `SCA gate` | `ci-pr.yaml` job `sca_gate` | The FOSSA verdict, or an accounted-for reason there is none. **Not** `FOSSA Scan / SCA Scan`; see the warning below |
 | `CHANGELOG updated` | `ci-pr.yaml` job `changelog` | Advisory today; see note below |
 | `DCO sign-off` | `dco.yaml` job `dco` | a sign-off on every commit the PR adds |
 | `DCO check self-test` | `ci-pr.yaml` job `dco_selftest` | the gate's own logic still working |
 
-⚠️ **Do not select `FOSSA Scan`.** It looks like the right entry and is not. A
-check by that exact name comes from `build-and-test.yml`, where the job carries
-`if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch`,
-so on every pull request it reports **skipped**, and GitHub counts a skipped
-check as passing. Requiring `FOSSA Scan` therefore enforces nothing. The context that
-gates is `FOSSA Scan / SCA Scan`: the `ci-pr.yaml` caller job (`name: FOSSA Scan`)
-plus the inner job of the reusable workflow it calls (`name: "SCA Scan"`), which
-exits non-zero on findings because `.github/workflow-config.json` sets both FOSSA
-modes to `BLOCK`. Reusable-workflow jobs always surface as
-`<caller job name> / <inner job name>`, never as the caller name alone.
+⚠️ **Two FOSSA-shaped entries are wrong, and the right one is neither.** Pick
+`SCA gate`.
+
+- **`FOSSA Scan` enforces nothing.** A check by that exact name comes from
+  `build-and-test.yml`, where the job carries
+  `if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch`,
+  so on every pull request it reports **skipped**, and GitHub counts a skipped
+  check as passing.
+- **`FOSSA Scan / SCA Scan` deadlocks fork pull requests.** It is the real
+  scanning context on a same-repo pull request: the `ci-pr.yaml` caller job
+  (`name: FOSSA Scan`) plus the inner job of the reusable workflow it calls
+  (`name: "SCA Scan"`), which exits non-zero on findings because
+  `.github/workflow-config.json` sets both FOSSA modes to `BLOCK`. But that caller
+  is now skipped for fork pull requests, because a fork gets no repository
+  secrets and the Vault-backed scan cannot run. A skipped *plain* job still
+  reports `skipped`; a skipped reusable-workflow *caller* never creates the
+  ` / SCA Scan` context at all. Required contexts that are never created stay
+  pending forever, so requiring this one makes every external contribution
+  unmergeable.
+- **`SCA gate` is the one to require.** `ci-pr.yaml` job `sca_gate` always
+  reports. It passes on a FOSSA success, fails on a FOSSA failure, and passes a
+  fork's skip with a logged reason. It re-derives the fork condition itself and
+  **fails** a skip it cannot account for, so narrowing `fossa_scan`'s `if` later
+  cannot quietly switch the gate off on same-repo pull requests.
+
+Reusable-workflow jobs always surface as `<caller job name> / <inner job name>`,
+never as the caller name alone.
 
 ⚠️ **Both DCO rows are required, and dropping either removes a control.** DCO
 stands in for a contributor licence agreement, so the repository is not covered
@@ -250,10 +269,11 @@ Four more notes on the list:
   `CHANGELOG_GATE_MODE: advisory`, so the script warns and exits 0. Requiring it
   makes the check's presence a merge precondition now, so flipping the mode to
   `blocking` later needs no ruleset change.
-- On a pull request, FOSSA runs in diff mode (`enable_diff_mode` is true for
-  `pull_request` events). It blocks on findings that are new relative to the base
-  branch, not on the full dependency inventory. That is what keeps `main` from
-  entering an irregular state; do not read a green PR as a clean full scan.
+- On a **same-repo** pull request, FOSSA runs in diff mode (`enable_diff_mode` is
+  true for `pull_request` events). It blocks on findings that are new relative to
+  the base branch, not on the full dependency inventory. That is what keeps `main`
+  from entering an irregular state; do not read a green PR as a clean full scan.
+  On a fork pull request it does not run at all — see the fork section below.
 - `Analyze (go)` (CodeQL) passes on every PR. Add it if you want code scanning to
   block merges, after settling the configuration question in the Security Settings
   section. It is not in the list above because that is a policy call, not a
@@ -262,25 +282,47 @@ Four more notes on the list:
   `transition_on_merge.yaml`, which runs on `pull_request: closed`, and the check
   name varies with the Jira key (e.g. `... Vault and JIRA Operations (SOL-152328)`).
 
-🚨 **CI cannot currently green-light a fork pull request.** Two separate problems,
-both of which need a CI change. Tracked separately.
+**How a fork pull request gets a verdict.** SOL-152411 fixed the two problems that
+made this impossible. What it changed, and what it deliberately did not:
 
-1. **Seven checks never appear.** `build-and-test.yml` triggers on `push`, not
-   `pull_request`. A fork contributor's push fires in their fork, so `lint`,
-   `build`, and the five `e2e-*` checks never report on this repository's commit.
-   Those required contexts stay pending forever.
-2. **`FOSSA Scan / SCA Scan` fails.** `ci-pr.yaml` passes `use_vault: true` and
-   `secrets.VAULT_URL`. GitHub withholds secrets from `pull_request` runs
-   triggered by a fork, so the reusable workflow finds an empty Vault URL and
-   exits 1. It runs, and it goes red.
+1. **The seven `build-and-test.yml` checks now report.** That workflow used to
+   trigger on `push` only, so a fork contributor's push fired in their fork and
+   `lint`, `build`, and the five `e2e-*` checks never reported on this
+   repository's commit — required contexts pending forever. It now also triggers
+   on `pull_request`. None of those jobs reads a secret: the e2e suites pull
+   public images (`solace/solace-pubsub-standard`, `quay.io/keycloak/keycloak`),
+   take their broker credentials from committed `.env` files, and generate their
+   own self-signed TLS certs with `openssl`. A read-only `GITHUB_TOKEN` is enough.
+2. **FOSSA no longer goes red for a missing secret.** `ci-pr.yaml` passes
+   `use_vault: true` and `secrets.VAULT_URL`, and GitHub withholds secrets from a
+   fork-triggered `pull_request` run, so the reusable workflow used to find an
+   empty Vault URL and exit 1 on every external contribution. The `fossa_scan`
+   job is now skipped for fork pull requests, and the always-reporting `SCA gate`
+   job is the required context instead.
+3. **`pull_request_target` was not introduced**, and neither was a `workflow_run`
+   follow-up. Both would run untrusted code with an elevated token to buy a
+   pre-merge scan on a path that already requires a maintainer to approve the
+   workflow run and a code owner to approve the pull request.
 
-Nobody has ever opened a fork pull request against this repository, so nothing
-below is observed. `CHANGELOG updated` should be fine: `ci-pr.yaml` gives that job
-only `contents: read` and it reads no secrets. `Analyze (go)` appears to come from
-CodeQL default setup, which the Security Settings section asks you to confirm.
-Copilot review is inconsistent even on same-repo pull requests, so do not count on
-it. Verify `CHANGELOG updated`, `Analyze (go)`, and `FOSSA Scan / SCA Scan`
-against a real fork pull request before you treat any of them as a gate.
+**The residual gap, stated so nobody assumes otherwise.** A fork pull request gets
+no pre-merge FOSSA verdict. A contributor who adds a dependency with a licensing
+conflict or a critical/high vulnerability is caught by the full scan on push to
+`main`, which is detection after merge, not prevention before it. Two things close
+that gap and both are human: read `go.mod` and `go.sum` in any fork pull request
+that touches them, and treat a red FOSSA on `main` as a revert, not a backlog item.
+
+Also worth knowing: on a same-repo pull request FOSSA runs in diff mode, so a green
+`SCA gate` there is not a clean full scan either — see the diff-mode note above.
+
+Nobody has ever opened a fork pull request against this repository, so none of the
+above is observed on a real external contribution. `CHANGELOG updated` should be
+fine: `ci-pr.yaml` gives that job only `contents: read` and it reads no secrets.
+`Analyze (go)` appears to come from CodeQL default setup, which the Security
+Settings section asks you to confirm. Copilot review is inconsistent even on
+same-repo pull requests, so do not count on it. Verify `SCA gate`,
+`CHANGELOG updated`, `Analyze (go)`, and the `lint` job's annotation behavior on a
+read-only token against a real fork pull request before treating any of them as a
+gate.
 
 **A third problem, and this one we create deliberately.** The GitHub Actions
 Permissions section below tells you to require approval for all outside
@@ -288,9 +330,11 @@ collaborators. That holds the entire workflow run, not just one job, until a
 maintainer approves it.
 
 The consequence, in order: an external contributor opens their first pull request,
-and **no checks run at all**. Not `FOSSA Scan / SCA Scan`, not `CHANGELOG updated`,
-not the seven that were already broken. Every required context sits pending and the
-pull request reads as stuck rather than as rejected or passing.
+and **no checks run at all**. Not `SCA gate`, not `CHANGELOG updated`, not the seven
+from `build-and-test.yml`. Every required context sits pending and the pull request
+reads as stuck rather than as rejected or passing. This is independent of the
+SOL-152411 fix: that made the checks *capable* of reporting on a fork pull request,
+and this setting decides *when* they are allowed to start.
 
 That is expected, not broken. Maintainers need to know it, or the first community
 contribution gets triaged as a CI outage. Two things follow:
@@ -303,8 +347,10 @@ This also constrains the required-check list. Every context you require is a
 context that reports only after a human approves the run, so requiring more of
 them lengthens the stall rather than tightening the gate.
 
-Until the CI fix lands, merge community contributions by pushing the branch into
-this repository yourself.
+Copying a community branch into this repository to test it is no longer necessary,
+and is now the worse option: a same-repo branch is a trusted context, so doing it
+runs the contributor's code with this repository's secrets. Approve the fork run
+instead.
 
 ---
 
@@ -373,9 +419,11 @@ writing; re-check, do not assume.
 - ✅ All secrets removed from git history (`git log --all -S "password"`)
 - ✅ `.gitignore` properly configured (`.env`, `broker-config.yaml`)
 - ✅ No sensitive data in issues or PRs
-- ⬜ **Required status checks corrected** per the Branch Protection section above,
-  including the `FOSSA Scan / SCA Scan` swap. The ruleset still holds the old
-  list.
+- ⬜ **Required status checks corrected** per the Branch Protection section above.
+  The ruleset still holds the old list. The supply-chain context to register is
+  `SCA gate` — not `FOSSA Scan`, which enforces nothing, and not
+  `FOSSA Scan / SCA Scan`, which never reports on a fork pull request and would
+  leave every external contribution pending.
 - ⬜ **"Allow GitHub Actions to create and approve pull requests" turned off.**
   Still on.
 - ⬜ **Fork pull request workflows set to require approval for all outside

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -463,31 +463,60 @@ writing; re-check, do not assume.
   > today, which is the only reason a repo-wide FOSSA outage is not already
   > blocking everyone.
   >
-  > Check it, do not assume it. The scan runs almost entirely outside this
-  > repository: `ci-pr.yaml` calls
+  > Check it, do not assume it, and note that our SHA pin buys less than it looks
+  > like. `ci-pr.yaml` calls
   > `SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml`
-  > at a pinned SHA, and that workflow in turn pulls a nested action from `@main`
-  > and runs a container image by digest. Our pin does not freeze either of those,
-  > so the scan's behaviour can change without a single line changing here.
+  > at a pinned SHA, but that workflow references four nested actions at `@main`
+  > (`workflow-config-loader`, `sca-setup-deps`, `sca/sca-scan`, `fossa-guard`) and
+  > runs a container image by digest, where the registry namespace is derived from
+  > `github.repository_owner` at runtime. No SHA written here freezes any of that,
+  > so the scan's behaviour changes without a line changing in this repository.
+  > Repinning or bumping our reference is not a remedy.
   >
-  > Recent history, as evidence that this is not hypothetical. The move to the
-  > `SolaceProducts` org broke FOSSA twice in one afternoon on 2026-07-31, with
-  > two unrelated causes and a green window in between:
+  > Recent history, as evidence that this is not hypothetical. One root cause, the
+  > move to the `SolaceProducts` org, produced two different failures on
+  > 2026-07-31. **FOSSA did not go green at any point that day.**
   >
-  > | Time (UTC) | Symptom | Cause |
-  > |---|---|---|
-  > | until 07-30 ~20:48 | green | |
-  > | 07-31 14:46 to ~15:27 | fails in ~13s | Vault OIDC role `cicd-workflows-secret-read-role` binds on the `repository` claim, which the org rename changed. Token exchange rejected with `claim "repository" does not match any associated bound claim values`. Fixed org-side. |
-  > | 07-31 from ~15:41 | fails in ~50s | Vault now authenticates. The scan container cannot be pulled: `manifest unknown` for `ghcr.io/solaceproducts/maas-build-actions@sha256:14d7b08…`. Referenced by the shared workflow, not by this repository. |
+  > | When (UTC) | Symptom | Cause | Whose fix |
+  > |---|---|---|---|
+  > | last green: 07-30 21:28 | `Test passed! 0 issues found` against project `SolaceDev_solace-broker-mcp` | | |
+  > | 07-31 14:46 to 15:34 | fails in ~13s | Vault OIDC role `cicd-workflows-secret-read-role` binds on the `repository` claim, which the rename changed. Token exchange rejected: `claim "repository" does not match any associated bound claim values`. | infra, since fixed |
+  > | 07-31 from 15:38 | fails in ~50s | Vault authenticates. The scan container cannot be pulled: `manifest unknown` for `ghcr.io/solaceproducts/maas-build-actions@sha256:14d7b08…`. Same rename, via `github.repository_owner` in the nested `fossa-guard` action. | infra |
+  > | next, once the container is pullable | expect a licensing block | PR #243 repointed `project_id` to `SolaceProducts_solace-broker-mcp`, a **new** FOSSA project carrying none of the old project's policy waivers. | **this repository** |
   >
-  > Both were infra-side and neither was fixable from this repository. Expect more
-  > of the same until the org move settles, and re-verify before you flip the
-  > required-checks list.
+  > That last row is the one that matters for this checklist item, because it is
+  > ours and it is not visible yet. On `main` at `43a9a93`, `fossa test` already
+  > reports three findings:
   >
-  > One item to clear that is *not* a cause of either failure:
-  > `.github/workflow-config.json` has no `secrets.vault.url`, so the URL comes
-  > from the `VAULT_URL` repository secret. That fallback works (runs log
-  > `✅ Vault configuration validated`), so setting the config key is tidiness.
+  > ```
+  > ⚑ Denied by policy CC-BY-SA-4.0 on github.com/perimeterx/marshmallow@v1.1.5
+  > ⚑ MPL-2.0 license detected in github.com/hashicorp/go-cleanhttp@v0.5.2
+  > ⚑ MPL-2.0 license detected in github.com/hashicorp/go-retryablehttp@v0.7.8
+  > Error: The scan has revealed issues. Number of issues found: 3
+  > ```
+  >
+  > `block_on` includes `policy_conflict`, and the guard maps "Denied by Policy" to
+  > exactly that, so the `marshmallow` finding should block once the guard runs.
+  > It is invisible today only because the guard steps die on the container pull
+  > before they can report, and the job's verdict is read from those steps. So
+  > **`SCA gate` is not one infra fix away from green.** Either waive or resolve
+  > the findings on the new FOSSA project, or expect the gate to go red for a
+  > second, legitimate reason the moment the first one clears.
+  >
+  > A related trap worth knowing: the shared workflow cannot distinguish "the guard
+  > could not run" from "the guard found violations". Both guard steps are
+  > `continue-on-error`, and the summary reads their `failure` outcome as findings.
+  > That is why runs on 07-31 printed
+  > `critical,high severity vulnerabilities detected` when nothing had been scanned
+  > at all. Do not act on that message without reading the job log.
+  >
+  > **Do not add `secrets.vault.url` to `.github/workflow-config.json`.** Its
+  > absence is not a defect and not the cause of anything above. It held
+  > `https://vault.maas-vault-prod.solace.cloud:8200` and was removed deliberately
+  > in `2d46757` ("Vault URL hardening") while preparing this repository to go
+  > public. The URL now comes from the `VAULT_URL` repository secret and resolves
+  > fine (runs log `✅ Vault configuration validated`). Re-adding it would put an
+  > internal hostname back into a public repository.
   >
   > `sca_gate` going red through all of this is the gate working. Leaving
   > `FOSSA Scan / SCA Scan` unrequired is what had been hiding it.

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -454,40 +454,43 @@ writing; re-check, do not assume.
   `FOSSA Scan / SCA Scan`, which never reports on a fork pull request and would
   leave every external contribution pending.
 
-  > **Precondition: fix FOSSA's Vault authentication before requiring `SCA gate`.**
+  > **Precondition: confirm `SCA gate` is green on a real pull request before
+  > registering it as required.**
   >
-  > FOSSA is currently failing on every pull request in this repository, for a
-  > reason unrelated to the checks themselves. The Vault OIDC role
-  > `cicd-workflows-secret-read-role` binds on the `repository` claim, and the
-  > move to the `SolaceProducts` org changed that claim, so the token exchange is
-  > rejected before any scan starts:
+  > `sca_gate` fails closed, by design. So if FOSSA is broken for any reason,
+  > making `SCA gate` required turns "FOSSA is broken" into "no pull request in
+  > this repository can merge". Branch protection holds zero required contexts
+  > today, which is the only reason a repo-wide FOSSA outage is not already
+  > blocking everyone.
   >
-  > ```
-  > failed to retrieve vault token. code: ERR_NON_2XX_3XX_RESPONSE,
-  > message: Response code 400 (Bad Request), vaultResponse:
-  > {"errors":["error validating claims: claim \"repository\" does not match
-  > any associated bound claim values"]}
-  > ```
+  > Check it, do not assume it. The scan runs almost entirely outside this
+  > repository: `ci-pr.yaml` calls
+  > `SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml`
+  > at a pinned SHA, and that workflow in turn pulls a nested action from `@main`
+  > and runs a container image by digest. Our pin does not freeze either of those,
+  > so the scan's behaviour can change without a single line changing here.
   >
-  > Every run from 2026-07-31 fails identically; runs from 2026-07-30 were green
-  > and the pinned shared-workflow SHA has not changed. Branch protection holds
-  > zero required contexts today, so nothing is blocked yet. Register `SCA gate`
-  > before the Vault role is fixed and every pull request in the repository
-  > becomes unmergeable, because `sca_gate` correctly fails a `failure` result.
+  > Recent history, as evidence that this is not hypothetical. The move to the
+  > `SolaceProducts` org broke FOSSA twice in one afternoon on 2026-07-31, with
+  > two unrelated causes and a green window in between:
   >
-  > Fix is Vault-side: add `SolaceProducts/solace-broker-mcp` to the role's bound
-  > claims. Two related items to clear at the same time, neither of which is the
-  > cause of the failure above:
-  > - `.github/workflow-config.json` still carries
-  >   `project_id: SolaceDev_solace-broker-mcp`, which will file scans under the
-  >   old org name once authentication works.
-  > - That file has no `secrets.vault.url`, so the URL comes from the `VAULT_URL`
-  >   repository secret. That fallback works today (the run logs
-  >   `✅ Vault configuration validated`), so setting the config key is tidiness,
-  >   not a fix.
+  > | Time (UTC) | Symptom | Cause |
+  > |---|---|---|
+  > | until 07-30 ~20:48 | green | |
+  > | 07-31 14:46 to ~15:27 | fails in ~13s | Vault OIDC role `cicd-workflows-secret-read-role` binds on the `repository` claim, which the org rename changed. Token exchange rejected with `claim "repository" does not match any associated bound claim values`. Fixed org-side. |
+  > | 07-31 from ~15:41 | fails in ~50s | Vault now authenticates. The scan container cannot be pulled: `manifest unknown` for `ghcr.io/solaceproducts/maas-build-actions@sha256:14d7b08…`. Referenced by the shared workflow, not by this repository. |
   >
-  > `sca_gate` failing here is the gate working. Leaving
-  > `FOSSA Scan / SCA Scan` unrequired is what had been hiding this.
+  > Both were infra-side and neither was fixable from this repository. Expect more
+  > of the same until the org move settles, and re-verify before you flip the
+  > required-checks list.
+  >
+  > One item to clear that is *not* a cause of either failure:
+  > `.github/workflow-config.json` has no `secrets.vault.url`, so the URL comes
+  > from the `VAULT_URL` repository secret. That fallback works (runs log
+  > `✅ Vault configuration validated`), so setting the config key is tidiness.
+  >
+  > `sca_gate` going red through all of this is the gate working. Leaving
+  > `FOSSA Scan / SCA Scan` unrequired is what had been hiding it.
 - ⬜ **"Allow GitHub Actions to create and approve pull requests" turned off.**
   Still on.
 - ⬜ **Fork pull request workflows set to require approval for all outside

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -453,6 +453,41 @@ writing; re-check, do not assume.
   `SCA gate` — not `FOSSA Scan`, which enforces nothing, and not
   `FOSSA Scan / SCA Scan`, which never reports on a fork pull request and would
   leave every external contribution pending.
+
+  > **Precondition: fix FOSSA's Vault authentication before requiring `SCA gate`.**
+  >
+  > FOSSA is currently failing on every pull request in this repository, for a
+  > reason unrelated to the checks themselves. The Vault OIDC role
+  > `cicd-workflows-secret-read-role` binds on the `repository` claim, and the
+  > move to the `SolaceProducts` org changed that claim, so the token exchange is
+  > rejected before any scan starts:
+  >
+  > ```
+  > failed to retrieve vault token. code: ERR_NON_2XX_3XX_RESPONSE,
+  > message: Response code 400 (Bad Request), vaultResponse:
+  > {"errors":["error validating claims: claim \"repository\" does not match
+  > any associated bound claim values"]}
+  > ```
+  >
+  > Every run from 2026-07-31 fails identically; runs from 2026-07-30 were green
+  > and the pinned shared-workflow SHA has not changed. Branch protection holds
+  > zero required contexts today, so nothing is blocked yet. Register `SCA gate`
+  > before the Vault role is fixed and every pull request in the repository
+  > becomes unmergeable, because `sca_gate` correctly fails a `failure` result.
+  >
+  > Fix is Vault-side: add `SolaceProducts/solace-broker-mcp` to the role's bound
+  > claims. Two related items to clear at the same time, neither of which is the
+  > cause of the failure above:
+  > - `.github/workflow-config.json` still carries
+  >   `project_id: SolaceDev_solace-broker-mcp`, which will file scans under the
+  >   old org name once authentication works.
+  > - That file has no `secrets.vault.url`, so the URL comes from the `VAULT_URL`
+  >   repository secret. That fallback works today (the run logs
+  >   `✅ Vault configuration validated`), so setting the config key is tidiness,
+  >   not a fix.
+  >
+  > `sca_gate` failing here is the gate working. Leaving
+  > `FOSSA Scan / SCA Scan` unrequired is what had been hiding this.
 - ⬜ **"Allow GitHub Actions to create and approve pull requests" turned off.**
   Still on.
 - ⬜ **Fork pull request workflows set to require approval for all outside

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -223,8 +223,11 @@ you rely on it:
   **fails** a skip it cannot account for, so narrowing `fossa_scan`'s `if` later
   cannot quietly switch the gate off on same-repo pull requests.
 
-Reusable-workflow jobs always surface as `<caller job name> / <inner job name>`,
-never as the caller name alone.
+The naming rule behind all three bullets: a reusable-workflow caller that **runs**
+surfaces as `<caller job name> / <inner job name>`, never as the caller name alone.
+A caller that is **skipped** does the opposite — its inner job never runs, so the
+only context produced is the bare caller name, reported as `skipped`. That
+asymmetry is why one FOSSA entry enforces nothing and the other deadlocks.
 
 ⚠️ **Both DCO rows are required, and dropping either removes a control.** DCO
 stands in for a contributor licence agreement, so the repository is not covered
@@ -281,6 +284,11 @@ Four more notes on the list:
 - Do **not** require `run-pull-request-checks / *`. Those come from
   `transition_on_merge.yaml`, which runs on `pull_request: closed`, and the check
   name varies with the Jira key (e.g. `... Vault and JIRA Operations (SOL-152328)`).
+  That workflow is now skipped for fork pull requests: it authenticates to Vault by
+  OIDC, which a fork run cannot do, so it could only ever go red — on an
+  already-merged external contribution, for a credential the contributor was never
+  eligible to hold. It also has nothing to transition, since an external
+  contribution has no SOL ticket.
 
 **How a fork pull request gets a verdict.** SOL-152411 fixed the two problems that
 made this impossible. What it changed, and what it deliberately did not:
@@ -307,9 +315,30 @@ made this impossible. What it changed, and what it deliberately did not:
 **The residual gap, stated so nobody assumes otherwise.** A fork pull request gets
 no pre-merge FOSSA verdict. A contributor who adds a dependency with a licensing
 conflict or a critical/high vulnerability is caught by the full scan on push to
-`main`, which is detection after merge, not prevention before it. Two things close
-that gap and both are human: read `go.mod` and `go.sum` in any fork pull request
-that touches them, and treat a red FOSSA on `main` as a revert, not a backlog item.
+`main`, which is detection after merge, not prevention before it. Until that
+changes, two human controls stand in, and both need someone to actually do them:
+
+- **Read `go.mod` and `go.sum`** in any fork pull request that touches them.
+- **Read the `.github/` diff too.** Moving to `pull_request` means a fork pull
+  request supplies the workflow definitions that run for it. It cannot reach a
+  secret and its token is read-only, so this is not a credential-theft path, but a
+  pull request can still weaken its own checks — including `SCA gate`, which runs
+  from the pull request's own ref. `DCO sign-off` is the exception, deliberately:
+  `dco.yaml` runs on `pull_request_target` so a pull request cannot edit the copy
+  that judges it.
+- **A red FOSSA on `main` needs an owner.** Nothing routes it today: the failure
+  lands on an already-merged commit, and no alert or assignee follows from it.
+  Whoever merges a dependency-touching fork pull request should watch the next
+  `main` run themselves.
+
+**Worth closing properly.** The vulnerability half of this gap does not actually
+need a credential. `govulncheck` (or `osv-scanner` over `go.mod`) needs no secret,
+no Vault, and no elevated token, so it would run fine as an eighth job in
+`build-and-test.yml` on a fork pull request — restoring *prevention* for
+critical/high vulnerabilities instead of leaving both halves to a human. Licensing
+is the harder half; `go-licenses` covers some of it. This was left out of
+SOL-152411 to keep that change to the trigger and gate problem, not because it is
+unavailable. It is the obvious follow-up.
 
 Also worth knowing: on a same-repo pull request FOSSA runs in diff mode, so a green
 `SCA gate` there is not a clean full scan either — see the diff-mode note above.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -114,6 +114,42 @@ go run ./cmd/server
 - [ ] Commits are signed off (DCO)
 - [ ] PR description follows the template
 
+### Getting CI to run on a branch
+
+**Pushing a branch no longer runs CI on its own.** `build-and-test.yml` triggers on
+pull requests against `main` and on pushes to `main`, not on every branch push.
+Three ways to get a verdict, cheapest first:
+
+1. **Locally**, which is the fastest loop and needs no CI at all:
+
+   ```bash
+   make check          # build, vet, lint, race tests
+   make e2e-all        # the basic-mcp E2E suite against Dockerized brokers
+   ```
+
+2. **Run the full suite on your branch without a pull request**, via
+   `workflow_dispatch`:
+
+   ```bash
+   gh workflow run build-and-test.yml --ref my-branch
+   gh run watch        # or: gh run list --workflow build-and-test.yml
+   ```
+
+   This needs write access, so it is for maintainers rather than fork
+   contributors.
+
+3. **Open the pull request.** A draft is enough; `opened` and `synchronize` both
+   fire for drafts, so every check runs and keeps running as you push.
+
+Why it changed: those seven jobs are required status checks, and a check that never
+reports leaves a required context pending forever. That is how a fork contribution
+used to become unmergeable, because a fork's push fires in the fork and never
+against this repository's commit. Moving to `pull_request` fixes that, and keeping
+`push: '**'` alongside it would run every check twice on same-repo pull requests,
+including five Dockerized E2E suites. The header comment in
+`.github/workflows/build-and-test.yml` records the alternatives that were
+considered and why they lose.
+
 ### PR Review Process
 
 1. **Automated checks** — CI must pass (build, lint, test, E2E, DCO sign-off)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -353,6 +353,13 @@ maintainer to approve it, not just the one on your first push. So checks can sit
 **pending**, and a check that was green can go back to pending after the PR is
 retitled or edited. That is normal and nothing for you to fix.
 
+You will also see the `FOSSA Scan` check report as **skipped**. Our licence and
+vulnerability scan authenticates against an internal service, and GitHub correctly
+withholds those credentials from a fork's workflow run, so the scan cannot run on
+your pull request. The `SCA gate` check accounts for that and passes. If your
+change adds or updates a dependency, expect a reviewer to look at `go.mod` and
+`go.sum` closely, since the automated scan is not there to do it.
+
 ## Questions?
 
 - **General questions:** Start a [GitHub Discussion](https://github.com/SolaceProducts/solace-broker-mcp/discussions)

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -108,6 +108,11 @@ These settings must be configured by repository admin:
 ### 3. Branch Protection (10 minutes)
 - Require PR reviews before merge
 - Require CI checks to pass
+- **Add `SCA gate` to the required status checks** — not `FOSSA Scan`, which
+  reports skipped on pull requests and so enforces nothing, and not
+  `FOSSA Scan / SCA Scan`, which never reports on a fork pull request and would
+  leave every external contribution pending forever. `.github/ADMIN_SETUP.md`
+  explains the asymmetry.
 - **Add `DCO sign-off` and `DCO check self-test` to the required status checks.**
   These are not cosmetic. DCO is the control the project carries in place of a
   contributor licence agreement. Both checks exist in CI, but until they are

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,12 +1,44 @@
 name: Build and Test
 
+# WHY `push` IS SCOPED TO main AND `pull_request` CARRIES FEATURE BRANCHES
+#
+# These seven jobs are required status checks. A check that never reports on a
+# pull request leaves the required context pending forever, which is how a fork
+# contribution used to become unmergeable: `push` fires in the contributor's
+# fork, never against this repository's commit.
+#
+# `pull_request` fixes that, but keeping `push: '**'` alongside it would run
+# every check twice on same-repo pull requests — including five Dockerized e2e
+# suites. The alternative considered was keeping `push: '**'` and gating each job
+# on `github.event_name == 'pull_request' || github.ref_name == <default>`. That
+# is strictly worse: it still cannot run CI for a branch with no pull request
+# (the condition is false there), and it adds an all-skipped workflow run to
+# every branch push. Deciding whether a push has an open pull request needs an
+# API call, so no declarative trigger preserves pre-pull-request branch CI.
+#
+# The cost, stated plainly: pushing a feature branch no longer runs CI on its
+# own. Open the pull request — a draft is enough, `opened` and `synchronize` both
+# fire for drafts — and every check runs.
+#
+# `workflow_call` stays because release.yml calls this workflow on a `v*` tag
+# push. A `push` filter that names `branches` never matches a tag, so the
+# `tags-ignore: ['v*']` that used to sit here was already dead config and is
+# gone rather than left to imply it does something.
 on:
   push:
     branches:
-      - '**'
-    tags-ignore:
-      - 'v*'
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_call:
+
+# Cancel superseded pull-request runs, never superseded pushes to main: every
+# commit on main must keep its own FOSSA verdict and e2e result. `github.ref` is
+# the fallback for the push and `workflow_call` (tag) paths, where
+# `pull_request.number` is empty.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Minimal token permissions — read-only access to repo contents.
 # golangci-lint-action uses checks: write to post inline annotations on PRs.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,12 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+    # Scoped to main to match dco.yaml, which is scoped for a correctness reason
+    # (see its header). Without this, a pull request against a throwaway base
+    # would spin up five Dockerized e2e suites and still not get a DCO verdict.
+    # Add a branch here if the project starts taking pull requests against
+    # release branches — and add it to dco.yaml at the same time.
+    branches: [main]
   workflow_call:
 
 # Cancel superseded pull-request runs, never superseded pushes to main: every
@@ -40,22 +46,44 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Minimal token permissions — read-only access to repo contents.
-# golangci-lint-action uses checks: write to post inline annotations on PRs.
-# FOSSA scan requires id-token, pull-requests, actions, packages, and statuses.
+# Read-only by default. Every elevated scope this workflow needs belongs to
+# `fossa_scan` alone, so it is granted there and nowhere else.
+#
+# This used to be one workflow-level block granting `pull-requests: write`,
+# `id-token: write`, `checks: write`, and `statuses: write` to every job. That
+# mattered little while the only trigger was `push`; it matters now that
+# `pull_request` is a trigger and the e2e jobs execute shell scripts taken from
+# the pull request's own ref. `statuses: write` is the sharp one — a step holding
+# it can POST a successful status under a context name that branch protection
+# requires, which is a way around the gate rather than through it.
+#
+# Forks were never exposed to this: GitHub forces a read-only token on a
+# fork-triggered `pull_request` run whatever a workflow asks for. The exposure
+# was a same-repo branch, and narrowing the default closes it.
+#
+# `contents: read` is all the seven build and test jobs need.
+# golangci-lint-action emits annotations as stdout workflow commands, not through
+# the checks API, so it needs no `checks: write` — the previous comment here
+# claimed otherwise and was wrong.
 permissions:
   contents: read
-  packages: read
-  pull-requests: write
-  id-token: write
-  actions: read
-  checks: write
-  statuses: write
 
 jobs:
   fossa_scan:
     if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     name: FOSSA Scan
+    # The scan authenticates to Vault by OIDC (`id-token`), reads the dependency
+    # graph and workflow metadata (`packages`, `actions`), and reports back on the
+    # commit (`pull-requests`, `statuses`, `checks`). Scoped to this job so no
+    # other job inherits any of it.
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
+      actions: read
+      checks: write
+      statuses: write
     uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       use_vault: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,22 +8,47 @@ name: Build and Test
 # fork, never against this repository's commit.
 #
 # `pull_request` fixes that, but keeping `push: '**'` alongside it would run
-# every check twice on same-repo pull requests — including five Dockerized e2e
-# suites. The alternative considered was keeping `push: '**'` and gating each job
-# on `github.event_name == 'pull_request' || github.ref_name == <default>`. That
-# is strictly worse: it still cannot run CI for a branch with no pull request
-# (the condition is false there), and it adds an all-skipped workflow run to
-# every branch push. Deciding whether a push has an open pull request needs an
-# API call, so no declarative trigger preserves pre-pull-request branch CI.
+# every check twice on same-repo pull requests, including five Dockerized e2e
+# suites.
+#
+# The alternative worth naming is not gating on event name. It is keeping
+# `push: '**'`, adding `pull_request`, and gating each job on fork-ness:
+#
+#   if: github.event_name == 'push'
+#       || github.event.pull_request.head.repo.full_name != github.repository
+#
+# That option does preserve pre-pull-request branch CI, declaratively, with no
+# API call: a push to any branch runs, a same-repo pull request all-skips
+# cheaply, and a fork pull request runs the contexts for the first time.
+#
+# It is rejected for a sharper reason than cost. It puts two check runs with the
+# same name on the same head SHA: a real `lint` from the push run and a skipped
+# `lint` from the pull-request run. If branch protection resolves a required
+# context against the most recent check run of that name, the gate becomes
+# order-dependent, and a skipped run landing last is a green gate over a red job.
+# This file exists because GitHub's skip-and-report behavior is asymmetric, so a
+# design that makes the gate depend on arrival order is the wrong trade even
+# though it is cheaper.
 #
 # The cost, stated plainly: pushing a feature branch no longer runs CI on its
-# own. Open the pull request — a draft is enough, `opened` and `synchronize` both
-# fire for drafts — and every check runs.
+# own. Two ways to get it, most convenient first:
+#
+#   1. `workflow_dispatch` runs the full suite on any ref, no pull request
+#      needed: `gh workflow run build-and-test.yml --ref my-branch`. Dispatch
+#      requires write access, so it adds no fork exposure, and `fossa_scan`'s
+#      `if` correctly evaluates false on a dispatch. Same pattern as
+#      `fossa-scan.yaml` and `llm-eval.yml`.
+#   2. Open the pull request. A draft is enough; `opened` and `synchronize` both
+#      fire for drafts.
 #
 # `workflow_call` stays because release.yml calls this workflow on a `v*` tag
-# push. A `push` filter that names `branches` never matches a tag, so the
-# `tags-ignore: ['v*']` that used to sit here was already dead config and is
-# gone rather than left to imply it does something.
+# push. The `tags-ignore: ['v*']` that used to sit here was load-bearing, not
+# dead config, and the mechanism is worth stating correctly: the old trigger
+# defined both `branches` and `tags-ignore`, so the tag ref was not undefined and
+# a non-`v*` tag push did run this workflow. What stops every tag push from
+# triggering it now is narrowing `branches` to main and dropping `tags-ignore`
+# together, because a filter list naming only `branches` leaves the tag ref
+# undefined.
 on:
   push:
     branches:
@@ -34,8 +59,9 @@ on:
     # (see its header). Without this, a pull request against a throwaway base
     # would spin up five Dockerized e2e suites and still not get a DCO verdict.
     # Add a branch here if the project starts taking pull requests against
-    # release branches — and add it to dco.yaml at the same time.
+    # release branches, and add it to dco.yaml at the same time.
     branches: [main]
+  workflow_dispatch:
   workflow_call:
 
 # Cancel superseded pull-request runs, never superseded pushes to main: every

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,11 +39,27 @@ on:
   workflow_call:
 
 # Cancel superseded pull-request runs, never superseded pushes to main: every
-# commit on main must keep its own FOSSA verdict and e2e result. `github.ref` is
-# the fallback for the push and `workflow_call` (tag) paths, where
-# `pull_request.number` is empty.
+# commit on main must keep its own FOSSA verdict and e2e result.
+#
+# The non-pull-request fallback is `github.sha`, not `github.ref`, and the
+# difference is not cosmetic. Keying every push to main as `refs/heads/main` puts
+# them all in one group, and `cancel-in-progress: false` does not mean "let them
+# all run". GitHub holds at most one pending run per group, and per the
+# workflow-syntax reference, "any existing `pending` job or workflow in the same
+# concurrency group will be canceled and the new queued job or workflow will take
+# its place." So a burst of three merges runs the first, queues the second, then
+# drops the second when the third arrives. The middle commit lands on main with
+# no FOSSA verdict and no e2e result, the exact outcome the paragraph above
+# exists to prevent. `queue: max` would also fix it, at the cost of serializing
+# main behind the longest e2e run. Per-commit groups cost nothing and delay
+# nothing.
+#
+# Known and bounded: tagging a commit already running as a main push collides,
+# because both resolve to the same `github.sha`. That costs the release run a
+# wait, not a verdict. Two runs in a group means one runs and one pends, and
+# nothing is dropped until a third arrives.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Read-only by default. Every elevated scope this workflow needs belongs to

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -19,8 +19,22 @@ permissions:
   statuses: write
 
 jobs:
+  # Skipped for fork pull requests, and it has to be. GitHub withholds repository
+  # secrets from a `pull_request` run triggered by a fork, so `secrets.VAULT_URL`
+  # arrives empty and the shared workflow exits 1 on its own input validation —
+  # red on every external contribution, for a secret the contributor cannot have.
+  #
+  # The two ways to scan a fork's code with real credentials both run untrusted
+  # code with an elevated token: `pull_request_target`, and a `workflow_run`
+  # follow-up that checks out the head ref. Neither is worth a pre-merge scan on a
+  # path that already needs a maintainer to approve the workflow run and a code
+  # owner to approve the pull request. The backstop is the full FOSSA scan on push
+  # to `main` in build-and-test.yml, plus a reviewer reading `go.mod`.
+  #
+  # Do not make this the required status check — see `sca_gate` below.
   fossa_scan:
     name: FOSSA Scan
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       use_vault: true
@@ -28,6 +42,54 @@ jobs:
     secrets:
       # Vault address is injected from an org/repo secret, not committed to the repo.
       VAULT_URL: ${{ secrets.VAULT_URL }}
+
+  # THIS is the required status check for supply-chain scanning, not
+  # `FOSSA Scan / SCA Scan`.
+  #
+  # A skipped *plain* job reports `skipped`, which GitHub counts as a passing
+  # required check. A skipped *reusable-workflow caller* is different: the inner
+  # job never runs, so the `FOSSA Scan / SCA Scan` context is never created at
+  # all. Requiring a context that is never created leaves it pending forever and
+  # the pull request unmergeable — trading a red check for a stuck one. Observed
+  # on PR #232, where the already-gated caller in build-and-test.yml produced
+  # bare `FOSSA Scan` as `skipped` and no ` / SCA Scan` context.
+  #
+  # This job always reports, so it is safe to require. It does not blindly trust
+  # `skipped`: it re-derives the fork condition itself and fails a skip it cannot
+  # account for. Without that, narrowing `fossa_scan`'s `if` later — or an
+  # upstream change that skips the caller for some other reason — would silently
+  # turn the gate off on same-repo pull requests, which is the exact trap the
+  # `FOSSA Scan` warning in ADMIN_SETUP.md documents.
+  sca_gate:
+    name: SCA gate
+    needs: fossa_scan
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require a FOSSA verdict, or a reason there cannot be one
+        env:
+          SCAN_RESULT: ${{ needs.fossa_scan.result }}
+          IS_FORK_PR: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          set -euo pipefail
+          case "$SCAN_RESULT" in
+            success)
+              echo "FOSSA scan passed."
+              ;;
+            skipped)
+              if [ "$IS_FORK_PR" != "true" ]; then
+                echo "::error::FOSSA scan was skipped on a same-repo pull request, where it should always run. Treating an unexplained skip as a failure rather than passing the gate. Check the 'if' condition on the fossa_scan job."
+                exit 1
+              fi
+              echo "::notice::FOSSA scan skipped: a fork pull request gets no repository secrets, so the Vault-backed scan cannot run. Supply-chain review for this pull request is the full scan on push to main plus a reviewer reading go.mod. See .github/ADMIN_SETUP.md."
+              ;;
+            *)
+              echo "::error::FOSSA scan reported '${SCAN_RESULT}'."
+              exit 1
+              ;;
+          esac
 
   # The DCO gate itself runs from .github/workflows/dco.yaml on
   # pull_request_target, which means it executes the *base ref's* script — so a

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -60,6 +60,16 @@ jobs:
   # upstream change that skips the caller for some other reason — would silently
   # turn the gate off on same-repo pull requests, which is the exact trap the
   # `FOSSA Scan` warning in ADMIN_SETUP.md documents.
+  #
+  # What that does NOT buy, stated so nobody reads more into it: this workflow
+  # runs on `pull_request`, so it runs from the pull request's own ref. A pull
+  # request that edits this job — `exit 0`, or dropping `needs: fossa_scan` —
+  # still reports `SCA gate` as green. That is the tamper hole `dco.yaml` avoids
+  # by living on `pull_request_target`, and it is not worth the same treatment
+  # here: on a fork pull request the gate passes anyway, so tampering gains
+  # nothing, which leaves only a collaborator editing it on a same-repo pull
+  # request. The control for that is review, not the trigger. Read `.github/`
+  # diffs.
   sca_gate:
     name: SCA gate
     needs: fossa_scan

--- a/.github/workflows/transition_on_merge.yaml
+++ b/.github/workflows/transition_on_merge.yaml
@@ -9,5 +9,21 @@ permissions:
   id-token: write
 
 jobs:
+  # Same-repo pull requests only, for two reasons that point the same way.
+  #
+  # Mechanically: the shared workflow authenticates to Vault via OIDC, and GitHub
+  # gives a fork-triggered `pull_request` run a read-only token, no repository
+  # secrets, and no `id-token: write` however this file asks for it. On a fork
+  # pull request it can only fail, and it fails *after* close or merge — so the
+  # first community contributor would watch a red X appear on their just-merged
+  # contribution, for a credential they were never eligible to hold.
+  #
+  # Semantically: this transitions the Jira ticket named in the branch or title.
+  # An external contribution has no SOL ticket to transition, so there is nothing
+  # for it to do even if it could authenticate.
+  #
+  # These checks must not be required — see .github/ADMIN_SETUP.md, which also
+  # explains why the context name is unstable.
   run-pull-request-checks:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: SolaceDev/re-workflows/.github/workflows/transition-pr-on-merge.yaml@release/v3

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,8 +38,8 @@ Moving pointers let consumers track a stream instead of a fixed version:
 
 **Publish gate** — automated. Clearing it makes the build publishable as a pre-release:
 
-- CI green — lint, build, `go vet`, `go test -race`, three E2E suites (basic MCP, OAuth, monitoring); runs on every branch push **[Implemented]**
-- Security scans clean — FOSSA SCA (dependencies, licenses); runs on PRs, default-branch pushes, and release tags **[Implemented]**
+- CI green — lint, build, `go vet`, `go test -race`, five E2E suites (basic MCP, OAuth, monitoring, management, action); runs on pull requests and on pushes to `main`, not on every branch push **[Implemented]**
+- Security scans clean — FOSSA SCA (dependencies, licenses); runs on same-repo pull requests, default-branch pushes, and release tags. A fork pull request gets no scan, because GitHub withholds the credential — see `.github/ADMIN_SETUP.md` **[Implemented]**
 - No open P0/P1 bugs **[Planned]**
 - Eval harness passes **[Planned]**
 - Coverage threshold met **[Planned]**


### PR DESCRIPTION
## What this does

Makes CI able to pass or fail an external contributor's pull request. Today it cannot: seven required checks never report on a fork PR, and the one supply-chain check that does run goes red for a missing secret the contributor could never have.

Closes [SOL-152411](https://sol-jira.atlassian.net/browse/SOL-152411).

## The three problems

**Seven checks never appeared.** `build-and-test.yml` triggered on `push` only, so a fork contributor's push fired in *their* fork and `lint`, `build`, and the five `e2e-*` checks never reported against this repository's commit. Required contexts that never report stay pending forever.

It now also triggers on `pull_request`, and `push` narrows to `main` so same-repo PRs don't run every check twice. I verified none of those jobs needs a secret: the e2e suites pull public images (`solace/solace-pubsub-standard`, `quay.io/keycloak/keycloak`), take broker credentials from committed `.env` files, and generate their own self-signed certs with `openssl`. A read-only `GITHUB_TOKEN` is enough.

**FOSSA went red for a reason no contributor could act on.** GitHub withholds repository secrets from a fork-triggered `pull_request` run, so `secrets.VAULT_URL` arrived empty and the shared workflow exited 1 on its own input validation. `fossa_scan` is now skipped for fork PRs.

**Skipping it is not enough on its own, and this is the part worth reviewing.** The ticket suggested just adding the `if`. That alone would have swapped a red check for a stuck one:

- A skipped **plain** job reports `skipped`, and GitHub counts that as passing.
- A skipped reusable-workflow **caller** is different: the inner job never runs, so the `FOSSA Scan / SCA Scan` context is never created at all. A required context that is never created stays pending forever.

Since `FOSSA Scan / SCA Scan` is the context `ADMIN_SETUP.md` tells admins to require, gating the caller would have made every external contribution unmergeable. Confirmed against live check runs on PR #232, where the already-gated caller in `build-and-test.yml` produced bare `FOSSA Scan` as `skipped` and no ` / SCA Scan` context.

So there's a new `sca_gate` job that always reports and is the context to require. It fails closed on a FOSSA failure **and** on a skip it cannot account for — it re-derives the fork condition itself rather than trusting `skipped`, so narrowing `fossa_scan`'s `if` later can't quietly switch the gate off on same-repo PRs.

## A concurrency block comes with the trigger change

Running on `pull_request` means a same-repo PR can have several runs in flight as
commits land, so this adds a `concurrency` block. Superseded PR runs cancel;
pushes to `main` never do, because every commit on `main` has to keep its own
FOSSA verdict and e2e result.

The non-PR fallback keys on `github.sha`, not `github.ref`, and that detail is
load-bearing. `cancel-in-progress: false` does not mean "let them all run":
GitHub holds at most one pending run per group and cancels the existing pending
run when a new one queues. Keying every push to `main` as `refs/heads/main` would
mean a burst of three merges runs the first, queues the second, and drops the
second when the third arrives, landing that commit on `main` with no verdict at
all. Per-commit groups avoid it without serializing anything. Copilot caught this
on review; the first version of this PR had the `github.ref` bug.

## What I deliberately did not do

No `pull_request_target`, and no `workflow_run` follow-up either. Both run untrusted code with an elevated token to buy a pre-merge scan on a path that already needs a maintainer to approve the workflow run and a code owner to approve the PR.

## Known gap, documented not papered over

A fork PR gets no pre-merge FOSSA verdict. The backstop is the full scan on push to `main` plus a human reading `go.mod`. That's detection after merge, not prevention before it.

The vulnerability half of that gap doesn't actually need a credential — `govulncheck` would run fine as an eighth job on a fork PR. I left it out to keep this change to the trigger and gate problem, and wrote it up in `ADMIN_SETUP.md` as the follow-up rather than leaving the gap looking unavoidable. Happy to file it.

## Also in here

Three things a review pass turned up that belong with this change:

- `transition_on_merge.yaml` would have gone red on every *closed* fork PR — it authenticates to Vault by OIDC, which a fork run cannot do. Same failure class this ticket exists to remove, so acceptance criterion 2 wasn't met without it. Gated to same-repo, which is also semantically right: an external contribution has no SOL ticket to transition.
- `build-and-test.yml`'s workflow-level `permissions` block granted `pull-requests: write`, `id-token: write`, `checks: write`, and `statuses: write` to all eight jobs. Only `fossa_scan` needs any of it. Not a regression from `push: '**'`, but it matters more now that the e2e jobs run shell from the PR's own ref, and `statuses: write` lets a step POST a green status under a required context name. Default is `contents: read`; the elevated scopes moved onto `fossa_scan`.
- Two docs had become false. `ADMIN_SETUP.md` still asserted reusable-workflow jobs "always surface as `<caller> / <inner>`, never as the caller name alone" — the exact behavior this change is built on disproving. `RELEASING.md` still advertised CI "on every branch push" and three e2e suites, marked `[Implemented]`.

## The trade-off to push back on if you disagree

Pushing a feature branch no longer runs CI on its own. Open the PR — a draft is enough — and every check runs.

The alternative was keeping `push: '**'` and gating each job on `github.event_name == 'pull_request' || github.ref_name == main`. That's strictly worse: it still can't run CI for a branch with no PR (the condition is false there), and it adds an all-skipped workflow run to every branch push. Deciding whether a push has an open PR needs an API call, so no declarative trigger preserves pre-PR branch CI.

## Verification

- `make check` — exit 0, 31 packages ok.
- `actionlint` v1.7.7 across all seven workflows — exit 0.
- `sca_gate`'s decision table unit-tested outside CI: `success`→pass, `failure`→fail, `cancelled`→fail, `skipped`+fork→pass, `skipped`+same-repo→**fail**.
- Claim (a) above confirmed against live check-run data on PR #232, not inferred.
- `workflow_call` retained, so `release.yml`'s tag path still works; `fossa_scan`'s `if` still evaluates false there, unchanged.

**Not verifiable from here:** no fork PR has ever been opened against this repo. `SCA gate` has no live run behind it. `ADMIN_SETUP.md` says so and lists what to confirm against a real external contribution before treating any of it as a gate.

No CHANGELOG entry — CI-only, outside the production surface `.github/scripts/production-surface.sh` defines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
