### PR TITLE
ci(SOL-152951): refresh the build/test third-party inventory for Guardian SHA pins

### DIFF
--- a/.github/scripts/build-test-licenses-check.test.sh
+++ b/.github/scripts/build-test-licenses-check.test.sh
@@ -39,6 +39,11 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 CHECK="$REPO_ROOT/.github/scripts/build-test-licenses-check.sh"
 DOC="THIRD_PARTY_BUILD_TEST.md"
 
+# A syntactically valid 40-character SHA that no action is pinned to, used by the
+# version-bump cases. A constant rather than a literal at each use site, so the
+# mutation and the row it expects cannot drift apart.
+BUMPED_SHA="0123456789abcdef0123456789abcdef01234567"
+
 pass=0
 fail=0
 
@@ -47,7 +52,16 @@ fail=0
 # sed delimiters a source of bugs in the test itself.
 
 drop_row() { # <tmp> <name>
+    # Confirm a row actually went. `grep -v` that matches nothing exits 0 and
+    # copies the file unchanged, so a case naming a row that has been renamed or
+    # deleted would assert against a pristine tree. That is not hypothetical: the
+    # licence-hint case below named the SCA reusable workflow, and when
+    # DATAGO-147232 removed it the mutation quietly became a no-op.
+    local before after
+    before=$(wc -l <"$1/$DOC")
     grep -vF "\`$2\`" "$1/$DOC" >"$1/t" && mv "$1/t" "$1/$DOC"
+    after=$(wc -l <"$1/$DOC")
+    [ "$after" -lt "$before" ]
 }
 
 add_row() { # <tmp> <name> <version>
@@ -68,22 +82,41 @@ add_duplicate_row() { # <tmp> <name> <version> — a second row for a component 
 }
 
 change_version() { # <tmp> <name> <new version>
+    # Rebuild from NF rather than from a fixed four columns. The tables here
+    # carry three, four, or five: the actions table gained a "Release" column
+    # when every action moved to a SHA pin, and a hardcoded rebuild silently
+    # truncated its last column — leaving a row that still parsed, so nothing
+    # complained, but that no longer matched what the file was supposed to say.
+    #
+    # `END { exit !hit }` makes a mutation that matched no row fail the case
+    # loudly instead of asserting against an unchanged document.
     awk -v comp="\`$2\`" -v ver="$3" -F' \\| ' '
-        index($0, comp) && /^\| `/ { $2 = ver; print $1 " | " $2 " | " $3 " | " $4; next }
+        index($0, comp) && /^\| `/ {
+            $2 = ver
+            row = $1
+            for (i = 2; i <= NF; i++) row = row " | " $i
+            print row
+            hit = 1
+            next
+        }
         { print }
+        END { exit !hit }
     ' "$1/$DOC" >"$1/t" && mv "$1/t" "$1/$DOC"
 }
 
-set_sca_workflow_ref() { # <tmp> <new ref> — rewrite the short SHA on the
-    # reusable-workflow row. That row has three columns, so change_version, which
-    # rebuilds four, would malform it and the case would then fail on the parse
-    # check instead of the comparison it is meant to test. Target the ref field
-    # and keep the row's shape.
+set_solace_action_ref() { # <tmp> <new ref> — rewrite the short SHA on one
+    # Solace composite-action row. Those rows have three columns and carry the
+    # only short-SHA refs left in the file, so they are what exercises
+    # version_matches()'s prefix branch.
+    #
     # Addressed to the row, then replacing the backticked hex run. Matching the
     # whole row instead would need escaped `|` inside an ERE, which BSD sed reads
-    # as an empty alternation and rejects. The workflow path in the same row is
+    # as an empty alternation and rejects. The action path in the same row is
     # backticked too but is not all hex, so it cannot match.
-    sed -E "/sca-scan-and-guard\.yaml/ s#\`[0-9a-f]+\`#\`$2\`#" \
+    #
+    # `guardian-db-sync` is an arbitrary but stable pick among the five. The
+    # other four keep the correct ref, so each case isolates one wrong row.
+    sed -E "/guardian-db-sync/ s#\`[0-9a-f]+\`#\`$2\`#" \
         "$1/$DOC" >"$1/t" && mv "$1/t" "$1/$DOC"
     # A sed that matched nothing exits 0, which would make every case using this
     # mutation vacuous. Confirm the row actually changed.
@@ -110,9 +143,18 @@ add_dash_uses_action() { # <tmp> — the `- uses:` step form, which an anchor
 
 bump_action_version() { # <tmp> — Dependabot bumps actions daily; a version
     # column nothing defends is decoration.
+    #
+    # Matches the pin by shape rather than by value. This mutation used to
+    # rewrite the literal `actions/checkout@v4`, and when DATAGO-147232 SHA-pinned
+    # every action it matched nothing: the bump case asserted exit 1 against an
+    # untouched tree, and its paired case asserted exit 0 against a row change
+    # with no workflow change behind it. Naming today's SHA would reintroduce the
+    # same rot on the next Dependabot re-pin.
     unlink_workflows "$1"
-    sed -i.bak 's|actions/checkout@v4|actions/checkout@v5|g' "$1/.github/workflows/"*.y*ml
+    sed -i.bak -E "s|(actions/checkout@)[0-9a-f]{40}|\1$BUMPED_SHA|g" "$1/.github/workflows/"*.y*ml
     rm -f "$1/.github/workflows/"*.bak
+    # sed exits 0 whether or not it substituted, so prove the workflows changed.
+    grep -rqF "$BUMPED_SHA" "$1/.github/workflows/"
 }
 
 bump_action_version_and_row() { # <tmp> — the same bump, with the row updated to
@@ -127,7 +169,7 @@ bump_action_version_and_row() { # <tmp> — the same bump, with the row updated 
     # they stay green against a copy that lost a file, passing for the wrong
     # reason. Verified by deleting a file inside unlink_workflows: only this case
     # noticed.
-    bump_action_version "$1" && change_version "$1" "actions/checkout" "v5"
+    bump_action_version "$1" && change_version "$1" "actions/checkout" "${BUMPED_SHA:0:7}"
 }
 
 add_second_dockerfile() { # <tmp> — discovery must be derived, not hardcoded
@@ -289,19 +331,19 @@ assert_check "wrong container image tag fails" 1 \
     change_version "apache/kafka" "4.1.0"
 
 # --- short-SHA comparison, both directions ------------------------------------
-# A reusable workflow is pinned to a 40-character SHA and documented by a short
-# prefix, so version_matches() accepts a prefix of at least 7 characters. All
-# three properties of that rule need a case: a longer prefix must still pass, a
-# prefix below the floor must not, and a prefix that is merely the right length
+# The Solace composite actions are pinned to a 40-character SHA and documented by
+# a short prefix, so version_matches() accepts a prefix of at least 7 characters.
+# All three properties of that rule need a case: a longer prefix must still pass,
+# a prefix below the floor must not, and a prefix that is merely the right length
 # must still have to be correct. Without the middle case the floor can be
 # weakened to 1 with the whole suite staying green, which is a fail-open — a
 # one-character stale row would then satisfy any future re-pin.
 assert_check "a longer correct short SHA still passes" 0 \
-    set_sca_workflow_ref "fc521b087f"
+    set_solace_action_ref "2bb76658de"
 assert_check "a correct short SHA below the 7-character floor fails" 1 \
-    set_sca_workflow_ref "fc521"
+    set_solace_action_ref "2bb76"
 assert_check "a wrong SHA of acceptable length fails" 1 \
-    set_sca_workflow_ref "fc521b9"
+    set_solace_action_ref "2bb7669"
 
 # --- discovery is derived, not hardcoded -------------------------------------
 # A hand-maintained input list fails open as the repository grows, which is the
@@ -315,12 +357,14 @@ assert_check "a sibling worktree's Dockerfile is not mistaken for an input" 0 \
 
 # --- remediation hints are actionable ----------------------------------------
 # A hint that names a repository which does not exist costs the reader a
-# detour and teaches them to distrust the message. Reusable workflows are
-# referenced as OWNER/REPO/.github/workflows/file.yaml@ref, so deriving the repo
-# with `basename` names the workflow file instead.
+# detour and teaches them to distrust the message. An action inside another
+# repository is referenced as OWNER/REPO/path/to/action@ref, so deriving the repo
+# with `basename` names the action's directory instead. `sca/sca-scan` is the
+# deepest such path in the repository, and the one where basename is furthest
+# from the right answer.
 EXPECT_STDERR="gh api repos/SolaceDev/solace-public-workflows" \
-    assert_check "the licence hint names the repo, not the workflow file" 1 \
-    drop_row "SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml"
+    assert_check "the licence hint names the repo, not the action subpath" 1 \
+    drop_row "SolaceDev/solace-public-workflows/.github/actions/sca/sca-scan"
 unset EXPECT_STDERR
 
 # --- image reference parsing -------------------------------------------------

--- a/THIRD_PARTY_BUILD_TEST.md
+++ b/THIRD_PARTY_BUILD_TEST.md
@@ -12,9 +12,11 @@ itself**, and which are **not compiled into the shipped binary**.
 > Legal checklist, which asks for a "list of all used 3rd party products used at
 > build and test time" alongside the release list.
 
-**Generated** 2026-08-05. Every licence below was read from the component's own
-licence file or from the GitHub API for its source repository. None was inferred
-from a package name or carried over from another row. See
+**Generated** 2026-08-05; the GitHub Actions section was refreshed 2026-08-07
+when Guardian enrollment re-pinned every action to a commit SHA. Every licence
+below was read from the component's own licence file or from the GitHub API for
+its source repository, at the ref in use rather than at the default branch. None
+was inferred from a package name or carried over from another row. See
 [Rebuilding this file](#rebuilding-this-file) for how to regenerate it.
 
 Kept honest by `.github/scripts/build-test-licenses-check.sh`, which fails CI
@@ -148,36 +150,65 @@ listed.
 Actions run on GitHub's runners during CI. They are not distributed with the
 product and never enter the binary.
 
-| Action | Version | License | License text |
-|---|---|---|---|
-| `actions/attest-build-provenance` | v4 | MIT | [license](https://github.com/actions/attest-build-provenance/blob/main/LICENSE) |
-| `actions/checkout` | v4 | MIT | [license](https://github.com/actions/checkout/blob/main/LICENSE) |
-| `actions/download-artifact` | v4 | MIT | [license](https://github.com/actions/download-artifact/blob/main/LICENSE) |
-| `actions/setup-go` | v5 | MIT | [license](https://github.com/actions/setup-go/blob/main/LICENSE) |
-| `actions/setup-node` | v4 | MIT | [license](https://github.com/actions/setup-node/blob/main/LICENSE) |
-| `actions/upload-artifact` | v4 | MIT | [license](https://github.com/actions/upload-artifact/blob/main/LICENSE) |
-| `docker/build-push-action` | v6 | Apache-2.0 | [license](https://github.com/docker/build-push-action/blob/master/LICENSE) |
-| `docker/login-action` | v3 | Apache-2.0 | [license](https://github.com/docker/login-action/blob/master/LICENSE) |
-| `docker/metadata-action` | v5 | Apache-2.0 | [license](https://github.com/docker/metadata-action/blob/master/LICENSE) |
-| `docker/setup-buildx-action` | v3 | Apache-2.0 | [license](https://github.com/docker/setup-buildx-action/blob/master/LICENSE) |
-| `docker/setup-qemu-action` | v3 | Apache-2.0 | [license](https://github.com/docker/setup-qemu-action/blob/master/LICENSE) |
-| `golangci/golangci-lint-action` | v7 | MIT | [license](https://github.com/golangci/golangci-lint-action/blob/master/LICENSE) |
-| `softprops/action-gh-release` | v2 | MIT | [license](https://github.com/softprops/action-gh-release/blob/master/LICENSE) |
+Every action is pinned to a commit SHA rather than a moving tag, so the "Pinned
+ref" column carries a short SHA and is what the drift check compares. "Release"
+is the tag that commit corresponds to, recorded because a SHA alone tells a
+reader nothing about which version they are auditing. Licence links resolve at
+that tag, not at the default branch, for the reason the `segmentio/asm` note
+below spells out.
 
-### Solace-internal reusable workflows
+| Action | Pinned ref | Release | License | License text |
+|---|---|---|---|---|
+| `actions/attest-build-provenance` | `0f67c3f` | v4.1.1 | MIT | [license](https://github.com/actions/attest-build-provenance/blob/v4.1.1/LICENSE) |
+| `actions/checkout` | `11d5960` | v4.4.0 | MIT | [license](https://github.com/actions/checkout/blob/v4.4.0/LICENSE) |
+| `actions/download-artifact` | `d3f86a1` | v4.3.0 | MIT | [license](https://github.com/actions/download-artifact/blob/v4.3.0/LICENSE) |
+| `actions/github-script` | `f28e40c` | v7.1.0 | MIT | [license](https://github.com/actions/github-script/blob/v7.1.0/LICENSE.md) |
+| `actions/setup-go` | `40f1582` | v5.6.0 | MIT | [license](https://github.com/actions/setup-go/blob/v5.6.0/LICENSE) |
+| `actions/setup-node` | `49933ea` | v4.4.0 | MIT | [license](https://github.com/actions/setup-node/blob/v4.4.0/LICENSE) |
+| `actions/upload-artifact` | `ea165f8` | v4.6.2 | MIT | [license](https://github.com/actions/upload-artifact/blob/v4.6.2/LICENSE) |
+| `docker/build-push-action` | `10e90e3` | v6.19.2 | Apache-2.0 | [license](https://github.com/docker/build-push-action/blob/v6.19.2/LICENSE) |
+| `docker/login-action` | `c94ce9f` | v3.7.0 | Apache-2.0 | [license](https://github.com/docker/login-action/blob/v3.7.0/LICENSE) |
+| `docker/metadata-action` | `c299e40` | v5.10.0 | Apache-2.0 | [license](https://github.com/docker/metadata-action/blob/v5.10.0/LICENSE) |
+| `docker/setup-buildx-action` | `8d2750c` | v3.12.0 | Apache-2.0 | [license](https://github.com/docker/setup-buildx-action/blob/v3.12.0/LICENSE) |
+| `docker/setup-qemu-action` | `c7c5346` | v3.7.0 | Apache-2.0 | [license](https://github.com/docker/setup-qemu-action/blob/v3.7.0/LICENSE) |
+| `golangci/golangci-lint-action` | `9fae48a` | v7.0.1 | MIT | [license](https://github.com/golangci/golangci-lint-action/blob/v7.0.1/LICENSE) |
+| `softprops/action-gh-release` | `3bb1273` | v2.6.2 | MIT | [license](https://github.com/softprops/action-gh-release/blob/v2.6.2/LICENSE) |
+
+`actions/github-script` names its licence file `LICENSE.md` rather than
+`LICENSE`. Worth the sentence only because the obvious URL 404s, and a reader who
+hits that is likely to assume the row is wrong rather than that the filename is
+unusual.
+
+### Solace-internal composite actions
 
 Not third-party. Listed so the inventory accounts for every `uses:` in the
 repository rather than silently skipping the ones that did not fit the table.
+All five come from one repository, pinned to a single commit.
 
-| Workflow | Ref | Owner |
+| Action | Ref | Owner |
 |---|---|---|
-| `SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml` | `fc521b0` | Solace |
+| `SolaceDev/solace-public-workflows/.github/actions/fossa-guard` | `2bb7665` | Solace |
+| `SolaceDev/solace-public-workflows/.github/actions/sca/sca-scan` | `2bb7665` | Solace |
+| `SolaceDev/solace-public-workflows/guardian-db-sync` | `2bb7665` | Solace |
+| `SolaceDev/solace-public-workflows/guardian-vulnerability-gate` | `2bb7665` | Solace |
+| `SolaceDev/solace-public-workflows/prisma-cloud-scan` | `2bb7665` | Solace |
 
-A second entry, `SolaceDev/re-workflows/.github/workflows/transition-pr-on-merge.yaml`,
-was dropped when SOL-152855 removed the workflow that called it: a public
-repository cannot resolve a reusable workflow from an internal repository in
-another organisation. The drift check flagged the stale row on the first build
-after that landed, which is the reverse direction working as intended.
+`2bb7665` is a branch commit, not a tag, so there is no release to record beside
+it. The repository itself is Apache-2.0.
+
+Two entries have been dropped from this table, both by the reverse-direction
+check rather than by anyone remembering to look.
+
+`SolaceDev/re-workflows/.github/workflows/transition-pr-on-merge.yaml` went when
+SOL-152855 removed the workflow that called it: a public repository cannot
+resolve a reusable workflow from an internal repository in another organisation.
+
+`SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml`
+went when DATAGO-147232 moved FOSSA and Prisma scanning off the Vault-backed
+reusable workflow onto the composite actions above. This table previously held
+that one row; it now holds five, and the whole third-party table above changed
+from tags to SHA pins in the same change. None of it was reflected here until
+this update, which is what SOL-152951 is about.
 
 ## Container images
 


### PR DESCRIPTION
## What

`main` has been red on **Third-party licenses current** since #257 merged. This makes it green and fixes two silent-pass defects in the self-test that the red baseline was hiding.

`THIRD_PARTY_BUILD_TEST.md` is one of the two third-party lists the Solace public-repository Legal checklist requires. #257 SHA-pinned every action, added five Solace composite actions plus `actions/github-script`, and dropped the SCA reusable workflow. The inventory was not updated to match, so the compliance artifact described thirteen actions at the wrong ref, omitted five, and listed one component nothing uses.

The gate was right. The data it guards was stale.

## Changes

**`THIRD_PARTY_BUILD_TEST.md`**

- Actions table carries the short SHA the check compares, plus the release tag that SHA resolves to. A SHA alone tells an auditor nothing about which version they are reading.
- Every licence re-read **at the pinned ref**, not at the default branch, and licence links now resolve at the tag. That is the exact mistake the file already documents for `segmentio/asm`, which relicensed after the version we consume. `actions/github-script` uses `LICENSE.md`, so the obvious URL 404s; there is a note.
- The Solace table moves from one reusable workflow to the five composite actions that replaced it.

**`.github/scripts/build-test-licenses-check.test.sh`**

All four self-test failures reported `expected exit 0, got 1`. They were one defect, not four: every case asserting a clean run inherits the stale baseline. Two more only became visible once the baseline was green, and both are the silent-pass shape this suite exists to catch.

| Defect | Effect | Fix |
|---|---|---|
| `bump_action_version` rewrote the literal `actions/checkout@v4` | Matched nothing after SHA-pinning. One case asserted exit 1 against an untouched tree; its pair asserted exit 0 against a row change with no workflow change behind it. | Matches the pin by shape, and proves it substituted |
| `change_version` rebuilt a fixed four columns | Silently truncated the fifth column from the widened actions table, leaving a row that still parsed | Rebuilds from `NF` |

`drop_row` and `change_version` now fail loudly when they match nothing, so a case naming a since-renamed row cannot go vacuous. That is not hypothetical: it is how the licence-hint case broke.

**Each new guard was verified by injecting the defect it is meant to catch**, not by reading it. All three reported `the test's own mutation failed` rather than passing.

## Verification

| Command | Result |
|---|---|
| `make check` | pass, coverage 88.3% (85% floor) |
| `build-test-licenses-check.sh` | pass, 41 components, 41 rows |
| `build-test-licenses-check.test.sh` | 26 passed, 0 failed |
| `licenses-check.sh` / `licenses-check.test.sh` | pass (other two steps of the same job) |

No CHANGELOG entry: nothing under `internal/config/`, `internal/tools/`, or `tools.yaml` is touched, and this file does not ship.

## Two things I did not fix here

**Dependabot will fail this gate on every action bump.** It re-pins SHAs and does not edit Markdown, so each bump PR needs a manual row update. That is the gate working as designed, but the ergonomics deserve a decision rather than a surprise. Not in this PR.

**Composite actions under `.github/actions/` are invisible to the check.** Check 3 greps `.github/workflows/` only. The directory does not exist today so there is no live exposure, but #257's own description claims to add `.github/actions/guardian-scan`, and if that lands its third-party `uses:` would go undocumented with the gate green. That is a fail-open in the property this script calls its most important one. Left out deliberately: it is a discovery-semantics change that deserves its own test and review, not a rider on a data fix.

SOL-152951

🤖 Generated with [Claude Code](https://claude.com/claude-code)