### PR TITLE
SOL-152946: Updating dead links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to the Solace Broker MCP Server! Thi
 
 ## Code of Conduct
 
-This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [andrea.ross@solace.com](mailto:andrea.ross@solace.com).
+This project adheres to the [Contributor Covenant Code of Conduct](.github/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [andrea.ross@solace.com](mailto:andrea.ross@solace.com).
 
 ## How Can I Contribute?
 
@@ -40,7 +40,7 @@ When reporting a bug, please include:
 - **Logs** — Relevant log output with structured fields (redact credentials!)
 - **Screenshots** — If applicable
 
-**Security vulnerabilities:** Do NOT report security issues via public GitHub issues. See [SECURITY.md](../SECURITY.md) for the responsible disclosure process.
+**Security vulnerabilities:** Do NOT report security issues via public GitHub issues. See [SECURITY.md](.github/SECURITY.md) for the responsible disclosure process.
 
 ### Suggesting Features
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to the Solace Broker MCP Server! Thi
 
 ## Code of Conduct
 
-This project adheres to the [Contributor Covenant Code of Conduct](.github/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [andrea.ross@solace.com](mailto:andrea.ross@solace.com).
+This project adheres to the [Contributor Covenant Code of Conduct](/.github/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [andrea.ross@solace.com](mailto:andrea.ross@solace.com).
 
 ## How Can I Contribute?
 
@@ -40,7 +40,7 @@ When reporting a bug, please include:
 - **Logs** — Relevant log output with structured fields (redact credentials!)
 - **Screenshots** — If applicable
 
-**Security vulnerabilities:** Do NOT report security issues via public GitHub issues. See [SECURITY.md](.github/SECURITY.md) for the responsible disclosure process.
+**Security vulnerabilities:** Do NOT report security issues via public GitHub issues. See [SECURITY.md](/.github/SECURITY.md) for the responsible disclosure process.
 
 ### Suggesting Features
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,7 +69,7 @@ Fixes #(issue number)
 
 ### Security
 - [ ] **No credentials in code** (checked all files, commits, and logs)
-- [ ] Followed [secure logging rules](../docs/secure-logging-rules.md)
+- [ ] Followed [secure logging rules](../docs/internal/secure-logging-rules.md)
 - [ ] Credential-carrying types implement `slog.LogValuer`
 - [ ] No security vulnerabilities introduced (checked with golangci-lint/gosec)
 

--- a/docs/superpowers/plans/oauth-token-exchange/SOL-150796-T2-config-schema.md
+++ b/docs/superpowers/plans/oauth-token-exchange/SOL-150796-T2-config-schema.md
@@ -17,7 +17,7 @@ This file records decisions made *during implementation* of T2. It complements �
 
 ### The starting point — what the MCP server already does today
 
-Hop 1 (`mcp_client_auth.mode: oauth`) shipped in SOL-149989. At startup, the MCP server calls `oidc.NewProvider(ctx, cfg.MCPClientAuth.Issuer)` ([internal/auth/middleware.go:127](../../../internal/auth/middleware.go)). `go-oidc` reaches out to the IdP and fetches `<issuer>/.well-known/openid-configuration` — the OIDC Discovery document. From that document it learns the JWKS URL (needed to verify inbound agent tokens), the token endpoint, and other coordinates. **The MCP server already does live OIDC Discovery at startup today.** It is not a future capability.
+Hop 1 (`mcp_client_auth.mode: oauth`) shipped in SOL-149989. At startup, the MCP server calls `oidc.NewProvider(ctx, cfg.MCPClientAuth.Issuer)` ([internal/auth/middleware.go:127](../../../../internal/auth/middleware.go)). `go-oidc` reaches out to the IdP and fetches `<issuer>/.well-known/openid-configuration` — the OIDC Discovery document. From that document it learns the JWKS URL (needed to verify inbound agent tokens), the token endpoint, and other coordinates. **The MCP server already does live OIDC Discovery at startup today.** It is not a future capability.
 
 That changes the framing of every "should the Hop 2 schema have an issuer-URL field?" question. The Discovery doc — including `token_endpoint` — is already sitting in process memory after Hop 1 boots. Any future Hop 2 runtime can read it directly from there. No second Discovery fetch, no second HTTP round trip, no new field.
 


### PR DESCRIPTION
## Summary

Fixes dead links found in the Contributing tab, plus two more dead links surfaced by a follow-up repo-wide sweep: a wrong-directory link in the PR template, and an off-by-one relative path in an OAuth design doc.

Fixes #152946

## Type of Change

- [x] Documentation update

## Motivation and Context

The `Contributor Covenant Code of Conduct` and `SECURITY.md` links in `.github/CONTRIBUTING.md` resolved to nonexistent paths at repo root (e.g. `blob/main/CODE_OF_CONDUCT.md`), 404ing when clicked from the Contributing tab. Both files actually live in `.github/`.

A repo-wide dead-link sweep while fixing this ticket turned up two more genuine dead links, included here to avoid a second PR against the same file family:
- `.github/PULL_REQUEST_TEMPLATE.md` linked to `../docs/secure-logging-rules.md`, but the file is at `docs/internal/secure-logging-rules.md`.
- `docs/superpowers/plans/oauth-token-exchange/SOL-150796-T2-config-schema.md` linked to `internal/auth/middleware.go` with one `../` too few, undershooting the repo root.

## Changes Made

- `.github/CONTRIBUTING.md`: Code of Conduct and Security links now use root-relative paths (`/.github/CODE_OF_CONDUCT.md`, `/.github/SECURITY.md`) — these resolve correctly both from the Contributing tab (which treats relative links as root-relative) and from normal blob view (where a leading slash is the explicit root marker), avoiding the file-relative vs. root-relative conflict flagged in review.
- `.github/PULL_REQUEST_TEMPLATE.md`: fixed the secure logging rules link to `../docs/internal/secure-logging-rules.md`.
- `docs/superpowers/plans/oauth-token-exchange/SOL-150796-T2-config-schema.md`: fixed the relative path depth to `internal/auth/middleware.go`.

## Testing

**Tests Performed:**
- [x] Verified all link targets exist in the repo tree at their corrected paths
- [x] Confirmed via the GitHub API (contents endpoint, HTML render) at the PR head that the CONTRIBUTING.md links resolve correctly

**Test Coverage:**
- Docs-only change; no code paths affected

## Checklist

### Code Quality
- [x] Self-review completed (checked for typos, logic errors, edge cases)

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

---

**For Reviewers:**

**Focus Areas**: The root-relative link choice in `CONTRIBUTING.md` — confirming it resolves correctly in both the Contributing tab and normal blob view.
