### PR TITLE
SOL-152856: Add a required CI gate that runs actionlint and zizmor over every GitHub Actions

### DIFF
--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -214,6 +214,7 @@ gh api repos/OWNER/REPO/rulesets/13942241 \
 | `Licence headers present` | `ci-pr.yaml` job `license_headers` | Every `.go` file outside `vendor/` opening with the Apache-2.0 header. Needs no secret and no Go toolchain, so it reports on fork pull requests too |
 | `CHANGELOG updated` | `ci-pr.yaml` job `changelog` | Advisory today; see note below |
 | `Commit identity routable` | `ci-pr.yaml` job `identity` | Every commit the PR adds using a routable author and committer address, so a machine hostname does not publish permanently with the history (SOL-152902). **Not yet registered** — see below |
+| `workflow-lint` | `workflow-lint.yaml` job `workflow-lint` | Every file under `.github/workflows/` passing actionlint (correctness, shellcheck over `run:` blocks) and zizmor (workflow security, including SHA-pinning via `unpinned-uses`), so workflow security is enforced by a tool rather than argued in a code comment (SOL-152856). **Not yet registered** — see below |
 | `DCO` | the CNCF `dco2` GitHub App | a `Signed-off-by` trailer on every commit the pull request adds. DCO stands in for a contributor licence agreement, so this is the control behind the repository's provenance claim |
 
 ⚠️ **Require `Guardian scan gate`, and nothing FOSSA-shaped.** The old
@@ -254,6 +255,27 @@ SOL-152902 delivered would have disappeared with that script.
 Register it once it has reported green on a real pull request — the same rule
 applied to every other context here, and the one that would have caught the
 `Guardian scan` mistake. Until it is required it enforces nothing.
+
+⚠️ **`workflow-lint` is new and not yet in the ruleset.** It went in with
+SOL-152856. Register it on the same terms as the row above: read the context name
+off a real run rather than assuming it, then add it.
+
+```bash
+gh run list --workflow workflow-lint.yaml --limit 1 --json databaseId \
+  --jq '.[0].databaseId' \
+  | xargs -I{} gh run view {} --json jobs --jq '.jobs[].name'
+```
+
+Its job id and `name:` are deliberately identical, so the context is the bare
+`workflow-lint` with no `caller / inner` suffix — but read it anyway. Assuming a
+name is what produced the `FOSSA Scan` versus `FOSSA Scan / SCA Scan` gap.
+
+One property matters when registering it: `workflow-lint.yaml` carries **no
+`paths:` filter**, deliberately. A required check filtered to
+`.github/workflows/**` never creates a check run on a pull request that touches
+only Go code, so the context stays pending forever and the pull request cannot
+merge. If someone later adds a `paths:` filter to make it cheaper, this required
+context is what breaks. Condition inside the job, never in the trigger.
 
 `DCO` is served by the CNCF `dco2` GitHub App, so its `integration_id` is `974774`,
 not the `15368` an Actions-produced context carries. Pinning it to Actions would

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -151,6 +151,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Self-test the licence-header check
         run: .github/scripts/license-header-check.test.sh
       - name: Verify every Go file carries the Apache-2.0 header

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -73,7 +73,9 @@ jobs:
       pull-requests: write
       checks: write
       statuses: write
-    secrets: inherit
+    # No `secrets: inherit` — guardian-scan.yaml's jobs carry
+    # `environment: guardian` and resolve the FOSSA/Guardian/Prisma secrets from
+    # that environment themselves. Nothing to pass down.
     with:
       git_ref: ${{ inputs.version }}
       product_full_version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          # Build from a cold module cache. A release runs once per tag, so the
+          # cache buys little, and a cache entry restored from a less-trusted
+          # ref is an input to an artifact we then attest.
+          cache: false
       - name: Self-test the licence check
         run: .github/scripts/licenses-check.test.sh
       - name: Verify THIRD_PARTY_LICENSES.md and NOTICE match the binary
@@ -82,8 +86,18 @@ jobs:
       pull-requests: write
       checks: write
       statuses: write
