### PR TITLE
SOL-153050: state the registered ruleset, not the work to register it

### DIFF
--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -188,9 +188,8 @@ review.
 ### Required status checks
 
 **Require branches to be up to date before merging** is on, and the context list
-is applied. Twelve contexts are registered, corrected under SOL-152412 from the
-old `lint` / `build` / `FOSSA Scan` list. This table is the single authoritative
-copy.
+is applied. Thirteen contexts are registered. This table is the single
+authoritative copy.
 
 Read the live list rather than trusting the table:
 
@@ -213,7 +212,7 @@ gh api repos/OWNER/REPO/rulesets/13942241 \
 | `Third-party licenses current` | `ci-pr.yaml` job `licenses` | `THIRD_PARTY_LICENSES.md` still matching `go list -deps ./cmd/server`. Needs no secret, so it reports on fork pull requests too |
 | `Licence headers present` | `ci-pr.yaml` job `license_headers` | Every `.go` file outside `vendor/` opening with the Apache-2.0 header. Needs no secret and no Go toolchain, so it reports on fork pull requests too |
 | `CHANGELOG updated` | `ci-pr.yaml` job `changelog` | Advisory today; see note below |
-| `Commit identity routable` | `ci-pr.yaml` job `identity` | Every commit the PR adds using a routable author and committer address, so a machine hostname does not publish permanently with the history (SOL-152902). **Not yet registered** — see below |
+| `Commit identity routable` | `ci-pr.yaml` job `identity` | Every commit the PR adds using a routable author and committer address, so a machine hostname does not publish permanently with the history. Pinned to Actions (`15368`), not to the `dco2` App — see below |
 | `DCO` | the CNCF `dco2` GitHub App | a `Signed-off-by` trailer on every commit the pull request adds. DCO stands in for a contributor licence agreement, so this is the control behind the repository's provenance claim |
 
 ⚠️ **Require `Guardian scan gate`, and nothing FOSSA-shaped.** The old
@@ -239,21 +238,25 @@ The naming rule still holds: a reusable-workflow caller that **runs** surfaces a
 the bare caller name. `guardian-scan.yaml` sidesteps it by triggering directly
 rather than being called, so its contexts are plain job names.
 
-⚠️ **Both DCO rows are required, and dropping either removes a control.** DCO
+⚠️ **The `DCO` row is required, and dropping it removes a control.** DCO
 stands in for a contributor licence agreement, so dropping the row does not weaken
 the control — it removes it, along with the repository's claim that every
 contribution carries a sign-off. An unrequired check enforces nothing, the same
 trap the old `FOSSA Scan` context was.
 
-⚠️ **`Commit identity routable` is new and not yet in the ruleset.** It went in
-with SOL-153050, when DCO enforcement moved to the `dco2` App and the
-non-routable-address check that had been sharing `dco-check.sh` needed its own
-home. The App checks sign-off and nothing else, so without this job the control
-SOL-152902 delivered would have disappeared with that script.
+⚠️ **`Commit identity routable` and `DCO` are two controls, not one, and they pin
+to different sources.** `DCO` is the sign-off gate, served by the `dco2` App and
+pinned to `974774`. `Commit identity routable` rejects non-routable author and
+committer addresses, comes from GitHub Actions, and is pinned to `15368`. Pinning
+either to the other's id means the context never matches and nothing reports.
 
-Register it once it has reported green on a real pull request — the same rule
-applied to every other context here, and the one that would have caught the
-`Guardian scan` mistake. Until it is required it enforces nothing.
+Both are required. The App checks sign-off and nothing else, so dropping the
+identity row does not weaken that control — it removes it.
+
+**Register a new context only once it has reported green on a real pull request**,
+and only after the pull request creating it has merged. Registering early leaves
+every open pull request with a context its branch cannot produce. This is the rule
+that would have caught the `Guardian scan` mistake.
 
 `DCO` is served by the CNCF `dco2` GitHub App, so its `integration_id` is `974774`,
 not the `15368` an Actions-produced context carries. Pinning it to Actions would


### PR DESCRIPTION
## Summary

`Commit identity routable` was registered in the `main-protection` ruleset (pinned to Actions `15368`), completing the last open acceptance criterion of SOL-153050. `.github/ADMIN_SETUP.md` still described the ruleset as it was before that change. This reconciles it.

Doc-only. No workflow, script, or production surface touched.

## Changes Made

- **Context count** — twelve → thirteen.
- **Table cell** — `Commit identity routable` no longer reads **"Not yet registered"**; it now names the pin (`15368`, Actions) that distinguishes it from `DCO` (`974774`, the `dco2` App).
- **`Both DCO rows` heading** — leftover from when `DCO sign-off` and `DCO check self-test` were separate contexts. The body was already singular; only the heading was not.
- **The ⚠️ block** — replaced an instruction with a rule (see below).

## The one worth reviewing

The old block said to register this specific check once it had reported green. That was a task, and it stopped being true the moment it was done. It now states what the two controls are, that they pin to different sources, and the general rule:

> **Register a new context only once it has reported green on a real pull request**, and only after the pull request creating it has merged.

That rule applies to the next context anyone adds — SOL-152858 will need it for CodeQL.

## Verification

The doc's required-checks table was diffed against the live ruleset as a set:

```
gh api repos/SolaceProducts/solace-broker-mcp/rulesets/13942241 \
  --jq '.rules[]|select(.type=="required_status_checks")
        |.parameters.required_status_checks[]|"\(.context)\t\(.integration_id // "UNPINNED")"'
```

13 contexts, doc == live, none `UNPINNED`.

## A note on style

This diff adds no dates and no ticket numbers, and removes the one pre-existing `SOL-152902` reference in the text it touches. `ADMIN_SETUP.md` is world-readable: it should declare what the setup is, while git and Jira hold how it got there. An internal ticket id is not resolvable by most of this file's readers.

Nine `SOL-` references remain elsewhere in the file, all pointing at closed tickets. Deliberately left alone — that is a separate cleanup, not part of fixing what the ruleset change made stale.

## Testing

Doc-only; no tests apply. CI's `CHANGELOG updated` check is advisory here — `production-surface.sh` scopes production surface to `internal/config/`, `internal/tools/`, and `internal/composite/definitions/tools.yaml`, none of which this touches.

## Related

- Closes the last acceptance criterion of SOL-153050
- Follows PR #294, which created the check this registers