### PR TITLE
Prepare release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-11
+
+`v0.7.0` was tagged but its release pipeline failed before publishing anything, so it has no binary archives, no container image, and no GitHub Release — only a git tag and a Go module version. **0.7.1 is the first published release of the 0.7 line**, and because git history is cumulative it contains everything listed under 0.7.0 below in addition to the change here. Anyone looking for 0.7.0 downloads wants 0.7.1.
+
+Taken together with 0.7.0, this is the first release published from the public repository, and the first whose artifacts can be verified: every binary archive and the container image now carries a build provenance attestation tracing it to the workflow run and commit that produced it, with the commands in `README.md`. Also new since 0.6.0 — the `describe-semp-schema` tool, which lets an agent enumerate a SEMPv2 operation's configurable attributes before attempting a write; an optional `filter_tools_list` flag narrowing `tools/list` to what the caller is actually authorized to invoke; and a second third-party inventory, `THIRD_PARTY_BUILD_TEST.md`, covering the components used to build and test the project rather than ship in it.
+
+**Two breaking changes, both from the move to the `SolaceProducts` GitHub organization.** The Go module path is now `github.com/SolaceProducts/solace-broker-mcp`. The container image is published to `ghcr.io/solaceproducts/solace-broker-mcp` — and the old path does not fail loudly, it keeps serving the last image pushed there, so a stale reference silently stops receiving updates. Migration notes are in the **Changed** section under 0.7.0.
+
 ### Changed
 
 - Updated the embedded SEMPv2 OpenAPI specs to the 10.26.3 rolling release (`10.26.3.10320`), so tool schemas track current broker attributes. The three spec files are renamed to `semp-v2-swagger-{action,config,monitor}.10.26.3.json` and continue to be sourced from the private-extended variant. Loading is unaffected — specs are picked up by the embed glob and typed from their `basePath`, not their filename. Tracked under SOL-152939.
@@ -357,7 +365,8 @@ This project uses [Semantic Versioning](https://semver.org/):
 
 ## Links
 
-- [Unreleased]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.7.0...HEAD
+- [Unreleased]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.7.1...HEAD
+- [0.7.1]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.7.0...v0.7.1
 - [0.7.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.6.0...v0.7.0
 - [0.6.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.5.0...v0.6.0
 - [0.5.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.4.0...v0.5.0


### PR DESCRIPTION
## Summary

Promotes `[Unreleased]` to `## [0.7.1] - 2026-08-11` and adds its comparison link. One file.

> [!IMPORTANT]
> The tag is **not** pushed automatically. Merge this, then push `v0.7.1` by hand.

## Why 0.7.1 and not a retry of v0.7.0

`v0.7.0`'s pipeline failed in the Guardian gate before publishing anything — no archives, no image, no GitHub Release. Two things rule out reusing that tag:

- **The fix isn't in the tagged tree.** `secrets: inherit` at both `workflow_call` hops ([DATAGO-148031](https://sol-jira.atlassian.net/browse/DATAGO-148031), #291) landed on `main` *after* the tag. A tag-triggered run executes the workflow definitions from the tagged commit, so `gh run rerun --failed` would have replayed the broken ones. It would have failed a third time.
- **The tag can't move.** `v0.7.0` is already cached by `proxy.golang.org` (`@v/list` includes it; `v0.7.0.info` returns 200), so it is a live, resolvable Go module version even without a GitHub Release. Re-pointing the tag would produce checksum-database mismatches for anyone who has fetched it — a hard `go get` failure, not a warning. `RELEASING.md`'s "never delete and re-push a tag" holds on its own merits here.

So this rolls forward, per the documented Rollback policy.

## Why PATCH

The only user-visible change of its own is the rolling refresh of the embedded SEMPv2 specs to 10.26.3. No new tools, no config surface, no behaviour change — filed under **Changed**. The CI fix gets no entry: it's workflow-only, and the release notes explain its consequence in prose.

MINOR would be defensible if you read "new broker attributes visible in tool schemas" as a feature. It was considered and rejected: 0.8.0 would imply a feature release and leave the 0.7 line abandoned one tag in.

## Why the block opens with prose

0.7.1's own delta is a single entry, but it is the **first published release of the line** and carries everything from 0.7.0. Three paragraphs, each doing one job:

1. Why 0.7.0 has no downloads — otherwise that's a mystery someone files an issue about.
2. What a consumer gets since 0.6.0: provenance attestations, `describe-semp-schema`, `filter_tools_list`, `THIRD_PARTY_BUILD_TEST.md`.
3. The two breaking changes, above the detail rather than inside it — including that the old image path doesn't fail loudly, it keeps serving a frozen image.

Deliberately not promoted into the highlights: the licence headers, Kafka E2E coverage, write-tool description pointers, and the whole Fixed and Security sections. All present under 0.7.0; none is why someone upgrades. No `### Highlights` heading either — Keep a Changelog defines a fixed set of section types, so this is prose under the version heading rather than a new section.

## Verified before committing

- `extract-release-notes.sh v0.7.1` emits the 11-line block, with neither the empty `[Unreleased]` heading nor the 0.7.0 block leaking in
- `extract-release-notes.test.sh` — 9 passed, 0 failed
- `licenses-check.sh` — `THIRD_PARTY_LICENSES.md` and `NOTICE` match the 28 modules in `./cmd/server`'s closure

## After merging

Tag the merge commit, then the same post-release work that v0.7.0 never reached — tracked on SOL-152543:

1. **The GHCR package will be created private.** A GHCR package's visibility is independent of the repository and does not follow it public. Until flipped, external `docker pull` fails and so does the documented `gh attestation verify oci://…`, which needs pull access to resolve a tag to a digest. Owner is aware; manual step, no CI behind it.
2. Re-run the documented README commands **unauthenticated** once it's public, including one with `--bundle-from-oci` — the only thing that exercises the registry-side copy of the attestation.

Note the archive attestations are already proven: all four succeeded on both v0.7.0 attempts. `build-docker`'s attest step is the one thing still never executed.

## Checklist

- [x] Self-review completed
- [x] Commits signed off (DCO)
- [x] Branch up to date with `main`
- [x] CHANGELOG.md updated (this PR *is* the changelog change)
