### PR TITLE
SOL-152897: pin every third-party GitHub Action to a commit SHA

### DIFF
--- a/.github/scripts/build-test-licenses-check.test.sh
+++ b/.github/scripts/build-test-licenses-check.test.sh
@@ -39,6 +39,12 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 CHECK="$REPO_ROOT/.github/scripts/build-test-licenses-check.sh"
 DOC="THIRD_PARTY_BUILD_TEST.md"
 
+# A well-formed but unmistakably synthetic 40-character SHA, used as the "re-pinned
+# to something else" value. It has to be 40 hex characters or the subject's
+# short-SHA prefix comparison never engages and the action cases stop testing the
+# path they exist to test.
+FAKE_PIN="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
 pass=0
 fail=0
 
@@ -68,17 +74,21 @@ add_duplicate_row() { # <tmp> <name> <version> — a second row for a component 
 }
 
 change_version() { # <tmp> <name> <new version>
-    awk -v comp="\`$2\`" -v ver="$3" -F' \\| ' '
-        index($0, comp) && /^\| `/ { $2 = ver; print $1 " | " $2 " | " $3 " | " $4; next }
+    # Assigning a field makes awk rebuild the whole record with OFS, so this
+    # round-trips a row of any width. An earlier version printed `$1 " | " ... $4`
+    # explicitly, which silently truncated anything wider than four columns and
+    # forced a separate helper for the three-column reusable-workflow row.
+    awk -v comp="\`$2\`" -v ver="$3" -F' \\| ' -v OFS=' | ' '
+        index($0, comp) && /^\| `/ { $2 = ver; print; next }
         { print }
     ' "$1/$DOC" >"$1/t" && mv "$1/t" "$1/$DOC"
 }
 
 set_sca_workflow_ref() { # <tmp> <new ref> — rewrite the short SHA on the
-    # reusable-workflow row. That row has three columns, so change_version, which
-    # rebuilds four, would malform it and the case would then fail on the parse
-    # check instead of the comparison it is meant to test. Target the ref field
-    # and keep the row's shape.
+    # reusable-workflow row. change_version can now rebuild a row of any width, so
+    # this no longer exists out of necessity; it is kept because it addresses the
+    # row by its distinguishing content rather than by a component name that is a
+    # 76-character workflow path, which keeps the length cases below readable.
     # Addressed to the row, then replacing the backticked hex run. Matching the
     # whole row instead would need escaped `|` inside an ERE, which BSD sed reads
     # as an empty alternation and rejects. The workflow path in the same row is
@@ -108,26 +118,46 @@ add_dash_uses_action() { # <tmp> — the `- uses:` step form, which an anchor
     printf '        - uses: example/sneaky-action@v1\n' >>"$1/.github/workflows/dco.yaml"
 }
 
-bump_action_version() { # <tmp> — Dependabot bumps actions daily; a version
-    # column nothing defends is decoration.
+bump_action_version() { # <tmp> — Dependabot re-pins actions daily; a pin column
+    # nothing defends is decoration.
+    #
+    # The pin in use is read out of the workflows rather than written here. An
+    # earlier version of this mutation hardcoded `actions/checkout@v4`, and when
+    # the actions were pinned to SHAs it matched nothing: the mutation became a
+    # no-op, the gate correctly reported green, and the case failed. Failing was
+    # the good outcome, but it only worked because this case expects exit 1. The
+    # same staleness in a case expecting exit 0 would have passed for the wrong
+    # reason and gone unnoticed. Deriving the pin removes the trap for both.
     unlink_workflows "$1"
-    sed -i.bak 's|actions/checkout@v4|actions/checkout@v5|g' "$1/.github/workflows/"*.y*ml
+    local cur
+    cur=$({ grep -rhoE 'actions/checkout@[0-9a-f]{40}' "$1/.github/workflows/" || true; } |
+        head -1 | cut -d@ -f2)
+    if [ -z "$cur" ]; then
+        echo "bump_action_version: no SHA-pinned actions/checkout in the workflows;" \
+             "this mutation would be vacuous" >&2
+        return 1
+    fi
+    sed -i.bak "s|actions/checkout@${cur}|actions/checkout@${FAKE_PIN}|g" \
+        "$1/.github/workflows/"*.y*ml
     rm -f "$1/.github/workflows/"*.bak
+    # A sed that matched nothing exits 0. Confirm the tree actually changed.
+    grep -rqF "actions/checkout@${FAKE_PIN}" "$1/.github/workflows/"
 }
 
 bump_action_version_and_row() { # <tmp> — the same bump, with the row updated to
     # match: valid to valid, the maintainer's most common edit.
     #
     # Honest about what this adds. It buys no new coverage of version comparison
-    # itself — the baseline already exercises the exact-match branch on every
-    # action row. What it does buy is a control over the workflow-copy mutations:
+    # itself — every action row is a SHA pin and so takes the prefix branch, which
+    # the length cases below already cover, and the Go module, npm and image rows
+    # cover exact match. What it does buy is a control over the workflow-copy mutations:
     # it is the only case that replaces the symlinked workflows and still expects
     # exit 0, so a corrupted or truncated `unlink_workflows` shows up here and
     # nowhere else. The three cases that mutate workflows all expect exit 1, and
     # they stay green against a copy that lost a file, passing for the wrong
     # reason. Verified by deleting a file inside unlink_workflows: only this case
     # noticed.
-    bump_action_version "$1" && change_version "$1" "actions/checkout" "v5"
+    bump_action_version "$1" && change_version "$1" "actions/checkout" "\`${FAKE_PIN:0:7}\`"
 }
 
 add_second_dockerfile() { # <tmp> — discovery must be derived, not hardcoded

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -138,15 +138,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.11.4
           # The action's fallback restore key is prefixed on OS + workdir +
@@ -168,10 +168,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
@@ -225,10 +225,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
@@ -255,10 +255,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
@@ -317,10 +317,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
@@ -351,10 +351,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
@@ -385,10 +385,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -118,7 +118,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Run the DCO check's self-test against this PR's version
         run: .github/scripts/dco-check.test.sh
 
@@ -129,7 +129,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Run the release-notes extraction self-test against this PR's version
         run: .github/scripts/extract-release-notes.test.sh
 
@@ -153,9 +153,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
       - name: Self-test the licence check
@@ -184,7 +184,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Advise on a missing [Unreleased] entry for behavior-changing PRs

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -111,7 +111,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the base ref (this is what makes the gate untamperable)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # fetch-depth: 0 does two load-bearing things: it gives the check real
           # history instead of a shallow clone, and it fetches

--- a/.github/workflows/llm-eval.yml
+++ b/.github/workflows/llm-eval.yml
@@ -33,17 +33,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ inputs.target_branch }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
       - name: Setup Node (for Claude CLI install)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Extract release notes from CHANGELOG
         run: .github/scripts/extract-release-notes.sh "${GITHUB_REF_NAME}" release-notes.md
       - name: Upload release notes
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-notes
           path: release-notes.md
@@ -66,9 +66,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
       - name: Self-test the licence check
@@ -135,10 +135,10 @@ jobs:
             goarch: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
@@ -183,12 +183,12 @@ jobs:
       # name — and all of these jobs are inline in this file, so attesting from
       # the release job would produce the same values.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ env.ARCHIVE }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: binary-${{ matrix.goos }}-${{ matrix.goarch }}
           path: ${{ env.ARCHIVE }}
@@ -216,16 +216,16 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -233,7 +233,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/solaceproducts/solace-broker-mcp
           tags: |
@@ -244,7 +244,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -263,7 +263,7 @@ jobs:
       # by default — it only reads the registry copy when passed
       # `--bundle-from-oci`.
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ghcr.io/solaceproducts/solace-broker-mcp
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -277,10 +277,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: binary-*
           merge-multiple: true
@@ -293,12 +293,12 @@ jobs:
       # A single artifact downloaded by name extracts flat into the working dir
       # (no name-subdirectory), so body_path: release-notes.md below resolves.
       - name: Download release notes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-notes
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           body_path: release-notes.md
           generate_release_notes: true

--- a/THIRD_PARTY_BUILD_TEST.md
+++ b/THIRD_PARTY_BUILD_TEST.md
@@ -148,21 +148,29 @@ listed.
 Actions run on GitHub's runners during CI. They are not distributed with the
 product and never enter the binary.
 
-| Action | Version | License | License text |
-|---|---|---|---|
-| `actions/attest-build-provenance` | v4 | MIT | [license](https://github.com/actions/attest-build-provenance/blob/main/LICENSE) |
-| `actions/checkout` | v4 | MIT | [license](https://github.com/actions/checkout/blob/main/LICENSE) |
-| `actions/download-artifact` | v4 | MIT | [license](https://github.com/actions/download-artifact/blob/main/LICENSE) |
-| `actions/setup-go` | v5 | MIT | [license](https://github.com/actions/setup-go/blob/main/LICENSE) |
-| `actions/setup-node` | v4 | MIT | [license](https://github.com/actions/setup-node/blob/main/LICENSE) |
-| `actions/upload-artifact` | v4 | MIT | [license](https://github.com/actions/upload-artifact/blob/main/LICENSE) |
-| `docker/build-push-action` | v6 | Apache-2.0 | [license](https://github.com/docker/build-push-action/blob/master/LICENSE) |
-| `docker/login-action` | v3 | Apache-2.0 | [license](https://github.com/docker/login-action/blob/master/LICENSE) |
-| `docker/metadata-action` | v5 | Apache-2.0 | [license](https://github.com/docker/metadata-action/blob/master/LICENSE) |
-| `docker/setup-buildx-action` | v3 | Apache-2.0 | [license](https://github.com/docker/setup-buildx-action/blob/master/LICENSE) |
-| `docker/setup-qemu-action` | v3 | Apache-2.0 | [license](https://github.com/docker/setup-qemu-action/blob/master/LICENSE) |
-| `golangci/golangci-lint-action` | v7 | MIT | [license](https://github.com/golangci/golangci-lint-action/blob/master/LICENSE) |
-| `softprops/action-gh-release` | v2 | MIT | [license](https://github.com/softprops/action-gh-release/blob/master/LICENSE) |
+Every action is pinned to a commit SHA, because a tag is mutable and the owner of
+`v4` can move it. The Pin column is the short form of that SHA and is the field the
+drift check compares; the workflow file carries the full SHA with the same version
+beside it as a comment, and Dependabot maintains the two together. Licence links
+resolve at the pinned SHA rather than the default branch, for the same reason the
+Go module rows link to their tag: the licence that applies is the one in the tree
+that actually ran.
+
+| Action | Pin | Version | License | License text |
+|---|---|---|---|---|
+| `actions/attest-build-provenance` | `0f67c3f` | v4.1.1 | MIT | [license](https://github.com/actions/attest-build-provenance/blob/0f67c3f4856b2e3261c31976d6725780e5e4c373/LICENSE) |
+| `actions/checkout` | `11d5960` | v4.4.0 | MIT | [license](https://github.com/actions/checkout/blob/11d5960a326750d5838078e36cf38b85af677262/LICENSE) |
+| `actions/download-artifact` | `d3f86a1` | v4.3.0 | MIT | [license](https://github.com/actions/download-artifact/blob/d3f86a106a0bac45b974a628896c90dbdf5c8093/LICENSE) |
+| `actions/setup-go` | `40f1582` | v5.6.0 | MIT | [license](https://github.com/actions/setup-go/blob/40f1582b2485089dde7abd97c1529aa768e1baff/LICENSE) |
+| `actions/setup-node` | `49933ea` | v4.4.0 | MIT | [license](https://github.com/actions/setup-node/blob/49933ea5288caeca8642d1e84afbd3f7d6820020/LICENSE) |
+| `actions/upload-artifact` | `ea165f8` | v4.6.2 | MIT | [license](https://github.com/actions/upload-artifact/blob/ea165f8d65b6e75b540449e92b4886f43607fa02/LICENSE) |
+| `docker/build-push-action` | `10e90e3` | v6.19.2 | Apache-2.0 | [license](https://github.com/docker/build-push-action/blob/10e90e3645eae34f1e60eeb005ba3a3d33f178e8/LICENSE) |
+| `docker/login-action` | `c94ce9f` | v3.7.0 | Apache-2.0 | [license](https://github.com/docker/login-action/blob/c94ce9fb468520275223c153574b00df6fe4bcc9/LICENSE) |
+| `docker/metadata-action` | `c299e40` | v5.10.0 | Apache-2.0 | [license](https://github.com/docker/metadata-action/blob/c299e40c65443455700f0fdfc63efafe5b349051/LICENSE) |
+| `docker/setup-buildx-action` | `8d2750c` | v3.12.0 | Apache-2.0 | [license](https://github.com/docker/setup-buildx-action/blob/8d2750c68a42422c14e847fe6c8ac0403b4cbd6f/LICENSE) |
+| `docker/setup-qemu-action` | `c7c5346` | v3.7.0 | Apache-2.0 | [license](https://github.com/docker/setup-qemu-action/blob/c7c53464625b32c7a7e944ae62b3e17d2b600130/LICENSE) |
+| `golangci/golangci-lint-action` | `9fae48a` | v7.0.1 | MIT | [license](https://github.com/golangci/golangci-lint-action/blob/9fae48acfc02a90574d7c304a1758ef9895495fa/LICENSE) |
+| `softprops/action-gh-release` | `3bb1273` | v2.6.2 | MIT | [license](https://github.com/softprops/action-gh-release/blob/3bb12739c298aeb8a4eeaf626c5b8d85266b0e65/LICENSE) |
 
 ### Solace-internal reusable workflows
 


### PR DESCRIPTION
Closes SOL-152897.

A git tag is mutable. `actions/checkout@v4` ran whatever `v4` pointed at when the job started, and the owner of that tag can move it. This replaces all 43 third-party `uses:` refs across the six workflow files with the commit SHA the tag resolved to, keeping the version in a trailing comment that Dependabot maintains.

It matters most in `release.yml`, which holds `id-token: write` and `attestations: write`. An action running there can mint a build provenance attestation consumers are told to trust, and two of the actions in that job are not GitHub-owned.

## This is a runtime no-op

No version changed. Each SHA is what that major tag already pointed at, so a green CI proves the pin rather than a bump. Every SHA was verified to be a published non-prerelease release whose exact semver tag resolves to it.

`actions/checkout` v4.4.0 and `actions/setup-go` v5.6.0 are not ancestors of their repo's default branch. That is expected: both sit on upstream `releases/v4` / `releases/v5` maintenance branches while `main` has moved on. Verified rather than assumed.

## Why this did not wait for #253

The ticket asked to land #253 first. I did not, for two reasons:

- #253 is `BEHIND` and red on both `SCA gate` and `FOSSA Scan`.
- It bundles 13 major-version jumps (checkout 4→7, setup-go 5→7, golangci-lint-action 7→9 among them). Those are behaviour changes. Landing them in the same diff as the pinning makes a red CI unattributable.

Pinning first keeps this diff a no-op. Dependabot re-proposes the bumps on top as SHA bumps, reviewable on their own merits.

**One thing #253 carries that is still wanted:** a genuinely newer Solace reusable workflow, `fc521b0` (2026-04-29) → `4c3adb2` (2026-08-05). That is a forward update. It is untouched here and comes back with the recreated PR.

## Compliance doc and its gate

`build-test-licenses-check.sh` compares the documented version against the ref in use, so pinning drifted all 13 Action rows and turned the gate red. The Actions table now carries a `Pin` column of short SHAs (the field the check compares) alongside the readable version. The gate already accepted a short-SHA row for exactly this case, which the Solace reusable-workflow row was already using.

Licence links now resolve at the pinned SHA instead of a mutable default branch, matching the rule the Go module rows in the same file already state. All 13 were checked to exist at that SHA with an SPDX matching the row.

## A vacuous test fixture, found and fixed

The gate's self-test mutated `actions/checkout@v4` to force drift. Pinning made that sed match nothing, so the mutation silently became a no-op. The case expecting exit 1 failed loudly — but its exit-0 sibling would have passed for the wrong reason. The fixture now derives the pin in use at runtime and asserts the tree actually changed.

## Verification

| Command | Result |
| --- | --- |
| `make build-all` | exit 0 |
| `make vet` | exit 0 |
| `make test-cover` | exit 0, coverage 88.3% |
| `build-test-licenses-check.sh` | exit 0, 36 components / 36 rows |
| `build-test-licenses-check.test.sh` | 26 passed, 0 failed |
| all 4 `.github/scripts/*.test.sh` | 87 passed, 0 failed |

Coupling proven by defect injection rather than by reading: forcing `version_matches` to `return 0` produces 6 failures, and reverting the workflows to tags makes both action-bump fixtures fail loudly.

`make lint` is red, identically on a clean `origin/main` worktree, on files under a different local checkout. Pre-existing and environmental; this change touches no Go.

No CHANGELOG entry: `production-surface.sh` scopes that to `internal/config/`, `internal/tools/` and `tools.yaml`. No `/check-logs` run: no Go changed.

## Deliberately left out

- **Enforcement for newly added actions.** A *new* action added as a mutable tag still passes the gate today. The ticket assigns that to SOL-152856 (`zizmor`'s `unpinned-uses`); noted on the ticket with the exact gap so it is not rediscovered.
- **Dependabot grouping.** `github-actions` groups all patterns into one PR, so one red member blocks every patch in the group. Real, pre-existing, and worth its own ticket. I did not change it here because the effect is only observable on Dependabot's next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)