### PR TITLE
ci(DATAGO-147232): 14-day minimum release age for Dependabot and Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ version: 2
 # commit-message config has no field for a DCO Signed-off-by trailer, so its
 # PRs are exempted from that check instead — see .github/workflows/dco.yaml
 # and .github/scripts/dco-check.sh. Tracked under SOL-152808.
+#
+# `cooldown` holds every update back until the release is at least 14 days old,
+# so a freshly-published (and possibly yanked or compromised) version is not
+# proposed the moment it lands. Renovate applies the same 14-day window via
+# `minimumReleaseAge` in .github/renovate.json.
 updates:
   # Three go.mod files exist in this repo; each needs its own entry because
   # Dependabot's `directory` matches exactly one path per ecosystem entry.
@@ -19,6 +24,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 14
     groups:
       go-minor-patch:
         update-types: ["minor", "patch"]
@@ -33,6 +40,8 @@ updates:
     directory: "/test/e2e-common/broker-driver"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 14
     groups:
       go-minor-patch:
         update-types: ["minor", "patch"]
@@ -44,6 +53,8 @@ updates:
     directory: "/test/e2e-basic-mcp/agent"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 14
     groups:
       go-minor-patch:
         update-types: ["minor", "patch"]
@@ -58,6 +69,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 14
     groups:
       github-actions:
         patterns: ["*"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "ignorePaths": ["**/node_modules/**"],
   "labels": ["dependencies", "llm-eval"],
   "schedule": ["before 9am on monday"],
+  "minimumReleaseAge": "14 days",
   "prHourlyLimit": 1,
   "commitBody": "Signed-off-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
   "packageRules": [


### PR DESCRIPTION
Hold dependency updates until a release is **at least 14 days old**, so a freshly published (and possibly yanked or compromised) version isn't proposed the moment it lands.

- **`dependabot.yml`** — `cooldown.default-days: 14` on all four update entries (3 `gomod` + `github-actions`).
- **`renovate.json`** — `minimumReleaseAge: "14 days"` (top-level; applies to the Claude Code CLI pin Renovate manages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)