### PR TITLE
SOL-152862: Get the LLM eval workflow green again, red since the org move and unexercised ever since 

### DIFF
--- a/.github/workflows/llm-eval.yml
+++ b/.github/workflows/llm-eval.yml
@@ -108,15 +108,15 @@ jobs:
       - name: Broker logs (on failure)
         if: failure() && inputs.broker_target == 'local-docker'
         run: |
-          echo "=== solace-e2e-mon-a ==="
-          docker logs solace-e2e-mon-a 2>&1 | tail -100 || true
-          echo "=== solace-e2e-mon-b ==="
-          docker logs solace-e2e-mon-b 2>&1 | tail -100 || true
+          echo "=== solace-e2e-llm-a ==="
+          docker logs solace-e2e-llm-a 2>&1 | tail -100 || true
+          echo "=== solace-e2e-llm-b ==="
+          docker logs solace-e2e-llm-b 2>&1 | tail -100 || true
 
       - name: MCP server log (on failure)
         if: failure() && inputs.broker_target == 'local-docker'
-        run: cat test/e2e-monitoring/bin/mcp-server.log 2>/dev/null || echo "(no server log)"
+        run: cat test/e2e-llm/bin/mcp-server.log 2>/dev/null || echo "(no server log)"
 
       - name: Tear down local brokers
         if: always() && inputs.broker_target == 'local-docker'
-        run: docker compose -f test/e2e-monitoring/docker-compose.yml down -v
+        run: docker compose -f test/e2e-llm/docker-compose.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ go.work.sum
 # Dependency directory
 vendor/
 
+# Node.js dependencies — only test/e2e-llm installs any (pinned Claude CLI).
+# npm ci restores from the checked-in package-lock.json on every run.
+node_modules/
+
 # IDE files
 .idea/
 .vscode/
@@ -47,6 +51,7 @@ broker-config.yaml
 !test/e2e-management/.env
 !test/e2e-action/.env
 !test/e2e-oauth/.env
+!test/e2e-llm/.env
 
 # Working documents that must not be committed (see OPEN_SOURCE_STATUS.md)
 Mark2-report.md

--- a/test/e2e-common/lib.sh
+++ b/test/e2e-common/lib.sh
@@ -478,7 +478,7 @@ verify_monitor_object() {
         sleep 1
         attempt=$((attempt + 1))
     done
-    log_warn "  monitor NOT visible: $description on $label after ${max_attempts}s — proceeding anyway"
+    log_warn "  monitor NOT visible: $description on $label after ${max_attempts}s"
     return 1
 }
 

--- a/test/e2e-llm/.env
+++ b/test/e2e-llm/.env
@@ -1,0 +1,43 @@
+# Single source of truth for LLM e2e suite broker + MCP configuration.
+# Read by: docker-compose.yml, e2e-common/lib.sh (via helpers.sh), and the
+# MCP server (via ENV_FILE). Ports are distinct from the other e2e suites
+# so servers never clash when run in parallel.
+#
+# Suite-level knobs (LLM_SERVICE_ENDPOINT, LLM_SERVICE_API_KEY, target
+# selection) live in config.env / targets/*.env — this file is only the
+# broker/MCP wiring that lib.sh consumes.
+
+# Broker SEMP ports (host-side)
+BROKER_A_SEMP_PORT=8102
+BROKER_B_SEMP_PORT=8104
+
+# Broker SMF ports (host-side)
+BROKER_A_SMF_PORT=55661
+BROKER_B_SMF_PORT=55662
+
+# Broker credentials (shared by both brokers)
+BROKER_USERNAME=admin
+BROKER_PASSWORD=admin
+
+# MCP server credential env vars (resolved via ${VAR_NAME} substitution in broker config)
+E2E_A_USERNAME=admin
+E2E_A_PASSWORD=admin
+E2E_B_USERNAME=admin
+E2E_B_PASSWORD=admin
+
+# MCP server port — distinct from monitoring (9090) and management suites so
+# servers can co-exist. Matches targets/local-docker.env's MCP_URL.
+MCP_PORT=9094
+
+# Static bearer token shared by the MCP server (mcp_client_auth.dev_token) and
+# every e2e client. Matches targets/local-docker.env's MCP_BEARER_TOKEN.
+MCP_DEV_TOKEN=e2e-static-dev-token
+
+# F8 bridge remote hostnames — each side points at the sibling's internal
+# container hostname (this suite's docker-compose.yml names them
+# solace-e2e-llm-{a,b}). Reachable over the compose network's default bridge
+# on 55555, the SMF plaintext listener's *internal* container port. Overrides
+# monitoring/helpers.sh's default (solace-e2e-mon-*), which is wrong for this
+# suite's network.
+F8_REMOTE_HOST_FROM_A=solace-e2e-llm-b
+F8_REMOTE_HOST_FROM_B=solace-e2e-llm-a

