### PR TITLE
DATAGO-147338: FOSSA: authenticate with the FOSSA_API_KEY Actions secret

### DIFF
--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -225,7 +225,7 @@ against a real pull request before you rely on them:
   (`name: "SCA Scan"`), which exits non-zero on findings because
   `.github/workflow-config.json` sets both FOSSA modes to `BLOCK`. But that caller
   is now skipped for fork pull requests, because a fork gets no repository
-  secrets and the Vault-backed scan cannot run. A skipped *plain* job still
+  secrets and the credentialed scan cannot run. A skipped *plain* job still
   reports `skipped`; a skipped reusable-workflow *caller* never creates the
   ` / SCA Scan` context at all. Required contexts that are never created stay
   pending forever, so requiring this one makes every external contribution
@@ -315,11 +315,13 @@ made this impossible. What it changed, and what it deliberately did not:
    take their broker credentials from committed `.env` files, and generate their
    own self-signed TLS certs with `openssl`. A read-only `GITHUB_TOKEN` is enough.
 2. **FOSSA no longer goes red for a missing secret.** `ci-pr.yaml` passes
-   `use_vault: true` and `secrets.VAULT_URL`, and GitHub withholds secrets from a
-   fork-triggered `pull_request` run, so the reusable workflow used to find an
-   empty Vault URL and exit 1 on every external contribution. The `fossa_scan`
+   `use_vault: false` and `secrets.FOSSA_API_KEY`, and GitHub withholds secrets
+   from a fork-triggered `pull_request` run, so the reusable workflow used to find
+   an empty credential and exit 1 on every external contribution. The `fossa_scan`
    job is now skipped for fork pull requests, and the always-reporting `SCA gate`
-   job is the required context instead.
+   job is the required context instead. Moving the key off Vault onto an Actions
+   secret did not close this gap: GitHub withholds every repository secret from a
+   fork run, whatever its source.
 3. **`pull_request_target` was not introduced**, and neither was a `workflow_run`
    follow-up. Both would run untrusted code with an elevated token to buy a
    pre-merge scan on a path that already requires a maintainer to approve the
@@ -345,8 +347,8 @@ changes, two human controls stand in, and both need someone to actually do them:
   `main` run themselves.
 
 **Worth closing properly.** The vulnerability half of this gap does not actually
-need a credential. `govulncheck` (or `osv-scanner` over `go.mod`) needs no secret,
-no Vault, and no elevated token, so it would run fine as an eighth job in
+need a credential. `govulncheck` (or `osv-scanner` over `go.mod`) needs no secret
+and no elevated token, so it would run fine as an eighth job in
 `build-and-test.yml` on a fork pull request — restoring *prevention* for
 critical/high vulnerabilities instead of leaving both halves to a human. Licensing
 is the harder half; `go-licenses` covers some of it. This was left out of
@@ -493,7 +495,7 @@ writing; re-check, do not assume.
   > | When (UTC) | Symptom | Cause | Whose fix |
   > |---|---|---|---|
   > | last green: 07-30 21:28 | `Test passed! 0 issues found` against project `SolaceDev_solace-broker-mcp` | | |
-  > | 07-31 14:46 to 15:34 | fails in ~13s | Vault OIDC role `cicd-workflows-secret-read-role` binds on the `repository` claim, which the rename changed. Token exchange rejected: `claim "repository" does not match any associated bound claim values`. | infra, since fixed |
+  > | 07-31 14:46 to 15:34 | fails in ~13s | Vault OIDC role `cicd-workflows-secret-read-role` binds on the `repository` claim, which the rename changed. Token exchange rejected: `claim "repository" does not match any associated bound claim values`. | infra, since fixed — and now unreachable: FOSSA authenticates with the `FOSSA_API_KEY` secret, not a Vault OIDC role |
   > | 07-31 from 15:38 | fails in ~50s | Vault authenticates. The scan container cannot be pulled: `manifest unknown` for `ghcr.io/solaceproducts/maas-build-actions@sha256:14d7b08…`. Same rename, via `github.repository_owner` in the nested `fossa-guard` action. | infra |
   > | next, once the container is pullable | expect a licensing block | PR #243 repointed `project_id` to `SolaceProducts_solace-broker-mcp`, a **new** FOSSA project carrying none of the old project's policy waivers. | **this repository** |
   >
@@ -523,13 +525,11 @@ writing; re-check, do not assume.
   > `critical,high severity vulnerabilities detected` when nothing had been scanned
   > at all. Do not act on that message without reading the job log.
   >