+    # No `secrets: inherit`. Every `secrets.*` reference in guardian-scan.yaml
+    # sits in a job declaring `environment: guardian`, and all six names —
+    # FOSSA_API_KEY, GUARDIAN_URL, GUARDIAN_API_TOKEN, PRISMACLOUD_* — exist in
+    # that environment, which the job resolves itself. Nothing was reading
+    # through `inherit`.
+    #
+    # Worth stating because one of them, FOSSA_API_KEY, also exists as an org
+    # secret, so `inherit` looked load-bearing. It was not: environment secrets
+    # outrank org secrets, so the `guardian` copy is what those jobs already
+    # got. What `inherit` actually did was hand the scan every other org and
+    # repo secret (LLM_SERVICE_API_KEY, VAULT_URL) that it never references.
     uses: ./.github/workflows/release-readiness-check.yaml
-    secrets: inherit
     with:
       version: ${{ github.ref_name }}
 
@@ -117,6 +131,9 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          # Cold cache, same reasoning as the `licenses` job above — and it
+          # matters more here, since these are the binaries we publish.
+          cache: false
 
       - name: Build
         env:
@@ -245,9 +262,13 @@ jobs:
           merge-multiple: true
           path: dist/
 
+      # `--` rather than `./*.tar.gz`, which is the other fix shellcheck offers
+      # for SC2035: `./` would prefix every line of the published checksums file
+      # with `./`, changing a release artifact people verify against. `--` stops
+      # option parsing and leaves the filenames bare.
       - name: Generate checksums
         working-directory: dist
-        run: sha256sum *.tar.gz > checksums-sha256.txt
+        run: sha256sum -- *.tar.gz > checksums-sha256.txt
 
       # A single artifact downloaded by name extracts flat into the working dir
       # (no name-subdirectory), so body_path: release-notes.md below resolves.

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -1,0 +1,114 @@
+name: Workflow lint
+
+# actionlint (correctness) and zizmor (security) over `.github/workflows/`, so
+# that what used to be argued in a code comment is re-checked on every edit.
+#
+# WHY THERE IS NO `paths:` FILTER
+#
+# The obvious shape for this workflow is `pull_request` filtered to
+# `.github/workflows/**` — it only has something to say when a workflow changes.
+# That shape is wrong for a *required* check, and wrong in the specific way this
+# repository has already been bitten by. GitHub does not report a filtered-out
+# check as skipped; it never creates the check run at all, so the required
+# context sits pending forever and the pull request cannot merge. That is the
+# same failure mode build-and-test.yml's header comment dissects at length: a
+# required check that never reports is worse than one that reports cheaply.
+#
+# So it runs on every pull request against main. The cost is a few seconds of
+# runner time on pull requests that touch no workflow; the alternative is a
+# permanently unmergeable pull request the first time someone changes only Go
+# code. If this ever needs to be conditional, condition it inside the job so the
+# check still reports, never in the trigger.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-lint:
+    name: workflow-lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      # Pinned, because an unpinned linter changes its verdict without a commit
+      # and a gate that moves on its own is not a gate.
+      #
+      # The floor is not arbitrary. v1.7.7 rejects `artifact-metadata: write` in
+      # release.yml as an unknown permission scope; the scope is real and the
+      # release publishes fine with it, and v1.7.12 is the first release that
+      # knows it. So the pin cuts both ways — hold it steady, but treat a
+      # finding against a newly-added GitHub feature as a reason to bump rather
+      # than a reason to edit the workflow. `go install` at a version tag is
+      # verified against the Go checksum database.
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: v1.7.12
+        run: go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+
+      - name: Install zizmor
+        env:
+          ZIZMOR_VERSION: 1.29.0
+        run: pipx install "zizmor==${ZIZMOR_VERSION}"
+
+      # actionlint discovers `.github/workflows/` itself and shellchecks every
+      # `run:` block on the way through.
+      #
+      # That second half is worth knowing about: actionlint shells out to
+      # shellcheck and silently skips those rules when it is absent, so a clean
+      # local run on a machine without shellcheck proves less than it appears
+      # to. The runner image ships it (0.9.0 on ubuntu-24.04), so CI is the
+      # stricter environment. It is also the one tool here that is *not*
+      # version-pinned — it moves when the runner image moves. Pin it with
+      # `-shellcheck <path>` if that drift ever produces a surprise.
+      - name: actionlint
+        run: actionlint -color
+
+      # Two flags carry the gate's strictness, and both are set on purpose
+      # rather than inherited, because zizmor's defaults are a moving target
+      # across releases and "whatever the tool felt like today" is not a
+      # policy anyone can review.
+      #
+      # --persona=regular       the low-false-positive set. `auditor` and
+      #                         `pedantic` are for a human reading output, not
+      #                         for a blocking check.
+      # --min-severity=low      blocks everything except purely informational
+      #                         code smells. One informational finding stands
+      #                         today (superfluous-actions on the release step,
+      #                         suggesting `gh release` over an action); it is a
+      #                         refactor to weigh on its own merits, not
+      #                         something to hold the gate open for.
+      #
+      # --no-online-audits is deterministic on purpose: it drops
+      # known-vulnerable-actions, ref-confusion and stale-action-refs, which
+      # would let this check go red with no commit behind it. unpinned-uses is
+      # offline and still enforced, so SHA pinning stays gated. The dropped
+      # audits are worth a scheduled non-blocking run; that is not this ticket.
+      - name: zizmor
+        run: |
+          zizmor --color=always \
+            --no-online-audits \
+            --persona=regular \
+            --min-severity=low \
+            .github/workflows/