--- a/test/e2e-llm/fixtures.sh
+++ b/test/e2e-llm/fixtures.sh
@@ -170,8 +170,13 @@ _spawn_llm_kick_client_on() {
 
 # Provision both brokers' LLM fixtures + prime the action queues.
 # Called from setup-fixtures.sh AFTER create_fixtures (so BIN_DIR/broker-driver
-# is built and monitoring fixtures are up first).
+# is built and monitoring fixtures are up first). Starts with a cleanup pass
+# to match the "safe to re-run" contract in setup-fixtures.sh's header:
+# without it, a second setup on a live suite hits ALREADY_EXISTS on the
+# LLM standing queues/kick-targets (monitoring's create_fixtures cleans its
+# own fixtures but has no knowledge of these).
 create_llm_standing_fixtures() {
+    cleanup_llm_standing_fixtures
     _create_e2e_llm_action_queue_on "$BROKER_A_SEMP_CONFIG" a "$E2E_LLM_ACTION_QUEUE_A"
     _create_e2e_llm_action_queue_on "$BROKER_B_SEMP_CONFIG" b "$E2E_LLM_ACTION_QUEUE_B"
     # Prime both brokers so A1/A2/B1 pass regardless of which run-scenario.sh

--- a/test/e2e-llm/run-scenario.sh
+++ b/test/e2e-llm/run-scenario.sh
@@ -302,15 +302,19 @@ invoke_claude() {
     local claude_args=(
         --mcp-config "$MCP_CONFIG"
         --strict-mcp-config
-        # `--tools ""` disables Claude's built-in tools (Bash, Read, WebSearch, …)
-        # so the agent can only reach for MCP tools.
-        --tools ""
         # `--allowed-tools` IS load-bearing in --print mode — it's the
         # auto-approve list. Without it, every MCP tool call gets denied with
         # "I need permission to run X — please approve and I'll retry." Wildcard
         # auto-approves every tool from our MCP server (the only one loaded,
         # thanks to --strict-mcp-config), so the list stays maintenance-free
         # as the server adds tools. Assertion logic catches wrong tool choices.
+        # Built-in tools (Bash, Read, WebSearch, …) are NOT on this allow-list,
+        # so in --print mode they can't run — the auto-approve gate keeps the
+        # agent effectively confined to MCP tools without a `--tools ""` flag.
+        # A prior version of this argv did pass `--tools ""` to disable built-
+        # ins explicitly; CLI 2.1.181 reinterprets that as "disable ALL tools
+        # including MCP", so the agent had no tools and answered every
+        # scenario "I don't have the Solace MCP tools available" (SOL-152862).
         --allowed-tools "mcp__solace-broker__*"
         --output-format stream-json
         --verbose

--- a/test/e2e-monitoring/.env
+++ b/test/e2e-monitoring/.env
@@ -23,3 +23,10 @@ E2E_B_PASSWORD=admin
 # e2e client (curl in helpers.sh). Same ${VAR} substitution
 # pattern as credentials.
 MCP_DEV_TOKEN=e2e-static-dev-token
+
+# F8 bridge remote hostnames — each side points at the sibling's internal
+# container hostname (fixed by docker-compose.yml's `hostname:` field).
+# Reachable over the compose network's default bridge on 55555, the SMF
+# plaintext listener's *internal* container port.
+F8_REMOTE_HOST_FROM_A=solace-e2e-mon-b
+F8_REMOTE_HOST_FROM_B=solace-e2e-mon-a

--- a/test/e2e-monitoring/helpers.sh
+++ b/test/e2e-monitoring/helpers.sh
@@ -133,8 +133,12 @@ cleanup_multi_queue_on() {
 # .env-configurable like the host-mapped ports — reachable from the sibling
 # container over the compose network's default bridge on 55555, the SMF
 # plaintext listener's *internal* container port).
-F8_REMOTE_HOST_FROM_A="solace-e2e-mon-b"
-F8_REMOTE_HOST_FROM_B="solace-e2e-mon-a"
+# Overridable via each suite's .env (same SUITE_DIR/.env indirection lib.sh
+# uses for ports/creds) so the LLM suite — which sources this file for its
+# F1–F8 fixture code — can point bridges at solace-e2e-llm-* instead of
+# monitoring's containers. Defaults preserve monitoring's original wiring.
+F8_REMOTE_HOST_FROM_A="${F8_REMOTE_HOST_FROM_A:-solace-e2e-mon-b}"
+F8_REMOTE_HOST_FROM_B="${F8_REMOTE_HOST_FROM_B:-solace-e2e-mon-a}"
 F8_SMF_PORT=55555
 
 # Bridge health-state constants and predicate, mirroring bridgeInboundUpStates


### PR DESCRIPTION
## Summary

Restore the LLM eval workflow (`llm-eval.yml`) to green — it has been failing since the SOL-151807 refactor promoted `test/e2e-monitoring/llm` to a peer at `test/e2e-llm`. The suite has been unexercised since, so nothing surfaced the regression.

Fixes [SOL-152862](https://sol-jira.atlassian.net/browse/SOL-152862)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The LLM eval is the only automated check that the MCP tools behave sensibly when a real model drives them, but it is manual and non-gating so nothing surfaced that every run has failed. Both `main` runs on 2026-07-31 failed; the surface error (`solace-e2e-mon-a: No such container`) was teardown noise, not the cause. Four independent regressions all landed together at the org move and stayed hidden until this ticket.

## Changes Made

Root causes and fixes:

- **Missing `.env` for the LLM suite.** `e2e-common/lib.sh` unconditionally sources `$SUITE_DIR/.env`. Before the refactor the LLM code lived under `test/e2e-monitoring/llm/` and rode on monitoring's `.env`; after the promote no `.env` was added at the new location. Every run failed on line 30 of `lib.sh` before setup could progress. → Added `test/e2e-llm/.env` with this suite's ports, creds, MCP dev token, and F8 bridge remote hosts.
- **F8 bridge remote hosts hardcoded to monitoring's containers.** `test/e2e-monitoring/helpers.sh` declared `F8_REMOTE_HOST_FROM_A="solace-e2e-mon-b"` and `..._FROM_B="solace-e2e-mon-a"` as bare constants. The LLM suite reuses monitoring's F1–F8 fixture code (its `helpers.sh` header commits to that), so bridges got configured to point at hostnames that don't exist on the LLM compose network. Bridge verification then timed out at 30 s and failed `create_fixtures`. → Made both env-overridable (`${VAR:-default}`), added the two lines to `test/e2e-monitoring/.env` (original values preserved), and to `test/e2e-llm/.env` with `solace-e2e-llm-{b,a}`.
- **`create_llm_standing_fixtures` was not idempotent.** No cleanup pass at the top, so a second `setup-fixtures.sh` on a live suite hit HTTP 400 `ALREADY_EXISTS` on the LLM standing queues / kick targets. Violates the "Safe to re-run" contract stated in `setup-fixtures.sh`'s own header. → Added `cleanup_llm_standing_fixtures` call at the top of `create_llm_standing_fixtures`, mirroring the pattern monitoring's `create_fixtures` already uses.
- **`--tools ""` no longer means what the comment said.** In Claude CLI 2.1.181 (the version pinned in `package.json` and used by CI), empty-string is interpreted as "disable **all** tools including MCP", not "disable only the built-ins". Every scenario therefore answered *"I don't have the Solace MCP tools available in this session"* once setup got past the earlier blockers. `--allowed-tools "mcp__solace-broker__*"` in `--print` mode already restricts auto-approval to MCP tools, so the empty-tools flag was redundant even before it broke. → Dropped the flag from `run-scenario.sh`; replaced the stale comment with one explaining why for future readers.

Drive-bys in the same critical path:

- Fixed `llm-eval.yml`'s teardown log-tail step (was `docker logs solace-e2e-mon-*`, now `solace-e2e-llm-*`), MCP-log path (`test/e2e-monitoring/bin/…` → `test/e2e-llm/bin/…`), and compose teardown path (`test/e2e-monitoring/docker-compose.yml` → `test/e2e-llm/docker-compose.yml`). Leftover from the pre-refactor layout — the reason the *symptom* observed in the ticket was container-name errors.
- Dropped `verify_monitor_object`'s "…proceeding anyway" tail from its log_warn line — the function actually returns 1 under `set -e`, so the message was misleading.
- Added `node_modules/` to `.gitignore` (only `test/e2e-llm/` installs any; `npm ci` restores from `package-lock.json`), and negated `!test/e2e-llm/.env` alongside the other suites' checked-in `.env` files.

## Testing

**Test Environment:**
- Go version: 1.25.0 (per go.mod)
- OS: Fedora Linux 7.0.10 (local); ubuntu-24.04 (CI)
- Broker version: solace/solace-pubsub-standard:latest (10.26.0.8586)
- Claude CLI: 2.1.181 (pinned via `test/e2e-llm/package.json`)

**Tests Performed:**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (LLM suite scaffolding restored)
- [ ] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**
- Local repro of the original failure: `BROKER_TARGET=local-docker bash test/e2e-llm/setup-fixtures.sh` exited 1 at `lib.sh:30`. After fixes: setup exits 0, F1–F8 fixtures + LLM standing fixtures provision cleanly, bridges verify in 0 s on both brokers.
- Second consecutive `setup-fixtures.sh` invocation without teardown: no `ALREADY_EXISTS` errors (confirms the idempotency fix).
- End-to-end scenario locally with the pinned CLI against LiteLLM proxy: `./run-scenario.sh scenarios/f1-list-vpns.json` — LLM called `list-vpns`, produced the expected VPN set (`default`, `test-vpn`, `test-vpn-empty`), assertions matched, PASS.
- Bisected CLI flags to isolate `--tools ""` as the second blocker (three progressive invocations, only the one with `--tools ""` returned "no MCP tools available").
- Green `workflow_dispatch` run against this branch: https://github.com/SolaceProducts/solace-broker-mcp/actions/runs/31039920539/job/92421437382

## Breaking Changes

Not applicable.

## Checklist

### Code Quality
- [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (the two `.env` files contain the same admin/admin dev creds and static dev bearer token that the other suites already check in)
- [x] Followed [secure logging rules](../docs/secure-logging-rules.md)
- [x] Credential-carrying types implement `slog.LogValuer` (no new credential-carrying types)
- [x] No security vulnerabilities introduced

### Testing
- [x] All tests pass locally: `go test -race ./...` (no Go code touched)
- [x] No race conditions detected
- [x] Edge cases covered by tests (idempotent re-run of setup)
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated (`test/e2e-llm/README.md` update for cadence + owner is filed as a follow-up in the ticket — AC calls for it and I want to align with the team on cadence rather than picking unilaterally)
- [ ] docs/ updated (no architecture changes)
- [x] godoc comments added/updated for exported functions (no Go changes)
- [ ] CHANGELOG.md updated (test infra only — not `internal/`; no changelog required per CLAUDE.md's rule)
- [x] Examples updated (no user-facing examples changed)

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing https://github.com/SolaceProducts/solace-broker-mcp/actions/runs/31039920539/job/92421437382

## Screenshot
<img width="501" height="860" alt="image" src="https://github.com/user-attachments/assets/d161f70c-249a-4119-afe1-b2875f9116ec" />



## Additional Notes

**One-time CI setup this PR depends on (already done):** repo secret `LLM_SERVICE_API_KEY` and repo variables `LLM_SERVICE_ENDPOINT` + `LLM_SERVICE_MODEL_NAME` are now populated (were absent because org-scoped secrets don't transfer between GitHub organisations).

**Ticket AC deferred to a follow-up:** documenting the suite's cadence + owner in `test/e2e-llm/README.md`. That decision is a team call, not a code change, so bundling it here would gate the workflow-green fix on unrelated coordination.

## Related Issues/PRs

- Fixes SOL-152862
- Related to SOL-151807 (the refactor that surfaced these regressions)
- Next step: [SOL-152815](https://sol-jira.atlassian.net/browse/SOL-152815) and [SOL-152813](https://sol-jira.atlassian.net/browse/SOL-152813)
- Need to file a ticket to add Kafka Receiver/Sender coverage to LLM eval suite

---

**For Reviewers:**

**Focus Areas:**
- The `F8_REMOTE_HOST_FROM_*` env indirection in `e2e-monitoring/helpers.sh` — does this feel like the right shape, vs. deriving from `docker-compose.yml`'s `hostname:` fields, or vs. skipping F8 entirely for LLM? The parameterize choice keeps LLM using the same fixture set as monitoring (its `helpers.sh` header commits to "wholesale reuse of F1–F8"), which felt like the least-surprising option.
- Comment in `run-scenario.sh` about `--tools ""` — I've left a load-bearing paragraph explaining the CLI-version regression so we don't reintroduce it. Feels heavy but the failure mode is silent (no error, LLM just says "no tools"), which is the exact class of thing I want future readers to be warned about.
