### PR TITLE
docs: Solace style guide and clarity pass across the doc set

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,7 +40,7 @@ When reporting a bug, please include:
 - **Logs** — Relevant log output with structured fields (redact credentials!)
 - **Screenshots** — If applicable
 
-**Security vulnerabilities:** Do NOT report security issues via public GitHub issues. See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
+**Security vulnerabilities:** Don't report security issues in public GitHub issues. See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
 
 ### Suggesting Features
 
@@ -114,7 +114,7 @@ go run ./cmd/server
 - [ ] Commits are signed off (DCO)
 - [ ] PR description follows the template
 
-### Getting CI to run on a branch
+### Getting CI to Run on a Branch
 
 **Pushing a branch no longer runs CI on its own.** `build-and-test.yml` triggers on
 pull requests against `main` and on pushes to `main`, not on every branch push.
@@ -173,17 +173,17 @@ This project follows standard Go coding principles. Key guidelines:
 
 ### Naming Conventions
 
-- **Package names:** Short, lowercase, singular (e.g., `config`, `semp`, `tools`)
-- **Variables:** Descriptive, camelCase (e.g., `brokerPool`, `httpClient`)
-- **Functions:** Verb-first, descriptive (e.g., `GetSempV2`, `ValidateParams`)
-- **Interfaces:** `-er` suffix when applicable (e.g., `Client`, `Handler`)
+- **Package names:** Short, lowercase, singular (for example, `config`, `semp`, `tools`)
+- **Variables:** Descriptive, camelCase (for example, `brokerPool`, `httpClient`)
+- **Functions:** Verb-first, descriptive (for example, `GetSempV2`, `ValidateParams`)
+- **Interfaces:** `-er` suffix when applicable (for example, `Client`, `Handler`)
 
 ### Error Handling
 
 - Always check errors — do not use `_` to discard
 - Wrap errors with context: `fmt.Errorf("reading config: %w", err)`
 - Return errors; do not log and continue (except in deferred cleanup)
-- Use structured errors for API errors (e.g., `sempv2.SEMPError`)
+- Use structured errors for API errors (for example, `sempv2.SEMPError`)
 
 ### Security — Credential Handling
 
@@ -277,23 +277,23 @@ Add feature X
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
-#### Sign off automatically
+#### Sign Off Automatically
 
-To stop having to remember the `-s`, install the repo's git hook — once per clone:
+To stop having to remember the `-s`, install the repo's git hook, once per clone:
 
 ```bash
 make hooks
 ```
 
 That installs `.githooks/prepare-commit-msg` into the repository's hooks directory
-— `.git/hooks/` — where it adds the `Signed-off-by` trailer to every commit
+(`.git/hooks/`), where it adds the `Signed-off-by` trailer to every commit
 message, including ones made by tools and editors that never pass `-s`. The copy
 is read out of `origin/main`, **not** out of your working tree, so `git fetch`
 before your first `make hooks` on a fresh clone. It signs off with the identity
-git would record —
-your `git config user.email`, or `GIT_COMMITTER_EMAIL` if you commit through
-tooling that sets it — which is the same address CI matches against. It does not
-duplicate the trailer if you also pass `-s`, and it never fails a commit.
+git would record: your `git config user.email`, or `GIT_COMMITTER_EMAIL` if you
+commit through tooling that sets it. That's the same address CI matches against.
+It does not duplicate the trailer if you also pass `-s`, and it never fails a
+commit.
 
 Verify it works:
 
@@ -307,11 +307,11 @@ The hook is a convenience, not the control: the `DCO sign-off` CI check is the
 enforcement and re-verifies every commit regardless of what ran locally. Re-run
 `make hooks` after a change to `.githooks/` lands on `main`; it upgrades its own
 copy but refuses to overwrite an unrelated `prepare-commit-msg` hook you already
-have, and refuses to install anywhere but inside this repository's git directory —
-a `core.hooksPath` pointing into the working tree, or into a shared hooks directory
+have, and refuses to install anywhere but inside this repository's git directory.
+A `core.hooksPath` pointing into the working tree, or into a shared hooks directory
 outside the repo, is a refusal, not a warning.
 
-If you edit the hook, run its suite by hand — no CI job runs it:
+If you edit the hook, run its suite by hand. No CI job runs it:
 
 ```bash
 .githooks/prepare-commit-msg.test.sh
@@ -325,21 +325,21 @@ HOOKS_REF=HEAD make hooks
 
 `HEAD` is a commit, not your working tree, so an uncommitted edit installs nothing
 new. That is the one case where you are opting into running your own branch; the
-default `origin/main` is what keeps a branch you have checked out — a fork's pull
-request, say — from installing itself into `.git/hooks/`, where it would outlive
+default `origin/main` is what keeps a branch you have checked out (a fork's pull
+request, say) from installing itself into `.git/hooks/`, where it would outlive
 the branch. Any ref works: `HOOKS_REF=upstream/main make hooks` if your remote is
 not called `origin`.
 
 Run it on the oldest git you expect contributors to have, not just yours. Two of
-the cases pass on git 2.50 but catch a real bug only on git 2.39 — the version
-Debian bookworm, Ubuntu 22.04 and RHEL 9 ship — so a green run on a current git
+the cases pass on git 2.50 but catch a real bug only on git 2.39 (the version
+Debian bookworm, Ubuntu 22.04, and RHEL 9 ship), so a green run on a current git
 proves less than it looks like it does.
 
 Those refusals, and the trusted ref, are all the same point: nothing about a
 checked-out branch should decide what code runs on your machine during an ordinary
 `git commit`. Activating the tracked directory with `core.hooksPath .githooks`, or
-symlinking into it, would make git run the hook from whatever branch is checked out
-— so reviewing a fork's pull request would execute that fork's hook. The full
+symlinking into it, would make git run the hook from whatever branch is checked out,
+so reviewing a fork's pull request would execute that fork's hook. The full
 reasoning is in the header of `.githooks/prepare-commit-msg`.
 
 **All commits in a PR must be signed off.** If you forget, you can amend:
@@ -374,15 +374,15 @@ checks, precisely:
   count.
 - Merge commits are exempt while re-merging their parents reproduces exactly what
   they recorded, so refreshing your branch with `git merge main` is fine. A merge
-  that contributes something of its own — a conflict resolution, or files edited
-  or added during the merge — needs its own sign-off (`git merge --signoff`).
+  that contributes something of its own, such as a conflict resolution or files
+  edited or added during the merge, needs its own sign-off (`git merge --signoff`).
   Octopus merges and merges the check cannot recompute always need one.
 - `Co-Authored-By:` trailers are ignored. Co-authors do not need their own
   sign-off.
 
 The check reports the offending commits and the exact commands to fix them. There
-is no label or flag that skips it. Use your real name — no pseudonyms or
-anonymous contributions.
+is no label or flag that skips it. Use your real name. Pseudonyms and
+anonymous contributions aren't accepted.
 
 ### Author identity
 
@@ -441,7 +441,7 @@ maintainer to approve it, not just the one on your first push. So checks can sit
 **pending**, and a check that was green can go back to pending after the PR is
 retitled or edited. That is normal and nothing for you to fix.
 
-You will also see the `Guardian scan` check report as **skipped**. Our licence,
+You will also see the `Guardian scan` check report as **skipped**. Our license,
 vulnerability, and container scan reports to an internal service, and GitHub
 correctly withholds those credentials from a fork's workflow run, so the scan
 cannot run on your pull request. The `Guardian scan gate` check accounts for that

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -149,7 +149,7 @@ These settings must be configured by repository admin:
 - Topics for discoverability
 - See: ADMIN_SETUP.md → "Repository Settings"
 
-### 2. Support channels (5 minutes)
+### 2. Support Channels (5 minutes)
 - Leave GitHub Discussions **off**
 - Confirm Issues is on
 - See: ADMIN_SETUP.md → "Features"
@@ -158,12 +158,12 @@ These settings must be configured by repository admin:
 - Require PR reviews before merge
 - Require CI checks to pass
 - **Add `Guardian scan gate` to the required status checks** (from
-  `guardian-scan.yaml`) — the always-reporting supply-chain gate. Not
+  `guardian-scan.yaml`), the always-reporting supply-chain gate — not
   `Guardian scan` itself, which is skipped on fork pull requests.
   `.github/ADMIN_SETUP.md` explains why the gate is the safe context to require.
 - **Add `DCO sign-off` and `DCO check self-test` to the required status checks.**
-  These are not cosmetic. DCO is the control the project carries in place of a
-  contributor licence agreement. Both checks exist in CI, but until they are
+  These checks are not cosmetic. DCO is the control the project carries in place of a
+  contributor license agreement. Both checks exist in CI, but until they are
   *required* they enforce nothing, so the control is incomplete until this step
   is done. `.github/ADMIN_SETUP.md` has the exact strings and the reason each is
   needed.
@@ -175,7 +175,7 @@ These settings must be configured by repository admin:
   validity checks and non-provider patterns. Confirm, do not re-enable
 - Dependabot alerts and Dependabot security updates are already on. Scheduled
   Go module and GitHub Actions updates run on Dependabot too
-  (`.github/dependabot.yml`) — Renovate can't be enrolled for a public repo
+  (`.github/dependabot.yml`). Renovate can't be enrolled for a public repo
   under the org's current system, so it stays scoped to just the pinned Claude
   Code CLI version (`.github/renovate.json`). Dependabot's PRs are exempted
   from the `DCO sign-off` check rather than expected to satisfy it; see
@@ -191,7 +191,7 @@ These settings must be configured by repository admin:
 
 ### 6. Make Repository Public (5 minutes)
 **ONLY AFTER:**
-- Admin tasks above are complete
+- Admin tasks in the preceding sections are complete
 - A release has been cut that covers what is on `main`. The newest release is
   v0.6.0 (tagged 2026-07-28), and `main` has moved on since with `[Unreleased]`
   entries in `CHANGELOG.md`, so v0.6.0 does **not** describe `main` today. Cut one
@@ -208,7 +208,7 @@ These settings must be configured by repository admin:
 This table is a historical record of PR #15 (2026-04-24), not current state. As of
 2026-07-29 one gap remains behind the Security row: "Allow GitHub Actions to
 create and approve pull requests" is still on. Secret scanning and its push
-protection have since been enabled. Do not cite the score below as go/no-go
+protection have since been enabled. Do not cite the following score as go/no-go
 evidence without re-checking the live settings.
 
 | Category | Before PR #15 | After PR #15 | Target |
@@ -227,8 +227,8 @@ evidence without re-checking the live settings.
 public release.
 
 Both lines describe 2026-04-24 and are not a current assessment. The Security
-row they include has since been overtaken by the live settings noted above, so
-the real figure today is lower. Re-score against the live settings before
+row they include has since been overtaken by the live settings noted in the
+preceding paragraph, so the real figure today is lower. Re-score against the live settings before
 treating the 80% threshold as met.
 
 ---
@@ -259,7 +259,7 @@ treating the 80% threshold as met.
 ## Contact
 
 For questions about open source readiness:
-- support@solace.com
+- [support@solace.com](mailto:support@solace.com)
 - See CONTRIBUTING.md for contribution process
 - See SECURITY.md for security concerns
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -2,19 +2,19 @@
 
 Thanks for using the Solace Broker MCP Server. Here's where to go, depending on what you need.
 
-## Commercial support
+## Commercial Support
 
 If you have a Solace support contract, contact [support@solace.com](mailto:support@solace.com). Support will route your question, including anything specific to this project.
 
-## Community support
+## Community Support
 
 Everyone else, ask in the [Solace Community](https://solace.community/). It's the best place to get help from other users and from the people who build this.
 
-## Bugs and feature requests
+## Bugs and Feature Requests
 
 Open a [GitHub Issue](https://github.com/SolaceProducts/solace-broker-mcp/issues/new/choose).
 
-## Security issues
+## Security Issues
 
 Don't open a public issue. See [SECURITY.md](SECURITY.md) for how to report a vulnerability privately.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An MCP (Model Context Protocol) server for Solace event brokers, built with Go u
   - [Install with go install](#install-with-go-install)
   - [Docker Deployment](#docker-deployment)
   - [Connect from Claude Code](#connect-from-claude-code)
-  - [Connect from Solace Agent Mesh (SAM)](#connect-from-solace-agent-mesh-sam)
+  - [Connect from Solace Agent Mesh](#connect-from-solace-agent-mesh)
 - [Development Setup](#development-setup)
   - [Configuration Options](#configuration-options)
 - [Project Structure](#project-structure)
@@ -106,7 +106,7 @@ The server exposes read-only tools grouped by what they inspect, plus write tool
 - [Examples](docs/examples.md) — Claude Desktop config, natural-language queries, and multi-broker setup
 - [Configuration](docs/configuration.md) — server settings, event broker config, client auth, and rate-limit/retry settings
 - [Authentication](docs/authentication.md) — OAuth/OIDC and static token setup for MCP clients
-- [SAM Integration](docs/sam-integration.md) — wire this MCP server into a Solace Agent Mesh project as an agent
+- [Agent Mesh Integration](docs/sam-integration.md) — wire this MCP server into an Agent Mesh project as an agent
 
 ## Prerequisites
 
@@ -303,7 +303,7 @@ Example query:
 List queues in the default VPN on the dev broker
 ```
 
-### Connect from Solace Agent Mesh (SAM)
+### Connect from Solace Agent Mesh
 
 After the MCP server is running, configure it to accept a static dev token (local development only). For production, use `mcp_client_auth.mode: oauth` — see [Authentication](docs/authentication.md).
 
