### PR TITLE
Prepare release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-10
+
 ### Added
 
 - New `THIRD_PARTY_BUILD_TEST.md` inventory covering the third-party components used to build and test the project but not shipped in the binary: the Go modules of the two e2e submodules, the nine npm packages the LLM eval suite installs, the GitHub Actions and reusable workflows CI uses, and the five container images pulled by the build and the e2e fixtures. This is the second of the two third-party lists the Solace public-repository Legal checklist requires; `THIRD_PARTY_LICENSES.md` remains the release inventory and is unchanged. Every licence was read from the component's own licence file or its source repository rather than inferred. Nothing found constrains how we license or distribute the product — every Go module and GitHub Action is permissive (MIT, BSD-3-Clause, Apache-2.0) — but the file deliberately does not claim universal permissiveness: the Claude Code CLI used by the LLM eval suite ships under Anthropic's commercial terms and the Solace broker test fixture is proprietary, both being tools we run rather than code we link or redistribute. Kept honest by `.github/scripts/build-test-licenses-check.sh`, which fails CI on drift in either direction across all four sources, including component *versions*, under its own self-test. Discovery is derived with `find` rather than hardcoded, and prunes rather than filters, so a new submodule, lockfile, or Dockerfile cannot introduce components the gate is blind to and a sibling worktree cannot inject ones it does not have. The rebuild procedure lives in the document itself rather than only on the gate's failure path. Two further facts surfaced and recorded rather than smoothed over: `golang.org/x/oauth2` is pinned at two different versions across the repository's modules (no licensing consequence, both BSD-3-Clause), and the distroless runtime base is the one build input that reaches a published artifact, so its OS-package layers are a gap in the *release* inventory that neither file currently enumerates. Tracked under SOL-152861.
@@ -351,7 +353,8 @@ This project uses [Semantic Versioning](https://semver.org/):
 
 ## Links
 
-- [Unreleased]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.6.0...HEAD
+- [Unreleased]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.7.0...HEAD
+- [0.7.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.6.0...v0.7.0
 - [0.6.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.5.0...v0.6.0
 - [0.5.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.4.0...v0.5.0
 - [0.4.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.3.0...v0.4.0


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` block to `## [0.7.0] - 2026-08-10` and adds its comparison link. One file, +4/−1.

Per `RELEASING.md`: the release workflow extracts that dated block as the GitHub Release body and **fails the release if it is absent**, so it has to be in the tagged commit. Merging this is the go/no-go for the release.

> [!IMPORTANT]
> The tag is **not** pushed automatically. Merge this, then push `v0.7.0` by hand.

## Why 0.7.0

Pre-1.0 breaking changes bump MINOR, and the block carries two: the Go module path (`SolaceDev` → `SolaceProducts`) and the published container image path. PATCH would be wrong.

This is also the first release whose artifacts carry build provenance attestations, and the first published to `ghcr.io/solaceproducts/solace-broker-mcp`.

## Verified before committing, rather than discovered at tag time

- `.github/scripts/extract-release-notes.sh v0.7.0` succeeds and emits the 39-line block — including the attestation entry, and without leaking the now-empty `[Unreleased]` heading
- `.github/scripts/extract-release-notes.test.sh` — 9 passed, 0 failed
- `.github/scripts/licenses-check.sh` — `THIRD_PARTY_LICENSES.md` and `NOTICE` match the 28 modules in the dependency closure of `./cmd/server`, so the runbook's "regenerate the inventory before tagging" step needs no change this time

## After merging — the release is not done when the run is green

Two things only a real release settles, both tracked on SOL-152543:

1. **The GHCR package will be created private.** A GHCR package's visibility is set independently of the repository and does not follow it public. Until it is flipped, an external `docker pull` fails and so does the documented `gh attestation verify oci://…`, which needs pull access to resolve the tag to a digest. Owner is aware; this is a manual step with no CI behind it.
2. **The README is currently ahead of reality** and becomes true with this release. Its `docker run` and Compose examples already point at the `solaceproducts` path, which holds no images yet — verified: anonymous `ghcr.io` returns 403 for that path today. Worth re-running the documented commands unauthenticated once the package is public, since that is what an outside consumer has.

Note also that this is the first ever execution of the attestation steps. If `build-binaries` fails on attest, nothing publishes. If `build-docker` fails *after* the image push, the image is live without an attestation — recovery is roll-forward to the next PATCH, per Rollback.

## Checklist

- [x] Self-review completed
- [x] Commits signed off (DCO)
- [x] Branch up to date with `main`
- [x] CHANGELOG.md updated (this PR *is* the changelog change)