-  > **Do not add `secrets.vault.url` to `.github/workflow-config.json`.** Its
-  > absence is not a defect and not the cause of anything above. It held
-  > `https://vault.maas-vault-prod.solace.cloud:8200` and was removed deliberately
-  > in `2d46757` ("Vault URL hardening") while preparing this repository to go
-  > public. The URL now comes from the `VAULT_URL` repository secret and resolves
-  > fine (runs log `✅ Vault configuration validated`). Re-adding it would put an
-  > internal hostname back into a public repository.
+  > **Never put a credential or an internal hostname in
+  > `.github/workflow-config.json`.** It is committed in a repository that is going
+  > public, and it holds scan *policy* only. FOSSA's credential is the
+  > `FOSSA_API_KEY` Actions secret. The old `secrets.vault` block went with the move
+  > off Vault; no `secrets` key should reappear here.
   >
   > `sca_gate` going red through all of this is the gate working. Leaving
   > `FOSSA Scan / SCA Scan` unrequired is what had been hiding it.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -390,11 +390,11 @@ maintainer to approve it, not just the one on your first push. So checks can sit
 retitled or edited. That is normal and nothing for you to fix.
 
 You will also see the `FOSSA Scan` check report as **skipped**. Our licence and
-vulnerability scan authenticates against an internal service, and GitHub correctly
-withholds those credentials from a fork's workflow run, so the scan cannot run on
-your pull request. The `SCA gate` check accounts for that and passes. If your
-change adds or updates a dependency, expect a reviewer to look at `go.mod` and
-`go.sum` closely, since the automated scan is not there to do it.
+vulnerability scan needs an API key held as a repository secret, and GitHub
+correctly withholds repository secrets from a fork's workflow run, so the scan
+cannot run on your pull request. The `SCA gate` check accounts for that and
+passes. If your change adds or updates a dependency, expect a reviewer to look at
+`go.mod` and `go.sum` closely, since the automated scan is not there to do it.
 
 ## Questions?
 

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -13,12 +13,6 @@
       "project_id": "SolaceProducts_solace-broker-mcp",
       "team": null,
       "labels": ["broker"]
-    },
-    "secrets": {
-      "vault": {
-        "secret_path": "secret/data/tools/githubactions",
-        "role": "cicd-workflows-secret-read-role"
-      }
     }
   }
 }

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,10 +114,15 @@ jobs:
   fossa_scan:
     if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     name: FOSSA Scan
-    # The scan authenticates to Vault by OIDC (`id-token`), reads the dependency
-    # graph and workflow metadata (`packages`, `actions`), and reports back on the
-    # commit (`pull-requests`, `statuses`, `checks`). Scoped to this job so no
-    # other job inherits any of it.
+    # The scan reads the dependency graph and workflow metadata (`packages`,
+    # `actions`) and reports back on the commit (`pull-requests`, `statuses`,
+    # `checks`). Scoped to this job so no other job inherits any of it.
+    #
+    # `id-token: write` is unused since FOSSA moved off Vault, but do not remove it.
+    # The shared workflow declares these scopes at workflow level and its `sca_scan`
+    # job declares none of its own, and a called workflow cannot request more than
+    # its caller grants — so a caller granting less fails at job-creation time,
+    # before any step runs. Grant the union it declares.
     permissions:
       contents: read
       packages: read
@@ -128,11 +133,11 @@ jobs:
       statuses: write
     uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
-      use_vault: true
+      use_vault: false
       config_file: '.github/workflow-config.json'
     secrets:
-      # Vault address is injected from an org/repo secret, not committed to the repo.
-      VAULT_URL: ${{ secrets.VAULT_URL }}
+      # Org-level Actions secret, not Vault.
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -20,9 +20,10 @@ permissions:
 
 jobs:
   # Skipped for fork pull requests, and it has to be. GitHub withholds repository
-  # secrets from a `pull_request` run triggered by a fork, so `secrets.VAULT_URL`
-  # arrives empty and the shared workflow exits 1 on its own input validation —
-  # red on every external contribution, for a secret the contributor cannot have.
+  # secrets from a `pull_request` run triggered by a fork — every secret, whatever
+  # its source — so `secrets.FOSSA_API_KEY` arrives empty and the shared workflow
+  # exits 1 on its own validation: red on every external contribution, for a secret
+  # the contributor cannot have.
   #
   # The two ways to scan a fork's code with real credentials both run untrusted
   # code with an elevated token: `pull_request_target`, and a `workflow_run`
@@ -37,11 +38,12 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
-      use_vault: true
+      use_vault: false
       config_file: '.github/workflow-config.json'
     secrets:
-      # Vault address is injected from an org/repo secret, not committed to the repo.
-      VAULT_URL: ${{ secrets.VAULT_URL }}
+      # Org-level Actions secret, not Vault. The workflow-level `id-token: write` is
+      # still required — see the note in build-and-test.yml.
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   # THIS is the required status check for supply-chain scanning, not
   # `FOSSA Scan / SCA Scan`.
