### PR TITLE
SOL-153089: Publish PRM at the RFC 9728 canonical path (keep WWW-Authenticate URI unchanged)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- OAuth Protected Resource Metadata (PRM) is now also served at the RFC 9728 §3.1 canonical path `/.well-known/oauth-protected-resource/mcp`, in addition to the existing bare `/.well-known/oauth-protected-resource`. Both paths return the same document. The `WWW-Authenticate` challenge on a 401 continues to advertise the bare URL, so clients that follow the challenge verbatim (e.g. Claude Code) are unaffected; clients that build the RFC 9728 canonical path directly (e.g. SAM's Automatic OAuth discovery) now get a 200 instead of a 404. Tracked under SOL-153089.
+
 ## [0.7.1] - 2026-08-11
 
 `v0.7.0` was tagged but its release pipeline failed before publishing anything, so it has no binary archives, no container image, and no GitHub Release — only a git tag and a Go module version. **0.7.1 is the first published release of the 0.7 line**, and because git history is cumulative it contains everything listed under 0.7.0 below in addition to the change here. Anyone looking for 0.7.0 downloads wants 0.7.1.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -851,10 +851,12 @@ func main() {
 	// it; see buildMCPEndpoint for the full layer order and 413 rationale.
 	mux.Handle("/mcp", buildMCPEndpoint(authedHandler, correlationEnabled))
 
-	// Register OAuth Protected Resource Metadata endpoint (RFC 9728)
-	// This enables MCP clients to discover the authorization server for OAuth flows.
+	// Register OAuth Protected Resource Metadata endpoint (RFC 9728). Served at
+	// both the RFC 9728 canonical path (§3.1: suffixed with the resource path)
+	// and the bare path we advertise in WWW-Authenticate.
 	if metadataHandler := auth.NewProtectedResourceMetadataHandler(cfg); metadataHandler != nil {
 		mux.Handle("/.well-known/oauth-protected-resource", metadataHandler)
+		mux.Handle("/.well-known/oauth-protected-resource/mcp", metadataHandler)
 		slog.Info("registered OAuth protected resource metadata endpoint")
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -134,6 +135,27 @@ func buildMux(readiness *health.ReadinessState) *http.ServeMux {
 	mux.Handle("/ready", readyz)
 
 	return mux
+}
+
+// registerMetadataRoutes serves PRM (RFC 9728) at the bare path (advertised in
+// WWW-Authenticate) and at the §3.1 canonical path derived from resource_url.
+// The canonical route is skipped when the two would collide (empty/"/" path),
+// which would otherwise panic ServeMux. No-op when mode != oauth.
+func registerMetadataRoutes(mux *http.ServeMux, cfg *config.ServerConfig) {
+	metadataHandler := auth.NewProtectedResourceMetadataHandler(cfg)
+	if metadataHandler == nil {
+		return
+	}
+
+	const barePath = "/.well-known/oauth-protected-resource"
+	mux.Handle(barePath, metadataHandler)
+
+	parsed, _ := url.Parse(cfg.MCPClientAuth.ResourceURL)
+	resourcePath := strings.TrimRight(parsed.Path, "/")
+	if resourcePath != "" {
+		mux.Handle(barePath+resourcePath, metadataHandler)
+	}
+	slog.Info("registered OAuth protected resource metadata endpoint")
 }
 
 // buildRootHandler returns the outermost HTTP handler for the server: the mux
@@ -851,14 +873,7 @@ func main() {
 	// it; see buildMCPEndpoint for the full layer order and 413 rationale.
 	mux.Handle("/mcp", buildMCPEndpoint(authedHandler, correlationEnabled))
 
-	// Register OAuth Protected Resource Metadata endpoint (RFC 9728). Served at
-	// both the RFC 9728 canonical path (§3.1: suffixed with the resource path)
-	// and the bare path we advertise in WWW-Authenticate.
-	if metadataHandler := auth.NewProtectedResourceMetadataHandler(cfg); metadataHandler != nil {
-		mux.Handle("/.well-known/oauth-protected-resource", metadataHandler)
-		mux.Handle("/.well-known/oauth-protected-resource/mcp", metadataHandler)
-		slog.Info("registered OAuth protected resource metadata endpoint")
-	}
+	registerMetadataRoutes(mux, cfg)
 
 	// Catch-all: return JSON 404 for any unregistered path. MCP SDK clients
 	// probe multiple OAuth discovery endpoints during (re-)authentication

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -539,6 +539,15 @@ func TestRegisterMetadataRoutes(t *testing.T) {
 			canonStatus: http.StatusOK,
 		},
 		{
+			// Pins that the canonical path is derived from resource_url, not
+			// hardcoded to /mcp — regressing the derivation would fail here.
+			name:        "path prefix from ingress — canonical follows resource_url path",
+			cfg:         oauthCfg("https://gateway.example.com/broker/mcp"),
+			bareStatus:  http.StatusOK,
+			canonPath:   "/.well-known/oauth-protected-resource/broker/mcp",
+			canonStatus: http.StatusOK,
+		},
+		{
 			name:       "empty path — canonical collides with bare, skip",
 			cfg:        oauthCfg("https://mcp.example.com"),
 			bareStatus: http.StatusOK,

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SolaceProducts/solace-broker-mcp/internal/config"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/health"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -504,5 +505,76 @@ func TestReadyz_AfterInit_Returns200(t *testing.T) {
 	}
 	if rec.Body.String() != `{"status":"ready"}` {
 		t.Errorf("GET /readyz body = %q, want %q", rec.Body.String(), `{"status":"ready"}`)
+	}
+}
+
+// TestRegisterMetadataRoutes exercises the mux wiring for PRM (RFC 9728):
+// both the bare path and the §3.1 canonical path (derived from resource_url)
+// must return the same document. Non-oauth modes register nothing.
+func TestRegisterMetadataRoutes(t *testing.T) {
+	oauthCfg := func(resourceURL string) *config.ServerConfig {
+		return &config.ServerConfig{
+			Port: 9090,
+			MCPClientAuth: config.MCPClientAuthConfig{
+				Mode:        config.AuthModeOAuth,
+				Issuer:      "https://auth.example.com",
+				Audience:    "solace-mcp-server",
+				ResourceURL: resourceURL,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		cfg         *config.ServerConfig
+		bareStatus  int
+		canonPath   string // "" means the canonical route should not be registered
+		canonStatus int
+	}{
+		{
+			name:        "oauth mode — both paths registered",
+			cfg:         oauthCfg("http://localhost:9090/mcp"),
+			bareStatus:  http.StatusOK,
+			canonPath:   "/.well-known/oauth-protected-resource/mcp",
+			canonStatus: http.StatusOK,
+		},
+		{
+			name:       "empty path — canonical collides with bare, skip",
+			cfg:        oauthCfg("https://mcp.example.com"),
+			bareStatus: http.StatusOK,
+		},
+		{
+			name:       "static mode — no registration",
+			cfg:        &config.ServerConfig{MCPClientAuth: config.MCPClientAuthConfig{Mode: config.AuthModeStatic}},
+			bareStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			registerMetadataRoutes(mux, tt.cfg)
+
+			bareRec := httptest.NewRecorder()
+			bareReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+			mux.ServeHTTP(bareRec, bareReq)
+			if bareRec.Code != tt.bareStatus {
+				t.Errorf("bare path status = %d, want %d", bareRec.Code, tt.bareStatus)
+			}
+
+			if tt.canonPath == "" {
+				return
+			}
+
+			canonRec := httptest.NewRecorder()
+			canonReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tt.canonPath, nil)
+			mux.ServeHTTP(canonRec, canonReq)
+			if canonRec.Code != tt.canonStatus {
+				t.Errorf("canonical path status = %d, want %d", canonRec.Code, tt.canonStatus)
+			}
+			if bareRec.Body.String() != canonRec.Body.String() {
+				t.Errorf("body mismatch: bare=%q canonical=%q", bareRec.Body.String(), canonRec.Body.String())
+			}
+		})
 	}
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -604,7 +604,7 @@ A browser window opens on first use for user login. The IdP must support anonymo
 The numbered steps in detail:
 
 1. Claude Code connects to the MCP server and receives a `401 Unauthorized` response
-2. Claude Code fetches the OAuth Protected Resource Metadata from `/.well-known/oauth-protected-resource` to discover the authorization server
+2. Claude Code fetches the OAuth Protected Resource Metadata from `/.well-known/oauth-protected-resource` to discover the authorization server (the server also serves the same document at the RFC 9728 canonical path `/.well-known/oauth-protected-resource/mcp` for clients that build that URL directly)
 3. **Option A:** Claude Code uses the pre-registered client credentials and skips DCR
    **Option B:** Claude Code performs Dynamic Client Registration (RFC 7591) to obtain a client ID at runtime
 4. A browser window opens for the user to log in with IdP credentials

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -656,10 +656,12 @@ Under `mode: disabled` and `mode: static` the server binds `127.0.0.1` only by d
 
 - Verify the MCP client supports OAuth (Claude Code and Claude Desktop do)
 - Check that the `resource_url` matches the URL the client is connecting to
-- Verify the `/.well-known/oauth-protected-resource` endpoint returns valid metadata:
+- Verify the PRM endpoint returns valid metadata. Both paths return the same document:
   ```bash
   curl http://localhost:9090/.well-known/oauth-protected-resource
+  curl http://localhost:9090/.well-known/oauth-protected-resource/mcp
   ```
+  The bare path is what `WWW-Authenticate` advertises on a 401. The `/mcp`-suffixed path is the RFC 9728 §3.1 canonical path used by clients that construct it directly (e.g. SAM's Automatic OAuth discovery).
 
 ### "Allowed Client Scopes rejected request to client-registration service"
 

--- a/docs/superpowers/specs/2026-05-20-client-auth-mode-design.md
+++ b/docs/superpowers/specs/2026-05-20-client-auth-mode-design.md
@@ -62,7 +62,7 @@ The three modes are tiered, not interleaved: `mode: static` and `mode: disabled`
 | Startup log | `WARN: client_auth.mode = disabled` banner | `WARN: client_auth.mode = static` banner | `INFO: client auth via OAuth/OIDC` |
 | Client must send | Nothing required (any/no `Authorization` header accepted) | `Authorization: Bearer <dev_token>` on every request | `Authorization: Bearer <JWT from IdP>` on every request |
 | Server validates | Nothing — passes every request to handler | Constant-time compare against `dev_token` | JWT signature, `iss`, `aud`, `exp`; refreshes JWKS from issuer |
-| `/.well-known/oauth-protected-resource` | Not served (404) | Not served (404) | Served — advertises issuer, audience, resource URL |
+| `/.well-known/oauth-protected-resource` (bare, advertised in `WWW-Authenticate`) and `/.well-known/oauth-protected-resource<resource_url path>` (RFC 9728 §3.1 canonical) | Not served (404) | Not served (404) | Served — same document at both paths; advertises issuer, audience, resource URL |
 | Broker URL `http://` allowed | Yes | Yes | No — `https://` required |
 | Self-signed TLS allowed | Yes (per-broker `insecure_skip_verify: true`) | Yes | Yes (per-broker; normally false in prod) |
 | Token expiration | n/a | 24h synthetic (matches current static verifier) | Whatever the IdP issues (`exp`) |


### PR DESCRIPTION
## Summary

Serve the OAuth Protected Resource Metadata (PRM) document at the RFC 9728 §3.1 canonical path `/.well-known/oauth-protected-resource/mcp` in addition to the existing bare `/.well-known/oauth-protected-resource`. The `WWW-Authenticate` challenge URL is unchanged.

Jira: [SOL-153089](https://sol-jira.atlassian.net/browse/SOL-153089)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

RFC 9728 §3.1 requires that PRM for a resource at `https://host/mcp` be published at `https://host/.well-known/oauth-protected-resource/mcp`. We only served the bare path. Claude Code works today because it follows the `resource_metadata` URL in `WWW-Authenticate` verbatim, so the non-standard bare URL lines up. SAM's Automatic OAuth discovery builds the canonical path directly instead — and got a 404:

```
GET /.well-known/oauth-protected-resource/mcp   → 404
```

This unblocks the first step of SAM's Automatic OAuth flow. SAM has its own downstream bugs tracked separately.

## Changes Made

- `cmd/server/main.go` — register the PRM handler at `/.well-known/oauth-protected-resource/mcp` in addition to the bare path. Both routes serve the same document via the same handler instance.
- `internal/auth/middleware.go` — no change. `WWW-Authenticate: Bearer resource_metadata="…"` still advertises the bare URL, so clients that follow the challenge verbatim see no change.
- `CHANGELOG.md` — Unreleased/Fixed entry.

## Testing

**Test Environment:**
- Go version: 1.24
- OS: macOS

**Tests Performed:**
- [x] Tested locally with `go test ./cmd/server/... ./internal/auth/...` — pass

**Test Coverage:**
- Existing `NewProtectedResourceMetadataHandler` unit tests in `internal/auth/middleware_test.go` cover the handler behavior; the change is a second mux registration of the same handler, so no new unit test was added. Acceptance criteria will be re-verified with `curl` against both paths and by re-running the Claude Code and SAM auto-discover flows.

## Breaking Changes

None. The bare path continues to work, and `WWW-Authenticate` is unchanged.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what")
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code**
- [x] Followed secure logging rules (no logging change)

### Testing
- [x] All tests pass locally for touched packages
- [x] No race conditions detected

### Documentation
- [x] CHANGELOG.md updated

### Git & CI
- [x] All commits are signed off (DCO)
- [x] Commits have clear, descriptive messages

## Additional Notes

No deprecation of the bare path in this change — the story explicitly defers that. Revisit if ever needed.

## Related Issues/PRs

- [RFC 9728 §3.1](https://datatracker.ietf.org/doc/html/rfc9728#section-3.1)

---

**For Reviewers:**

**Focus Areas**: mux ordering — both routes are exact matches (no trailing slash), so `/.well-known/oauth-protected-resource/mcp` doesn't shadow anything and the bare path stays exact. Confirm that's your read too.