@@ -314,9 +314,9 @@ mcp_client_auth:
   dev_token: "sam-mcp-dev-token-local-only"
 ```
 
-Then in your SAM project, add an MCP-tooled agent that points at this server with the matching bearer token. For complete setup instructions, see: [SAM Integration](docs/sam-integration.md).
+Then in your Agent Mesh project, add an MCP-tooled agent that points at this server with the matching bearer token. For complete setup instructions, see: [Agent Mesh Integration](docs/sam-integration.md).
 
-Example queries through the SAM web UI:
+Example queries through the Agent Mesh web UI:
 
 ```
 What event brokers are configured?

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Each event broker needs:
 - `auth.mode` — `basic`, `bearer`, or `oauth` (examples below use basic auth; for bearer token authentication, set `auth.mode: bearer` and provide `auth.token` instead; for OAuth token exchange, see [Step 2b: Configure broker OAuth (Hop 2)](docs/authentication.md#step-2b-configure-broker-oauth-hop-2))
 - `auth.username` / `auth.password` — credentials (use `${VAR_NAME}` to reference environment variables)
 
-**Broker alias contract.** The map key under `brokers:` (for example, `my-broker`) is the alias that appears in tool inputs (`broker="my-broker"`), logs, and `list-brokers` output. Aliases must be 1–63 characters, contain only letters, digits, and hyphens, and start and end with an alphanumeric character. Comparison is case-insensitive — `Prod` and `prod` collide and the server will refuse to start. Original casing is preserved in all user-facing output.
+**Broker alias contract.** The map key under `brokers:` (for example, `my-broker`) is the alias that appears in tool inputs (`broker="my-broker"`), logs, and `list-brokers` output. Aliases must be 1–63 characters, contain only letters, digits, and hyphens, and start and end with an alphanumeric character. Comparison is case-insensitive — `Prod` and `prod` collide and the server refuses to start. Original casing is preserved in all user-facing output.
 
 **2. Create a `.env` file** next to the config file:
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ An MCP (Model Context Protocol) server for Solace event brokers, built with Go u
 
 ## Overview
 
-An HTTP service that exposes Solace event broker management and monitoring to AI assistants through the Model Context Protocol (MCP). The server provides 40 tools: 24 read-only tools that query event broker status, inspect queues, diagnose client issues, and monitor message traffic, plus 16 optional write and action tools (off by default) for operational actions and configuration. It uses SEMP v1 and v2 API calls.
+An HTTP service that exposes Solace event broker management and monitoring to AI assistants through the Model Context Protocol (MCP). The server provides 40 tools: 24 read-only tools that query event broker status, inspect queues, diagnose client issues, and monitor message traffic, plus 16 optional write and action tools (off by default) for operational actions and configuration. It uses the Solace Element Management Protocol (SEMP) v1 and v2 APIs.
 
-MCP-compatible clients, for example Claude Code, invoke these tools using natural language. The AI assistant translates requests into tool calls. The server handles authentication, rate limiting, retries, and response formatting.
+MCP-compatible clients, for example, Claude Code, invoke these tools using natural language. The AI assistant translates requests into tool calls. The server handles authentication, rate limiting, retries, and response formatting.
 
 ## Features
 
-- **24 read-only monitoring tools** — Event broker status, message VPNs, queues, clients, REST delivery points, bridges, Kafka receivers/senders, and SEMPv2 schema introspection
-- **16 optional write and action tools** — Disconnect clients, delete queued messages, reset statistics, and create, update, or delete message VPNs, queues, topic endpoints, and REST delivery points; gated behind `enable_write_tools` (off by default)
+- **24 read-only monitoring tools** — Event broker status, Message VPNs, queues, clients, REST delivery points, bridges, Kafka receivers/senders, and SEMPv2 schema introspection
+- **16 optional write and action tools** — Disconnect clients, delete queued messages, reset statistics, and create, update, or delete Message VPNs, queues, topic endpoints, and REST delivery points; gated behind `enable_write_tools` (off by default)
 - **Client authentication** — Development mode (no auth), static bearer tokens, or OAuth 2.1/OIDC with JWT validation
 - **Claim-based tool authorization** — Under OAuth mode, gate individual MCP tools by a configurable OIDC claim carrying the caller's group or role memberships (`groups` by default); `list-brokers` stays exempt so callers can always discover configured brokers
 - **Multi-broker configuration** — Connect to multiple brokers and address them by configured alias
@@ -95,7 +95,7 @@ The server exposes read-only tools grouped by what they inspect, plus write tool
 | Actions | `delete-queue-messages`, `clear-queue-stats`, `disconnect-client`, `clear-client-stats` | One tool per operational action. Destructive tools (`delete-queue-messages`, `disconnect-client`) are annotated `destructiveHint` so clients can prompt before invocation, and their descriptions ask the model to confirm; the `clear-*-stats` tools are non-destructive. |
 | Management | `create-message-vpn`, `update-message-vpn`, `delete-message-vpn`, `create-queue`, `update-queue`, `delete-queue`, `create-topic-endpoint`, `update-topic-endpoint`, `delete-topic-endpoint`, `create-rdp`, `update-rdp`, `delete-rdp` | Create, update, and delete Config-API objects (Message VPNs, queues, topic endpoints, REST delivery points). `delete-*` and the service-affecting `update-*` tools are annotated `destructiveHint` so clients can prompt before invocation, and their descriptions ask the model to confirm; `create-*` is additive and not annotated. |
 
-**The action and management tools are write tools, gated behind `enable_write_tools: true` in the config — default off; not registered in `tools/list` when disabled.** That's 16 write tools in total (4 action, 12 management), on top of the 24 read-only tools.
+**The action and management tools are write tools, gated behind `enable_write_tools: true` in the config — default off; not registered in `tools/list` when disabled.** That's 16 write tools in total (four action, 12 management), on top of the 24 read-only tools.
 
 > **Confirmation is not enforced.** `enable_write_tools` is the only enforced control. `destructiveHint` and the confirmation text in tool descriptions are hints, not enforced by the MCP protocol — whether the user is actually prompted depends on the client and the model.
 
@@ -150,7 +150,7 @@ Each event broker needs:
 - `auth.mode` — `basic`, `bearer`, or `oauth` (examples below use basic auth; for bearer token authentication, set `auth.mode: bearer` and provide `auth.token` instead; for OAuth token exchange, see [Step 2b: Configure broker OAuth (Hop 2)](docs/authentication.md#step-2b-configure-broker-oauth-hop-2))
 - `auth.username` / `auth.password` — credentials (use `${VAR_NAME}` to reference environment variables)
 
-**Broker alias contract.** The map key under `brokers:` (e.g. `my-broker`) is the alias that appears in tool inputs (`broker="my-broker"`), logs, and `list-brokers` output. Aliases must be 1–63 characters, contain only letters, digits, and hyphens, and start and end with an alphanumeric character. Comparison is case-insensitive — `Prod` and `prod` collide and the server will refuse to start. Original casing is preserved in all user-facing output.
+**Broker alias contract.** The map key under `brokers:` (for example, `my-broker`) is the alias that appears in tool inputs (`broker="my-broker"`), logs, and `list-brokers` output. Aliases must be 1–63 characters, contain only letters, digits, and hyphens, and start and end with an alphanumeric character. Comparison is case-insensitive — `Prod` and `prod` collide and the server will refuse to start. Original casing is preserved in all user-facing output.
 
 **2. Create a `.env` file** next to the config file:
 
@@ -221,7 +221,7 @@ If you have the Go toolchain installed ([Go 1.25+](https://go.dev/dl/)), install
 go install github.com/SolaceProducts/solace-broker-mcp/cmd/server@latest
 ```
 
-This builds the latest tagged release and places a `server` binary in `$(go env GOBIN)` (or `$(go env GOPATH)/bin`). Ensure that directory is on your `PATH`. Pin a specific version by replacing `@latest` with a tag, for example `@v1.2.0`.
+This builds the latest tagged release and places a `server` binary in `$(go env GOBIN)` (or `$(go env GOPATH)/bin`). Ensure that directory is on your `PATH`. Pin a specific version by replacing `@latest` with a tag, for example, `@v1.2.0`.
 
 Run it the same way as the downloaded binary, pointing `CONFIG_FILE` at your config:
 
@@ -291,7 +291,7 @@ services:
 
 ### Connect from Claude Code
 
-Once the MCP server is running (via binary, Docker, or `go run`), add it as an MCP server:
+After the MCP server is running (via binary, Docker, or `go run`), add it as an MCP server:
 
 ```bash
 claude mcp add solace-broker --transport http http://localhost:9090/mcp
@@ -305,7 +305,7 @@ List queues in the default VPN on the dev broker
 
 ### Connect from Solace Agent Mesh (SAM)
 
-Once the MCP server is running, configure it to accept a static dev token (local development only). For production, use `mcp_client_auth.mode: oauth` — see [Authentication](docs/authentication.md).
+After the MCP server is running, configure it to accept a static dev token (local development only). For production, use `mcp_client_auth.mode: oauth` — see [Authentication](docs/authentication.md).
 
 ```yaml
 # broker-config.yaml
@@ -448,7 +448,7 @@ See [SUPPORT.md](.github/SUPPORT.md) for details.
 
 ## Security
 
-For security vulnerability reporting, please see [SECURITY.md](.github/SECURITY.md).
+For security vulnerability reporting, see [SECURITY.md](.github/SECURITY.md).
 
 ## Disclaimer
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,14 +22,14 @@ Fixed tags name one exact build and never move:
 
 | Tag | Resolves to | Status |
 |-----|-------------|--------|
-| `{version}` | the exact version, e.g. `0.4.0` or `0.4.0-beta.1` | [Implemented] |
-| `sha-<short-sha>` | the commit the build came from, e.g. `sha-860c190` | [Implemented] |
+| `{version}` | the exact version, for example, `0.4.0` or `0.4.0-beta.1` | [Implemented] |
+| `sha-<short-sha>` | the commit the build came from, for example, `sha-860c190` | [Implemented] |
 
 Moving pointers let consumers track a stream instead of a fixed version:
 
 | Pointer | Resolves to | Status |
 |---------|-------------|--------|
-| `{major}.{minor}` | newest stable patch of that minor, e.g. `0.4` | [Implemented] |
+| `{major}.{minor}` | newest stable patch of that minor, for example, `0.4` | [Implemented] |
 | `:latest` | newest **stable** version | [Planned] — today `:latest` moves to the newest tag of *any* maturity, including pre-releases |
 | `:edge` | newest tag of any maturity (release-on-green) | [Planned] |
 | `:alpha`, `:beta` | newest tag at that stage | [Planned] |
@@ -94,7 +94,7 @@ waits on
 
 A failed job blocks the GitHub Release, binaries, checksums, and the container image: `build-docker` waits on the FOSSA scan as well as the build, so a failing SCA gate publishes nothing. That matters because a registry push cannot be withdrawn — the binaries are only artifacts until `release` publishes them, but the image is live the moment it is pushed.
 
-One window remains: the image is pushed *before* it is attested, so a run that fails on the attest step leaves `latest` live with no attestation — a consumer's `gh attestation verify` then fails because the release is incomplete, not because the image was tampered with. That ordering is unavoidable, since attesting a registry digest requires the digest to exist. If a release run fails partway, check `ghcr.io` and roll forward (see Rollback).
+One window remains: the image is pushed *before* it is attested, so a run that fails on the attest step leaves `latest` live with no attestation — a consumer's `gh attestation verify` then fails because the release is incomplete, not because the image was tampered with. That ordering is unavoidable, because attesting a registry digest requires the digest to exist. If a release run fails partway, check `ghcr.io` and roll forward (see Rollback).
 
 Pre-release tags (`v0.4.0-beta.1`) and the `:edge`/`:alpha`/`:beta` pointers follow the same workflow once continuous pre-release publishing is wired up **[Planned]**.
 
@@ -110,7 +110,7 @@ The manual steps around the automated workflow.
 Before tagging:
 
 1. Confirm `main` is green: `gh run list --branch main --limit 1`.
-2. Update `CHANGELOG.md` on `main`: move the `[Unreleased]` items into a new dated `## [X.Y.Z]` version section and update the comparison links at the bottom. This is **required** — the release workflow extracts that block as the Release body and fails the release if the dated block is absent. Do it in a "prepare release" PR *before* tagging, so the block lives in the tagged commit.
+2. Update `CHANGELOG.md` on `main`: move the `[Unreleased]` items into a new dated `## [X.Y.Z]` version section and update the comparison links at the bottom. This step is **required** — the release workflow extracts that block as the Release body and fails the release if the dated block is absent. Do it in a "prepare release" PR *before* tagging, so the block lives in the tagged commit.
 3. Regenerate the third-party license inventory from the toolchain: `go-licenses report ./cmd/server` supplies the module, version, and license data for `THIRD_PARTY_LICENSES.md`. Reconcile it against the FOSSA scan, which remains the authoritative check.
 
 After pushing the tag:
@@ -150,7 +150,7 @@ If a job fails for environmental reasons, re-run it: `gh run rerun <run-id>`. Ne
 
 Tags are never reused — we roll forward, not back.
 
-- **Bad release:** fix on the default branch, then tag the next PATCH (e.g. `v0.4.1`). The fix follows the same gates, and the new tag moves the moving pointers forward to the good build.
+- **Bad release:** fix on the default branch, then tag the next PATCH (for example, `v0.4.1`). The fix follows the same gates, and the new tag moves the moving pointers forward to the good build.
 - **Steer users away:** mark the bad GitHub Release as a pre-release or delete it. The tag and artifacts remain for auditability; pin-by-version and pin-by-digest consumers are unaffected.
 
 ## DORA metrics **[Planned]**

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,8 +1,8 @@
 # Tools
 
 The complete tools reference lives in **[docs/tools-reference.md](docs/tools-reference.md)** —
-per-tool parameters, output schema, and example invocations for all 21 tools
-(17 read-only + 4 action tools).
+per-tool parameters, output schema, and example invocations for all 40 tools
+(24 read-only + 16 write tools).
 
 Quick links:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -180,7 +180,7 @@ Most IdPs organize clients and users into an isolated namespace — called a rea
 >   -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
 >   quay.io/keycloak/keycloak:latest start-dev
 > ```
-> Then open the Admin Console at `http://localhost:8080/admin`, log in with `admin` / `admin`, click the realm dropdown in the top-left → **Create realm** → set a **Realm name** → **Create**. The built-in `master` realm can be used for quick local testing, but a dedicated realm is recommended.
+> Then open the Admin Console at `http://localhost:8080/admin`, log in with `admin` / `admin`, click the realm drop-down list in the top-left → **Create realm** → set a **Realm name** → **Create**. The built-in `master` realm can be used for quick local testing, but a dedicated realm is recommended.
 >
 > **Reference:** [`test/e2e-oauth/realm-export.json`](../test/e2e-oauth/realm-export.json) is a concrete, working example of this shape (realm, audience mappers, OAuth clients, test users) — test-only, not a production template, but useful to see the pieces fit together.
 
@@ -204,13 +204,13 @@ Skip this step when using Option B (Dynamic Client Registration).
 
 Create a client in the IdP with the following settings:
 
-- **Client ID:** any name (e.g. `mcp-client`) — pass this as `--client-id` in step 4
+- **Client ID:** any name (for example, `mcp-client`) — pass this as `--client-id` in step 4
 - **Flow:** Authorization Code with PKCE
 - **PKCE challenge method:** `S256`
-- **Client type:** Public (no secret) or Confidential (with secret) — a public client is recommended for MCP clients like Claude Code and Claude Desktop, since they run on a user's machine where a client secret cannot be stored securely. For Option B (Dynamic Client Registration), the MCP client should always be registered as public.
+- **Client type:** Public (no secret) or Confidential (with secret) — a public client is recommended for MCP clients like Claude Code and Claude Desktop, since they run on a user's machine where a client secret cannot be stored securely. For Option B (Dynamic Client Registration), always register the MCP client as public.
 - **Redirect URI:** `http://localhost:<port>/callback`, where `<port>` matches the `--callback-port` used when adding the server to Claude Code
 
-> **Keycloak:** **Clients** → **Create client** → set a **Client ID** (e.g. `mcp-client`) → click **Next**.
+> **Keycloak:** **Clients** → **Create client** → set a **Client ID** (for example, `mcp-client`) → click **Next**.
 > - **Client authentication:** leave **OFF** for a public client (no secret required); turn **ON** for a confidential client (requires `--client-secret`)
 >
 > Enable **Standard flow** and disable all other flows. Enable **Require PKCE** and set the **PKCE Method** to `S256` → click **Next**. Under **Login settings**, set **Valid redirect URIs** to `http://localhost:*` → **Save**.
@@ -233,7 +233,7 @@ mcp_client_auth:
   resource_url: "https://your-mcp-server.example.com/mcp"
 ```
 
-See the Keycloak configuration below for an example.
+See the following Keycloak configuration for an example.
 
 The `audience` value must exactly match the value configured in step 1.2. Set `resource_url` to the externally reachable URL of the MCP endpoint — this is advertised to clients for OAuth discovery, so it must be the public-facing URL, not the server's internal bind address (these differ when running behind a reverse proxy or ingress).
 
@@ -252,11 +252,11 @@ The `audience` value must exactly match the value configured in step 1.2. Set `r
 >   resource_url: "https://localhost:9090/mcp"
 > ```
 
-> **Note:** Under `mode: oauth` the validator enforces `https://` on **both** the `issuer` and `resource_url` URLs (an `http://` value is rejected at startup). When running Keycloak locally for testing, terminate TLS in front of it (for example, via Caddy or a reverse proxy) or run Keycloak with a TLS cert. `resource_url` is the externally advertised identifier for OAuth discovery, so it must be `https://` even when the MCP server's own listener is plaintext behind an upstream terminator — see [TLS for the MCP server's own listener](#tls-for-the-mcp-servers-own-listener) below.
+> **Note:** Under `mode: oauth` the validator enforces `https://` on **both** the `issuer` and `resource_url` URLs (an `http://` value is rejected at startup). When running Keycloak locally for testing, terminate TLS in front of it (for example, via Caddy or a reverse proxy) or run Keycloak with a TLS cert. `resource_url` is the externally advertised identifier for OAuth discovery, so it must be `https://` even when the MCP server's own listener is plaintext behind an upstream terminator — see [TLS for the MCP server's own listener](#tls-for-the-mcp-servers-own-listener).
 
 ### Step 2b: Configure broker OAuth (Hop 2)
 
-This step is only needed if one or more brokers should use `auth.mode: oauth` instead of `basic`/`bearer`. Under this mode, the MCP server obtains each broker's token by exchanging the calling agent's Hop 1 token (RFC 8693 token exchange) against the identity provider. `mcp_client_auth.mode: oauth` (Hop 1) is required first — RFC 8693 token exchange consumes the agent's Hop 1 JWT as its `subject_token`, so with `mode: static` or `mode: disabled` there is no agent token to exchange and Hop 2 has nothing to do.
+This step is only needed if one or more brokers use `auth.mode: oauth` instead of `basic`/`bearer`. Under this mode, the MCP server obtains each broker's token by exchanging the calling agent's Hop 1 token (RFC 8693 token exchange) against the identity provider. `mcp_client_auth.mode: oauth` (Hop 1) is required first — RFC 8693 token exchange consumes the agent's Hop 1 JWT as its `subject_token`, so with `mode: static` or `mode: disabled` there is no agent token to exchange and Hop 2 has nothing to do.
 
 > **Note:** Configuring `auth.mode: oauth` on a broker while Hop 1 is `static`/`disabled` is rejected at startup with:
 > ```
@@ -265,7 +265,7 @@ This step is only needed if one or more brokers should use `auth.mode: oauth` in
 > mcp_client_auth.mode must be oauth
 > ```
 
-Add the top-level `broker_oauth:` block with the IdP's token-exchange coordinates, and set `auth.mode: oauth` on each broker that should use it:
+Add the top-level `broker_oauth:` block with the IdP's token-exchange coordinates, and set `auth.mode: oauth` on each broker that uses it:
 
 ```yaml
 broker_oauth:
@@ -290,8 +290,8 @@ brokers:
 | `broker_oauth.idp_token_endpoint` | The IdP's token endpoint — where the MCP server POSTs the token-exchange request. Must be `https://` in production. |
 | `broker_oauth.mcp_server_client_id` | The MCP server's own `client_id`, registered at the IdP (this is a separate client registration from the one used for Hop 1 in step 1.2). |
 | `broker_oauth.mcp_server_client_auth` | How the MCP server authenticates itself to the IdP's token endpoint — a discriminated union, exactly one sub-block populated: `client_secret_basic.secret` (sent via HTTP Basic auth) or `client_secret_post.secret` (sent in the form body). |
-| `broker_oauth.grant_type` | The OAuth grant type used for the Hop 2 exchange — see [Grant type](#grant-type) below. |
-| `broker_oauth.audience_parameter_name` | Which request parameter carries the per-broker audience value — see [Audience parameter name](#audience-parameter-name) below. |
+| `broker_oauth.grant_type` | The OAuth grant type used for the Hop 2 exchange — see [Grant type](#grant-type). |
+| `broker_oauth.audience_parameter_name` | Which request parameter carries the per-broker audience value — see [Audience parameter name](#audience-parameter-name). |
 | `brokers.<alias>.auth.mode` | Set to `oauth` to use token exchange for this broker. |
 | `brokers.<alias>.auth.audience` | Optional, even under `auth.mode: oauth` — omitting it does not fail startup. This broker's audience value, forwarded to the IdP during exchange using whichever request parameter `audience_parameter_name` selects; when omitted, the exchange request carries no audience parameter at all. Omit if the broker's OAuth profile does not validate audience; set it only if it does. If set, it must not be whitespace-only (a `${VAR}` resolving to blank fails config load). |
 
@@ -309,7 +309,7 @@ This is the only grant type this version implements. The field exists (rather th
 
 #### Audience parameter name
 
-`audience_parameter_name` tells the runtime which OAuth request parameter should carry each broker's `auth.audience` value in the token-exchange POST. Different IdP families expect the audience on a different parameter, but this version implements only one:
+`audience_parameter_name` tells the runtime which OAuth request parameter carries each broker's `auth.audience` value in the token-exchange POST. Different IdP families expect the audience on a different parameter, but this version implements only one:
 
 ```yaml
 audience_parameter_name: "audience"
@@ -551,13 +551,14 @@ A browser window opens on first use for user login. The IdP must support anonymo
 > is emitted. This lets a caller always discover configured broker aliases
 > before invoking any other tool.
 
-> **Two independent auth legs.** Client→server auth (steps 1–8, the JWT above) is
-> distinct from server→broker auth (step 9 or 10 depending on whether tool
-> authorization is enabled), which uses each broker's configured `auth.mode`
-> (`basic`, `bearer`, or `oauth`). Broker-bound OAuth via RFC 8693 token
-> exchange (the `broker_oauth:` config block) obtains a broker-bound token by
-> exchanging the client's Hop 1 token, and requires `mcp_client_auth.mode:
-> oauth` — see [Step 2b: Configure broker OAuth (Hop 2)](#step-2b-configure-broker-oauth-hop-2) below.
+> **Two independent auth legs.** Client→server auth (steps 1–8, the JWT shown
+> in the preceding diagram) is distinct from server→broker auth (step 9 or 10
+> depending on whether tool authorization is enabled), which uses each
+> broker's configured `auth.mode` (`basic`, `bearer`, or `oauth`).
+> Broker-bound OAuth via RFC 8693 token exchange (the `broker_oauth:` config
+> block) obtains a broker-bound token by exchanging the client's Hop 1 token,
+> and requires `mcp_client_auth.mode: oauth` — see
+> [Step 2b: Configure broker OAuth (Hop 2)](#step-2b-configure-broker-oauth-hop-2).
 
 **Server→broker flow when `auth.mode: oauth` (Hop 2), cache miss:**
 
@@ -693,7 +694,7 @@ This error occurs during Dynamic Client Registration when the IdP rejects the re
 
 This is a tool-authorization denial. The token authenticated successfully, but the server's claim-based policy did not grant the tool. The caller-facing message is deliberately generic — grep the server logs for a `msg: "tool authorization"` line at the same `correlation_id` to see why:
 
-- `decision_reason: "missing_claim"` with `expected_claim: "<name>"` — the token had no claim by that name at the top level of the JWT. Common causes, in order of likelihood: (a) the IdP's memberships mapper is not applied to the caller's client scope (fix at the IdP); (b) `groups_claim_name` in the server config does not match the claim the IdP actually emits (fix at the server); (c) the IdP emits memberships inside a nested object (e.g. `authorization.roles`) — the server only reads top-level claims, so flatten the memberships into a top-level claim with an IdP mapper.
+- `decision_reason: "missing_claim"` with `expected_claim: "<name>"` — the token had no claim by that name at the top level of the JWT. Common causes, in order of likelihood: (a) the IdP's memberships mapper is not applied to the caller's client scope (fix at the IdP); (b) `groups_claim_name` in the server config does not match the claim the IdP actually emits (fix at the server); (c) the IdP emits memberships inside a nested object (for example, `authorization.roles`) — the server only reads top-level claims, so flatten the memberships into a top-level claim with an IdP mapper.
 - `decision_reason: "not_permitted"` with `matched_groups: []` — the claim was present but none of the caller's memberships grant the tool. Fix by adding the tool to a group the caller is a member of, or adding the caller to a group that already grants it.
 
-`list-brokers` is exempt and will always succeed for any authenticated caller — a successful `list-brokers` call in the same session as a denied tool call confirms the token itself is valid and it is the tool-authorization policy that is denying. See [Tool authorization](configuration.md#tool-authorization) for the full audit-line schema.
+`list-brokers` is exempt and always succeeds for any authenticated caller — a successful `list-brokers` call in the same session as a denied tool call confirms the token itself is valid and it is the tool-authorization policy that is denying. See [Tool authorization](configuration.md#tool-authorization) for the full audit-line schema.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,14 +35,14 @@ The server resolves variables at startup. The `.env` file loads automatically be
 | YAML field | Env var | Default | Description |
 |---|---|---|---|
 | `port` | `MCP_SERVER_PORT` | `9090` | Port the MCP server listens on. |
-| `listen_address` | — | see below | Host the server binds to. Empty binds all interfaces; the default depends on the client auth mode. |
+| `listen_address` | — | see Bind address | Host the server binds to. Empty binds all interfaces; the default depends on the client auth mode. |
 | `allow_remote_unauthenticated` | — | `false` | Opt-in to a non-loopback `listen_address` while `mcp_client_auth.mode: disabled`. Acknowledges that the listener has no client authentication. |
 | `allow_insecure_broker_tls` | — | `false` | Opt-in to a broker with `insecure_skip_verify: true` while `mcp_client_auth.mode: oauth`. Acknowledges that disabling broker certificate verification exposes the broker admin credential to a man-in-the-middle. |
 | `tls_cert_file` | — | none | Path to TLS certificate (PEM). |
 | `tls_key_file` | — | none | Path to TLS private key (PEM). |
 | `tls_terminated_upstream` | — | `false` | Opt-in to a plaintext listener while `mcp_client_auth.mode: oauth`. Acknowledges that TLS is terminated by an upstream proxy/ingress. Ignored in the dev modes. |
 | `log_level` | — | `info` | Log verbosity: `debug`, `info`, `warn`, `error`. |
-| `enable_write_tools` | — | `false` | When `true`, register every tool that is not read-only (16 in total): the four action-API tools (`delete-queue-messages`, `clear-queue-stats`, `disconnect-client`, `clear-client-stats`) plus the 12 Config-API management tools (`create`/`update`/`delete` for `message-vpn`, `queue`, `topic-endpoint`, and `rdp`). This includes the non-destructive stats-reset tools (which still mutate broker state) and provisioning tools such as `delete-message-vpn`. When `false`, those tools are skipped at registration and never appear in `tools/list`. Secure-by-default for trial / dev deployments. |
+| `enable_write_tools` | — | `false` | When `true`, register every tool that is not read-only (16 in total): the four action-API tools (`delete-queue-messages`, `clear-queue-stats`, `disconnect-client`, `clear-client-stats`) plus the twelve Config-API management tools (`create`/`update`/`delete` for `message-vpn`, `queue`, `topic-endpoint`, and `rdp`). This includes the non-destructive stats-reset tools (which still mutate broker state) and provisioning tools such as `delete-message-vpn`. When `false`, those tools are skipped at registration and never appear in `tools/list`. Secure-by-default for trial / dev deployments. |
 
 **TLS:** Provide both `tls_cert_file` and `tls_key_file` together — providing only one is a startup error. When both are set, the server starts with HTTPS; when neither is set, plain HTTP.
 
@@ -52,7 +52,7 @@ tls_cert_file: "/etc/certs/server.pem"
 tls_key_file: "/etc/certs/server-key.pem"
 ```
 
-Under `mode: oauth` (production) a plaintext listener would carry client bearer tokens and tool results in cleartext, so it is **refused at startup** unless either TLS certs are set (above) or `tls_terminated_upstream: true` acknowledges that an upstream proxy/ingress terminates TLS. With the acknowledgment the server serves plaintext and logs a startup `WARN`. The dev modes (`static`/`disabled`) are unaffected. See [Authentication](authentication.md) for the two deployment patterns.
+Under `mode: oauth` (production) a plaintext listener would carry client bearer tokens and tool results in cleartext, so it is **refused at startup** unless either TLS certs are set (see TLS) or `tls_terminated_upstream: true` acknowledges that an upstream proxy/ingress terminates TLS. With the acknowledgment the server serves plaintext and logs a startup `WARN`. The dev modes (`static`/`disabled`) are unaffected. See [Authentication](authentication.md) for the two deployment patterns.
 
 **Bind address:** When `listen_address` is unset, the effective bind depends on `mcp_client_auth.mode` so the dev modes are safe by default — they are not reachable from the network unless an operator opts in:
 
@@ -71,7 +71,7 @@ An explicit `listen_address` must be an IP address or `localhost`. Under `mode: 
 
 Configured under the `brokers` map. Each key defines an event broker alias for the `broker` parameter in MCP tools.
 
-Aliases must be 1–63 characters, contain only letters, digits, and hyphens, and start and end with an alphanumeric character. Comparison is case-insensitive — `Prod` and `prod` collide and the server will refuse to start. Original casing is preserved in all user-facing output.
+Aliases must be 1–63 characters, contain only letters, digits, and hyphens, and start and end with an alphanumeric character. Comparison is case-insensitive — `Prod` and `prod` collide and the server refuses to start. Original casing is preserved in all user-facing output.
 
 | YAML field | Default | Description |
 |---|---|---|
@@ -80,8 +80,8 @@ Aliases must be 1–63 characters, contain only letters, digits, and hyphens, an
 | `auth.username` | — | Basic auth username. |
 | `auth.password` | — | Basic auth password. |
 | `auth.token` | — | Bearer token (used when `auth.mode: bearer`). |
-| `auth.audience` | — | Optional, even under `auth.mode: oauth` — omitting it does not fail config load or startup. RFC 8693 audience value for this broker, forwarded to the IdP during token exchange (requires the top-level `broker_oauth:` block — see [Broker OAuth (Hop 2)](#broker-oauth-hop-2) below). When omitted, the runtime sends the token-exchange request without an audience parameter at all. Omit when the broker's OAuth profile does not validate audience; set it only if the broker's OAuth profile does. If set, it must not be whitespace-only — a `${VAR}` that resolves to blank does fail config load. |
-| `insecure_skip_verify` | `false` | Skip TLS certificate verification. Development only. Under `mcp_client_auth.mode: oauth` (production) it is **refused at startup** unless `allow_insecure_broker_tls: true` is also set (see below). |
+| `auth.audience` | — | Optional, even under `auth.mode: oauth` — omitting it does not fail config load or startup. RFC 8693 audience value for this broker, forwarded to the IdP during token exchange (requires the top-level `broker_oauth:` block — see [Broker OAuth (Hop 2)](#broker-oauth-hop-2)). When omitted, the runtime sends the token-exchange request without an audience parameter at all. Omit when the broker's OAuth profile does not validate audience; set it only if the broker's OAuth profile does. If set, it must not be whitespace-only — a `${VAR}` that resolves to blank does fail config load. |
+| `insecure_skip_verify` | `false` | Skip TLS certificate verification. Development only. Under `mcp_client_auth.mode: oauth` (production) it is **refused at startup** unless `allow_insecure_broker_tls: true` is also set (see Broker TLS in production). |
 
 Solace recommends using `https://` event broker URLs in production environments.
 
@@ -99,19 +99,19 @@ brokers:
 
 Configured under the top-level `broker_oauth` key. Required when any broker uses `auth.mode: oauth` — obtains the broker-bound token by exchanging the calling agent's Hop 1 token (RFC 8693 token exchange) against an identity provider.
 
-`mcp_client_auth.mode: oauth` (Hop 1) is required first: token exchange consumes the agent's Hop 1 JWT as its `subject_token`, so a broker with `auth.mode: oauth` while Hop 1 is `static`/`disabled` is **refused at config load** with an `mcp_client_auth.mode must be oauth` error naming the affected broker(s). The `broker_oauth:` block itself is likewise required once any broker uses `auth.mode: oauth` — omitting it fails config load with `broker_oauth block is required when any broker uses auth.mode: "oauth"`. Every field in the table below (other than `circuit_breaker`/`retry_after`) is required; an empty or unsupported value fails config load naming that field.
+`mcp_client_auth.mode: oauth` (Hop 1) is required first: token exchange consumes the agent's Hop 1 JWT as its `subject_token`, so a broker with `auth.mode: oauth` while Hop 1 is `static`/`disabled` is **refused at config load** with an `mcp_client_auth.mode must be oauth` error naming the affected broker(s). The `broker_oauth:` block itself is likewise required once any broker uses `auth.mode: oauth` — omitting it fails config load with `broker_oauth block is required when any broker uses auth.mode: "oauth"`. Every field in the following table (other than `circuit_breaker`/`retry_after`) is required; an empty or unsupported value fails config load naming that field.
 
 | YAML field | Default | Description |
 |---|---|---|
 | `idp_token_endpoint` | — | **Required.** The IdP's token endpoint URL (the token-exchange POST target). Must be `https://` in production. |
 | `mcp_server_client_id` | — | **Required.** The MCP server's own `client_id`, registered at the IdP. |
-| `mcp_server_client_auth` | — | **Required.** Discriminated union — exactly one of the sub-blocks below must be populated. |
+| `mcp_server_client_auth` | — | **Required.** Discriminated union — exactly one of the following sub-blocks must be populated. |
 | `mcp_server_client_auth.client_secret_basic.secret` | — | Client secret sent via HTTP Basic auth (RFC 6749 §2.3). |
 | `mcp_server_client_auth.client_secret_post.secret` | — | Client secret sent in the token-request form body (RFC 6749 §2.3). |
 | `grant_type` | — | **Required.** Selects the OAuth grant type for the Hop 2 exchange. Must be `"urn:ietf:params:oauth:grant-type:token-exchange"` (RFC 8693) — the only grant type this version implements; any other value is rejected at config load. |
 | `audience_parameter_name` | — | **Required.** Which request parameter carries each broker's `auth.audience` value. Must be `audience` (RFC 8693 default) — the only value implemented in this version; any other value, including `scope` (Entra On-Behalf-Of style) or `resource` (RFC 8707), is rejected at config load. |
-| `circuit_breaker` | omitted (all defaults, enabled) | Optional. See below. |
-| `retry_after` | omitted (default cap) | Optional. See below. |
+| `circuit_breaker` | omitted (all defaults, enabled) | Optional. See [Circuit breaker](#circuit-breaker). |
+| `retry_after` | omitted (default cap) | Optional. See [Retry-After gate](#retry-after-gate). |
 
 ```yaml
 mcp_client_auth:
@@ -165,12 +165,12 @@ Configured under the `mcp_client_auth` key. The `mode` field is required and sel
 
 | YAML field | Description |
 |---|---|
-| `mcp_client_auth.mode` | **Required.** One of `disabled`, `static`, or `oauth`. Selects the client auth backend and the operational profile (dev vs. production). |
+| `mcp_client_auth.mode` | **Required.** One of `disabled`, `static`, or `oauth`. Selects the client auth backend and the operational profile (dev versus production). |
 | `mcp_client_auth.dev_token` | Static bearer token. Required when `mcp_client_auth.mode` is `static`. |
 | `mcp_client_auth.issuer` | IdP issuer URL. Required when `mcp_client_auth.mode` is `oauth`. |
 | `mcp_client_auth.audience` | Expected `aud` claim value. Required when `mcp_client_auth.mode` is `oauth`. |
 | `mcp_client_auth.resource_url` | OAuth resource URL (for example, `https://mcp.example.com/mcp`). Required when `mcp_client_auth.mode` is `oauth`. |
-| `mcp_client_auth.tool_authorization` | Claim-based tool authorization block. Required under `mcp_client_auth.mode: oauth` — the `enabled` field must be set explicitly to `true` or `false`; omitting the block, or omitting `enabled` from it, is a startup error. Not legal under `static` or `disabled`. See [Tool authorization](#tool-authorization) below. |
+| `mcp_client_auth.tool_authorization` | Claim-based tool authorization block. Required under `mcp_client_auth.mode: oauth` — the `enabled` field must be set explicitly to `true` or `false`; omitting the block, or omitting `enabled` from it, is a startup error. Not legal under `static` or `disabled`. See [Tool authorization](#tool-authorization). |
 
 ## Tool Authorization
 
@@ -217,8 +217,8 @@ mcp_client_auth:
 |---|---|
 | `enabled` | Required. `true` turns tool authorization on; `false` turns it off. There is no default — the field must be present under `mode: oauth`. |
 | `filter_tools_list` | Optional, defaults to `false`. When `true`, `tools/list` returns only the tools the caller's groups grant, instead of every registered tool. Only meaningful when tool authorization is on (`enabled: true` in this same block) — setting it while `enabled: false` logs a startup `WARN` and leaves filtering off, since there is no policy to filter against. See [Filtering `tools/list`](#filtering-toolslist) below. |
-| `groups_claim_name` | Name of the OIDC claim in the caller's JWT that carries their group or role memberships. Optional; defaults to `"groups"`. Must match the claim your IdP emits (see [Authentication](authentication.md) for setting this up on the IdP side). Only meaningful when `enabled: true`. **Top-level lookup only** — the value is read from the top of the JWT claims object; nested paths (e.g. `authorization.roles`) are not supported. If your IdP emits memberships inside a nested object, flatten them into a top-level claim with an IdP mapper before the token is issued. |
-| `access_level_groups` | Map from group name — as it appears in the caller's token — to the list of MCP tool names that group grants. Required when `enabled: true`. Union semantics: a caller is allowed to invoke a tool when at least one of their groups grants it. A tool that no group grants is unreachable by every caller. **No wildcard** — a group that should grant every tool must list every tool name explicitly. This is deliberate: an "all tools" glob would silently include every newly-added tool at upgrade time, without the operator noticing the surface expanded. |
+| `groups_claim_name` | Name of the OIDC claim in the caller's JWT that carries their group or role memberships. Optional; defaults to `"groups"`. Must match the claim your IdP emits (see [Authentication](authentication.md) for setting this up on the IdP side). Only meaningful when `enabled: true`. **Top-level lookup only** — the value is read from the top of the JWT claims object; nested paths (for example, `authorization.roles`) are not supported. If your IdP emits memberships inside a nested object, flatten them into a top-level claim with an IdP mapper before the token is issued. |
+| `access_level_groups` | Map from group name — as it appears in the caller's token — to the list of MCP tool names that group grants. Required when `enabled: true`. Union semantics: a caller is allowed to invoke a tool when at least one of their groups grants it. A tool that no group grants is unreachable by every caller. **No wildcard** — a group intended to grant every tool must list every tool name explicitly. This is deliberate: an "all tools" glob would silently include every newly-added tool at upgrade time, without the operator noticing the surface expanded. |
 
 **`list-brokers` and `describe-semp-schema` are structurally exempt.** Every authenticated caller can invoke these tools regardless of their groups; neither is composed with the authorization wrapper. `list-brokers` lets callers discover which broker aliases exist; `describe-semp-schema` lets callers inspect the SEMPv2 schema for any operation (spec content only, no broker state). Listing either tool in an `access_level_groups` entry is inert — the server emits a startup `WARN` naming the group but the grant has no effect.
 

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -2,7 +2,7 @@
 
 This document describes the architecture **as implemented**. Where a package
 exists only as a capability gate or is wired behind a feature flag, that status
-is called out inline (e.g. _skeleton_, _gated_) so the doc never implies a
+is called out inline (for example, _skeleton_, _gated_) so the doc never implies a
 subsystem is live when the code is a stub. Component claims carry `file:line`
 references so a reviewer can verify each one against the code.
 

--- a/docs/internal/e2e-testing.md
+++ b/docs/internal/e2e-testing.md
@@ -73,7 +73,7 @@ All test configuration lives in a single file: `test/e2e-basic-mcp/.env`. This f
 
 - **docker-compose.yml** — broker port mappings and admin password
 - **helpers.sh** — broker URLs, SEMP auth, fixture management
-- **MCP server** — credential resolution via `ENV_FILE` (reads `E2E_A_USERNAME`, etc.)
+- **MCP server** — credential resolution via `ENV_FILE` (reads `E2E_A_USERNAME` and so on)
 
 ```bash
 # Broker SEMP ports (host-side)
@@ -283,7 +283,7 @@ Phase 2:        add go-openai client → point at LiteLLM endpoint
                 → feed results back → agentic loop
 ```
 
-Because LiteLLM exposes an OpenAI-compatible API, a Go OpenAI client (e.g. `github.com/sashabaranov/go-openai`) can target it with no MCP changes. The agent's `session.ListTools()` output maps directly to OpenAI function definitions.
+Because LiteLLM exposes an OpenAI-compatible API, a Go OpenAI client (for example, `github.com/sashabaranov/go-openai`) can target it with no MCP changes. The agent's `session.ListTools()` output maps directly to OpenAI function definitions.
 
 ---
 

--- a/docs/internal/packaging-release.md
+++ b/docs/internal/packaging-release.md
@@ -16,7 +16,7 @@ var Version = "dev"
 ```
 
 `Version` is a package-level variable imported wherever the version string is
-needed (MCP server metadata, User-Agent header, health endpoints, etc.).
+needed (MCP server metadata, User-Agent header, health endpoints, and so on).
 
 ### Local development
 
@@ -230,7 +230,7 @@ The binary is statically linked with no external dependencies.
 
 The server handles `SIGTERM` and `SIGINT` for graceful shutdown (120s timeout).
 To run as a background service with auto-restart, use your platform's process
-manager (systemd, supervisord, launchd, etc.).
+manager (systemd, supervisord, launchd, and so on).
 
 > **Future:** Pre-built service templates (systemd unit, launchd plist) are
 > planned for a future release. See `docs/todo-gaps.md` for details.
@@ -274,7 +274,7 @@ path specified by `ENV_FILE`) and from the process environment.
 
 ## Health Checks
 
-The server exposes a liveness probe at `GET /livez` which returns:
+The server exposes a liveness probe at `GET /livez`, which returns:
 
 ```json
 {"status":"alive"}
@@ -295,7 +295,7 @@ which has no shell, curl, or wget.
 | Docker | `HEALTHCHECK CMD ["/solace-broker-mcp", "--health"]` (built into image) |
 | Docker (external) | `curl http://localhost:9090/health` from host |
 | Kubernetes | `httpGet` liveness/readiness probe on `/health` port 9090 |
-| Bare metal | `curl http://localhost:9090/health` (cron, monitoring agent, etc.) |
+| Bare metal | `curl http://localhost:9090/health` (cron, monitoring agent, and so on) |
 
 ## Security Considerations
 

--- a/docs/internal/secure-logging-rules.md
+++ b/docs/internal/secure-logging-rules.md
@@ -10,9 +10,9 @@ These must never appear in log output, in any environment:
 
 | Item | Where it lives in our code |
 |---|---|
-| SEMP passwords | `AuthConfig.Password`, `HTTPClient.password` |
-| SEMP usernames | `AuthConfig.Username`, `HTTPClient.username` |
-| SEMP bearer tokens | `AuthConfig.Token`, `HTTPClient.token` |
+| SEMP passwords | `AuthConfig.Password`, `auth.BasicAuthenticator.password` |
+| SEMP usernames | `AuthConfig.Username`, `auth.BasicAuthenticator.username` |
+| SEMP bearer tokens | `AuthConfig.Token`, `auth.BearerAuthenticator.token` |
 | Raw `Authorization` header values | Built in `HTTPClient.Execute()` |
 | TLS private keys | If we ever load them |
 | URLs with embedded credentials | `http://user:pass@host` patterns |
@@ -48,7 +48,8 @@ Never `fmt.Sprintf` into the message string with external data. Always `slog.Str
 - `AuthConfig` — expose only `Mode`
 - `BrokerConfig` — expose `URL`, `InsecureSkipVerify`, `Auth.Mode`
 - `HTTPClient` — lower risk (unexported fields) but should still get `LogValuer` for defense in depth
-- When Story 1B adds OAuth config, that struct gets `LogValuer` too
+- OAuth config types (`BrokerOAuthConfig`, `BrokerClientAuth`, `ClientSecretAuth`) also implement `LogValuer`, excluding secret material
+- Any new credential-carrying type follows the same pattern
 
 ### Rule 3: `ReplaceAttr` safety net on the handler
 

--- a/docs/internal/semp/get-broker-status-curated-fields.md
+++ b/docs/internal/semp/get-broker-status-curated-fields.md
@@ -12,7 +12,7 @@ This document captures the curated field set the `get-broker-status` MCP tool wi
 The four SEMPv1 commands underpinning this tool return ~462 fields total in the XSD-aligned response structs. Returning all of them would:
 - bloat LLM context windows for every invocation,
 - bury the operationally meaningful signals,
-- mix configuration facts (e.g., `cpu-cores`) with health indicators (e.g., `physical-memory-usage-percent`).
+- mix configuration facts (for example, `cpu-cores`) with health indicators (for example, `physical-memory-usage-percent`).
 
 Research across Solace public docs, internal Confluence runbooks, and the Solace Community forum identified a much smaller set of fields that operators *actually* check when assessing broker health. That set is what this tool returns.
 
@@ -36,7 +36,7 @@ Research across Solace public docs, internal Confluence runbooks, and the Solace
 
 | XML field | JSON key (camelCase) | Operational meaning |
 |---|---|---|
-| `description` | `description` | Broker version (e.g. `"Solace PubSub+ Software Enterprise Version 10.25.0.217"`) — support-lifecycle check, every operator runbook starts here. The string is also inspected by the platform-detection helper that gates the appliance-only hardware step (see "show hardware details" below). |
+| `description` | `description` | Broker version (for example, `"Solace PubSub+ Software Enterprise Version 10.25.0.217"`) — support-lifecycle check, every operator runbook starts here. The string is also inspected by the platform-detection helper that gates the appliance-only hardware step (see "show hardware details" below). |
 | `uptime/total-secs` | `uptime.totalSecs` | Broker uptime in seconds — surfaces unexpected reboots |
 
 ### `show system` → 17 fields
@@ -84,7 +84,7 @@ Two groups: uptime/restart context, plus scaling/capacity (added per reviewer fe
 | `physical-memory-usage-percent` | `physicalMemoryUsagePercent` | Headline memory pressure indicator — Datadog alarms on this |
 | `subscription-memory-usage-percent` | `subscriptionMemoryUsagePercent` | Subscription-table memory pressure |
 
-### `show message-spool detail` → 15 fields
+### `show message-spool detail` → 16 fields
 
 All under `<message-spool-info>`.
 
@@ -127,13 +127,13 @@ The full broker reply is wide (~30 elements per slot, plus dynamic telemetry: SF
 
 | XML path | JSON key | Operational meaning |
 |---|---|---|
-| `platform` | `platform` | Chassis model name (e.g. `"Solace Event Broker 3560"`) |
+| `platform` | `platform` | Chassis model name (for example, `"Solace Event Broker 3560"`) |
 | `mainboard/chassis-serial` | `chassisSerial` | Chassis serial number — primary support identifier |
 | `mainboard/bios-version` | `biosVersion` | Mainboard BIOS version |
 | derived from `mainboard/cpus/cpu` count | `cpuCount` | Number of populated CPU sockets |
 | `mainboard/cpus/cpu[0]` | `cpuModel` | First-socket CPU model string |
 | parsed from `mainboard/memory` | `systemMemoryGiB` | System memory in GiB (the broker emits a unit-qualified string like `"32.0 GiB"`; the value is parsed to a numeric and dropped if the unit isn't `GiB`) |
-| `power-redundancy/power-redundancy-config` | `power.redundancyConfiguration` | Power redundancy mode (e.g. `"1+1"`) |
+| `power-redundancy/power-redundancy-config` | `power.redundancyConfiguration` | Power redundancy mode (for example, `"1+1"`) |
 | `power-redundancy/operational-power-supplies` | `power.operationalCount` | Operational PSU count (parsed to int) |
 | `disks/disk[*]` | `disks[]` | One entry per populated disk: `{ id, deviceModel, serial }` |
 | `fabric[*]/slot[*]` | `slots[]` | One entry per populated blade slot: `{ slot, blade, productNumber, serial, operationalState }`. Empty slots and `"in use by slot N/M"` placeholders are filtered out — operators want the inventory, not gaps. `operationalState` maps the ADB-only `operational-state-up` boolean to `"up"`/`"down"`; absent on blades that don't emit it. |
@@ -218,7 +218,7 @@ On an appliance, the same envelope additionally carries:
 }
 ```
 
-## Excluded fields — Story 8 vs. operator reality
+## Excluded fields — Story 8 versus operator reality
 
 Story 8's acceptance criteria listed 11 specific output fields. Comparing them against the curated set:
 

--- a/docs/internal/semp/get-discard-stats-curated-fields.md
+++ b/docs/internal/semp/get-discard-stats-curated-fields.md
@@ -18,9 +18,9 @@ and if so where?". Returning all of them would bloat LLM context and bury
 the operational signal.
 
 This tool keeps only the fields that directly answer "where did messages
-go?" — every other class of stat belongs in a different tool
-(`get-broker-status` for capacity/uptime, `get-replication-status` for
-replication, etc.).
+go?" — every other class of stat belongs in a different tool, for example
+`get-broker-status` for capacity/uptime or `get-replication-status` for
+replication.
 
 ## Decision — protocol
 

--- a/docs/internal/semp/sempv1-client-design.md
+++ b/docs/internal/semp/sempv1-client-design.md
@@ -20,7 +20,7 @@ use both.
 
 ---
 
-## 2. Goals & Non-Goals
+## 2. Goals and Non-Goals
 
 ### Goals
 - Loosely coupled to the rest of the codebase (tools choose v1 or v2 independently)
@@ -70,7 +70,7 @@ from failure.
 |---|---|---|
 | `<parse-error>msg</parse-error>` | text only | Unknown command, malformed XML, schema validation failure |
 | `<permission-error>msg</permission-error>` | text only | User role lacks privilege for the command |
-| `<limit-error>msg</limit-error>` | text only | Response exceeds broker buffer (e.g. "response too big: use sequenced get") |
+| `<limit-error>msg</limit-error>` | text only | Response exceeds broker buffer (for example, "response too big: use sequenced get") |
 | `<execute-result code="fail" reason="..." reasonCode="..."/>` | attributes | Config/admin command passed parse but failed execution |
 
 Successful commands always include `<execute-result code="ok"/>` at the tail
@@ -558,7 +558,7 @@ acceptance criteria should read this section first.
 
 | # | Story 4 literal text | Spec position | Reason for drift | Spec ref |
 |---|---|---|---|---|
-| D1 | `Execute(request string) (string, error)` (line 1112) | `Execute(ctx context.Context, xml string) (*Result, error)` | (a) Matches existing v2 client's `Execute` shape for consistent mental model. (b) `*Result` leaves room to add fields (e.g. `SEMPVersion`) without breaking callers. (c) Bytes represent XML naturally. | §6.1, §6.2 |
+| D1 | `Execute(request string) (string, error)` (line 1112) | `Execute(ctx context.Context, xml string) (*Result, error)` | (a) Matches existing v2 client's `Execute` shape for consistent mental model. (b) `*Result` leaves room to add fields (for example, `SEMPVersion`) without breaking callers. (c) Bytes represent XML naturally. | §6.1, §6.2 |
 | D2 | No `context.Context` in v1 signature (line 1112) | `ctx` is required | (a) Standard Go idiom. (b) Matches v2 client. (c) Needed for per-call timeout + cancellation. | §6.3 |
 | D3 | `SEMPClient { v1, v2 }` container struct (line 1113–1119) | Peer fields `sempV1` + `sempV2` directly on existing `BrokerClient` | (a) The proposed wrapper has no behavior — just groups two pointers. (b) Peer pattern matches the current codebase (zero refactor churn). (c) Story itself says v1/v2 are used "simultaneously, not swappable" — no cross-protocol logic needs a shared home. (d) YAGNI: if orchestration becomes a thing, add a wrapper then. | §10.1 |
 | D4 | Interface file at `internal/semp/v1executor.go` (line 1111) | Interface in `internal/semp/sempv1/client.go` | Mirrors the existing `sempv2/` package layout. Minor file-layout choice, same effective public surface. | §4 |
@@ -601,7 +601,7 @@ drifts, not gaps:
 | # | Question | Current plan |
 |---|---|---|
 | Rate limit | Where does the retry decorator live? | Story 5; leave TODO comment |
-| Pilot choice | `get-redundancy-status` vs. `get-broker-status`? | Decide after Phase 1 |
+| Pilot choice | `get-redundancy-status` versus `get-broker-status`? | Decide after Phase 1 |
 | Integration tests | Build tag + skip, or always-on with Docker? | Parked |
 
 ---

--- a/docs/internal/threat-model.md
+++ b/docs/internal/threat-model.md
@@ -1,7 +1,7 @@
 # Threat Model — Solace Broker MCP Server
 
-This is a STRIDE threat model over the trust boundaries in
-[`architecture.md`](architecture.md). It exists because threat-modelling a
+This document applies STRIDE to the trust boundaries in
+[`architecture.md`](architecture.md). It exists because threat-modeling a
 design and recording it is a PRODUCTS-tier requirement on the
 [Open Source Solace Software Checklist](https://sol-jira.atlassian.net/wiki/spaces/DC/pages/6616154181/Open+Source+Solace+Software+Checklist),
 and this repository is a SolaceProducts repo. SOL-152900.
@@ -101,7 +101,7 @@ circuit breaker on that path.
 | Threat (STRIDE) | Mitigation | Status |
 |---|---|---|
 | Plaintext secret typed directly into the YAML config, no `${VAR}` indirection (Info Disclosure) | None — `${VAR}` substitution is a documented convention, not enforced by `validate()` (`internal/config/config.go:1240-1297`) | **No mitigation — accepted risk** |
-| Config-level credential structs (`AuthConfig`, `BrokerConfig`, etc.) logged raw (Info Disclosure) | `LogValue()` implemented on every credential-bearing config type, pinned by CI unit tests (`internal/config/config.go:429,441,457,272,245,263`; tests at `config_test.go:1360,1388,1419`) | Mitigated |
+| Config-level credential structs (`AuthConfig`, `BrokerConfig`, and so on) logged raw (Info Disclosure) | `LogValue()` implemented on every credential-bearing config type, pinned by CI unit tests (`internal/config/config.go:429,441,457,272,245,263`; tests at `config_test.go:1360,1388,1419`) | Mitigated |
 | `BasicAuthenticator`/`BearerAuthenticator` logged raw (Info Disclosure) | Documented rule (secure-logging-rules.md), not implemented as `LogValuer` on these two types (`internal/semp/auth/basic.go:13-17`, `bearer.go:12-14`) | Partial — backstop only, see next row |
 | Same, as a backstop | Global `ReplaceAttr` redacts any attr key matching `password/token/secret/authorization/credential/api_key/private_key` (`cmd/server/main.go:58-90`) | Mitigated as defense-in-depth, not as the documented control |
 | A newly-added credential-bearing struct ships with no `LogValuer` and no test (Info Disclosure) | No linter or CI gate enforces the secure-logging rules generally — only `/check-logs`, a manual developer skill | **No mitigation — accepted risk, developer-discipline-dependent** |

--- a/docs/internal/todo-gaps.md
+++ b/docs/internal/todo-gaps.md
@@ -18,8 +18,8 @@ Tracked gaps from Jira stories that are deferred or pending further discussion.
 - Session cookies handled automatically (verified via integration test)
 
 **Reason deferred:** Requires a test broker environment and decision on test
-gating strategy (env-var skip vs. build tags). To be implemented when CI broker
-infrastructure is ready.
+gating strategy (env-var skip versus build tags). To be implemented when CI
+broker infrastructure is ready.
 
 ## SOL-148427 — Implement Tool Manager Foundation
 
@@ -67,7 +67,7 @@ launchd plist for macOS) when operators request it.
 **Status:** Deferred (future enhancement)
 
 **Motivation:** Streamable HTTP requires the server to be running before the
-MCP client connects. For laptop users (e.g., Claude Desktop), stdio transport
+MCP client connects. For laptop users (for example, Claude Desktop), stdio transport
 enables auto-start — the client spawns the server as a subprocess on launch,
 removing the need for manual startup or OS-level service configuration.
 

--- a/docs/internal/understand-anything.md
+++ b/docs/internal/understand-anything.md
@@ -86,7 +86,7 @@ Then `/reload-plugins` (or restart Claude Code) so the `/understand` skill loads
   agent uses (for Claude Code, that's Anthropic — the same trust boundary you already
   accept by using Claude Code on this repo). The tool itself is local: no telemetry, no
   phone-home. For a more sensitive repo you can point the agent at a local model
-  (e.g. Ollama).
+  (for example, Ollama).
 
 ---
 

--- a/docs/internal/unit-test-coverage.md
+++ b/docs/internal/unit-test-coverage.md
@@ -90,8 +90,8 @@ never in `./...` to begin with; CI vets it in its own step.
 real coverage climbs, raise the floor to stay a few points under it — the
 gate is only as useful as the gap between it and reality is small. Don't
 raise it to sit flush against actual; a small buffer avoids CI going red on
-an incidental, defensible dip (e.g. a legitimately hard-to-unit-test error
-branch) that isn't the kind of collapse this gate exists to catch.
+an incidental, defensible dip (for example, a legitimately hard-to-unit-test
+error branch) that isn't the kind of collapse this gate exists to catch.
 
 ## Running locally
 

--- a/docs/internal/unit-test-coverage.md
+++ b/docs/internal/unit-test-coverage.md
@@ -50,7 +50,7 @@ tests, 37.2%) and the test-helper packages consumed only by other packages'
 tests (`internal/oauth/cache/cachetest`,
 `internal/composite/postprocess/postprocesstest`, 0%, ~110 lines combined).
 
-The line is **shipped code vs. the apparatus that tests it**, not "hard to
+The line is **shipped code versus the apparatus that tests it**, not "hard to
 test." `test/performance/` holds standalone binaries — a load generator, a
 mock SEMP server, a fidelity differ, a memory sampler — that exist only to
 drive a perf harness and never enter a release artifact. They are explicitly

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -34,8 +34,8 @@ each name means.
 ### Implementation status
 
 This schema is published **ahead of the code** so the names can be reviewed before they
-freeze at GA. Each capability is tagged with its status as of this draft, and the capability
-headings below carry the same tag:
+freeze at GA. Each capability is tagged with its status as of this draft, and the following
+capability headings carry the same tag:
 
 | Capability | Status | Notes |
 |---|---|---|
@@ -79,7 +79,7 @@ not rename what is already there.
 | Metric units | Base units, per Prometheus convention. Durations are in **seconds** (`_seconds`); counters end in `_total`. |
 | Audit units | Durations are in **milliseconds** (`duration_ms`). This differs from metrics on purpose: metrics follow Prometheus base units, audit follows common SIEM JSON convention. |
 | Timestamps | RFC 3339, UTC. |
-| Naming basis | Where OpenTelemetry publishes a semantic convention, we adopt it and translate `.` to `_` for Prometheus (for example `http.request.method` becomes `http_request_method`). Where OTel has no convention, we use a documented Solace-specific name. Each name below is tagged **OTel** or **Solace**. |
+| Naming basis | Where OpenTelemetry publishes a semantic convention, we adopt it and translate `.` to `_` for Prometheus (for example `http.request.method` becomes `http_request_method`). Where OTel has no convention, we use a documented Solace-specific name. Each name in this document is tagged **OTel** or **Solace**. |
 | Cardinality | Every metric name and label key is documented here. A CI check that fails the build on any undocumented name or label key is planned for GA; today the catalog is maintained by review. Label values are drawn from finite domains (configured brokers, SEMP operations, HTTP status codes, the retry cap), so series cardinality stays bounded. No label carries a free-text or unbounded value. |
 | Redaction | Credentials, tokens, and raw tool arguments are never written to any signal. |
 
@@ -102,7 +102,7 @@ avoid. Pin dashboards to `mcp_schema_version` and SIEM queries to `audit_schema_
 ## Metrics — [Planned]
 
 > _Status: **[Planned]**. The `/metrics` endpoint and instruments are not yet wired in the
-> build; the names, types, and labels below are the proposal under review._
+> build; the following names, types, and labels are the proposal under review._
 
 All metrics are served on the `/metrics` endpoint in Prometheus text exposition
 format, behind `OBS_METRICS_ENABLED`. One exception: whether the authentication-failure
@@ -173,7 +173,7 @@ recorded per retry attempt so you can see retry storms and per-broker latency.
 
 | Metric | Type | Labels | Basis |
 |---|---|---|---|
-| `mcp_semp_request_total` | Counter | `http_request_method`, `http_response_status_code`, `server_address`, `broker`, `api`, `operation`, `attempt` | Mixed (see below) |
+| `mcp_semp_request_total` | Counter | `http_request_method`, `http_response_status_code`, `server_address`, `broker`, `api`, `operation`, `attempt` | Mixed (see the following list) |
 | `mcp_semp_request_duration_seconds` | Histogram | same label set | Mixed |
 
 - **OTel** labels (adopted from the OpenTelemetry HTTP semantic conventions,
@@ -314,11 +314,11 @@ present, once the metrics endpoint is wired, for diagnosing memory pressure and 
 ## Audit trail — [Planned]
 
 > _Status: **[Planned]**. Only the capability gate exists today; audit-event emission lands in
-> a later story. The fields and delivery behavior below are the proposed schema._
+> a later story. The following fields and delivery behavior are the proposed schema._
 
 One JSON event is emitted per **state-changing** operation (for example `disconnect-client`,
 `delete-queue`, broker shutdown), at completion, with the outcome known. Read-only calls are
-not audited. Authentication lifecycle events are also emitted (see below). The stream is
+not audited. Authentication lifecycle events are also emitted (see [Authentication events](#authentication-events)). The stream is
 enabled with `OBS_AUDIT_LOG_ENABLED`.
 
 Every event carries a top-level `"event": "audit"` tag so your log shipper can route the
@@ -329,7 +329,7 @@ audit sub-stream to a dedicated SIEM index.
 | Field | Meaning | Type |
 |---|---|---|
 | `event` | Routing tag, always `audit` | string |
-| `audit_event_type` | Which kind of audit record this is; discriminate on this, not on `event` | string (closed set, below) |
+| `audit_event_type` | Which kind of audit record this is; discriminate on this, not on `event` | string (closed set; see following paragraph) |
 | `timestamp_utc` | When the event was recorded | RFC 3339 UTC |
 | `started_at_utc` | When the call began | RFC 3339 UTC |
 | `duration_ms` | How long the call took | integer (ms) |
@@ -355,7 +355,7 @@ can tell record kinds apart from field presence alone. `event`, `audit_event_typ
 |---|---|---|---|---|---|---|
 | `operation` | yes | on `error` only | — | yes | yes | yes |
 | `auth_success` | — | — | — | — | — | yes |
-| `auth_failure` | — | — | yes | — | — | see below |
+| `auth_failure` | — | — | yes | — | — | see following note |
 | `authz_denied` | — | — | yes | `tool` only | — | yes |
 | `broker_auth_retry` | `success` or `error` | — | — | — | yes | yes |
 | `audit_drop` | — | — | — | — | — | — |
@@ -364,7 +364,7 @@ can tell record kinds apart from field presence alone. `event`, `audit_event_typ
   happened, so one predicate does the job of two.
 - **On `auth_failure` the principal is unknown by definition**, since authentication is what
   failed. `principal.sub` and `agent_client_id` appear only when the token parsed far enough to
-  yield them: an expired or audience-mismatched token will, a malformed or absent one will not.
+  yield them: an expired or audience-mismatched token does, a malformed or absent one does not.
 - **`audit_drop` is a notice, not an outcome.** It reports that a record could not be written,
   and carries only the five common fields.
 
@@ -377,7 +377,7 @@ with a dot in it. A record carries `"principal": { "sub": "..." }`. It is the sc
 nested field; every other field is flat and snake_case. The nesting is deliberate: it leaves
 room for a second member without renaming a field, which is what makes deferring
 `preferred_username` (open item 3) a reversible choice. Collectors that flatten nested
-objects will render it as `principal.sub` regardless, which is why the tables above use the
+objects render it as `principal.sub` regardless, which is why the preceding tables use the
 dotted form.
 
 **`principal` identity.** The audit event records only `principal.sub`, the opaque OIDC
@@ -397,7 +397,7 @@ stored.
 ### Authentication events
 
 Alongside destructive-operation events, the audit stream records authentication lifecycle
-events. The names below are distinct **event types**, not values of the shared `outcome`
+events. The following names are distinct **event types**, not values of the shared `outcome`
 field:
 
 - `auth_success`, carrying `principal` and `agent_client_id`.
@@ -407,7 +407,7 @@ field:
 This keeps failed **authentication** a distinct, queryable signal rather than folding it
 into a generic error, so a query like "show me every rejected credential" stays clean.
 
-**Authorization has its own record type: `authz_denied`.** The three event types above cover
+**Authorization has its own record type: `authz_denied`.** The three preceding event types cover
 authentication, meaning who proved who they were and who failed to. Authorization is the
 separate question of whether an authenticated caller was permitted the tool they asked for,
 and a denial emits `audit_event_type: authz_denied` carrying `tool`, the principal, and
@@ -457,8 +457,8 @@ which you own.** The server does not itself persist or sign events.
 
 ## Distributed tracing — [Planned]
 
-> _Status: **[Planned]**. OTLP export is not yet wired; the spans, attributes, and export
-> protocol below are the proposed design._
+> _Status: **[Planned]**. OTLP export is not yet wired; the following spans, attributes, and
+> export protocol are the proposed design._
 
 OpenTelemetry spans at each hop of a request, exported over OTLP, enabled with
 `OBS_TRACING_ENABLED` (never automatic; you opt in after deploying a collector).
@@ -482,7 +482,8 @@ composite executor, and each SEMP attempt. Named spans:
 - `semp.attempt`: one per SEMP request attempt.
 
 Other span names follow the OpenTelemetry HTTP semantic conventions where applicable. Span
-names beyond `semp.attempt`, and span kinds, are open items in this review (see below).
+names beyond `semp.attempt`, and span kinds, are open items in this review (see
+[Open items for this review](#open-items-for-this-review), item 4).
 
 ### Span attributes
 
@@ -500,7 +501,7 @@ audit record**, which is the point of a single vocabulary: filter a dashboard by
 the SIEM unchanged, with no translation table.
 
 **On the span, the key is `error_type`, not the OTel-conventional `error.type`.** This is a
-deliberate exception to the naming rule above, taken so the key is identical across metrics,
+deliberate exception to the preceding naming rule, taken so the key is identical across metrics,
 logs, audit, and spans and the four surfaces cannot disagree about why a call failed. The
 values match OTel's `error.type` semantics. If your trace backend or trace-based SLOs key off
 the dotted `error.type`, tell us in your feedback, because this is the kind of thing that is
@@ -535,7 +536,7 @@ they arrive differently on each of the two metric egresses:
 - **OTLP push.** Resource attributes are **not promoted to labels by default**. If you ingest
   our OTLP metrics straight into Prometheus, set `promote_resource_attributes` to include
   `service.name`, `service.instance.id`, `deployment.environment`, and `cloud.region`, or the
-  same dashboard will show empty variable dropdowns.
+  same dashboard will show empty variable drop-down lists.
 
 ---
 
@@ -547,8 +548,8 @@ One ID threads a request from the AI agent, through the server and every retry, 
 broker, and back. Today it anchors your logs and the broker's own log entry on the same
 call; once traces and the audit trail ship, it is the key that joins those to them.
 
-This section describes behavior that is implemented and on by default, unlike the metric,
-audit, and trace schemas above.
+This section describes behavior that is implemented and on by default, unlike the preceding
+metric, audit, and trace schemas.
 
 - **Inbound**, in priority order: the W3C `traceparent` header (its trace-id is used); then
   a legacy `X-Correlation-ID` header; otherwise the server generates a time-sortable UUIDv7.
@@ -622,7 +623,8 @@ Notes:
   whose closed `reason` set (`missing_claim`, `not_permitted`) is authorization throughout.
   A denied call produces no `operation` record at all.
 - **Load-shedding / saturation is not an `outcome` value** either; it is planned as a
-  separate metric in a later release (see below).
+  separate metric in a later release (see
+  [Planned for a later release](#planned-for-a-later-release-not-frozen-in-this-review)).
 
 ---
 

--- a/docs/sam-integration.md
+++ b/docs/sam-integration.md
@@ -82,7 +82,7 @@ sam run
 
 ```
 Initialized MCPToolset for server: url='http://localhost:9090/mcp'
-Agent card tool manifest populated with 23 tools.
+Agent card tool manifest populated with 24 tools.
 Registered new agent 'SolaceBrokerAgent' in registry.
 ```
 

--- a/docs/sam-integration.md
+++ b/docs/sam-integration.md
@@ -1,10 +1,10 @@
-# Connecting solace-broker-mcp to Solace Agent Mesh (SAM)
+# Connecting solace-broker-mcp to Solace Agent Mesh
 
-This guide shows how to integrate this MCP server with SAM. For general MCP support in SAM — connection types, tool filtering, TLS/SSL config, environment variable passing — see the upstream [MCP Integration tutorial](https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/docs/documentation/developing/tutorials/mcp-integration.md).
+This guide shows how to integrate this MCP server with Agent Mesh. For general MCP support in Agent Mesh — connection types, tool filtering, TLS/SSL config, environment variable passing — see the upstream [MCP Integration tutorial](https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/docs/documentation/developing/tutorials/mcp-integration.md).
 
 ## Prerequisites
 
-- A working SAM project (`sam init` complete, agents start cleanly)
+- A working Agent Mesh project (`sam init` complete, agents start cleanly)
 - Ability to run this MCP server locally with configured `broker-config.yaml` and `.env` files. For instructions, see [Quickstart](../README.md#quickstart)
 
 ## Steps
@@ -19,7 +19,7 @@ mcp_client_auth:
 
 For production, use `mode: oauth` instead — see [authentication.md](authentication.md).
 
-**2. Create the SAM agent** — `<sam-project>/configs/agents/solace_broker_agent.yaml`:
+**2. Create the Agent Mesh agent** — `<sam-project>/configs/agents/solace_broker_agent.yaml`:
 
 ```yaml
 !include ../shared_config.yaml
@@ -61,7 +61,7 @@ apps:
         request_timeout_seconds: 60
 ```
 
-**3. Add the matching token to the SAM `.env` file**:
+**3. Add the matching token to the Agent Mesh `.env` file**:
 
 ```env
 SOLACE_BROKER_MCP_URL="http://localhost:9090/mcp"
@@ -78,7 +78,7 @@ go run ./cmd/server
 sam run
 ```
 
-**5. Verify** — the SAM logs should include:
+**5. Verify** — the Agent Mesh logs should include:
 
 ```
 Initialized MCPToolset for server: url='http://localhost:9090/mcp'
@@ -86,7 +86,7 @@ Agent card tool manifest populated with 23 tools.
 Registered new agent 'SolaceBrokerAgent' in registry.
 ```
 
-Open the SAM web UI (`http://localhost:8000`) and ask the orchestrator a broker-related question — the orchestrator delegates to the `SolaceBrokerAgent`, which calls the MCP tools.
+Open the Agent Mesh web UI (`http://localhost:8000`) and ask the orchestrator a broker-related question — the orchestrator delegates to the `SolaceBrokerAgent`, which calls the MCP tools.
 
 ## Authentication Chain
 
@@ -94,11 +94,11 @@ Open the SAM web UI (`http://localhost:8000`) and ask the orchestrator a broker-
 SAM agent ─(Bearer SOLACE_BROKER_MCP_TOKEN)→ MCP server ─(basic BROKER_USERNAME/PASSWORD)→ Solace event broker
 ```
 
-The bearer token in the SAM `.env` and the `dev_token` in the MCP server configuration must be identical.
+The bearer token in the Agent Mesh `.env` and the `dev_token` in the MCP server configuration must be identical.
 
-## Additional SAM MCP Configuration
+## Additional Agent Mesh MCP Configuration
 
-The following topics are covered in the [SAM MCP Integration tutorial](https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/docs/documentation/developing/tutorials/mcp-integration.md):
+The following topics are covered in the [Agent Mesh MCP Integration tutorial](https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/docs/documentation/developing/tutorials/mcp-integration.md):
 
 - Other connection types (`stdio`, `sse`, Docker)
 - Tool filtering (`tool_name`, `allow_list`, `deny_list`)

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -162,7 +162,7 @@ indexed here — a `monitor/...` operation returns `unknown operation`.
 **Typical invocation.** Most calls happen unprompted. The eight
 `create-*`/`update-*` write tool descriptions each point at
 `describe-semp-schema` with the relevant operation, so an agent planning a
-write calls this tool without the user asking for it — an ordinary request
+write operation calls this tool without the user asking for it — an ordinary request
 like *"Create a queue named orders with a spool quota of 500 MB"* is what
 triggers it in practice. If you are watching a trace and see
 `describe-semp-schema` fire immediately before a `create-*` or `update-*`
@@ -815,8 +815,7 @@ Annotations: `readOnly: false`, `destructiveHint: true`, `idempotentHint: false`
 { "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" }
 ```
 
-**Example request:** "Disconnect consumer-7 on the default VPN." (The agent asks
-you to confirm before acting.)
+**Example request:** "Disconnect consumer-7 on the default VPN." (The tool description instructs the agent to confirm before acting.)
 
 ### clear-client-stats
 
@@ -858,8 +857,7 @@ Annotations: `readOnly: false`, `destructiveHint: true`, `idempotentHint: false`
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "dead-letter.q" }
 ```
 
-**Example request:** "Drain dead-letter.q on the default VPN." (The agent asks
-you to confirm before acting.)
+**Example request:** "Drain dead-letter.q on the default VPN." (The tool description instructs the agent to confirm before acting.)
 
 ### clear-queue-stats
 
@@ -927,7 +925,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 { "broker": "prod-broker", "msgVpnName": "orders-vpn", "msgVpnConfig": { "enabled": true, "maxConnectionCount": 100 } }
 ```
 
-**Example request:** "Create a VPN called orders-vpn on prod-broker, enabled, with 100 max connections." (The agent asks you to confirm before acting.)
+**Example request:** "Create a VPN called orders-vpn on prod-broker, enabled, with 100 max connections." (The tool description instructs the agent to confirm before acting.)
 
 ### update-message-vpn
 
@@ -948,7 +946,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "orders-vpn", "msgVpnConfig": { "enabled": false } }
 ```
 
-**Example request:** "Disable the orders-vpn VPN on prod-broker." (The agent asks you to confirm before acting.)
+**Example request:** "Disable the orders-vpn VPN on prod-broker." (The tool description instructs the agent to confirm before acting.)
 
 ### delete-message-vpn
 
@@ -968,7 +966,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "orders-vpn" }
 ```
 
-**Example request:** "Delete the orders-vpn VPN on prod-broker." (The agent asks you to confirm before acting.)
+**Example request:** "Delete the orders-vpn VPN on prod-broker." (The tool description instructs the agent to confirm before acting.)
 
 ### create-queue
 
@@ -990,7 +988,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q", "queueConfig": { "ingressEnabled": true, "egressEnabled": true } }
 ```
 
-**Example request:** "Create a queue orders.q in the default VPN on prod-broker." (The agent asks you to confirm before acting.)
+**Example request:** "Create a queue orders.q in the default VPN on prod-broker." (The tool description instructs the agent to confirm before acting.)
 
 ### update-queue
 
@@ -1013,7 +1011,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q", "queueConfig": { "egressEnabled": false } }
 ```
 
-**Example request:** "Turn off egress on orders.q in the default VPN." (The agent asks you to confirm before acting.)
+**Example request:** "Turn off egress on orders.q in the default VPN." (The tool description instructs the agent to confirm before acting.)
 
 ### delete-queue
 
@@ -1033,7 +1031,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q" }
 ```
 
-**Example request:** "Delete orders.q from the default VPN on prod-broker." (The agent asks you to confirm before acting.)
+**Example request:** "Delete orders.q from the default VPN on prod-broker." (The tool description instructs the agent to confirm before acting.)
 
 ### create-topic-endpoint
 
@@ -1055,7 +1053,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 { "broker": "prod-broker", "msgVpnName": "default", "topicEndpointName": "orders.te", "topicEndpointConfig": { "ingressEnabled": true, "egressEnabled": true } }
 ```
 
-**Example request:** "Create a topic endpoint orders.te in the default VPN on prod-broker." (The agent asks you to confirm before acting.)
+**Example request:** "Create a topic endpoint orders.te in the default VPN on prod-broker." (The tool description instructs the agent to confirm before acting.)
 
 ### update-topic-endpoint
 
@@ -1078,7 +1076,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "topicEndpointName": "orders.te", "topicEndpointConfig": { "egressEnabled": false } }
 ```
 
-**Example request:** "Turn off egress on the orders.te topic endpoint in the default VPN." (The agent asks you to confirm before acting.)
+**Example request:** "Turn off egress on the orders.te topic endpoint in the default VPN." (The tool description instructs the agent to confirm before acting.)
 
 ### delete-topic-endpoint
 
@@ -1099,7 +1097,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "topicEndpointName": "orders.te" }
 ```
 
-**Example request:** "Delete the orders.te topic endpoint from the default VPN." (The agent asks you to confirm before acting.)
+**Example request:** "Delete the orders.te topic endpoint from the default VPN." (The tool description instructs the agent to confirm before acting.)
 
 ### create-rdp
 
@@ -1123,7 +1121,7 @@ Annotations: `readOnly: false`, `destructiveHint: false`.
 { "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp", "rdpConfig": { "clientProfileName": "default" } }
 ```
 
-**Example request:** "Create an RDP called webhook-rdp in the default VPN on prod-broker." (The agent asks you to confirm before acting.)
+**Example request:** "Create an RDP called webhook-rdp in the default VPN on prod-broker." (The tool description instructs the agent to confirm before acting.)
 
 ### update-rdp
 
@@ -1145,7 +1143,7 @@ Annotations: `readOnly: false`, `destructiveHint: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp", "rdpConfig": { "enabled": true } }
 ```
 
-**Example request:** "Enable the webhook-rdp RDP on the default VPN." (The agent asks you to confirm before acting.)
+**Example request:** "Enable the webhook-rdp RDP on the default VPN." (The tool description instructs the agent to confirm before acting.)
 
 ### delete-rdp
 
@@ -1166,4 +1164,4 @@ Annotations: `readOnly: false`, `destructiveHint: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp" }
 ```
 
-**Example request:** "Delete the webhook-rdp RDP from the default VPN on prod-broker." (The agent asks you to confirm before acting.)
+**Example request:** "Delete the webhook-rdp RDP from the default VPN on prod-broker." (The tool description instructs the agent to confirm before acting.)

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -63,7 +63,7 @@ enumerate inner fields — the authoritative field list per tool is the `select`
 set documented under each tool's **Returns**.
 
 Five tools depart from the generic envelope with a strict, field-level output
-schema: `get-discard-stats` and the four action tools (documented inline below).
+schema: `get-discard-stats` and the four action tools (documented inline in this reference).
 
 ### Errors
 
@@ -111,7 +111,7 @@ flag and documented under [Management](#management-config-api).
 | Actions | [`disconnect-client`](#disconnect-client), [`clear-client-stats`](#clear-client-stats), [`delete-queue-messages`](#delete-queue-messages), [`clear-queue-stats`](#clear-queue-stats) | write |
 | Management | [`create-message-vpn`](#create-message-vpn), [`update-message-vpn`](#update-message-vpn), [`delete-message-vpn`](#delete-message-vpn), [`create-queue`](#create-queue), [`update-queue`](#update-queue), [`delete-queue`](#delete-queue), [`create-topic-endpoint`](#create-topic-endpoint), [`update-topic-endpoint`](#update-topic-endpoint), [`delete-topic-endpoint`](#delete-topic-endpoint), [`create-rdp`](#create-rdp), [`update-rdp`](#update-rdp), [`delete-rdp`](#delete-rdp) | write |
 
-Example invocations below show the `arguments` object of an MCP `tools/call`
+The following example invocations show the `arguments` object of an MCP `tools/call`
 request. A full request wraps it: `{"method":"tools/call","params":{"name":"<tool>","arguments":{...}}}`.
 
 ---
@@ -154,7 +154,7 @@ indexed here — a `monitor/...` operation returns `unknown operation`.
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `operation` | string | yes | SEMPv2 operation identifier in `<specType>/<operationId>` form, e.g. `config/createMsgVpnQueue`. `specType` must be `config` or `action`. Take the value from the target write tool's description. |
+| `operation` | string | yes | SEMPv2 operation identifier in `<specType>/<operationId>` form, for example `config/createMsgVpnQueue`. `specType` must be `config` or `action`. Take the value from the target write tool's description. |
 | `view` | string | no | `trimmed` (default) — compact per-attribute list. `raw` — full OpenAPI definition verbatim. |
 
 **Returns (`trimmed`):** `{ "operation", "method", "definition", "attributes": [...] }` where each attribute carries `name`, `type`, `description`, `enum`, `default`, `pattern`, `maxLength`, `minimum`, `maximum`, `writableOnCreate`, `writableOnUpdate`, and any applicable flags (`requiredForCreate`, `identifying`, `writeOnly`, `sensitive`, `deprecated`, `autoDisable`, `requiresDisable`). Object-typed attributes backed by a `$ref` carry a nested `properties` list instead of writability flags.
@@ -162,7 +162,7 @@ indexed here — a `monitor/...` operation returns `unknown operation`.
 **Typical invocation.** Most calls happen unprompted. The eight
 `create-*`/`update-*` write tool descriptions each point at
 `describe-semp-schema` with the relevant operation, so an agent planning a
-write will call this tool without the user asking for it — an ordinary request
+write calls this tool without the user asking for it — an ordinary request
 like *"Create a queue named orders with a spool quota of 500 MB"* is what
 triggers it in practice. If you are watching a trace and see
 `describe-semp-schema` fire immediately before a `create-*` or `update-*`
@@ -815,8 +815,8 @@ Annotations: `readOnly: false`, `destructiveHint: true`, `idempotentHint: false`
 { "broker": "prod-broker", "msgVpnName": "default", "clientName": "consumer-7" }
 ```
 
-**Example request:** "Disconnect consumer-7 on the default VPN." (The agent will
-ask you to confirm before acting.)
+**Example request:** "Disconnect consumer-7 on the default VPN." (The agent asks
+you to confirm before acting.)
 
 ### clear-client-stats
 
@@ -858,7 +858,7 @@ Annotations: `readOnly: false`, `destructiveHint: true`, `idempotentHint: false`
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "dead-letter.q" }
 ```
 
-**Example request:** "Drain dead-letter.q on the default VPN." (The agent will ask
+**Example request:** "Drain dead-letter.q on the default VPN." (The agent asks
 you to confirm before acting.)
 
 ### clear-queue-stats
@@ -885,7 +885,7 @@ Annotations: `readOnly: false`, `destructiveHint: false`, `idempotentHint: true`
 
 Create, update, and delete SEMPv2 **config** objects — Message VPNs, queues,
 topic endpoints, and REST delivery points. Gated behind `enable_write_tools`
-(off by default), the same as the action tools above.
+(off by default), the same as the preceding action tools.
 
 - `create-*` is **additive** (not destructive); config attributes you omit take
   the broker default.
@@ -919,7 +919,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 |---|---|---|---|
 | `broker` | string | yes | Target broker alias. |
 | `msgVpnName` | string | yes | Name of the VPN to create. |
-| `msgVpnConfig` | object | no | MsgVpn attributes (e.g. `enabled`, `maxConnectionCount`, `maxMsgSpoolUsage`). Omitted attributes take broker defaults. |
+| `msgVpnConfig` | object | no | MsgVpn attributes (for example, `enabled`, `maxConnectionCount`, `maxMsgSpoolUsage`). Omitted attributes take broker defaults. |
 
 **Returns:** step-keyed envelope, step `createVpn`.
 
@@ -927,7 +927,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 { "broker": "prod-broker", "msgVpnName": "orders-vpn", "msgVpnConfig": { "enabled": true, "maxConnectionCount": 100 } }
 ```
 
-**Example request:** "Create a VPN called orders-vpn on prod-broker, enabled, with 100 max connections." (The agent will ask you to confirm before acting.)
+**Example request:** "Create a VPN called orders-vpn on prod-broker, enabled, with 100 max connections." (The agent asks you to confirm before acting.)
 
 ### update-message-vpn
 
@@ -948,7 +948,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "orders-vpn", "msgVpnConfig": { "enabled": false } }
 ```
 
-**Example request:** "Disable the orders-vpn VPN on prod-broker." (The agent will ask you to confirm before acting.)
+**Example request:** "Disable the orders-vpn VPN on prod-broker." (The agent asks you to confirm before acting.)
 
 ### delete-message-vpn
 
@@ -968,7 +968,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "orders-vpn" }
 ```
 
-**Example request:** "Delete the orders-vpn VPN on prod-broker." (The agent will ask you to confirm before acting.)
+**Example request:** "Delete the orders-vpn VPN on prod-broker." (The agent asks you to confirm before acting.)
 
 ### create-queue
 
@@ -982,7 +982,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 | `broker` | string | yes | Target broker alias. |
 | `msgVpnName` | string | yes | The VPN to create the queue in. |
 | `queueName` | string | yes | Name of the queue to create. |
-| `queueConfig` | object | no | Queue attributes (e.g. `accessType`, `egressEnabled`, `ingressEnabled`, `maxMsgSpoolUsage`, `permission`). Omitted attributes take broker defaults. |
+| `queueConfig` | object | no | Queue attributes (for example, `accessType`, `egressEnabled`, `ingressEnabled`, `maxMsgSpoolUsage`, `permission`). Omitted attributes take broker defaults. |
 
 **Returns:** step-keyed envelope, step `createQueue`.
 
@@ -990,7 +990,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q", "queueConfig": { "ingressEnabled": true, "egressEnabled": true } }
 ```
 
-**Example request:** "Create a queue orders.q in the default VPN on prod-broker." (The agent will ask you to confirm before acting.)
+**Example request:** "Create a queue orders.q in the default VPN on prod-broker." (The agent asks you to confirm before acting.)
 
 ### update-queue
 
@@ -1013,7 +1013,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q", "queueConfig": { "egressEnabled": false } }
 ```
 
-**Example request:** "Turn off egress on orders.q in the default VPN." (The agent will ask you to confirm before acting.)
+**Example request:** "Turn off egress on orders.q in the default VPN." (The agent asks you to confirm before acting.)
 
 ### delete-queue
 
@@ -1033,7 +1033,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "queueName": "orders.q" }
 ```
 
-**Example request:** "Delete orders.q from the default VPN on prod-broker." (The agent will ask you to confirm before acting.)
+**Example request:** "Delete orders.q from the default VPN on prod-broker." (The agent asks you to confirm before acting.)
 
 ### create-topic-endpoint
 
@@ -1047,7 +1047,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 | `broker` | string | yes | Target broker alias. |
 | `msgVpnName` | string | yes | The VPN to create the topic endpoint in. |
 | `topicEndpointName` | string | yes | Name of the topic endpoint to create. |
-| `topicEndpointConfig` | object | no | TopicEndpoint attributes (e.g. `accessType`, `egressEnabled`, `ingressEnabled`, `maxMsgSpoolUsage`, `permission`). Omitted attributes take broker defaults. |
+| `topicEndpointConfig` | object | no | TopicEndpoint attributes (for example, `accessType`, `egressEnabled`, `ingressEnabled`, `maxMsgSpoolUsage`, `permission`). Omitted attributes take broker defaults. |
 
 **Returns:** step-keyed envelope, step `createTopicEndpoint`.
 
@@ -1055,7 +1055,7 @@ Annotations: `readOnly: false`, `destructive: false`.
 { "broker": "prod-broker", "msgVpnName": "default", "topicEndpointName": "orders.te", "topicEndpointConfig": { "ingressEnabled": true, "egressEnabled": true } }
 ```
 
-**Example request:** "Create a topic endpoint orders.te in the default VPN on prod-broker." (The agent will ask you to confirm before acting.)
+**Example request:** "Create a topic endpoint orders.te in the default VPN on prod-broker." (The agent asks you to confirm before acting.)
 
 ### update-topic-endpoint
 
@@ -1078,7 +1078,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "topicEndpointName": "orders.te", "topicEndpointConfig": { "egressEnabled": false } }
 ```
 
-**Example request:** "Turn off egress on the orders.te topic endpoint in the default VPN." (The agent will ask you to confirm before acting.)
+**Example request:** "Turn off egress on the orders.te topic endpoint in the default VPN." (The agent asks you to confirm before acting.)
 
 ### delete-topic-endpoint
 
@@ -1099,7 +1099,7 @@ Annotations: `readOnly: false`, `destructive: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "topicEndpointName": "orders.te" }
 ```
 
-**Example request:** "Delete the orders.te topic endpoint from the default VPN." (The agent will ask you to confirm before acting.)
+**Example request:** "Delete the orders.te topic endpoint from the default VPN." (The agent asks you to confirm before acting.)
 
 ### create-rdp
 
@@ -1115,7 +1115,7 @@ Annotations: `readOnly: false`, `destructiveHint: false`.
 | `broker` | string | yes | Target broker alias. |
 | `msgVpnName` | string | yes | The Message VPN to create the RDP in. |
 | `restDeliveryPointName` | string | yes | Name of the RDP to create. |
-| `rdpConfig` | object | no | RestDeliveryPoint attributes (e.g. `enabled`, `clientProfileName`, `service`, `vendor`). Omitted attributes take broker defaults. |
+| `rdpConfig` | object | no | RestDeliveryPoint attributes (for example, `enabled`, `clientProfileName`, `service`, `vendor`). Omitted attributes take broker defaults. |
 
 **Returns:** step-keyed envelope, step `createRdp`.
 
@@ -1123,7 +1123,7 @@ Annotations: `readOnly: false`, `destructiveHint: false`.
 { "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp", "rdpConfig": { "clientProfileName": "default" } }
 ```
 
-**Example request:** "Create an RDP called webhook-rdp in the default VPN on prod-broker." (The agent will ask you to confirm before acting.)
+**Example request:** "Create an RDP called webhook-rdp in the default VPN on prod-broker." (The agent asks you to confirm before acting.)
 
 ### update-rdp
 
@@ -1145,7 +1145,7 @@ Annotations: `readOnly: false`, `destructiveHint: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp", "rdpConfig": { "enabled": true } }
 ```
 
-**Example request:** "Enable the webhook-rdp RDP on the default VPN." (The agent will ask you to confirm before acting.)
+**Example request:** "Enable the webhook-rdp RDP on the default VPN." (The agent asks you to confirm before acting.)
 
 ### delete-rdp
 
@@ -1166,4 +1166,4 @@ Annotations: `readOnly: false`, `destructiveHint: true`.
 { "broker": "prod-broker", "msgVpnName": "default", "restDeliveryPointName": "webhook-rdp" }
 ```
 
-**Example request:** "Delete the webhook-rdp RDP from the default VPN on prod-broker." (The agent will ask you to confirm before acting.)
+**Example request:** "Delete the webhook-rdp RDP from the default VPN on prod-broker." (The agent asks you to confirm before acting.)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -27,7 +27,7 @@ The Solace Event Broker MCP Server requires:
 
 | Requirement | Details |
 |---|---|
-| **Solace event broker** | One or more brokers with SEMP management enabled. The server connects to the SEMP management API (typically port 8080 for HTTP or 1943 for HTTPS). |
+| **Solace event broker** | One or more brokers with Solace Element Management Protocol (SEMP) management enabled. The server connects to the SEMP management API (typically port 8080 for HTTP or 1943 for HTTPS). |
 | **SEMPv1+v2 reachability** | The machine running the MCP server must have network access to both the SEMPv1 (`/SEMP`) and SEMPv2 (`/SEMP/v2`) endpoints on each broker's SEMP management port. |
 | **Broker credentials** | Per-broker SEMP credentials: a username and password (basic auth), a static token (bearer auth), or an OAuth identity provider for token exchange (`auth.mode: oauth` — requires `mcp_client_auth.mode: oauth`; see [Authentication](authentication.md#step-2b-configure-broker-oauth-hop-2)). |
 | **Runtime environment** | One of: Docker, a supported OS/architecture for the binary (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64), or Kubernetes. |
@@ -57,7 +57,7 @@ All methods use the same YAML configuration file and `.env` credentials. Configu
 
 ### Connecting an MCP Client
 
-Once the server is running, connect Claude Code to it:
+After the server is running, connect Claude Code to it:
 
 ```bash
 claude mcp add solace-broker --transport http http://localhost:9090/mcp
@@ -172,7 +172,7 @@ These tools modify broker state via the SEMPv2 action API. There is **one tool p
 
 **Naming convention.** Action-API tools use `<verb>-<resource>-<object>` (`delete-queue-messages`, `clear-queue-stats`, `disconnect-client`, `clear-client-stats`). The Config-API management tools ([below](#management-config-api)) use `<verb>-<object>` — a `create-`, `update-`, or `delete-` prefix on `message-vpn`, `queue`, `topic-endpoint`, or `rdp`. Action tools run an operational action against a live object; management tools change configuration.
 
-**Disabled by default.** These four action tools — together with the 12 Config-API management tools below — are write tools (they change broker state) and are gated behind the server-level `enable_write_tools` flag. With the default (`false`) they are not registered with the MCP server and do not appear in `tools/list` — clients see only the read-only tool set. Set `enable_write_tools: true` in the YAML config to expose them. This is independent of `mcp_client_auth.mode`: an authenticated client still cannot invoke these tools when the flag is off, because the server never registers them.
+**Disabled by default.** These four action tools — together with the 12 Config-API management tools below — are write tools (they change broker state) and are gated behind the server-level `enable_write_tools` flag. With the default (`false`) they are not registered with the MCP server and do not appear in `tools/list` — clients see only the read-only tool set. Set `enable_write_tools: true` in the YAML config to expose them. This gating is independent of `mcp_client_auth.mode`: an authenticated client still cannot invoke these tools when the flag is off, because the server never registers them.
 
 `enable_write_tools` is the only enforced control. `destructiveHint` and the confirmation text in tool descriptions are hints, not enforced by the MCP protocol — whether the user is actually prompted depends on the client and the model.
 
@@ -180,7 +180,7 @@ These tools modify broker state via the SEMPv2 action API. There is **one tool p
 
 | Tool | Destructive | Description |
 |---|---|---|
-| `delete-queue-messages` | **Yes** | Permanently delete all spooled messages from a queue. Irreversible — deleted messages cannot be recovered. Requires user confirmation before invocation. Use after confirmed intent to drain a queue (e.g. clearing a dead-letter backlog). |
+| `delete-queue-messages` | **Yes** | Permanently delete all spooled messages from a queue. Irreversible — deleted messages cannot be recovered. Requires user confirmation before invocation. Use after confirmed intent to drain a queue (for example, clearing a dead-letter backlog). |
 | `clear-queue-stats` | No | Reset a queue's statistics counters. Non-destructive: affects monitoring counters only, not spooled messages or delivery. |
 | `disconnect-client` | **Yes** | Forcibly disconnect a connected client. Service-impacting — terminates the session; the client must reconnect. Requires user confirmation before invocation. Common use: disconnect a slow subscriber identified via `list-slow-subscribers` or `get-client-details`. |
 | `clear-client-stats` | No | Reset a client's per-connection statistics counters. Non-destructive: affects monitoring counters only, does not disconnect the client. |


### PR DESCRIPTION
SOL-152973: docs: Solace style guide and clarity pass across the doc set

## What

Applies the Solace documentation style guide (`/docs-review`) and Solace R&D
writing standards (`/good-writing`) across README.md, TOOLS.md, RELEASING.md,
the public `docs/` set, internal engineering docs, and community (`.github/`)
docs.

Out of scope by design: generated/legal files (`THIRD_PARTY_*`), PR/issue
templates, the Contributor Covenant Code of Conduct, and frozen historical
planning docs under `docs/superpowers/` and `docs/oauth/`.

## Changes

- Forbidden terms (`e.g.`, `etc.`, `vs.`) replaced with their style-guide
  equivalents.
- Future tense ("will ask", "will refuse") replaced with present tense to
  match the style guide.
- Page-position references ("above"/"below") replaced with named section
  links or "following"/"preceding".
- Capitalization fixes (Message VPN, heading case) and a few punctuation and
  demonstrative-pronoun clarity fixes.
- A handful of verified factual corrections found while checking prose
  against code:
  - `docs/internal/secure-logging-rules.md`'s never-log list still named
    `HTTPClient.password`/`.username`/`.token`; those fields moved into the
    `auth.BasicAuthenticator`/`auth.BearerAuthenticator` implementations.
    Also replaced a stale "when Story 1B adds OAuth config" forward-reference
    with what's actually implemented today.
  - `docs/internal/semp/get-broker-status-curated-fields.md` had a subheading
    claiming 15 fields where the table below it (and the doc's own summary)
    already said 16.

No production code, schema, or behavior changes.

## Note on overlap with #277

This branch started before #277 (tool-count and RDP-documentation fixes)
merged. Both touched the same tool-count language in README.md,
docs/configuration.md, docs/tools-reference.md, and docs/user-guide.md. This
branch is rebased on top of #277 post-merge; its factual fixes are not
duplicated here, only the additional style/grammar pass on top of them.

## Verification

Docs-only change — no build, test, or schema surface touched. Reviewed the
resolved merge diff by hand for every file #277 also touched, to confirm no
regression of its fixes.

Andrea-developer gate: docs-only edit, no production surface touched —
skipped the Opus `/good:review` gate per the skill's own non-goal list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update: SAM → Solace Agent Mesh / Agent Mesh

Per updated brand guidance, replaced the "SAM" acronym in prose with "Solace
Agent Mesh" (first use per file) / "Agent Mesh" (subsequent uses). Applies to
README.md and docs/sam-integration.md — the only two files mentioning SAM in
prose. Left untouched: fenced code blocks, backtick-wrapped values, env var
names, config keys, and log strings (literal technical values that must
match the actual CLI/SDK, e.g. `sam init`, `sam run`, `SOLACE_BROKER_MCP_TOKEN`).
