### PR TITLE
SOL-152372 test: add stub AccessLevelGroups to opt-in ToolAuthorization subtests

### DIFF
--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1015,8 +1015,9 @@ func Test_OIDCVerifier_GroupsExtraction(t *testing.T) {
 				Issuer:   mock.issuer,
 				Audience: mock.audience,
 				ToolAuthorization: &config.ToolAuthorizationConfig{
-					Enabled:         boolPtr(true),
-					GroupsClaimName: strPtr("groups"),
+					Enabled:           boolPtr(true),
+					GroupsClaimName:   strPtr("groups"),
+					AccessLevelGroups: map[string][]string{"Ops": {"list-vpns"}},
 				},
 			},
 		}
@@ -1058,8 +1059,9 @@ func Test_OIDCVerifier_GroupsExtraction(t *testing.T) {
 				Issuer:   mock.issuer,
 				Audience: mock.audience,
 				ToolAuthorization: &config.ToolAuthorizationConfig{
-					Enabled:         boolPtr(true),
-					GroupsClaimName: strPtr("groups"),
+					Enabled:           boolPtr(true),
+					GroupsClaimName:   strPtr("groups"),
+					AccessLevelGroups: map[string][]string{"Ops": {"list-vpns"}},
 				},
 			},
 		}
@@ -1091,8 +1093,9 @@ func Test_OIDCVerifier_GroupsExtraction(t *testing.T) {
 				Issuer:   mock.issuer,
 				Audience: mock.audience,
 				ToolAuthorization: &config.ToolAuthorizationConfig{
-					Enabled:         boolPtr(true),
-					GroupsClaimName: strPtr("groups"),
+					Enabled:           boolPtr(true),
+					GroupsClaimName:   strPtr("groups"),
+					AccessLevelGroups: map[string][]string{"Ops": {"list-vpns"}},
 				},
 			},
 		}
@@ -1234,8 +1237,9 @@ func TestBuildTokenInfo(t *testing.T) {
 			MCPClientAuth: config.MCPClientAuthConfig{
 				Mode: config.AuthModeOAuth,
 				ToolAuthorization: &config.ToolAuthorizationConfig{
-					Enabled:         boolPtr(true),
-					GroupsClaimName: strPtr("roles"),
+					Enabled:           boolPtr(true),
+					GroupsClaimName:   strPtr("roles"),
+					AccessLevelGroups: map[string][]string{"Ops": {"list-vpns"}},
 				},
 			},
 		}
@@ -1260,8 +1264,9 @@ func TestBuildTokenInfo(t *testing.T) {
 			MCPClientAuth: config.MCPClientAuthConfig{
 				Mode: config.AuthModeOAuth,
 				ToolAuthorization: &config.ToolAuthorizationConfig{
-					Enabled:         boolPtr(true),
-					GroupsClaimName: strPtr("groups"),
+					Enabled:           boolPtr(true),
+					GroupsClaimName:   strPtr("groups"),
+					AccessLevelGroups: map[string][]string{"Ops": {"list-vpns"}},
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

Fixes SOL-152372

Five subtests in `internal/auth/middleware_test.go` construct `config.ServerConfig` directly with `ToolAuthorization.Enabled: true` but leave `AccessLevelGroups` empty — a config shape `LoadConfig`'s validator would reject at startup. This PR adds a minimal stub `AccessLevelGroups` value to each so the fixtures model a config that could actually exist.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

(Test hygiene fix — none of the above categories fit exactly.)

## Motivation and Context

Flagged by a Copilot review comment on PR #214 (SOL-152293). The token verifier under test only reads `Enabled` and `GroupsClaimName`, not `AccessLevelGroups`, so these tests pass today — but they model input that could never survive real config loading, which is confusing and fragile if the verifier is ever refactored to inspect that field. The sibling opt-out case (line ~1003) was already fixed under SOL-152293; these five opt-in sites were out of scope there.

## Changes Made

- Added `AccessLevelGroups: map[string][]string{"Ops": {"list-vpns"}}` to the five `ToolAuthorizationConfig` literals in `internal/auth/middleware_test.go` that set `Enabled: true`.
- No behavior, assertion, or production code changes.

## Testing

**Tests Performed:**
- [x] Tested locally with `go test -race ./internal/auth/...`
- [x] `make check` (build, vet, lint, race tests, coverage gate) passes — coverage 88.5%, above the 85% floor

**Test Coverage:**
- Confirmed via `grep -n 'Enabled: *boolPtr(true)' internal/auth/middleware_test.go` that every match now has `AccessLevelGroups` set.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected

### Git & CI
- [x] Commit signed off (DCO: `git commit -s`)
- [x] Branch is up to date with main

## Related Issues/PRs

- Related to #214 (SOL-152293)