### PR DESCRIPTION
## Summary

Adds a required CI gate that runs actionlint and zizmor over every GitHub Actions workflow, and fixes the five findings that surfaced so the gate starts green.

Jira: [SOL-152856](https://sol-jira.atlassian.net/browse/SOL-152856)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Motivation and Context

We have eight workflows and no linter over any of them; `make check` covers Go only. That gap holds while every editor is a squad member who has read the comments. It stops holding once the repository is public and the set of people who can propose a workflow change is everyone.

Two tools, because neither subsumes the other. **actionlint** catches correctness bugs — the class where a workflow silently does nothing, which is how the `FOSSA Scan` required-check gap went unnoticed for weeks — and shellchecks every `run:` block. **zizmor** audits workflow security specifically: unsafe interpolation, over-broad permissions, unpinned actions, cache and artifact handling.

Two of the ticket's three predicted findings turned out not to exist: there is no `pull_request_target` anywhere anymore (`dco.yaml` was retired under SOL-153050), and every action is already SHA-pinned (zizmor's online audits report zero `unpinned-uses`). The ticket has been updated with the corrected picture.

## Changes Made

**Findings resolved (commit 1)** — all fixed, none suppressed, so there is no ignore file and no inline suppressions:

- `ci-pr.yaml` — `persist-credentials: false` on the `license_headers` checkout. `actions/checkout` writes the `GITHUB_TOKEN` into `.git/config` by default. Every other checkout in the repo already set this; SOL-152962 swept for exactly this and missed this job.
- `release.yml` — `cache: false` on both `setup-go` steps. A restored cache entry is an untrusted input to a binary we then attest, and a release runs once per tag, so the cache was buying almost nothing.
- `release.yml`, `release-readiness-check.yaml` — dropped `secrets: inherit` from both reusable-workflow calls. Every `secrets.*` reference in `guardian-scan.yaml` sits in a job declaring `environment: guardian`, and all six names exist in that environment, so nothing was reading through `inherit`. `FOSSA_API_KEY` also exists as an org secret, which made `inherit` look load-bearing — but environment secrets outrank org secrets, so those jobs already resolved the `guardian` copy. What `inherit` actually did was hand the scan `LLM_SERVICE_API_KEY` and `VAULT_URL`, which it never references.
- `release.yml` — `sha256sum -- *.tar.gz` (SC2035). The other remedy shellcheck offers, `./*.tar.gz`, would prefix every line of the published checksums file with `./` and change an artifact people verify against.

**The gate (commit 2):**

- New `.github/workflows/workflow-lint.yaml`, job `workflow-lint`, `contents: read`, actions SHA-pinned.
- **No `paths:` filter, deliberately.** A required check filtered to `.github/workflows/**` never creates a check run on a PR that touches only Go code, so the required context sits pending forever and the PR cannot merge — the failure mode `build-and-test.yml`'s header comment dissects. If this ever needs to be conditional, condition it inside the job so the check still reports, never in the trigger.
- Tool versions pinned: actionlint `v1.7.12`, zizmor `1.29.0`. The actionlint floor is not arbitrary — v1.7.7 rejects `artifact-metadata: write` in `release.yml` as an unknown permission scope, a false positive against a real feature the release already publishes with.
- zizmor's `--persona=regular` and `--min-severity=low` are set explicitly rather than inherited, since its defaults move across releases. `--no-online-audits` keeps the gate deterministic; `unpinned-uses` is offline, so SHA pinning stays enforced.
- `.github/ADMIN_SETUP.md` — the `workflow-lint` row plus the registration procedure.

