### PR TITLE
SOL-152740: drop the retired Go Report Card badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # solace-broker-mcp
 
 [![Build Status](https://github.com/SolaceProducts/solace-broker-mcp/workflows/Build%20and%20Test/badge.svg)](https://github.com/SolaceProducts/solace-broker-mcp/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/SolaceProducts/solace-broker-mcp)](https://goreportcard.com/report/github.com/SolaceProducts/solace-broker-mcp)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/SolaceProducts/solace-broker-mcp)](go.mod)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](.github/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
  ## Summary

  Removes the retired Go Report Card badge from the README. Go Report Card was sunset on 1 July 2026; its badge now renders "go report: retired" in grey, advertising a dead service — a credibility problem the moment the repo goes public.

  Resolves SOL-152740.

  ## Type of Change

  - [x] Documentation update

  ## Motivation and Context

  The badge no longer says anything about our code — it just advertises a dead service. There's no capability gap to close: the sunset notice names golangci-lint as its successor, which we already run in the Build and Test workflow (`golangci-lint-action`, `build-and-test.yml`). The Build Status badge (line 3) goes red when lint fails, so lint signal is already covered.

  Considered and rejected: adding a dedicated lint badge. GitHub's `badge.svg` is per-workflow, not per-job, so a lint badge would require splitting `golangci-lint` into its own workflow — not worth restructuring CI for a second badge.

  ## Changes Made

  - Deleted the Go Report Card badge line from `README.md` (line 4).

  ## Testing

  README-only change; no code paths affected. Verified `git grep goreportcard.com` returns no matches and the remaining badges (Build Status, License, Go Version, Contributor Covenant) all resolve to live signals.

  ## Checklist

  - [x] Self-review completed
  - [x] All commits are signed off (DCO: `git commit -s`)
  - [x] Commits have clear, descriptive messages
  - [x] README.md updated
  - [x] No CHANGELOG entry needed — README-only, outside the production-surface scope (`internal/config/`, `internal/tools/`, `internal/composite/definitions/tools.yaml`)