### PR TITLE
SOL-152939: Update SEMP schemas to latest rolling release (10.26.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the embedded SEMPv2 OpenAPI specs to the 10.26.3 rolling release (`10.26.3.10320`), so tool schemas track current broker attributes. The three spec files are renamed to `semp-v2-swagger-{action,config,monitor}.10.26.3.json` and continue to be sourced from the private-extended variant. Loading is unaffected — specs are picked up by the embed glob and typed from their `basePath`, not their filename. Tracked under SOL-152939.
+
 ## [0.7.0] - 2026-08-10
 
 ### Added

--- a/internal/semp/sempv2/specs/semp-v2-swagger-action.10.26.3.json
+++ b/internal/semp/sempv2/specs/semp-v2-swagger-action.10.26.3.json
@@ -4703,7 +4703,7 @@
     },
     "description": "SEMP (starting in `v2`) is a RESTful API for configuring, monitoring, and administering a Solace Event Broker. This specification defines the following API:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate action|/SEMP/v2/\\_\\_private\\_action\\_\\_|Internal use only\n\n\n\nThe following APIs are also available:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate configuration|/SEMP/v2/\\_\\_private\\_config\\_\\_|Internal use only\nPrivate monitoring|/SEMP/v2/\\_\\_private\\_monitor\\_\\_|Internal use only\n\n\n\nFor tutorials, architectural and protocol design documentation, and other information about the SEMP API, consult the [SEMP documentation](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) on the Solace website. The SEMP API specifications are also [available for download](https://solace.com/downloads/).\n\nIf you need additional support, please contact us at [support@solace.com](mailto:support@solace.com).",
     "title": "SEMP (Solace Element Management Protocol)",
-    "version": "10.26.2.9715"
+    "version": "10.26.3.10320"
   },
   "parameters": {
     "countQuery": {

--- a/internal/semp/sempv2/specs/semp-v2-swagger-config.10.26.3.json
+++ b/internal/semp/sempv2/specs/semp-v2-swagger-config.10.26.3.json
@@ -28512,7 +28512,7 @@
         "subscriptionQos": {
           "description": "The quality of service (QoS) for the subscription as either 0 (deliver at most once) or 1 (deliver at least once). QoS 2 is not supported, but QoS 2 messages attracted by QoS 0 or QoS 1 subscriptions are accepted and delivered accordingly.\n\nThe minimum access scope/level required to retrieve this attribute is \"vpn/read-only\". The minimum access scope/level required to change this attribute is \"vpn/read-write\". Changes to this attribute are synchronized to HA mates and replication sites via config-sync. The default value is `0`.",
           "format": "int64",
-          "maximum": 1,
+          "maximum": 2,
           "minimum": 0,
           "type": "integer",
           "x-accessLevels": {
@@ -42825,7 +42825,7 @@
     },
     "description": "SEMP (starting in `v2`) is a RESTful API for configuring, monitoring, and administering a Solace Event Broker. This specification defines the following API:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate configuration|/SEMP/v2/\\_\\_private\\_config\\_\\_|Internal use only\n\n\n\nThe following APIs are also available:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate action|/SEMP/v2/\\_\\_private\\_action\\_\\_|Internal use only\nPrivate monitoring|/SEMP/v2/\\_\\_private\\_monitor\\_\\_|Internal use only\n\n\n\nFor tutorials, architectural and protocol design documentation, and other information about the SEMP API, consult the [SEMP documentation](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) on the Solace website. The SEMP API specifications are also [available for download](https://solace.com/downloads/).\n\nIf you need additional support, please contact us at [support@solace.com](mailto:support@solace.com).",
     "title": "SEMP (Solace Element Management Protocol)",
-    "version": "10.26.2.9715"
+    "version": "10.26.3.10320"
   },
   "parameters": {
     "countQuery": {

--- a/internal/semp/sempv2/specs/semp-v2-swagger-monitor.10.26.3.json
+++ b/internal/semp/sempv2/specs/semp-v2-swagger-monitor.10.26.3.json
@@ -47742,7 +47742,7 @@
         "subscriptionQos": {
           "description": "The quality of service (QoS) for the subscription as either 0 (deliver at most once) or 1 (deliver at least once). QoS 2 is not supported, but QoS 2 messages attracted by QoS 0 or QoS 1 subscriptions are accepted and delivered accordingly.\n\nThe minimum access scope/level required to retrieve this attribute is \"vpn/read-only\". (This description is taken from the corresponding attribute in the configuration API.)\n\n",
           "format": "int64",
-          "maximum": 1,
+          "maximum": 2,
           "minimum": 0,
           "type": "integer",
           "x-accessLevels": {
@@ -71818,7 +71818,7 @@
     },
     "description": "SEMP (starting in `v2`) is a RESTful API for configuring, monitoring, and administering a Solace Event Broker. This specification defines the following API:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate monitoring|/SEMP/v2/\\_\\_private\\_monitor\\_\\_|Internal use only\n\n\n\nThe following APIs are also available:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate action|/SEMP/v2/\\_\\_private\\_action\\_\\_|Internal use only\nPrivate configuration|/SEMP/v2/\\_\\_private\\_config\\_\\_|Internal use only\n\n\n\nFor tutorials, architectural and protocol design documentation, and other information about the SEMP API, consult the [SEMP documentation](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) on the Solace website. The SEMP API specifications are also [available for download](https://solace.com/downloads/).\n\nIf you need additional support, please contact us at [support@solace.com](mailto:support@solace.com).",
     "title": "SEMP (Solace Element Management Protocol)",
-    "version": "10.26.2.9715"
+    "version": "10.26.3.10320"
   },
   "parameters": {
     "countQuery": {


### PR DESCRIPTION
## Summary

Updates the embedded SEMPv2 OpenAPI specs to the **10.26.3** rolling release (`10.26.3.10320`).

## Changes

- Replaced the three embedded SEMPv2 specs (action, config, monitor) with the 10.26.3 rolling-release versions from the load pipeline, sourced from the private-extended variant.
- Renamed the spec files to `semp-v2-swagger-{action,config,monitor}.10.26.3.json`.
- Added a `CHANGELOG.md` entry (SOL-152939).