## Testing

**Test Environment:**
- Go: 1.25.0 (`go.mod`); actionlint v1.7.12, zizmor 1.29.0, shellcheck 0.11.0
- OS: macOS 26.6.1 (arm64)

No unit tests: this PR contains no Go code. Verification is the tool runs below.

**Before** — five findings on `main`:

| Rule | Site | Severity |
|---|---|---|
| `artipacked` | `ci-pr.yaml:152` | medium |
| `secrets-inherit` | `release.yml:85` | high |
| `secrets-inherit` | `release-readiness-check.yaml:69` | high |
| `cache-poisoning` | `release.yml:52` | medium |
| `cache-poisoning` | `release.yml:116` | medium |

Plus `SC2035` at `release.yml:267`, which only appears when shellcheck is installed — `actionlint` silently skips those rules without it.

**After:**

```
$ actionlint                                    # shellcheck 0.11.0 present
EXIT=0

$ zizmor --no-online-audits --persona=regular --min-severity=low .github/workflows/
No findings to report. Good job!
EXIT=0
```

**The gate is proven to fail, not merely observed to pass** — both tools against a known-bad workflow:

```
$ actionlint known-bad.yml     ->  EXIT=1
$ zizmor known-bad.yml         ->  EXIT=14
```

`make check` passes: exit 0, zero failures.

**Checked because these can pass locally and fail in CI:**
- `go.mod` is `go 1.25.0`; actionlint v1.7.12 requires exactly `go 1.25.0` — no toolchain download needed
- `setup-go` calls `core.addPath` on `$(go env GOPATH)/bin`, so `go install` binaries resolve (verified in the action's source, not assumed)
- Pipx 1.16.0 and shellcheck 0.9.0 are both in the ubuntu-24.04 runner image manifest
- Every CLI flag verified against each tool's own `--help`
- The licence-header scripts use `find` and `git rev-parse --show-toplevel`, so `persist-credentials: false` breaks nothing
- No dynamic `secrets[...]` lookups anywhere, so the static reference scan behind the `inherit` removal was complete
- The job needs no secrets, so it reports on fork PRs — necessary for a required check

## Checklist

- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what")
- [x] No credentials in code
- [x] All commits signed off (DCO)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (`behind_by=0`, no rebase needed)
- [x] No merge conflicts
- [x] `docs/` updated — `.github/ADMIN_SETUP.md`
- [ ] CI checks passing — **not yet; this PR is the first run of the new gate**

`CHANGELOG.md` not updated, and shouldn't be: `.github/` is not production surface per `.github/scripts/production-surface.sh`.

## Additional Notes

**One change ships unverified by CI.** The `secrets: inherit` removals only execute on the release path, which fires on tag push — no PR run exercises them. The static analysis is solid, but that isn't the same as observed. Before the next release, run:

```
gh workflow run release-readiness-check.yaml -f version=main
```

That exercises the Guardian scan through the modified call path without cutting a release. It has to wait until after merge, since `workflow_dispatch` only resolves against the default branch.

**shellcheck is the one unpinned tool here** — it comes from the runner image and moves when the image does, which is the same drift this PR pins the other two tools against. Documented in the workflow, with the flag to pin it if it ever surprises us.

**Still outstanding:** registering `workflow-lint` on the `main-protection` ruleset needs a repo admin and is routed to SOL-152412. Until it is required, it enforces nothing.

## Related Issues/PRs

- Implements [SOL-152856](https://sol-jira.atlassian.net/browse/SOL-152856)
- Registration blocked on [SOL-152412](https://sol-jira.atlassian.net/browse/SOL-152412) (admin ruleset change)
- Follows [SOL-152855](https://sol-jira.atlassian.net/browse/SOL-152855) and [SOL-153050](https://sol-jira.atlassian.net/browse/SOL-153050), which removed workflows the original ticket assumed
- Completes the sweep started in [SOL-152962](https://sol-jira.atlassian.net/browse/SOL-152962)
