### PR TITLE
docs: name the release jobs RELEASING.md actually has

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,7 +70,7 @@ git push origin v0.4.0
 Pushing the tag runs `.github/workflows/release.yml`, which:
 
 1. Re-runs the full build-and-test suite.
-2. Runs the FOSSA scan against the tag.
+2. Runs the release readiness check (the Guardian gate) against the tag.
 3. Builds binaries for `linux` and `darwin` × `amd64` and `arm64`, attesting each archive's build provenance in the job that built it.
 4. Builds and pushes a multi-arch image to `ghcr.io/solaceproducts/solace-broker-mcp` (`{version}`, `{major}.{minor}`, `latest`, `sha-<short-sha>` tags), and attests the image digest, pushing the attestation to the registry alongside it.
 5. Publishes a GitHub Release whose notes are the tagged version's `CHANGELOG.md` block (with the auto-generated PR list appended beneath), plus the binary archives and SHA-256 checksums. If no `## [X.Y.Z]` block exists for the tag, the release fails rather than falling back to auto-only notes.
@@ -81,18 +81,18 @@ The jobs are not fully serialized:
 
 ```
 push v* tag
-  ├─> test           (reuses build-and-test.yml)
-  ├─> release-notes  (CHANGELOG block must exist)
-  ├─> licenses       (inventory must match the binary)
-  └─> fossa_scan     (SCA gate)
+  ├─> test               (reuses build-and-test.yml)
+  ├─> release-notes      (CHANGELOG block must exist)
+  ├─> licenses           (inventory must match the binary)
+  └─> release-readiness  (Guardian gate)
 
 waits on
   build-binaries   test, release-notes, licenses
-  build-docker     test, release-notes, licenses, fossa_scan   ← pushes the image
-  release          build-binaries, build-docker, fossa_scan
+  build-docker     test, release-notes, licenses, release-readiness   ← pushes the image
+  release          build-binaries, build-docker, release-readiness
 ```
 
-A failed job blocks the GitHub Release, binaries, checksums, and the container image: `build-docker` waits on the FOSSA scan as well as the build, so a failing SCA gate publishes nothing. That matters because a registry push cannot be withdrawn — the binaries are only artifacts until `release` publishes them, but the image is live the moment it is pushed.
+A failed job blocks the GitHub Release, binaries, checksums, and the container image: `build-docker` waits on the readiness check as well as the build, so a failing Guardian gate publishes nothing. That matters because a registry push cannot be withdrawn — the binaries are only artifacts until `release` publishes them, but the image is live the moment it is pushed.
 
 One window remains: the image is pushed *before* it is attested, so a run that fails on the attest step leaves `latest` live with no attestation — a consumer's `gh attestation verify` then fails because the release is incomplete, not because the image was tampered with. That ordering is unavoidable, because attesting a registry digest requires the digest to exist. If a release run fails partway, check `ghcr.io` and roll forward (see Rollback).
 


### PR DESCRIPTION
## Summary

`RELEASING.md` named `fossa_scan` in four places. That job no longer exists — it became `release-readiness` when the shared `SolaceDev` SCA workflow was replaced by the local Guardian gate. Docs only; no behaviour change.

Doing this ahead of cutting `v0.7.0`, because the block being corrected is the one a releaser reads to know what waits on what.

## Changes Made

- The pipeline dependency block now names `release-readiness` and describes it as the Guardian gate, cross-checked against `release.yml`: `build-binaries` waits on `test`, `release-notes`, `licenses`; `build-docker` and `release` additionally wait on `release-readiness`.
- "Runs the FOSSA scan against the tag" → "Runs the release readiness check (the Guardian gate) against the tag".
- Realigned the monospace block, since `release-readiness` is longer than the name it replaced.

## Deliberately not changed

The Publish gate bullet still says a fork pull request gets no scan "because GitHub withholds the credential". The Guardian workflow reads its secrets from an Environment rather than from the caller, so that may no longer be the mechanism — but I have not verified what fork behaviour is now, and guessing in a runbook is worse than leaving a claim that was true when written. Worth a separate look.

## Testing

No code. Verified by parsing `release.yml` and diffing the `needs` graph against every job named in the doc; `grep fossa_scan RELEASING.md` is now empty.

## Checklist

- [x] Self-review completed
- [x] Commits signed off (DCO)
- [x] Branch up to date with `main`
- [x] No production surface touched, so no CHANGELOG entry (`production-surface.sh` scopes that to `internal/config/`, `internal/tools/`, and `tools.yaml`)
