### PR TITLE
SOL-152685: Repoint stale SolaceDev references to SolaceProducts

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 ### Reporting Bugs
 
-Before creating a bug report, please check the [existing issues](https://github.com/SolaceDev/solace-broker-mcp/issues) to avoid duplicates.
+Before creating a bug report, please check the [existing issues](https://github.com/SolaceProducts/solace-broker-mcp/issues) to avoid duplicates.
 
 When reporting a bug, please include:
 
@@ -46,7 +46,7 @@ When reporting a bug, please include:
 
 We welcome feature requests! Before submitting:
 
-1. Check [existing issues](https://github.com/SolaceDev/solace-broker-mcp/issues?q=label%3Aenhancement) and [discussions](https://github.com/SolaceDev/solace-broker-mcp/discussions) for similar ideas
+1. Check [existing issues](https://github.com/SolaceProducts/solace-broker-mcp/issues?q=label%3Aenhancement) and [discussions](https://github.com/SolaceProducts/solace-broker-mcp/discussions) for similar ideas
 2. Consider if the feature aligns with the project's goals (SEMP API management via MCP)
 3. Think about how it would benefit the broader community
 
@@ -355,8 +355,8 @@ retitled or edited. That is normal and nothing for you to fix.
 
 ## Questions?
 
-- **General questions:** Start a [GitHub Discussion](https://github.com/SolaceDev/solace-broker-mcp/discussions)
-- **Bugs or features:** Open a [GitHub Issue](https://github.com/SolaceDev/solace-broker-mcp/issues/new/choose)
+- **General questions:** Start a [GitHub Discussion](https://github.com/SolaceProducts/solace-broker-mcp/discussions)
+- **Bugs or features:** Open a [GitHub Issue](https://github.com/SolaceProducts/solace-broker-mcp/issues/new/choose)
 - **Security issues:** Email [andrea.ross@solace.com](mailto:andrea.ross@solace.com)
 - **Community chat:** Visit [Solace Community](https://solace.community/)
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Questions & Discussions
-    url: https://github.com/SolaceDev/solace-broker-mcp/discussions
+    url: https://github.com/SolaceProducts/solace-broker-mcp/discussions
     about: Ask questions, share ideas, and discuss with the community
   - name: 🏢 Solace Community
     url: https://solace.community/
     about: Get help from the broader Solace community
   - name: 🔒 Security Vulnerability
-    url: https://github.com/SolaceDev/solace-broker-mcp/security/policy
+    url: https://github.com/SolaceProducts/solace-broker-mcp/security/policy
     about: Report security vulnerabilities privately (do not use issues!)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -62,7 +62,7 @@ When you report a security vulnerability, here's what you can expect from us:
 
 Security fixes are released as:
 - **Patch versions** (e.g., v0.1.1 → v0.1.2)
-- **GitHub Security Advisories** at https://github.com/SolaceDev/solace-broker-mcp/security/advisories
+- **GitHub Security Advisories** at https://github.com/SolaceProducts/solace-broker-mcp/security/advisories
 - **CHANGELOG** entries with `[SECURITY]` prefix
 
 Subscribe to releases on GitHub to be notified of security updates.
@@ -196,4 +196,4 @@ Format:
 
 If you have questions about this security policy, contact [andrea.ross@solace.com](mailto:andrea.ross@solace.com).
 
-For non-security bugs and feature requests, please use [GitHub Issues](https://github.com/SolaceDev/solace-broker-mcp/issues).
+For non-security bugs and feature requests, please use [GitHub Issues](https://github.com/SolaceProducts/solace-broker-mcp/issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,11 +321,11 @@ This project uses [Semantic Versioning](https://semver.org/):
 
 ## Links
 
-- [Unreleased]: https://github.com/SolaceDev/solace-broker-mcp/compare/v0.6.0...HEAD
-- [0.6.0]: https://github.com/SolaceDev/solace-broker-mcp/compare/v0.5.0...v0.6.0
-- [0.5.0]: https://github.com/SolaceDev/solace-broker-mcp/compare/v0.4.0...v0.5.0
-- [0.4.0]: https://github.com/SolaceDev/solace-broker-mcp/compare/v0.3.0...v0.4.0
-- [0.3.0]: https://github.com/SolaceDev/solace-broker-mcp/compare/v0.2.0...v0.3.0
-- [0.2.0]: https://github.com/SolaceDev/solace-broker-mcp/compare/v0.1.0...v0.2.0
-- [0.1.0]: https://github.com/SolaceDev/solace-broker-mcp/compare/v0.0.1...v0.1.0
-- [0.0.1]: https://github.com/SolaceDev/solace-broker-mcp/releases/tag/v0.0.1
+- [Unreleased]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.6.0...HEAD
+- [0.6.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.5.0...v0.6.0
+- [0.5.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.4.0...v0.5.0
+- [0.4.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.3.0...v0.4.0
+- [0.3.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.2.0...v0.3.0
+- [0.2.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.1.0...v0.2.0
+- [0.1.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.0.1...v0.1.0
+- [0.0.1]: https://github.com/SolaceProducts/solace-broker-mcp/releases/tag/v0.0.1

--- a/docs/internal/packaging-release.md
+++ b/docs/internal/packaging-release.md
@@ -27,7 +27,7 @@ Local builds use the fallback value. No action required — see
 
 ldflags is a **compile-time string substitution** mechanism. It does not fetch
 anything from a remote repository. The long module path
-(`github.com/SolaceDev/solace-broker-mcp/internal/version.version`) is the
+(`github.com/SolaceProducts/solace-broker-mcp/internal/version.version`) is the
 same path used in Go `import` statements — the compiler resolves it against
 whatever source is on disk and replaces the variable's initial value in the
 compiled binary.
@@ -45,7 +45,7 @@ The version value itself comes from whatever string you pass. Common sources:
 Pass the fully-qualified variable path via `-ldflags -X`:
 
 ```bash
-go build -ldflags "-X github.com/SolaceDev/solace-broker-mcp/internal/version.version=0.1.0" ./cmd/server
+go build -ldflags "-X github.com/SolaceProducts/solace-broker-mcp/internal/version.version=0.1.0" ./cmd/server
 ```
 
 ## Building
@@ -64,7 +64,7 @@ Strip debug symbols with `-s -w` for a smaller binary and inject the version:
 ```bash
 VERSION=$(git describe --tags --always)
 CGO_ENABLED=0 go build \
-  -ldflags "-s -w -X github.com/SolaceDev/solace-broker-mcp/internal/version.version=${VERSION}" \
+  -ldflags "-s -w -X github.com/SolaceProducts/solace-broker-mcp/internal/version.version=${VERSION}" \
   -o solace-broker-mcp \
   ./cmd/server
 ```


### PR DESCRIPTION
## Summary

  Repoint stale `SolaceDev` references to `SolaceProducts` in docs and `.github/` metadata — the old-org links left out of the module-path rename (SOL-152669) to keep that change scoped.

  Resolves SOL-152685. Absorbs and closes SOL-152681 (duplicate).

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Dependency update

  ## Motivation and Context

  The repository moved from the `SolaceDev` org to `SolaceProducts`. The module-path PR (SOL-152669) renamed the Go module and updated all imports, but deliberately left a set of documentation and link references untouched to stay scoped. GitHub's redirect keeps the URLs working for now, but they should name `SolaceProducts` before the repo goes public.

  One of these is not a URL: the `-ldflags -X` module path in the release runbook is a Go **symbol** path. There is no redirect, and `-X` against a symbol that no longer exists fails silently — a manual/runbook build stamps the version as `dev` with no error. That case was tracked as SOL-152681 and is folded in here.

  ## Changes Made

  - `CHANGELOG.md` — repoint the 8 footer compare/release links (left the `[Unreleased]` BREAKING note untouched; it intentionally records the old path).
  - `.github/CONTRIBUTING.md` — repoint 4 issues/discussions links.
  - `.github/SECURITY.md` — repoint 2 advisories/issues links.
  - `.github/ISSUE_TEMPLATE/config.yml` — repoint 2 discussions/security-policy links.
  - `docs/internal/packaging-release.md` — repoint the 3 `-ldflags -X` module-path examples (absorbed from SOL-152681). The`ghcr.io/solacedev` image rows in the same file are left untouched (tracked separately by SOL-152684).

  ## Testing

  **Test Environment:**
  - Go version: go1.26.1
  - OS: macOS 26.5.2 (darwin 25.5.0), arm64
  - Broker version (if applicable): n/a

  **Tests Performed:**
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated (if applicable)
  - [ ] E2E tests added/updated (if applicable)
  - [ ] Tested locally with `go test -race ./...`
  - [ ] Tested with real Solace broker

  **Test Coverage:**
  Docs/metadata-only change; no code paths altered, so no unit/integration/E2E tests apply. Verified the ldflags fix by build:
  - `make build && ./solace-broker-mcp --version` → `v0.6.0-28-g43a9a93-dirty` (real version)
  - Runbook line-48 command with the new path → `0.1.0` (real version)
  - Control with the old `SolaceDev` path → `dev` (reproduces the silent failure the fix resolves)

  ## Breaking Changes

  n/a — no breaking changes.

  **Impact:**

  **Migration Guide:**

  ## Checklist

  ### Code Quality
  - [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
  - [x] Self-review completed (checked for typos, logic errors, edge cases)
  - [ ] Code is well-commented (explains "why", not "what") — n/a, no code
  - [ ] Complex logic has explanatory comments — n/a
  - [x] No commented-out code or debug statements left in

  ### Security
  - [x] **No credentials in code** (checked all files, commits, and logs)
  - [ ] Followed [secure logging rules](../docs/secure-logging-rules.md) — n/a, no logging changes
  - [ ] Credential-carrying types implement `slog.LogValuer` — n/a
  - [x] No security vulnerabilities introduced

  ### Testing
  - [ ] All tests pass locally: `go test -race ./...` — n/a, docs-only
  - [x] No race conditions detected — n/a, no code
  - [ ] Edge cases covered by tests — n/a
  - [ ] Error paths tested — n/a
  - [ ] Test names clearly describe what is being tested — n/a

  ### Documentation
  - [ ] README.md updated (if user-facing changes) — n/a
  - [x] docs/ updated (docs/internal/packaging-release.md)
  - [ ] godoc comments added/updated for exported functions — n/a
  - [ ] CHANGELOG.md updated (if applicable) — n/a; docs/.github only, not production surface (footer-link edit only, not an `[Unreleased]` entry)
  - [ ] Examples updated (if applicable) — n/a

  ### Git & CI
  - [ ] All commits are signed off (DCO: `git commit -s`)
  - [ ] Commits have clear, descriptive messages
  - [ ] Branch is up to date with main (rebased if needed)
  - [ ] No merge conflicts
  - [ ] CI checks passing (lint, build, test, E2E)

  ### Breaking Changes (if applicable)
  - [ ] Breaking changes documented in commit message — n/a
  - [ ] Breaking changes documented in PR description — n/a
  - [ ] Migration guide provided — n/a
  - [ ] Deprecated functionality marked with comments and deprecation notices — n/a

  ## Additional Notes

  Deliberately excluded, tracked separately:
  - Container image `ghcr.io/solacedev/...` (incl. the live publish target `.github/workflows/release.yml:127`) — **SOL-152684**.
  - Reusable-workflow `uses: SolaceDev/solace-public-workflows/...` and `SolaceDev/re-workflows/...` — those target genuine repos in the SolaceDev org; changing them breaks CI.
  - The GitHub Discussions links here get their org swapped; **SOL-152413** will later repoint them at the Solace Community entirely.

  ## Related Issues/PRs

  - Related to SOL-152415 (repo org move), SOL-152413 (discussions → Solace Community)
  - Depends on SOL-152669 (module-path rename, merged)
  - Duplicate folded in: SOL-152681 (closed)

  ---

  **For Reviewers:**

  **Focus Areas**: Confirm no in-scope reference was missed and no out-of-scope one was changed — in particular that the `ghcr.io/solacedev` image rows and the `uses: SolaceDev/...` workflow refs are untouched, and `CHANGELOG.md:19` is left as-is.