### PR TITLE
ci(DATAGO-147232): align FOSSA upload version with Prisma/db-sync (fix main Guardian gate 500)

### DIFF
--- a/.github/workflows/guardian-scan.yaml
+++ b/.github/workflows/guardian-scan.yaml
@@ -84,7 +84,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          COMMIT_SHA: ${{ github.sha }}
           GITHUB_REF: ${{ github.ref }}
           GIT_REF_INPUT: ${{ inputs.git_ref }}
           FULL_VERSION_INPUT: ${{ inputs.product_full_version }}
@@ -92,17 +91,18 @@ jobs:
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           set -euo pipefail
+          # FOSSA, Prisma, and db-sync must share one version prefix (DATAGO-147232).
+          if [ -n "$FULL_VERSION_INPUT" ]; then
+            FULL_VERSION="$FULL_VERSION_INPUT"
+          else
+            FULL_VERSION="$(git describe --tags --always)"
+          fi
           if [ "$EVENT_NAME" = "pull_request" ]; then
             MODE="pr"; IS_PR="true"; IS_TRUNK="false"
             FOSSA_BRANCH="PR"; FOSSA_REVISION="$HEAD_REF"
           else
             MODE="trunk"; IS_PR="false"; IS_TRUNK="true"
-            FOSSA_BRANCH="main"; FOSSA_REVISION="${GIT_REF_INPUT:-$COMMIT_SHA}"
-          fi
-          if [ -n "$FULL_VERSION_INPUT" ]; then
-            FULL_VERSION="$FULL_VERSION_INPUT"
-          else
-            FULL_VERSION="$(git describe --tags --always)"
+            FOSSA_BRANCH="main"; FOSSA_REVISION="$FULL_VERSION"
           fi
           # Enforce (block) only on trunk and only when not bypassed.
           ENFORCE="false"


### PR DESCRIPTION
## Problem
On trunk, `Guardian gate` fails: `db_synch_and_report` returns **HTTP 500** for `solace-broker-mcp`. Verified against the Guardian pod (prod), the real cause is `NoSuchKey`:

```
ERROR s3_client: Error reading s3://…/scan-backups/solace-broker-mcp/main/v0.6.0-98-ga554999/fossa_scan.json: NoSuchKey
ERROR db_synch: DB synch failed for …/main/v0.6.0-98-ga554999: NoSuchKey
```

FOSSA and Prisma uploaded to **different S3 prefixes** for the same build:

| Scan | Prefix | Version source |
|------|--------|----------------|
| FOSSA | `…/main/a554999d952da…/` | commit SHA (`fossa.revision`) |
| Prisma + db-sync | `…/main/v0.6.0-98-ga554999/` | `git describe` (`FULL_VERSION`) |

`db_synch_and_report` (unifiers `fossa,prisma`, `product-full-version=v0.6.0-98-ga554999`) finds `prisma_scan.json` but not `fossa_scan.json` → 500. The FOSSA action keys its upload on `fossa.revision` (`sca/fossa-scan/action.yaml`: `PRODUCT_FULL_VERSION="${SCA_FOSSA_REVISION:-${GITHUB_SHA}}"`).

## Fix
Resolve `FULL_VERSION` first and set `FOSSA_REVISION=FULL_VERSION` on trunk, so FOSSA, Prisma, and the db-sync all share one version prefix. PR mode is unchanged (no Guardian upload there, and `fossa.revision` stays the head ref for diff mode).

## Scope
Trunk only — `Guardian gate` is trunk-only (skipped on PRs), so this never affected PR merges; it made `main` red and blocked Guardian from reconciling FOSSA+Prisma. Verified in prod Guardian logs; actionlint clean.

Follow-up (separate, we own Guardian): `db_synch_and_report` should return a clearer 4xx than a generic 500 when a requested unifier's file is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)