@@ -93,7 +95,7 @@ jobs:
                 echo "::error::FOSSA scan was skipped on a same-repo pull request, where it should always run. Treating an unexplained skip as a failure rather than passing the gate. Check the 'if' condition on the fossa_scan job."
                 exit 1
               fi
-              echo "::notice::FOSSA scan skipped: a fork pull request gets no repository secrets, so the Vault-backed scan cannot run. Supply-chain review for this pull request is the full scan on push to main plus a reviewer reading go.mod. See .github/ADMIN_SETUP.md."
+              echo "::notice::FOSSA scan skipped: a fork pull request gets no repository secrets, so the credentialed scan cannot run. Supply-chain review for this pull request is the full scan on push to main plus a reviewer reading go.mod. See .github/ADMIN_SETUP.md."
               ;;
             *)
               echo "::error::FOSSA scan reported '${SCAN_RESULT}'."

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -23,8 +23,9 @@ jobs:
     uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       git_ref: ${{ inputs.git_ref }}
-      use_vault: true
+      use_vault: false
       config_file: '.github/workflow-config.json'
     secrets:
-      # Vault address is injected from an org/repo secret, not committed to the repo.
-      VAULT_URL: ${{ secrets.VAULT_URL }}
+      # Org-level Actions secret, not Vault. `id-token: write` above is still
+      # required — see the note in build-and-test.yml.
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,12 @@ jobs:
     uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@fc521b087f780457f92d4cb46038184e92ad2fbc # pinned 2026-05-12
     with:
       git_ref: ${{ github.ref_name }}
-      use_vault: true
+      use_vault: false
       config_file: '.github/workflow-config.json'
     secrets:
-      # Vault address is injected from an org/repo secret, not committed to the repo.
-      VAULT_URL: ${{ secrets.VAULT_URL }}
+      # Org-level Actions secret, not Vault. The workflow-level `id-token: write` is
+      # still required — see the note in build-and-test.yml.
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   build-binaries:
     needs: [test, release-notes, licenses]


### PR DESCRIPTION
https://sol-jira.atlassian.net/browse/DATAGO-147338

### What is the purpose of this change?

The org now distributes the FOSSA API key as a GitHub Actions secret instead of through Vault, so the Vault path in our scan workflows is the wrong one. `FOSSA_API_KEY` already exists as an org-level secret visible to this repo.

### How was this change implemented?

The four callers of the shared `sca-scan-and-guard` workflow (`ci-pr.yaml`, `build-and-test.yml`, `release.yml`, `fossa-scan.yaml`) now pass `use_vault: false` and `secrets.FOSSA_API_KEY` in place of `secrets.VAULT_URL`. The `sca_scanning.secrets.vault` block comes out of `workflow-config.json`, since its secret path and role existed only to locate the FOSSA token. Comments and admin docs that named Vault as the reason for the fork skip are reworded, and the internal Vault hostname still committed in `ADMIN_SETUP.md` is removed (it was the last copy in the tree).

### Key Design Decisions

`id-token: write` stays in all four callers even though nothing uses it now. The shared workflow declares its permissions at workflow level including that scope, and its `sca_scan` job declares none of its own, so that is what the nested job requests. A called workflow cannot request more than its caller grants, so a caller granting less fails at job creation, before any step runs. I confirmed this against a repo that omits it: `pubsubplus-kubernetes-helm-quickstart` calls the same workflow without `id-token: write` and its run failed having created zero jobs. The reason is written into `build-and-test.yml` so the scope is not later removed as dead weight.

### Is there anything the reviewers should focus on/be aware of?

Three things:

1. **This does not fix the currently red FOSSA check, and was never going to.** Vault was working fine before this change (run 31039440782 shows both Vault steps green). The failure is `Block on FOSSA Policy/Vulnerability Failures`, because both guards fail to pull `ghcr.io/solaceproducts/maas-build-actions` with `manifest unknown` (DATAGO-146668). The guards are `continue-on-error`, so the summary misreports that as findings.
2. **Overlaps with #257**, which removes these callers outright and moves FOSSA to the `guardian` Environment secret. Every file here is one it rewrites or deletes. Landing this smaller step first means #257 needs a rebase where taking its version is correct throughout. Happy to close this instead if that is preferred.
3. **`VAULT_URL` is now orphaned.** No workflow reads it: `transition_on_merge.yaml` still uses Vault for Jira, but it passes no `secrets:` block and no `secrets: inherit`, so its address comes from `re-workflows`. Left in place rather than deleted, since removing a secret is not reversible.

Verified by dispatching the manual scan on this branch (run 31040933545): the Vault steps are skipped, the log reports `FOSSA API key retrieved from GitHub Secrets`, and `fossa analyze` authenticated and uploaded (it emits the project dashboard URL), so the key is valid and not just present. Steps 1 to 18 pass; only the two pre-existing guard failures above remain. No CHANGELOG entry, since this touches no published contract.
