### PR TITLE
ci(DATAGO-148031): forward secrets to Guardian scan via workflow_call

### DIFF
--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -73,8 +73,7 @@ jobs:
       pull-requests: write
       checks: write
       statuses: write
-    # No `secrets: inherit`: guardian-scan.yaml reads its secrets from the
-    # `guardian` Environment, which resolves independently of the caller.
+    secrets: inherit
     with:
       git_ref: ${{ inputs.version }}
       product_full_version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
       checks: write
       statuses: write
     uses: ./.github/workflows/release-readiness-check.yaml
+    secrets: inherit
     with:
       version: ${{ github.ref_name }}
 


### PR DESCRIPTION
## Problem

`guardian-scan.yaml` passes on its direct `push`/`pull_request` triggers but fails when reached via `workflow_call` — the release path (`release.yml → release-readiness-check.yaml → guardian-scan.yaml`). Its `environment: guardian` jobs read `${{ secrets.FOSSA_API_KEY }}` (and the Prisma/Guardian secrets) as empty strings, so all four scan jobs fail with `A FOSSA API key was specified, but it is an empty string`. This blocks releases only — and blocked v0.7.0, the first public release.

## Root cause

A workflow reached via `workflow_call` gets an empty `secrets` context unless the caller opens it — including its own `environment:` secret resolution. Secrets also don't propagate through a chain automatically: each hop must forward them. The `guardian` environment has no protection rules or branch/tag policy, so that is not a factor.

## Fix

Add `secrets: inherit` on both call hops:
- `release.yml` → `release-readiness-check.yaml`
- `release-readiness-check.yaml` → `guardian-scan.yaml`

This keeps the reusable-workflow design and the environment-scoped secrets unchanged. No secrets move to repo/org scope.

## Verification

Dispatched **Release Readiness Check** against this branch (exercising the `workflow_call` chain in trunk mode). All jobs passed — FOSSA licensing, FOSSA vulnerability, Prisma scan, Guardian gate, and the aggregate `Guardian scan gate` — with the FOSSA key resolving (`fossa_api_key: ***`) instead of empty:
https://github.com/SolaceProducts/solace-broker-mcp/actions/runs/31499688304