### PR TITLE
SOL-153411: Migrate CodeQL to advanced setup with a blocking gate job

### DIFF
--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -111,30 +111,32 @@ gh api repos/OWNER/REPO --jq '.security_and_analysis'
 | Secret scanning push protection | On | None |
 | Secret scanning validity checks | On | None |
 | Secret scanning non-provider patterns | On | None |
-| Code scanning (CodeQL) | On — **default setup**, languages `actions` and `go` | **Disable default setup**, then swap the required context — see below |
+| Code scanning (CodeQL) | On — **advanced setup** (`.github/workflows/codeql.yml`), languages `actions` and `go`. Default setup retired 20 August 2026 | **Register `CodeQL gate`** as a required check once `codeql.yml` is on `main` — see below |
 
 Both secret-scanning settings are already on, so there is nothing to enable here.
 Confirm rather than change: alerts find credentials already committed, push
 protection rejects the next one before it lands, and losing either is a
 regression. Both stay free on public repositories.
 
-⚠️ **CodeQL is mid-migration from default setup to advanced setup (SOL-153411).**
-`.github/workflows/codeql.yml` and its `CodeQL gate` job are in the repository; the
-two remaining steps are admin actions, and their **order is load-bearing**.
-
-Default setup and advanced setup cannot both be active, so until step 1 happens
-there are two configurations competing and the required `CodeQL` context is still
-the one being produced.
+**CodeQL runs on advanced setup** — `.github/workflows/codeql.yml`, with the
+verdict in the `CodeQL gate` job. Default setup was retired under SOL-153411 on
+20 August 2026 because it scanned no fork pull request, no Dependabot pull
+request and no merge queue entry.
 
 ```bash
-# Before: the configuration this migration replaces.
-gh api repos/OWNER/REPO/code-scanning/default-setup
-# state: configured  languages: [actions, go]  query_suite: default
-# threat_model: remote  schedule: weekly  runner_type: standard
+gh api repos/OWNER/REPO/code-scanning/default-setup --jq '.state'
+# not-configured   <- advanced setup is the only configuration; see below for why
 ```
 
-⚠️ **`codeql.yml` cannot be green until step 2 happens, and that is not a bug in
-it.** GitHub refuses the upload outright while both configurations are live:
+⚠️ **One step remains: register `CodeQL gate` as a required status check** on
+ruleset `main-protection` (13 → 14 contexts). Until that lands, CodeQL scans and
+reports but does not block. Do it only once `codeql.yml` is on `main` — see
+"Order matters" below for why the sequence is not free-form.
+
+### Why the two setups cannot overlap, and what that forces
+
+Default and advanced setup cannot both be active, and GitHub enforces that at
+upload-processing time rather than by ignoring one:
 
 ```
 ##[error]Code Scanning could not process the submitted SARIF file:
@@ -142,32 +144,89 @@ CodeQL analyses from advanced configurations cannot be processed when
 the default setup is enabled
 ```
 
-Observed on PR #325, 19 August 2026. The analysis itself ran and uploaded fine;
-only the *processing* is refused. So "wait for the workflow to be green, then
-disable default setup" is circular — expect `Analyze (...)` and `CodeQL gate` to
-be red on the pull request that introduces them, and read that red as the
-coexistence rule, not as a broken workflow.
+Observed on PR #325, 19 August 2026. The analysis ran and uploaded fine; only the
+*processing* was refused. Two consequences, both of which invalidate the obvious
+migration order:
 
-That also rules out the tidy "add the new context, confirm it reports, then
-remove the old one" order: `CodeQL gate` cannot report a pass while `CodeQL`'s
-producer is still enabled. One of the two has to be uncovered briefly, and the
-choice is which:
+- **"Wait for the workflow to be green, then disable default setup" is circular.**
+  It cannot be green until default setup is off.
+- **"Add the new context, confirm it reports, then remove the old one" is also
+  impossible.** `CodeQL gate` cannot report a pass while `CodeQL`'s producer is
+  still enabled.
 
-1. **Capture the rollback**, then **remove `CodeQL`/`57789`** from ruleset
-   `main-protection` (14 → 13 contexts). CodeQL stops *blocking* here, but keeps
-   *scanning* — default setup is still on, and merges are not affected.
-2. **Disable default setup**: **Settings → Code security → "CodeQL analysis" row
-   → "Switch to advanced" → "Disable CodeQL"**. Advanced setup's uploads start
-   being processed from this point.
-3. **Confirm `CodeQL gate` is green** on `main` and on a live pull request.
-4. **Add `CodeQL gate`** to the ruleset (13 → 14, net count unchanged).
+So one of the two has to be uncovered briefly, and the choice is which.
 
-Between steps 1 and 4 CodeQL is scanning but not blocking. That is the cheaper of
-the two exposures: doing it the other way round — disabling default setup first —
-stops the required `CodeQL` context from being produced at all, which blocks
-**every** merge in the repository until step 4 lands. A short unenforced window
-beats a repository-wide merge freeze, and there are **zero open alerts** to slip
-through it.
+**Remove the required context first.** That leaves CodeQL **scanning but not
+blocking** for a bounded window — an exposure whose size you can see and whose
+mechanism does not depend on anything uncertain.
+
+Be careful about the reason, because the tempting version of it is wrong.
+Disabling default setup first does **not** stop the `CodeQL` context from being
+produced: advanced setup produces a `CodeQL` check run from the same
+`github-advanced-security` app (`57789`) once its upload is processed. Verified
+here on 20 August 2026, on PR #325's head after default setup was already off:
+
+```bash
+gh api repos/OWNER/REPO/commits/<sha>/check-runs --jq '.check_runs[].name'
+# CodeQL gate      app=15368 (github-actions)
+# Analyze (go)     app=15368
+# Analyze (actions) app=15368
+# CodeQL           app=57789 (github-advanced-security)   <- still produced
+```
+
+So the real exposure of the reverse order is narrower than a permanent freeze: a
+re-run gap on commits whose analysis predates the switch, not a guaranteed
+repository-wide block. The order above is still the right one, but for a
+different reason than "the old context disappears" — it is that it does not
+**depend** on that check-run name continuing to match in this repository, where
+the other order does. Prefer the sequence whose correctness you do not have to
+verify against an app's naming behaviour on a `bypass_actors: []` ruleset.
+
+⚠️ **Do not conclude from the above that `CodeQL`/`57789` could simply have stayed
+required.** It is pull-request-scoped: it does not report on a `merge_group` event
+(`github/codeql-action#1537`), so requiring it would leave every merge queue entry
+hanging — the exact failure SOL-152974 needs avoided. `CodeQL gate` exists because
+it reports on all three of pull requests, fork pull requests and merge queue
+entries.
+
+### Order matters — what was actually done, 20 August 2026
+
+Recorded because the sequence is the only part of this that is easy to get wrong,
+and because the ticket's own prescribed order could not work:
+
+1. **Captured the ruleset JSON as the rollback**, then removed `CodeQL`/`57789`
+   from `main-protection` (14 → 13). CodeQL stopped blocking; default setup was
+   still on, so it kept scanning.
+2. **Disabled default setup** (`PATCH /code-scanning/default-setup`,
+   `state=not-configured`; equivalently **Settings → Code security → "CodeQL
+   analysis" → "Switch to advanced" → "Disable CodeQL"**).
+3. **Re-ran PR #325's CodeQL workflow** and confirmed all three checks green —
+   `Analyze (actions)`, `Analyze (go)`, `CodeQL gate`. This is the live-pull-request
+   verification, done *before* the context became required rather than after.
+4. **Merge `codeql.yml` to `main`.**
+5. **Add `CodeQL gate`** to the ruleset (13 → 14, net count unchanged).
+
+⚠️ **Do not register `CodeQL gate` before step 4.** Any open pull request whose
+branch predates `codeql.yml` will not run the workflow at all, so the context
+never reports and the pull request cannot merge — the same never-reports trap
+`workflow-lint.yaml`'s header comment dissects. `strict_required_status_checks_policy`
+is `true`, so those branches must update to `main` anyway, which brings the
+workflow with it.
+
+```bash
+# Rollback capture, before touching anything.
+gh api repos/OWNER/REPO/rulesets/13942241 > /tmp/ruleset-13942241-rollback.json
+
+# Verify the live list, on the day it changes.
+gh api repos/OWNER/REPO/rulesets/13942241 \
+  --jq '.rules[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[] | "\(.context) \(.integration_id // "")"'
+```
+
+Reverting is a settings toggle plus the rollback file: re-enable default setup
+(`state=configured`, languages `actions` and `go`) and re-add `CodeQL`/`57789`.
+Migrating at **zero open alerts** is what made all of this cheap — there was no
+alert continuity to preserve.
 
 ```bash
 # Rollback capture, before touching anything.
@@ -221,7 +280,7 @@ run?" can be answered without opening a workflow file.
 | Tool | Covers | Config | Blocking? |
 |------|--------|--------|-----------|
 | golangci-lint | Go static analysis. Eight linters: `errcheck`, `staticcheck`, `gosec`, `govet`, `revive`, `bodyclose`, `ineffassign`, `noctx`. `gosec` carries the security patterns (`G706` excluded pending a gosec release) | `.golangci.yml` | **Yes** — required check `lint` |
-| CodeQL | SAST over Go and GitHub Actions workflows. `default` query suite, `remote` threat model, buildless Go extraction (`build-mode: none`), weekly schedule plus every push, **every** pull request (fork and Dependabot included) and every merge queue entry | `.github/workflows/codeql.yml` (advanced setup), verdict in `.github/scripts/codeql-gate.sh` | **Yes** — required check `CodeQL gate`, within the two limits below |
+| CodeQL | SAST over Go and GitHub Actions workflows. `default` query suite, `remote` threat model, `build-mode: autobuild` for Go and `none` for actions (what default setup used — read from its own `environment`, not inferred from runtime), weekly schedule plus every push, **every** pull request (fork and Dependabot included) and every merge queue entry | `.github/workflows/codeql.yml` (advanced setup), verdict in `.github/scripts/codeql-gate.sh` | **Scanning and reporting, not yet blocking** — `CodeQL gate` is pending registration; once registered it blocks within the two limits below |
 | FOSSA SCA | Third-party dependency licences and known vulnerabilities | `.github/workflow-config.json`, run from `guardian-scan.yaml` | **Detection, not prevention.** `Guardian scan gate` is required, but on a pull request FOSSA runs in diff mode and REPORT; the hard gate is on push to `main` and at the release tag |
 | Dependency Review | A pull request *introducing* a dependency with a known high or critical advisory | `ci-pr.yaml` job `dependency_review` | Not yet a required check — see [Required status checks](#required-status-checks) |
 
@@ -320,11 +379,16 @@ review.
 ### Required status checks
 
 **Require branches to be up to date before merging** is on, and the context list
-is applied. Sixteen contexts are documented below; **fourteen of them are
-registered** in the ruleset. The two that are not carry **Not yet registered** in
+is applied. Sixteen contexts are documented below; **thirteen of them are
+registered** in the ruleset. The three that are not carry **Not yet registered** in
 their own row — they are listed here because they run on every pull request and are
 candidates for registration, not because they gate anything today. This table is the
 single authoritative copy of both sets.
+
+The count dropped from fourteen to thirteen on 20 August 2026 when `CodeQL` was
+removed as part of the advanced-setup migration (SOL-153411). Registering
+`CodeQL gate` returns it to fourteen — see [Code Security](#code-security) for why
+the removal had to come first.
 
 Read the live list rather than trusting the table:
 
@@ -351,8 +415,8 @@ gh api repos/OWNER/REPO/rulesets/13942241 \
 | `Commit identity routable` | `ci-pr.yaml` job `identity` | Every commit the PR adds using a routable author and committer address, so a machine hostname does not publish permanently with the history. Pinned to Actions (`15368`), not to the `dco2` App — see below |
 | `workflow-lint` | `workflow-lint.yaml` job `workflow-lint` | Every file under `.github/workflows/` passing actionlint (correctness, plus shellcheck over `run:` blocks) and zizmor (workflow security, including SHA pinning via `unpinned-uses`), so workflow security is enforced by a tool rather than argued in a code comment. **Not yet registered** — see below |
 | `DCO` | the CNCF `dco2` GitHub App | a `Signed-off-by` trailer on every commit the pull request adds. DCO stands in for a contributor licence agreement, so this is the control behind the repository's provenance claim |
-| `CodeQL` | code-scanning default setup, via the `github-advanced-security` App | **Being replaced by `CodeQL gate` — SOL-153411.** New CodeQL alerts in the code a pull request changes. Pinned to app `57789`, **not** Actions (`15368`) — every other Actions context here is `15368`, and pinning this one there leaves it permanently pending, blocking all merges. Registered 19 August 2026. Remove *after* `CodeQL gate` is added and seen reporting; see the migration steps under [Code Security](#code-security) |
-| `CodeQL gate` | `codeql.yml` job `gate` | New CodeQL alerts at or above threshold, **and** the absence of a usable analysis. Pinned to Actions (`15368`) like every other workflow context here — not to app `57789`. Reports on fork pull requests, Dependabot pull requests and `merge_group` entries, which is the whole point of the migration. **Not yet registered** — see the migration steps under [Code Security](#code-security). Scope and limits: [Static analysis](#static-analysis) |
+| ~~`CodeQL`~~ | code-scanning default setup, via the `github-advanced-security` App | **Retired 20 August 2026 (SOL-153411) — no longer registered, and no longer produced.** Kept as a row because its `integration_id` is the one genuine exception in this table and someone will hit it again: it was pinned to app `57789`, **not** Actions (`15368`), and pinning it to `15368` left it permanently pending and blocked all merges. Replaced by `CodeQL gate` |
+| `CodeQL gate` | `codeql.yml` job `gate` | New CodeQL alerts at or above threshold, **and** the absence of a usable analysis — a missing, stale or errored one fails it rather than concluding `neutral`. Pin to Actions (`15368`) like every other workflow context here, **not** to app `57789`. Reports on fork pull requests, Dependabot pull requests and `merge_group` entries, which is the whole point of the migration; verified green on PR #325 before registration. **Not yet registered** — see [Code Security](#code-security). Scope and limits: [Static analysis](#static-analysis) |
 
 ⚠️ **Require `Guardian scan gate`, and nothing FOSSA-shaped.** The old
 `FOSSA Scan` and `FOSSA Scan / SCA Scan` contexts no longer exist — the
@@ -672,8 +736,16 @@ fine: `ci-pr.yaml` gives that job only `contents: read` and it reads no secrets.
 outside evidence rather than reasoning: on 19 August 2026, fork pull requests
 against `cli/cli` (advanced setup, the same `pull_request` trigger shape as
 `codeql.yml`) carried real verdicts from both `Analyze` jobs, so the SARIF upload
-is not blocked by the read-only-token downgrade. The `CodeQL` context it replaces
-was the opposite — default setup analyzes no fork ref at all. Copilot review is
+is not blocked by the read-only-token downgrade. Three Dependabot pull requests
+there behaved the same way. The `CodeQL` context it replaces was the opposite —
+default setup analyzes no fork ref at all.
+
+⚠️ Still worth doing for real. That is another repository's configuration, and the
+one thing not yet observed here is a **fork** pull request against *this* repo —
+it needs a fork plus maintainer approval of the run (SOL-152960). The same-repo
+half is confirmed locally: `CodeQL gate` went green on PR #325 on 20 August 2026,
+crediting only the two analyses whose `commit_sha` matched the commit under test
+out of six present on the ref. Copilot review is
 inconsistent even on same-repo pull requests, so do not count on it. Verify
 `Guardian scan gate`, `CHANGELOG updated`, `CodeQL gate`, `Dependencies free of
 high advisories`, and the `lint` job's annotation behavior on a read-only token
@@ -813,7 +885,7 @@ writing; re-check, do not assume.
 - ✅ **Required status checks corrected** per the Branch Protection section above
   — this document corrected 2026-08-17 (SOL-153190) to match the live ruleset,
   which was itself updated 2026-08-12. The `main-protection` ruleset now requires
-  all fourteen registered contexts in the table above, including `Guardian scan gate`
+  all thirteen registered contexts in the table above, including `Guardian scan gate`
   (from `guardian-scan.yaml`) in place of the retired `FOSSA Scan` / `FOSSA Scan /
   SCA Scan` contexts, with `strict_required_status_checks_policy: true` and an
   **empty bypass-actor list** — no admin override exists. Re-verify against the
@@ -834,7 +906,7 @@ writing; re-check, do not assume.
   > the scan itself was broken would have turned "scanning is broken" into "no
   > pull request can merge." That precondition was met before registration.
   > **There is no "branch protection holds zero required contexts" state
-  > anymore** — every one of the fourteen contexts, `Guardian scan gate`
+  > anymore** — every one of the thirteen contexts, `Guardian scan gate`
   > included, now blocks a merge if it is red or never reports, with nothing to
   > bypass it. One exception, added later: `CodeQL` can conclude `neutral`, which
   > GitHub counts as passing. Its replacement `CodeQL gate` cannot — it fails on a

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -111,23 +111,50 @@ gh api repos/OWNER/REPO --jq '.security_and_analysis'
 | Secret scanning push protection | On | None |
 | Secret scanning validity checks | On | None |
 | Secret scanning non-provider patterns | On | None |
-| Code scanning (CodeQL) | On — default setup, languages `actions` and `go` | None |
+| Code scanning (CodeQL) | On — **default setup**, languages `actions` and `go` | **Disable default setup**, then swap the required context — see below |
 
 Both secret-scanning settings are already on, so there is nothing to enable here.
 Confirm rather than change: alerts find credentials already committed, push
 protection rejects the next one before it lands, and losing either is a
 regression. Both stay free on public repositories.
 
-On CodeQL: the earlier uncertainty here is resolved. The configuration is
-repository-level default setup, readable through the API now that the repository is
-public, and the `CodeQL` check is a required status check. See
-[Static analysis](#static-analysis) for what it does and does not catch.
+⚠️ **CodeQL is mid-migration from default setup to advanced setup (SOL-153411).**
+`.github/workflows/codeql.yml` and its `CodeQL gate` job are in the repository; the
+two remaining steps are admin actions, and their **order is load-bearing**.
+
+Default setup and advanced setup cannot both be active, so until step 1 happens
+there are two configurations competing and the required `CodeQL` context is still
+the one being produced.
 
 ```bash
+# Before: the configuration this migration replaces.
 gh api repos/OWNER/REPO/code-scanning/default-setup
 # state: configured  languages: [actions, go]  query_suite: default
 # threat_model: remote  schedule: weekly  runner_type: standard
 ```
+
+1. **Wait for `codeql.yml` to be green on `main`**, then disable default setup:
+   **Settings → Code security → "CodeQL analysis" row → "Switch to advanced" →
+   "Disable CodeQL"**. Doing this before the workflow is observed green leaves a
+   window with no scanning at all.
+2. **Swap the required context** on ruleset `main-protection`: **add**
+   `CodeQL gate`, confirm it reports on a live pull request, **then remove**
+   `CodeQL`/`57789`. Reversed, every merge blocks on a context nobody produces.
+   Capture the ruleset JSON first — that file is the rollback. Net count stays 14.
+
+```bash
+# Rollback capture, before touching anything.
+gh api repos/OWNER/REPO/rulesets/13942241 > /tmp/ruleset-13942241.json
+
+# After: verify the live list, on the day it changes.
+gh api repos/OWNER/REPO/rulesets/13942241 \
+  --jq '.rules[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks[] | "\(.context) \(.integration_id // "")"'
+```
+
+Why bother: default setup never scanned a fork pull request, a Dependabot pull
+request, or a merge queue entry. See [Static analysis](#static-analysis) for what
+the replacement does and does not catch.
 
 **Nothing to enable for dependency review.** The `Dependencies free of high
 advisories` check reads the Dependency Review API, which is served by the
@@ -167,51 +194,62 @@ run?" can be answered without opening a workflow file.
 | Tool | Covers | Config | Blocking? |
 |------|--------|--------|-----------|
 | golangci-lint | Go static analysis. Eight linters: `errcheck`, `staticcheck`, `gosec`, `govet`, `revive`, `bodyclose`, `ineffassign`, `noctx`. `gosec` carries the security patterns (`G706` excluded pending a gosec release) | `.golangci.yml` | **Yes** — required check `lint` |
-| CodeQL | SAST over Go and GitHub Actions workflows. GitHub default setup, `default` query suite, `remote` threat model, weekly schedule plus every push and same-repo pull request | repository-level default setup; no file in the repository | **Yes** — required check `CodeQL`, within the three limits below |
+| CodeQL | SAST over Go and GitHub Actions workflows. `default` query suite, `remote` threat model, buildless Go extraction (`build-mode: none`), weekly schedule plus every push, **every** pull request (fork and Dependabot included) and every merge queue entry | `.github/workflows/codeql.yml` (advanced setup), verdict in `.github/scripts/codeql-gate.sh` | **Yes** — required check `CodeQL gate`, within the two limits below |
 | FOSSA SCA | Third-party dependency licences and known vulnerabilities | `.github/workflow-config.json`, run from `guardian-scan.yaml` | **Detection, not prevention.** `Guardian scan gate` is required, but on a pull request FOSSA runs in diff mode and REPORT; the hard gate is on push to `main` and at the release tag |
 | Dependency Review | A pull request *introducing* a dependency with a known high or critical advisory | `ci-pr.yaml` job `dependency_review` | Not yet a required check — see [Required status checks](#required-status-checks) |
 
-Three limits on "a pull request with a CodeQL finding cannot merge". All three are
-deliberate; none is a defect to be fixed later without a decision.
+Two limits on "a pull request with a CodeQL finding cannot merge". Both are
+deliberate; neither is a defect to be fixed later without a decision. Default setup
+had a third — it analyzed no Dependabot pull request and no fork pull request, so
+the check concluded `neutral` there and GitHub counts `neutral` as passing, leaving
+the gate absent rather than blocking. Advanced setup closes it: on 19 August 2026,
+two fork pull requests and three Dependabot pull requests against `cli/cli`
+(advanced setup, the same `pull_request` trigger shape as `codeql.yml`) each carried
+real verdicts from both `Analyze` jobs, so SARIF upload is not blocked by the
+read-only-token downgrade that applies to those events generally.
 
-**1. Severity.** The check fails on new alerts at severity `error`, or security
+**1. Severity.** The gate fails on new alerts at severity `error`, or security
 severity `critical` or `high`. A `medium` or `low` security-severity finding leaves
-the check green. Default setup exposes no per-repository threshold control; the
-ruleset rule that would (`code_scanning`, "Require code scanning results") is
-deliberately not used, because it blocks a pull request whose analysis never
-arrives — which is every Dependabot pull request, see limit 3.
+the gate green. The threshold is a constant in `codeql-gate.sh`, not a workflow
+input — there is no scenario where turning it off is the right call, so changing it
+takes a commit a reviewer can see. The ruleset rule that would enforce a threshold
+instead (`code_scanning`, "Require code scanning results") is deliberately not used:
+it blocks a pull request whose analysis never arrives, and it cannot express the
+new-findings-only scope below.
 
-**2. New findings only.** The check's own title is "No new alerts in code changed by
-this pull request". An alert already present on `main` is pre-existing, so a pull
-request that *attempts and fails* to fix one still passes. Confirmation that a fix
-landed comes from the post-merge `main` analysis:
+**2. New findings only.** An alert already open on `main` is pre-existing, so a pull
+request that *attempts and fails* to fix one still passes. The gate compares alert
+*numbers* between the pull request ref and `refs/heads/main`; those numbers are
+repository-scoped and stable across refs, so the comparison needs no rule-name and
+line-number fingerprinting. Confirmation that a fix landed comes from the post-merge
+`main` analysis:
 
 ```bash
 gh api repos/OWNER/REPO/code-scanning/alerts/<n> --jq '.state, .fixed_at'
 ```
 
-**3. Dependabot pull requests are not analyzed at all.** A known limitation of
-default setup: it does not run on Dependabot-authored pull requests. Verified on
-19 August 2026 across ~300 default-setup runs — every human pull request ref carries
-two analyses, no Dependabot ref carries any. The check then concludes `neutral`
-("N configurations not found"), and GitHub counts `success`, `skipped` and `neutral`
-all as passing, so the gate is absent rather than blocking there. Accepted
-knowingly: these pull requests change dependency versions, not our Go code, and
-`Dependencies free of high advisories` plus the FOSSA guards cover that surface.
-Closing it would mean migrating off default setup to an in-repo `codeql.yml`
-(advanced setup), which is a deliberate non-goal here.
+A false positive is **dismissable**: the gate reads the alerts API, not the raw
+SARIF, so dismissing an alert in the Security tab with a reason stops it blocking.
+That is the reason for the API round-trip — a gate nobody can open is worse than no
+gate.
 
-**Untested: fork pull requests.** No fork pull request has ever been opened against
-this repository, so whether default setup analyzes a fork ref is unobserved. If it
-behaves as it does for Dependabot, an outside contributor's pull request would carry
-a `neutral` CodeQL check and merge ungated. Verify on the first real one rather than
-assuming either way.
+**The gate fails on absence, not just on findings.** A missing analysis, an analysis
+that reported an extraction error, and a failed or cancelled `Analyze` matrix each
+fail `CodeQL gate` rather than letting it pass quietly. `codeql-gate.test.sh` asserts
+all three offline and runs as the job's first step, before the gate it guards.
 
-Do **not** require `Analyze (go)` or `Analyze (actions)` in place of `CodeQL`. They
-report success whenever the analysis completes, whatever it found, and their names
-are generated from the configured language list — so adding a language later leaves
-the required set silently covering less. `CodeQL` is stable across language changes
-and carries the verdict.
+On push to `main` and on the weekly schedule the gate runs in **report** mode: it
+prints findings and stays green. There is no merge left to block there, and a
+finding that lands on `main` must not wedge every open pull request behind a context
+nobody can turn green from a pull request.
+
+Do **not** require `Analyze (go)` or `Analyze (actions)` in place of `CodeQL gate`.
+`codeql-action/analyze` has no `fail-on-severity` input of any kind, so those jobs
+report success whenever analysis *completes*, whatever it found — and their names are
+generated from the language matrix, so adding a language later leaves the required
+set silently covering less. `CodeQL gate` is stable across language changes and
+carries the verdict; it also checks that one analysis arrived *per* expected
+language, which is what makes adding a language safe.
 
 ---
 
@@ -286,7 +324,8 @@ gh api repos/OWNER/REPO/rulesets/13942241 \
 | `Commit identity routable` | `ci-pr.yaml` job `identity` | Every commit the PR adds using a routable author and committer address, so a machine hostname does not publish permanently with the history. Pinned to Actions (`15368`), not to the `dco2` App — see below |
 | `workflow-lint` | `workflow-lint.yaml` job `workflow-lint` | Every file under `.github/workflows/` passing actionlint (correctness, plus shellcheck over `run:` blocks) and zizmor (workflow security, including SHA pinning via `unpinned-uses`), so workflow security is enforced by a tool rather than argued in a code comment. **Not yet registered** — see below |
 | `DCO` | the CNCF `dco2` GitHub App | a `Signed-off-by` trailer on every commit the pull request adds. DCO stands in for a contributor licence agreement, so this is the control behind the repository's provenance claim |
-| `CodeQL` | code-scanning default setup, via the `github-advanced-security` App | New CodeQL alerts in the code a pull request changes. Pinned to app `57789`, **not** Actions (`15368`) — every other Actions context here is `15368`, and pinning this one there leaves it permanently pending, blocking all merges. Registered 19 August 2026. Scope and limits: [Static analysis](#static-analysis) |
+| `CodeQL` | code-scanning default setup, via the `github-advanced-security` App | **Being replaced by `CodeQL gate` — SOL-153411.** New CodeQL alerts in the code a pull request changes. Pinned to app `57789`, **not** Actions (`15368`) — every other Actions context here is `15368`, and pinning this one there leaves it permanently pending, blocking all merges. Registered 19 August 2026. Remove *after* `CodeQL gate` is added and seen reporting; see the migration steps under [Code Security](#code-security) |
+| `CodeQL gate` | `codeql.yml` job `gate` | New CodeQL alerts at or above threshold, **and** the absence of a usable analysis. Pinned to Actions (`15368`) like every other workflow context here — not to app `57789`. Reports on fork pull requests, Dependabot pull requests and `merge_group` entries, which is the whole point of the migration. **Not yet registered** — see the migration steps under [Code Security](#code-security). Scope and limits: [Static analysis](#static-analysis) |
 
 ⚠️ **Require `Guardian scan gate`, and nothing FOSSA-shaped.** The old
 `FOSSA Scan` and `FOSSA Scan / SCA Scan` contexts no longer exist — the
@@ -445,10 +484,11 @@ Three more notes on the list:
   findings without blocking on them; the hard gate is on push to `main` and at the
   release tag. Do not read a green PR as a clean full scan. On a fork pull request
   the scan does not run at all — see the fork section below.
-- `CodeQL` blocks a pull request that introduces a new alert, but only above a
-  severity floor, only for findings new to the pull request, and not at all on
-  Dependabot pull requests. Read [Static analysis](#static-analysis) before quoting
-  it as a control, and do not swap it for `Analyze (go)` / `Analyze (actions)`.
+- `CodeQL gate` blocks a pull request that introduces a new alert, but only above a
+  severity floor and only for findings new relative to `main`. Read
+  [Static analysis](#static-analysis) before quoting it as a control, and do not swap
+  it for `Analyze (go)` / `Analyze (actions)`. Unlike the `CodeQL` context it
+  replaces, it does report on fork and Dependabot pull requests.
 
 **How a fork pull request gets a verdict.** SOL-152411 fixed the two problems that
 made this impossible. What it changed, and what it deliberately did not:
@@ -601,13 +641,16 @@ REPORT (not BLOCK), so a green `Guardian scan gate` there is not a clean full sc
 Nobody has ever opened a fork pull request against this repository, so none of the
 above is observed on a real external contribution. `CHANGELOG updated` should be
 fine: `ci-pr.yaml` gives that job only `contents: read` and it reads no secrets.
-`CodeQL` comes from code-scanning default setup and is a required check, but
-whether default setup analyzes a fork ref is unobserved — and it is known not to
-analyze Dependabot refs, so do not assume it covers forks. Copilot review is
+`CodeQL gate` should be fine on a fork ref, and this is the one item here with
+outside evidence rather than reasoning: on 19 August 2026, fork pull requests
+against `cli/cli` (advanced setup, the same `pull_request` trigger shape as
+`codeql.yml`) carried real verdicts from both `Analyze` jobs, so the SARIF upload
+is not blocked by the read-only-token downgrade. The `CodeQL` context it replaces
+was the opposite — default setup analyzes no fork ref at all. Copilot review is
 inconsistent even on same-repo pull requests, so do not count on it. Verify
-`Guardian scan gate`, `CHANGELOG updated`, `CodeQL`, `Dependencies free of high
-advisories`, and the `lint` job's annotation behavior on a read-only token against
-a real fork pull request before treating any of them as a gate.
+`Guardian scan gate`, `CHANGELOG updated`, `CodeQL gate`, `Dependencies free of
+high advisories`, and the `lint` job's annotation behavior on a read-only token
+against a real fork pull request before treating any of them as a gate.
 
 `Dependencies free of high advisories` is the one on that list whose fork
 behaviour is load-bearing rather than incidental, since closing the vulnerability
@@ -767,7 +810,9 @@ writing; re-check, do not assume.
   > anymore** — every one of the fourteen contexts, `Guardian scan gate`
   > included, now blocks a merge if it is red or never reports, with nothing to
   > bypass it. One exception, added later: `CodeQL` can conclude `neutral`, which
-  > GitHub counts as passing — see [Static analysis](#static-analysis). A scan outage today blocks everyone, which is what makes the "Who
+  > GitHub counts as passing. Its replacement `CodeQL gate` cannot — it fails on a
+  > missing analysis rather than concluding `neutral` — so that exception retires
+  > with the migration; see [Static analysis](#static-analysis). A scan outage today blocks everyone, which is what makes the "Who
   > picks up a red supply-chain scan on `main`" gap earlier in the Branch
   > Protection section (above) worth reading, not less.
   >

--- a/.github/ADMIN_SETUP.md
+++ b/.github/ADMIN_SETUP.md
@@ -133,14 +133,41 @@ gh api repos/OWNER/REPO/code-scanning/default-setup
 # threat_model: remote  schedule: weekly  runner_type: standard
 ```
 
-1. **Wait for `codeql.yml` to be green on `main`**, then disable default setup:
-   **Settings → Code security → "CodeQL analysis" row → "Switch to advanced" →
-   "Disable CodeQL"**. Doing this before the workflow is observed green leaves a
-   window with no scanning at all.
-2. **Swap the required context** on ruleset `main-protection`: **add**
-   `CodeQL gate`, confirm it reports on a live pull request, **then remove**
-   `CodeQL`/`57789`. Reversed, every merge blocks on a context nobody produces.
-   Capture the ruleset JSON first — that file is the rollback. Net count stays 14.
+⚠️ **`codeql.yml` cannot be green until step 2 happens, and that is not a bug in
+it.** GitHub refuses the upload outright while both configurations are live:
+
+```
+##[error]Code Scanning could not process the submitted SARIF file:
+CodeQL analyses from advanced configurations cannot be processed when
+the default setup is enabled
+```
+
+Observed on PR #325, 19 August 2026. The analysis itself ran and uploaded fine;
+only the *processing* is refused. So "wait for the workflow to be green, then
+disable default setup" is circular — expect `Analyze (...)` and `CodeQL gate` to
+be red on the pull request that introduces them, and read that red as the
+coexistence rule, not as a broken workflow.
+
+That also rules out the tidy "add the new context, confirm it reports, then
+remove the old one" order: `CodeQL gate` cannot report a pass while `CodeQL`'s
+producer is still enabled. One of the two has to be uncovered briefly, and the
+choice is which:
+
+1. **Capture the rollback**, then **remove `CodeQL`/`57789`** from ruleset
+   `main-protection` (14 → 13 contexts). CodeQL stops *blocking* here, but keeps
+   *scanning* — default setup is still on, and merges are not affected.
+2. **Disable default setup**: **Settings → Code security → "CodeQL analysis" row
+   → "Switch to advanced" → "Disable CodeQL"**. Advanced setup's uploads start
+   being processed from this point.
+3. **Confirm `CodeQL gate` is green** on `main` and on a live pull request.
+4. **Add `CodeQL gate`** to the ruleset (13 → 14, net count unchanged).
+
+Between steps 1 and 4 CodeQL is scanning but not blocking. That is the cheaper of
+the two exposures: doing it the other way round — disabling default setup first —
+stops the required `CodeQL` context from being produced at all, which blocks
+**every** merge in the repository until step 4 lands. A short unenforced window
+beats a repository-wide merge freeze, and there are **zero open alerts** to slip
+through it.
 
 ```bash
 # Rollback capture, before touching anything.

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -184,10 +184,14 @@ These settings must be configured by repository admin:
   bot-authored commit, a wider exemption than the retired workflow's single
   login-matched one, with no config key to narrow it. See ADMIN_SETUP.md →
   "Required status checks"
-- CodeQL is code-scanning default setup (`actions`, `go`), and `CodeQL` is a
-  required status check as of 19 August 2026. It does not analyze Dependabot pull
-  requests, and its fork behaviour is untested; see ADMIN_SETUP.md →
-  "Static analysis" before quoting it as a control
+- CodeQL is migrating from code-scanning default setup to advanced setup
+  (`.github/workflows/codeql.yml`, languages `actions` and `go`) under SOL-153411,
+  because default setup analyzed neither fork pull requests, Dependabot pull
+  requests, nor merge queue entries — and a required check that never reports makes
+  a fork pull request unmergeable. `CodeQL` is the required status check as of
+  19 August 2026 and `CodeQL gate` replaces it; the swap is two admin actions in a
+  load-bearing order. See ADMIN_SETUP.md → "Code Security" for those, and
+  "Static analysis" before quoting either as a control
 - See: ADMIN_SETUP.md → "Security Settings"
 
 ### 5. Actions Settings (5 minutes)

--- a/.github/OPEN_SOURCE_STATUS.md
+++ b/.github/OPEN_SOURCE_STATUS.md
@@ -184,14 +184,15 @@ These settings must be configured by repository admin:
   bot-authored commit, a wider exemption than the retired workflow's single
   login-matched one, with no config key to narrow it. See ADMIN_SETUP.md →
   "Required status checks"
-- CodeQL is migrating from code-scanning default setup to advanced setup
-  (`.github/workflows/codeql.yml`, languages `actions` and `go`) under SOL-153411,
-  because default setup analyzed neither fork pull requests, Dependabot pull
-  requests, nor merge queue entries — and a required check that never reports makes
-  a fork pull request unmergeable. `CodeQL` is the required status check as of
-  19 August 2026 and `CodeQL gate` replaces it; the swap is two admin actions in a
-  load-bearing order. See ADMIN_SETUP.md → "Code Security" for those, and
-  "Static analysis" before quoting either as a control
+- CodeQL runs on **advanced setup** (`.github/workflows/codeql.yml`, languages
+  `actions` and `go`) as of 20 August 2026 under SOL-153411. Default setup was
+  retired because it analyzed neither fork pull requests, Dependabot pull requests,
+  nor merge queue entries — and a required check that never reports makes a fork
+  pull request unmergeable. The `CodeQL` required context was removed with it;
+  `CodeQL gate` replaces it and is **pending registration**, so CodeQL currently
+  scans and reports without blocking. See ADMIN_SETUP.md → "Code Security" for the
+  remaining step and the ordering constraints, and "Static analysis" before quoting
+  any of it as a control
 - See: ADMIN_SETUP.md → "Security Settings"
 
 ### 5. Actions Settings (5 minutes)

--- a/.github/scripts/codeql-gate.sh
+++ b/.github/scripts/codeql-gate.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# The blocking half of CodeQL advanced setup (SOL-153411).
+#
+# `codeql-action/analyze` has no severity threshold input of any kind — its full
+# input list carries `output, upload, cleanup-level, ram, add-snippets,
+# skip-queries, threads, ref, sha, category, upload-database,
+# post-processed-sarif-path, wait-for-processing, token, matrix, expect-error`
+# and nothing resembling `fail-on`. So the matrix passes whenever analysis
+# *completes*, whatever it found, and the verdict has to live somewhere else.
+# This is that somewhere else, run as the `CodeQL gate` job in
+# .github/workflows/codeql.yml — the required status check.
+#
+# TWO FAILURE MODES, NOT ONE
+#
+# A finding at or above threshold fails the gate. So does a *missing* analysis.
+# The second is the one worth writing a script for: default setup's own check
+# concluded `neutral` ("N configurations not found") when no analysis arrived,
+# and GitHub counts `neutral` as passing, so the gate was absent rather than
+# blocking exactly when it was needed. That is the shape SOL-152410 and
+# SOL-152412 exist to prevent, and this script refuses to reproduce it.
+#
+# WHY THE FETCHING IS SOMEWHERE ELSE
+#
+# Everything here is a pure function of three JSON files. The workflow does the
+# `gh api` calls and writes them to disk; this script only judges. That is what
+# lets codeql-gate.test.sh run offline against fixtures on every pull request,
+# rather than asking a reviewer to trust the logic by reading it.
+#
+# Env (all required — a gate that defaults its own inputs is not a gate; see the
+# classification-script discussion on PR #322 for why a `:-` fallback to the
+# most permissive arm is the wrong default):
+#   CODEQL_GATE_MODE           blocking | report
+#   CODEQL_ANALYZE_RESULT      GitHub `needs.<job>.result` for the analyze matrix
+#   CODEQL_EXPECTED_LANGUAGES  space-separated, e.g. "actions go"
+#   CODEQL_ANALYZED_SHA        the commit the analyze jobs examined
+#   CODEQL_ANALYSES_JSON       flat JSON array: code-scanning analyses for the ref
+#   CODEQL_ALERTS_JSON         flat JSON array: open alerts for the ref
+#   CODEQL_BASELINE_JSON       flat JSON array: open alerts for refs/heads/main
+#
+set -euo pipefail
+
+: "${CODEQL_GATE_MODE:?set to blocking or report}"
+: "${CODEQL_ANALYZE_RESULT:?the analyze matrix job result}"
+: "${CODEQL_EXPECTED_LANGUAGES:?space-separated CodeQL languages}"
+: "${CODEQL_ANALYZED_SHA:?the commit SHA the analyze jobs examined}"
+: "${CODEQL_ANALYSES_JSON:?path to the analyses JSON}"
+: "${CODEQL_ALERTS_JSON:?path to the alerts JSON}"
+: "${CODEQL_BASELINE_JSON:?path to the baseline alerts JSON}"
+
+# The threshold, and deliberately not configurable. It reproduces what default
+# setup enforced and .github/ADMIN_SETUP.md documents: severity `error`, or
+# security severity `critical` or `high`. A `medium` or `low` security-severity
+# finding leaves the gate green. There is no scenario in which turning this off
+# is the right call, so it is a constant rather than a knob — change it in a
+# commit a reviewer can see, not in a workflow input.
+SEVERITY_FAIL='error'
+SECURITY_SEVERITY_FAIL='critical high'
+
+# Decide the mode once, so every non-OK exit below honours it. Same shape as
+# changelog-check.sh's CHANGELOG_GATE_MODE.
+#
+# `blocking` on `pull_request` and `merge_group` — the two events where a merge
+# can still be stopped. `report` on push/schedule, where the analysis being run
+# *is* the baseline and there is no merge left to block; a dirty `main` should
+# not wedge every open pull request behind a context nobody can turn green.
+case "$CODEQL_GATE_MODE" in
+  blocking) LEVEL='::error::'; EC=1 ;;
+  report)   LEVEL='::warning::'; EC=0 ;;
+  *)
+    echo "codeql-gate: CODEQL_GATE_MODE must be 'blocking' or 'report', got '${CODEQL_GATE_MODE}'." >&2
+    exit 2
+    ;;
+esac
+
+for f in "$CODEQL_ANALYSES_JSON" "$CODEQL_ALERTS_JSON" "$CODEQL_BASELINE_JSON"; do
+  if [ ! -f "$f" ]; then
+    echo "${LEVEL}codeql-gate: '$f' does not exist — the fetch step did not produce it, so there is nothing to judge. Refusing to pass on absence."
+    exit "$EC"
+  fi
+done
+
+# --- 1. Did the analysis run at all? -----------------------------------------
+#
+# `needs.analyze.result` is `success` only when every matrix leg succeeded;
+# `failure`, `cancelled` and `skipped` all mean no trustworthy verdict exists.
+if [ "$CODEQL_ANALYZE_RESULT" != "success" ]; then
+  echo "${LEVEL}CodeQL analysis did not complete: analyze = '${CODEQL_ANALYZE_RESULT}'. No verdict can be derived, so the gate fails rather than passes."
+  exit "$EC"
+fi
+
+# --- 2. Is there one analysis per expected language, and did any error out? ---
+#
+# Matched on two things, both necessary:
+#
+#   `category`   — set explicitly to `/language:<lang>` by the analyze step.
+#                  Matching on anything GitHub derives for us instead (analysis
+#                  key, environment blob) would make this depend on how a matrix
+#                  job name happens to be rendered.
+#   `commit_sha` — the commit analyzed. Analyses accumulate on a pull request ref
+#                  across pushes, so without this a stale analysis from an
+#                  earlier commit would satisfy the check while this commit went
+#                  unscanned. That is a vacuous pass with a plausible-looking
+#                  audit trail, which is the worst kind.
+missing=''
+for lang in $CODEQL_EXPECTED_LANGUAGES; do
+  count=$(jq \
+    --arg cat "/language:${lang}" \
+    --arg sha "$CODEQL_ANALYZED_SHA" \
+    '[.[] | select(.category == $cat) | select(.commit_sha == $sha)] | length' \
+    "$CODEQL_ANALYSES_JSON")
+  if [ "$count" -eq 0 ]; then
+    missing="${missing} ${lang}"
+  fi
+done
+
+if [ -n "$missing" ]; then
+  echo "${LEVEL}No CodeQL analysis of commit ${CODEQL_ANALYZED_SHA} was uploaded for:${missing}. Expected one per language in '${CODEQL_EXPECTED_LANGUAGES}'. An absent analysis is the vacuous-pass failure mode this gate exists to catch."
+  exit "$EC"
+fi
+
+# An analysis that uploaded but reported an extraction/query error is
+# inconclusive: it may have produced no findings because it examined nothing.
+errored=$(jq -r --arg sha "$CODEQL_ANALYZED_SHA" '[.[] | select(.commit_sha == $sha) | select((.category // "") | startswith("/language:")) | select((.error // "") != "")] | .[] | "\(.category): \(.error)"' "$CODEQL_ANALYSES_JSON")
+if [ -n "$errored" ]; then
+  echo "${LEVEL}CodeQL analysis completed but reported errors, so its result is inconclusive:"
+  sed 's/^/  - /' <<<"$errored"
+  exit "$EC"
+fi
+
+# --- 3. New findings at or above threshold ------------------------------------
+#
+# "New" means new relative to `main`, preserving default setup's documented
+# new-findings-only scope. The comparison is by alert *number*, which is
+# repository-scoped and stable across refs — an alert already open on `main`
+# carries the same number on a pull request ref, so no rule-name-plus-line
+# fingerprinting is needed and none of its fragility is inherited.
+new_alerts=$(
+  jq -r \
+    --slurpfile baseline "$CODEQL_BASELINE_JSON" \
+    --arg sev "$SEVERITY_FAIL" \
+    --arg secsev "$SECURITY_SEVERITY_FAIL" \
+    '
+    ([$baseline[0][]?.number]) as $known
+    | ($secsev | split(" ")) as $blocking_security
+    | [ .[]
+        | select(.state == "open")
+        | select((.number | IN($known[])) | not)
+        | select((.rule.severity == $sev)
+                 or (.rule.security_severity_level as $s | $blocking_security | index($s)))
+      ]
+    | .[]
+    | "#\(.number) [\(.rule.security_severity_level // .rule.severity // "?")] \(.rule.id // "?") — \(.most_recent_instance.location.path // "?"):\(.most_recent_instance.location.start_line // 0)"
+    ' "$CODEQL_ALERTS_JSON"
+)
+
+if [ -n "$new_alerts" ]; then
+  echo "${LEVEL}CodeQL found new alerts at or above the gate threshold (severity '${SEVERITY_FAIL}', or security severity '${SECURITY_SEVERITY_FAIL}'):"
+  sed 's/^/  - /' <<<"$new_alerts"
+  echo
+  echo "Fix the finding, or dismiss the alert in the repository's Security tab with a"
+  echo "reason if it is a false positive — a dismissed alert is no longer open and stops"
+  echo "blocking. Alerts already open on main are pre-existing and are not counted here."
+  exit "$EC"
+fi
+
+echo "CodeQL gate passed: analyses present for '${CODEQL_EXPECTED_LANGUAGES}', no new alerts at or above threshold."

--- a/.github/scripts/codeql-gate.test.sh
+++ b/.github/scripts/codeql-gate.test.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+#
+# Self-test for codeql-gate.sh. Builds throwaway analyses/alerts fixtures, runs
+# the real script against them, and asserts the exit code and the message.
+# Entirely offline — the gate's fetching lives in the workflow, so every
+# decision it makes is reachable from a file on disk.
+#
+# The cases that matter most are the ones asserting a *refusal*: a gate that
+# passes when the analysis is missing looks exactly like a gate that passed
+# because the code is clean, and that is the failure mode SOL-152410 and
+# SOL-152412 exist to prevent.
+#
+# Run manually:  .github/scripts/codeql-gate.test.sh
+# Runs in CI as the first step of the `CodeQL gate` job in
+# .github/workflows/codeql.yml, before the gate it guards.
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+GATE="${SCRIPT_DIR}/codeql-gate.sh"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass_count=0
+fail_count=0
+pass() { pass_count=$((pass_count + 1)); printf 'ok   - %s\n' "$1"; }
+fail() { fail_count=$((fail_count + 1)); printf 'FAIL - %s\n' "$1"; [ -n "${2:-}" ] && printf '       %s\n' "$2"; return 0; }
+
+# --- fixtures ----------------------------------------------------------------
+
+# The commit under analysis, and an earlier one whose analyses are stale.
+SHA='1111111111111111111111111111111111111111'
+OLD_SHA='2222222222222222222222222222222222222222'
+
+BOTH_ANALYSES="$WORK/analyses-both.json"
+cat > "$BOTH_ANALYSES" <<EOF
+[
+  {"category": "/language:go", "commit_sha": "$SHA", "error": "", "results_count": 0},
+  {"category": "/language:actions", "commit_sha": "$SHA", "error": "", "results_count": 0}
+]
+EOF
+
+GO_ONLY_ANALYSES="$WORK/analyses-go-only.json"
+printf '[{"category": "/language:go", "commit_sha": "%s", "error": "", "results_count": 0}]\n' "$SHA" > "$GO_ONLY_ANALYSES"
+
+ERRORED_ANALYSES="$WORK/analyses-errored.json"
+cat > "$ERRORED_ANALYSES" <<EOF
+[
+  {"category": "/language:go", "commit_sha": "$SHA", "error": "1 error(s) during extraction", "results_count": 0},
+  {"category": "/language:actions", "commit_sha": "$SHA", "error": "", "results_count": 0}
+]
+EOF
+
+# Every analysis belongs to an earlier commit — this commit was never scanned,
+# even though the ref carries a full, error-free set.
+STALE_ANALYSES="$WORK/analyses-stale.json"
+cat > "$STALE_ANALYSES" <<EOF
+[
+  {"category": "/language:go", "commit_sha": "$OLD_SHA", "error": "", "results_count": 0},
+  {"category": "/language:actions", "commit_sha": "$OLD_SHA", "error": "", "results_count": 0}
+]
+EOF
+
+# The realistic shape: a stale pair plus a fresh pair, as a re-pushed pull
+# request ref actually looks. This must pass.
+ACCUMULATED_ANALYSES="$WORK/analyses-accumulated.json"
+cat > "$ACCUMULATED_ANALYSES" <<EOF
+[
+  {"category": "/language:go", "commit_sha": "$OLD_SHA", "error": "", "results_count": 0},
+  {"category": "/language:actions", "commit_sha": "$OLD_SHA", "error": "", "results_count": 0},
+  {"category": "/language:go", "commit_sha": "$SHA", "error": "", "results_count": 0},
+  {"category": "/language:actions", "commit_sha": "$SHA", "error": "", "results_count": 0}
+]
+EOF
+
+# An error on the *stale* analysis must not condemn a clean fresh one.
+STALE_ERROR_ANALYSES="$WORK/analyses-stale-error.json"
+cat > "$STALE_ERROR_ANALYSES" <<EOF
+[
+  {"category": "/language:go", "commit_sha": "$OLD_SHA", "error": "1 error(s) during extraction", "results_count": 0},
+  {"category": "/language:actions", "commit_sha": "$OLD_SHA", "error": "", "results_count": 0},
+  {"category": "/language:go", "commit_sha": "$SHA", "error": "", "results_count": 0},
+  {"category": "/language:actions", "commit_sha": "$SHA", "error": "", "results_count": 0}
+]
+EOF
+
+EMPTY="$WORK/empty.json"
+printf '[]\n' > "$EMPTY"
+
+# alert <file> <number> <state> <severity> <security_severity>
+alert() {
+  cat > "$1" <<EOF
+[{"number": $2,
+  "state": "$3",
+  "rule": {"id": "go/example", "severity": "$4", "security_severity_level": "$5"},
+  "most_recent_instance": {"location": {"path": "internal/example.go", "start_line": 42}}}]
+EOF
+}
+
+HIGH_ALERT="$WORK/alert-high.json";     alert "$HIGH_ALERT" 7 open warning high
+MEDIUM_ALERT="$WORK/alert-medium.json"; alert "$MEDIUM_ALERT" 8 open warning medium
+DISMISSED="$WORK/alert-dismissed.json"; alert "$DISMISSED" 9 dismissed warning critical
+
+# severity `error` with no security severity at all — the non-security arm of
+# the threshold, which a `security_severity_level`-only check would miss.
+ERROR_SEV_ALERT="$WORK/alert-error-sev.json"
+cat > "$ERROR_SEV_ALERT" <<'EOF'
+[{"number": 11,
+  "state": "open",
+  "rule": {"id": "actions/example", "severity": "error", "security_severity_level": null},
+  "most_recent_instance": {"location": {"path": ".github/workflows/x.yml", "start_line": 3}}}]
+EOF
+
+# --- runner ------------------------------------------------------------------
+
+# run <mode> <analyze-result> <analyses> <alerts> <baseline>
+# Sets globals RC and OUT (stdout+stderr merged).
+run() {
+  RC=0
+  OUT=$(
+    CODEQL_GATE_MODE="$1" \
+    CODEQL_ANALYZE_RESULT="$2" \
+    CODEQL_EXPECTED_LANGUAGES="actions go" \
+    CODEQL_ANALYZED_SHA="$SHA" \
+    CODEQL_ANALYSES_JSON="$3" \
+    CODEQL_ALERTS_JSON="$4" \
+    CODEQL_BASELINE_JSON="$5" \
+    bash "$GATE" 2>&1
+  ) || RC=$?
+  return 0
+}
+
+has() { grep -q "$2" <<<"$1"; }
+
+# --- Case 1: clean run -> pass ------------------------------------------------
+run blocking success "$BOTH_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -eq 0 ] && has "$OUT" 'gate passed'; then
+  pass "clean analysis with no alerts passes"
+else
+  fail "clean analysis with no alerts passes" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 2: analysis did not complete -> refuse ------------------------------
+run blocking failure "$BOTH_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -ne 0 ] && has "$OUT" 'did not complete'; then
+  pass "failed analyze matrix fails the gate"
+else
+  fail "failed analyze matrix fails the gate" "rc=$RC out=[$OUT]"
+fi
+
+# A cancelled or skipped matrix is the same absence, and `skipped` is the one
+# most likely to arrive by accident (a job-level `if` someone adds later).
+for result in cancelled skipped; do
+  run blocking "$result" "$BOTH_ANALYSES" "$EMPTY" "$EMPTY"
+  if [ "$RC" -ne 0 ]; then
+    pass "analyze = $result fails the gate"
+  else
+    fail "analyze = $result fails the gate" "rc=$RC out=[$OUT]"
+  fi
+done
+
+# --- Case 3: one language never uploaded an analysis -> refuse ----------------
+run blocking success "$GO_ONLY_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -ne 0 ] && has "$OUT" 'actions'; then
+  pass "missing analysis for one language fails, naming it"
+else
+  fail "missing analysis for one language fails, naming it" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 4: no analyses at all -> refuse (the vacuous-pass regression) -------
+run blocking success "$EMPTY" "$EMPTY" "$EMPTY"
+if [ "$RC" -ne 0 ]; then
+  pass "no analyses at all fails rather than passes on absence"
+else
+  fail "no analyses at all fails rather than passes on absence" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 4b: analyses exist, but all for an earlier commit -> refuse ---------
+# The dangerous one: the ref looks fully scanned, and this commit was not.
+run blocking success "$STALE_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -ne 0 ] && has "$OUT" "$SHA"; then
+  pass "analyses for an earlier commit only fails, naming the unscanned commit"
+else
+  fail "analyses for an earlier commit only fails, naming the unscanned commit" "rc=$RC out=[$OUT]"
+fi
+
+# ...and the same ref once this commit *is* scanned must pass, or every re-push
+# would be permanently red.
+run blocking success "$ACCUMULATED_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -eq 0 ]; then
+  pass "stale analyses alongside fresh ones for this commit pass"
+else
+  fail "stale analyses alongside fresh ones for this commit pass" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 5: analysis uploaded but errored -> inconclusive, refuse ------------
+run blocking success "$ERRORED_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -ne 0 ] && has "$OUT" 'inconclusive'; then
+  pass "errored analysis is inconclusive and fails"
+else
+  fail "errored analysis is inconclusive and fails" "rc=$RC out=[$OUT]"
+fi
+
+# An error on a superseded analysis says nothing about this commit.
+run blocking success "$STALE_ERROR_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -eq 0 ]; then
+  pass "an error on a superseded analysis does not condemn this commit"
+else
+  fail "an error on a superseded analysis does not condemn this commit" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 6: new high security-severity alert -> refuse -----------------------
+run blocking success "$BOTH_ANALYSES" "$HIGH_ALERT" "$EMPTY"
+if [ "$RC" -ne 0 ] && has "$OUT" '#7'; then
+  pass "new high security-severity alert fails, naming the alert"
+else
+  fail "new high security-severity alert fails, naming the alert" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 7: severity `error` with no security severity -> refuse -------------
+run blocking success "$BOTH_ANALYSES" "$ERROR_SEV_ALERT" "$EMPTY"
+if [ "$RC" -ne 0 ] && has "$OUT" '#11'; then
+  pass "severity 'error' alert fails even with no security severity"
+else
+  fail "severity 'error' alert fails even with no security severity" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 8: medium security severity -> below threshold, pass ----------------
+run blocking success "$BOTH_ANALYSES" "$MEDIUM_ALERT" "$EMPTY"
+if [ "$RC" -eq 0 ]; then
+  pass "medium security-severity alert is below threshold and passes"
+else
+  fail "medium security-severity alert is below threshold and passes" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 9: alert already open on main -> pre-existing, pass -----------------
+# Same alert number on both refs. This is what preserves the documented
+# new-findings-only scope.
+run blocking success "$BOTH_ANALYSES" "$HIGH_ALERT" "$HIGH_ALERT"
+if [ "$RC" -eq 0 ]; then
+  pass "alert already open on main is pre-existing and passes"
+else
+  fail "alert already open on main is pre-existing and passes" "rc=$RC out=[$OUT]"
+fi
+
+# ...but a *different* alert alongside a pre-existing one must still fail, or a
+# single baseline entry would whitewash the whole ref.
+MIXED="$WORK/alert-mixed.json"
+cat > "$MIXED" <<'EOF'
+[{"number": 7,  "state": "open", "rule": {"id": "go/old", "severity": "warning", "security_severity_level": "high"},
+  "most_recent_instance": {"location": {"path": "a.go", "start_line": 1}}},
+ {"number": 12, "state": "open", "rule": {"id": "go/new", "severity": "warning", "security_severity_level": "critical"},
+  "most_recent_instance": {"location": {"path": "b.go", "start_line": 2}}}]
+EOF
+run blocking success "$BOTH_ANALYSES" "$MIXED" "$HIGH_ALERT"
+if [ "$RC" -ne 0 ] && has "$OUT" '#12'; then
+  pass "a new alert beside a pre-existing one still fails"
+else
+  fail "a new alert beside a pre-existing one still fails" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 10: dismissed alert -> not open, pass -------------------------------
+# The reason the gate reads the alerts API rather than the raw SARIF: a false
+# positive has to be dismissable, or the gate becomes unopenable.
+run blocking success "$BOTH_ANALYSES" "$DISMISSED" "$EMPTY"
+if [ "$RC" -eq 0 ]; then
+  pass "dismissed alert does not block"
+else
+  fail "dismissed alert does not block" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 11: report mode warns without blocking ------------------------------
+run report success "$BOTH_ANALYSES" "$HIGH_ALERT" "$EMPTY"
+if [ "$RC" -eq 0 ] && has "$OUT" '::warning::'; then
+  pass "report mode warns without failing"
+else
+  fail "report mode warns without failing" "rc=$RC out=[$OUT]"
+fi
+
+run report success "$EMPTY" "$EMPTY" "$EMPTY"
+if [ "$RC" -eq 0 ] && has "$OUT" '::warning::'; then
+  pass "report mode warns on a missing analysis without failing"
+else
+  fail "report mode warns on a missing analysis without failing" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 12: a missing input file is a refusal, not a pass -------------------
+run blocking success "$BOTH_ANALYSES" "$WORK/does-not-exist.json" "$EMPTY"
+if [ "$RC" -ne 0 ] && has "$OUT" 'does not exist'; then
+  pass "missing input file fails rather than passing on absence"
+else
+  fail "missing input file fails rather than passing on absence" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 13: an unrecognised mode is a hard error, not a silent default ------
+run enforcing success "$BOTH_ANALYSES" "$EMPTY" "$EMPTY"
+if [ "$RC" -eq 2 ]; then
+  pass "unrecognised CODEQL_GATE_MODE exits 2 instead of guessing"
+else
+  fail "unrecognised CODEQL_GATE_MODE exits 2 instead of guessing" "rc=$RC out=[$OUT]"
+fi
+
+# --- Case 14: every required variable is actually required -------------------
+# The `: "${VAR:?}"` guards, asserted one at a time. Without this, dropping an
+# `env:` line from the workflow would silently change what the gate enforces.
+for var in CODEQL_GATE_MODE CODEQL_ANALYZE_RESULT CODEQL_EXPECTED_LANGUAGES \
+           CODEQL_ANALYZED_SHA CODEQL_ANALYSES_JSON CODEQL_ALERTS_JSON \
+           CODEQL_BASELINE_JSON; do
+  # Export first, then unset one — `env -u X X=v` would re-set it and the case
+  # would pass for the wrong reason.
+  rc=0
+  (
+    export CODEQL_GATE_MODE=blocking
+    export CODEQL_ANALYZE_RESULT=success
+    export CODEQL_EXPECTED_LANGUAGES="actions go"
+    export CODEQL_ANALYZED_SHA="$SHA"
+    export CODEQL_ANALYSES_JSON="$BOTH_ANALYSES"
+    export CODEQL_ALERTS_JSON="$EMPTY"
+    export CODEQL_BASELINE_JSON="$EMPTY"
+    unset "$var"
+    bash "$GATE"
+  ) >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "unset $var fails the gate"
+  else
+    fail "unset $var fails the gate" "rc=$rc"
+  fi
+done
+
+printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
+[ "$fail_count" -eq 0 ]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,22 @@ name: CodeQL
 # context the ruleset requires; the `Analyze (...)` contexts stay unrequired,
 # exactly as before.
 #
+# EXPECT THIS TO BE RED UNTIL DEFAULT SETUP IS TURNED OFF
+#
+# The two configurations cannot coexist, and GitHub enforces that at upload
+# processing time rather than by ignoring one:
+#
+#   Code Scanning could not process the submitted SARIF file:
+#   CodeQL analyses from advanced configurations cannot be processed when
+#   the default setup is enabled
+#
+# The analysis runs and uploads; only the processing is refused. So the pull
+# request that introduces this file sees red `Analyze (...)` jobs and a red
+# `CodeQL gate`, and that is the coexistence rule rather than a defect. Neither
+# is a required context yet, so nothing is blocked by it. The admin steps that
+# clear it, in the one order that never freezes merges, are in
+# .github/ADMIN_SETUP.md under "Code Security".
+#
 # WHY THERE IS NO `paths:` FILTER
 #
 # Same reason as `workflow-lint.yaml`, which dissects it at length: GitHub does

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,269 @@
+name: CodeQL
+
+# CodeQL advanced setup — the workflow half of SOL-153411.
+#
+# WHY THIS FILE EXISTS AT ALL
+#
+# CodeQL used to be served by repository-level *default setup*, with no file in
+# the repository. Default setup has two blind spots that no ruleset or workflow
+# edit can close while it remains in use, and both of them bite a public
+# repository with `bypass_actors: []`:
+#
+#   1. It never scans fork pull requests. GitHub scopes default setup to pull
+#      requests against a protected branch "excluding pull requests from forks".
+#      A *required* check that never reports makes every fork pull request
+#      unmergeable by anyone.
+#   2. It never scans merge queue entries. A merge queue tests each entry on a
+#      `gh-readonly-queue/...` branch via the `merge_group` event, and default
+#      setup gives you no workflow file to add that trigger to. This blocked
+#      SOL-152974.
+#
+# Advanced setup fixes both, and the fork half is not inferred: on 19 August 2026
+# a fork pull request against `cli/cli` (advanced setup, same `pull_request`
+# trigger shape as below) carried real verdicts from both `Analyze` matrix jobs
+# *and* the `github-advanced-security` check. SARIF upload works from a fork pull
+# request; the analysis is not skipped.
+#
+# WHY THERE IS A SEPARATE GATE JOB
+#
+# `codeql-action/analyze` has no `fail-on-severity`, `fail-on` or threshold
+# input of any kind — verified against v4.37.7's `action.yml`. The job therefore
+# passes whenever analysis *completes*, whatever it found. That is precisely the
+# reason SOL-152858 refused to require `Analyze (go)`/`Analyze (actions)` and
+# required the `github-advanced-security` app's `CodeQL` context instead.
+#
+# So the verdict lives in `CodeQL gate` below, not in the matrix. This is
+# migration-plus-a-gate, never a workflow *instead of* one. `CodeQL gate` is the
+# context the ruleset requires; the `Analyze (...)` contexts stay unrequired,
+# exactly as before.
+#
+# WHY THERE IS NO `paths:` FILTER
+#
+# Same reason as `workflow-lint.yaml`, which dissects it at length: GitHub does
+# not report a filtered-out check as skipped, it never creates the check run, so
+# a required context sits pending forever and the pull request cannot merge. The
+# whole analysis costs 1.2–1.6 min against 7.2–8.2 min for `Build and Test`, so
+# it adds nothing to the critical path and there is nothing to optimise away. If
+# this ever needs to be conditional, condition it *inside* the job so the check
+# still reports — never in the trigger.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  # The weekly schedule default setup ran. Worth keeping: a CodeQL query-pack
+  # update can find something in unchanged code, and `main`'s alert set is also
+  # the baseline the gate diffs pull requests against.
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # codeql-action/init reads the workflow run to derive the analysis key.
+      actions: read
+      # codeql-action/analyze uploads the SARIF. Granted on fork pull requests
+      # too — this is the documented exception to the read-only downgrade, and
+      # the `cli/cli` observation above is the empirical confirmation.
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # Reproduces default setup's `languages: [actions, go]` verbatim, and
+        # its per-language build mode with it. The `default` query suite and the
+        # `remote` threat model are both CodeQL defaults, so neither needs
+        # stating — a config file would only be needed to *extend* the threat
+        # model to `local` or add custom queries, and doing either is
+        # deliberately out of scope here (SOL-153411).
+        #
+        # The build modes are not guessed. Default setup reports its own, and it
+        # is `autobuild` for Go, read live on 19 August 2026:
+        #
+        #   gh api repos/OWNER/REPO/code-scanning/analyses --jq '.[].environment'
+        #   {"build-mode":"autobuild","category":"/language:go",...}
+        #   {"build-mode":"none","category":"/language:actions",...}
+        #
+        # SOL-153411 called for `build-mode: none` on Go, inferring buildless
+        # extraction from the 1.1–1.4 min runtime. The inference was wrong — the
+        # API says `autobuild`, and 1.1–1.4 min is simply what compiling this
+        # module costs. `none` would have been a real change in what CodeQL can
+        # see in Go code, dressed up as a fidelity measure. Migrating and
+        # changing the extraction mode in one commit is exactly what the
+        # ticket's own "reproduce today's configuration" rule forbids.
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # `autobuild` compiles the module, so it needs a Go toolchain. Pinned to
+      # go.mod like every other workflow here rather than left to whatever the
+      # runner image ships, so the analyzed build matches the one we release.
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          # Load-bearing for the gate, not cosmetic. `CodeQL gate` matches
+          # analyses to expected languages on this exact string; leaving it
+          # implicit would make the gate's per-language completeness check
+          # depend on how GitHub happens to derive an analysis key from a
+          # matrix job name.
+          category: "/language:${{ matrix.language }}"
+          # Default is already true; stated because the gate depends on it.
+          # The gate queries the alerts API the moment this job ends, so the
+          # upload must be *processed*, not merely accepted, by then.
+          wait-for-processing: true
+
+  # The blocking half. Required context: `CodeQL gate`.
+  #
+  # `if: always()` and `needs: [analyze]` together are what make a failed or
+  # cancelled analysis a red gate rather than an absent one. A gate that
+  # disappears when the thing it guards breaks is the failure mode SOL-152410
+  # and SOL-152412 exist to prevent.
+  gate:
+    name: CodeQL gate
+    needs: [analyze]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Read-only: the gate reads alerts and analyses, and writes nothing.
+      security-events: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # First, and not decoration. The failure mode that matters for a gate
+      # like this one is a vacuous pass — a response shape that stops parsing
+      # and leaves the check green forever while nothing is actually enforced.
+      # Same reasoning as the `identity` and `licenses` jobs in ci-pr.yaml.
+      - name: Self-test the CodeQL gate
+        run: .github/scripts/codeql-gate.test.sh
+
+      # Fetch is deliberately separate from the decision: everything below
+      # writes JSON to disk and makes no judgement, so codeql-gate.sh is a pure
+      # function over three files and its self-test runs offline.
+      - name: Fetch the analyses and alerts for this ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME_IN: ${{ github.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Which ref the analysis landed on.
+          #
+          # For a pull request, codeql-action derives it from the checkout:
+          # `refs/pull/N/merge` normally, rewritten to `refs/pull/N/head` if the
+          # workflow moved off the merge commit (`git checkout HEAD^2`) —
+          # `getRef()` in the action's git-utils.ts. Both are fetched and unioned
+          # rather than picking one, so a later change to the checkout step
+          # cannot quietly leave the gate looking at an empty ref. Worth being
+          # explicit about because the *default* setup being replaced here
+          # uploaded to `refs/pull/N/head`, so the obvious guess is wrong in
+          # both directions.
+          case "$EVENT_NAME" in
+            pull_request) REFS="refs/pull/${PR_NUMBER}/merge refs/pull/${PR_NUMBER}/head" ;;
+            *)            REFS="$GITHUB_REF_NAME_IN" ;;
+          esac
+          echo "Candidate refs: $REFS"
+
+          # `--paginate` emits one JSON array per page, so pages are folded into
+          # a single flat array here and the per-ref results are unioned.
+          # codeql-gate.sh's contract is a flat array and its fixtures are flat
+          # arrays; normalising at the boundary keeps that true for a ref with
+          # more than one page (every re-run adds two more analyses).
+          # fetch_union <outfile> <refs, space-separated> <path-template with @REF@>
+          # Refs are an explicit argument rather than an inherited variable: a
+          # `VAR=x somefunction` prefix is not reliably scoped to the call in
+          # bash, and this is not the place to find that out.
+          fetch_union() {
+            local out="$1" refs="$2" tmpl="$3" ref
+            : > "$out.raw"
+            for ref in $refs; do
+              # A ref with no analyses returns `[]` and exit 0 — verified on
+              # 19 August 2026 against a nonexistent pull request ref and a
+              # nonexistent `gh-readonly-queue/...` ref, so unioning a ref that
+              # was never analyzed is free and the first merge queue entry does
+              # not go falsely red.
+              #
+              # A *non-zero* exit is therefore a real problem, most plausibly
+              # the token lacking `security-events: read`. Say so, because the
+              # bare `gh` error does not, and this is the one path that a fork
+              # pull request exercises differently from everything else here.
+              if ! gh api --paginate -H 'Accept: application/vnd.github+json' \
+                   "repos/${REPO}/code-scanning/${tmpl//@REF@/$ref}" >> "$out.raw"; then
+                echo "::error::Could not read code-scanning ${tmpl%%\?*} for ${ref}. If this is a fork pull request, check that the run's token still carries 'security-events: read'. Failing rather than treating an unreadable API as 'no findings'."
+                return 1
+              fi
+            done
+            # unique_by is harmless for analyses (distinct ids) and load-bearing
+            # for alerts, where the same alert appears under both candidate refs.
+            jq -s 'add // [] | unique_by(.id? // .number?)' "$out.raw" > "$out"
+            echo "$out: $(jq 'length' "$out") item(s)"
+          }
+
+          ALERTS_Q='alerts?state=open&ref=@REF@&per_page=100'
+          fetch_union analyses.json "$REFS" 'analyses?ref=@REF@&per_page=100'
+          fetch_union alerts.json "$REFS" "$ALERTS_Q"
+
+          # Baseline. Alert numbers are repository-scoped and stable across
+          # refs, so an alert already open on `main` carries the same number
+          # here — which is what preserves default setup's new-findings-only
+          # scope without fingerprinting rule names and line numbers.
+          fetch_union baseline.json 'refs/heads/main' "$ALERTS_Q"
+
+      - name: Decide
+        env:
+          # `blocking` on the two events a merge can actually be stopped at.
+          # `report` on push/schedule/dispatch, where the analysis of `main` is
+          # the baseline being refreshed and there is no merge left to block —
+          # findings there are printed, and the job stays green so a dirty
+          # `main` cannot wedge every open pull request behind a context nobody
+          # can turn green from a pull request.
+          CODEQL_GATE_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'blocking' || 'report' }}
+          CODEQL_ANALYZE_RESULT: ${{ needs.analyze.result }}
+          CODEQL_EXPECTED_LANGUAGES: actions go
+          # The commit the `analyze` jobs above actually examined. Analyses
+          # accumulate on a pull request ref across pushes, so without this the
+          # gate would accept a stale analysis from three commits ago as proof
+          # that this commit was scanned.
+          CODEQL_ANALYZED_SHA: ${{ github.sha }}
+          CODEQL_ANALYSES_JSON: analyses.json
+          CODEQL_ALERTS_JSON: alerts.json
+          CODEQL_BASELINE_JSON: baseline.json
+        run: .github/scripts/codeql-gate.sh

--- a/THIRD_PARTY_BUILD_TEST.md
+++ b/THIRD_PARTY_BUILD_TEST.md
@@ -12,7 +12,7 @@ itself**, and which are **not compiled into the shipped binary**.
 > Legal checklist, which asks for a "list of all used 3rd party products used at
 > build and test time" alongside the release list.
 
-**Generated** 2026-08-05; the GitHub Actions section was refreshed 2026-08-07
+**Generated** 2026-08-19; the GitHub Actions section was refreshed 2026-08-07
 when Guardian enrollment re-pinned every action to a commit SHA, and again
 2026-08-14 when Dependabot's `github-actions` group update moved the five
 `solace-public-workflows` actions to a newer commit on the same branch. Every
@@ -177,6 +177,8 @@ below spells out.
 | `docker/metadata-action` | `dc80280` | v6.2.0 | Apache-2.0 | [license](https://github.com/docker/metadata-action/blob/v6.2.0/LICENSE) |
 | `docker/setup-buildx-action` | `bb05f3f` | v4.2.0 | Apache-2.0 | [license](https://github.com/docker/setup-buildx-action/blob/v4.2.0/LICENSE) |
 | `docker/setup-qemu-action` | `96fe6ef` | v4.2.0 | Apache-2.0 | [license](https://github.com/docker/setup-qemu-action/blob/v4.2.0/LICENSE) |
+| `github/codeql-action/analyze` | `ff2f1c6` | v4.37.7 | MIT | [license](https://github.com/github/codeql-action/blob/v4.37.7/LICENSE) |
+| `github/codeql-action/init` | `ff2f1c6` | v4.37.7 | MIT | [license](https://github.com/github/codeql-action/blob/v4.37.7/LICENSE) |
 | `golangci/golangci-lint-action` | `ba0d7d2` | v9.3.0 | MIT | [license](https://github.com/golangci/golangci-lint-action/blob/v9.3.0/LICENSE) |
 | `softprops/action-gh-release` | `3d0d988` | v3.0.2 | MIT | [license](https://github.com/softprops/action-gh-release/blob/v3.0.2/LICENSE) |
 


### PR DESCRIPTION
## Summary

CodeQL was served by repository-level **default setup**, which scans no fork pull request, no Dependabot pull request, and no merge queue entry. Since `CodeQL` was a required check on a public repository whose ruleset has no bypass actors, that made every fork pull request unmergeable by anyone, and it blocked merge queue adoption. This migrates to advanced setup — an in-repo workflow plus a blocking gate job that carries the verdict.

Jira: [SOL-153411](https://sol-jira.atlassian.net/browse/SOL-153411)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Motivation and Context

Two blind spots that no ruleset or workflow edit can close while default setup is in use:

1. **Fork pull requests are never scanned.** A required check that never reports leaves the pull request permanently pending. With `bypass_actors: []`, nobody can merge it.
2. **Merge queue entries are never scanned.** A queue entry is tested on a `gh-readonly-queue/...` branch via `merge_group`, and default setup gives you no workflow file to add that trigger to.

Advanced setup fixes both. It also closes a third gap that was documented as accepted: default setup analyzed no Dependabot pull request either, so the check concluded `neutral` there — which GitHub counts as passing.

## Changes Made

- **`.github/workflows/codeql.yml`** — analyze matrix over `actions` and `go`, triggered on `pull_request`, `push` to `main`, `merge_group`, and the weekly schedule default setup ran. Every `uses:` pinned to a full SHA. Trigger shape and concurrency block match the `merge_group` convention #322 established.
- **`.github/scripts/codeql-gate.sh`** — the blocking half. `codeql-action/analyze` has no `fail-on-severity` input of any kind (verified against v4.37.7's `action.yml`), so the matrix passes whenever analysis *completes*, whatever it found. The gate carries the verdict, and it is the context the ruleset should require.
- **`.github/scripts/codeql-gate.test.sh`** — 27 offline cases, run as the job's first step, before the gate it guards.
- **`.github/ADMIN_SETUP.md`**, **`.github/OPEN_SOURCE_STATUS.md`** — the migration record, the remaining step, and the static-analysis table's qualifiers.
- **`THIRD_PARTY_BUILD_TEST.md`** — rows for `github/codeql-action/init` and `analyze` (MIT, read from the repo's own licence field), generated by `refresh-build-test-inventory.sh`.

### What the gate does

It fails on **two** things, not one:

- New alerts at or above threshold (severity `error`, or security severity `critical`/`high`), scoped to findings new relative to `main`. This reproduces exactly what default setup enforced.
- **A missing, stale, or errored analysis.** Default setup's check concluded `neutral` when no analysis arrived, and GitHub counts `neutral` as passing — so the gate was absent precisely when it was needed. This one fails instead.

Two design points worth a reviewer's attention:

- **It reads the alerts API, not the raw SARIF.** SARIF would be simpler and needs no token, but it cannot see dismissals — a false positive would be undismissable and the gate unopenable. The API round-trip buys that escape hatch.
- **It matches analyses on `commit_sha`, not just language.** Analyses accumulate on a pull request ref across pushes, so without that a stale analysis from three commits ago would satisfy a "one per language" check while the current commit went unscanned — a vacuous pass with a plausible-looking audit trail.

On push to `main` and on the weekly schedule the gate runs in **report** mode: there is no merge left to block, and a finding landing on `main` must not wedge every open pull request behind a context nobody can turn green from a pull request.

## Two corrections to the ticket

Both from reading the live API rather than reasoning from the ticket.

**1. Default setup uses `autobuild` for Go, not a buildless mode.** The ticket inferred `build-mode: none` from the 1.1–1.4 min Go runtime and asked for it as a fidelity measure. The API disagrees:

```
$ gh api repos/SolaceProducts/solace-broker-mcp/code-scanning/analyses --jq '.[].environment'
{"build-mode":"autobuild","category":"/language:go",...}
{"build-mode":"none","category":"/language:actions",...}
```

`none` would have been a real change in what CodeQL can see in Go code, dressed as fidelity. The matrix uses `autobuild` for Go and `none` for actions — what default setup actually did. `actions/setup-go` is pinned to `go.mod` so the analyzed build matches the released one.

**2. Fork coverage is evidence, not documentation.** The ticket's step 1 wanted a fork baseline first. I could not open a fork pull request here, but the question is answerable from a repo that already runs advanced setup. On 19 August 2026, against `cli/cli` (advanced setup, same `pull_request` trigger shape):

| Ref | `Analyze` jobs |
|---|---|
| fork PR `zwick/cli` → `cli/cli` | both `success` |
| fork PR `michaeljacholke/cli` → `cli/cli` | both `success` |
| 3 × `dependabot[bot]` PRs | both `success` |

So the SARIF upload is *not* blocked by the read-only token downgrade that applies to fork and Dependabot events generally. This is the empirical answer to SOL-152858's step 3, which closed unanswered.

## Testing

**Test Environment:** linux, tool versions matched to CI's pins.

- [x] `codeql-gate.test.sh` — **27 passed, 0 failed**. Covers: clean pass; `failure`/`cancelled`/`skipped` matrix; missing language; no analyses at all; analyses for an earlier commit only; stale + fresh together (must pass); errored analysis; errored *stale* analysis (must not condemn a clean fresh one); high and `critical` security severity; severity `error` with no security severity; `medium` below threshold; alert pre-existing on `main`; a new alert beside a pre-existing one; dismissed alert; report mode; missing input file; unrecognised mode → exit 2; and each of the seven required env vars asserted individually.
- [x] `actionlint` **v1.7.12** (CI's exact pin) with `shellcheck 0.9.0` (the runner image's version) — clean.
- [x] `zizmor` **1.29.0** with CI's exact flags (`--no-online-audits --persona=regular --min-severity=low`) — *No findings to report*.
- [x] `shellcheck 0.9.0` on both new scripts — clean. (`SC2001` excluded to match `changelog-check.sh`, which carries the same style note on `main`.)
- [x] **Fetch chain run against the live API**, not just unit-tested: the workflow's `fetch_union` logic was executed against this repository, then the gate run on the real output. It passed on a genuinely analyzed commit and failed on an unanalyzed one.
- [x] Verified a ref with **no** analyses returns `[]` with exit 0 — against a nonexistent PR ref and a nonexistent `gh-readonly-queue/...` ref — so unioning candidate refs is free and the first merge queue entry will not go falsely red.
- [x] **Green on this PR after the migration**, crediting only the 2 analyses whose `commit_sha` matched the commit under test out of 6 present on the refs.

No `CHANGELOG.md` entry: `.github/` is not production surface per `production-surface.sh`.

## Follow-up: the admin sequence lives in ADMIN_SETUP.md

**Single source of truth: `.github/ADMIN_SETUP.md` → Code Security.** Deliberately not duplicated here — an earlier revision of this body described the ticket's original ordering, which this PR's own doc changes prove is impossible, and two authoritative-looking texts disagreeing on a hard-to-reverse sequence against a `bypass_actors: []` ruleset is exactly the wrong thing to ship. Thanks @solace-aross for catching it.

**Steps 1–3 are already done** (20 August 2026), which is why this PR's checks are green rather than red:

| Step | State |
|---|---|
| Capture ruleset rollback, remove `CodeQL`/`57789` (14 → 13) | done |
| Disable default setup (`state=not-configured`) | done |
| Re-run this PR's CodeQL workflow, confirm all three checks green | done — live-PR verification, *before* the context is required |
| Merge `codeql.yml` to `main` | **this PR** |
| Register `CodeQL gate` (13 → 14) | after merge |

Until the last row lands, CodeQL **scans and reports but does not block**. `CodeQL gate` must not be registered before the merge: any open PR whose branch predates `codeql.yml` would never run the workflow, so the context would never report and that PR could not merge.

## Correction: why the ordering matters (@solace-aross)

The doc claimed disabling default setup first "stops the required `CodeQL` context from being produced at all." **That was an overclaim, and the review was right to push on it.** Advanced setup produces a `CodeQL` check run from the same `github-advanced-security` app. Now verified *here*, not only on `cli/cli` — on this PR's head, after default setup was already off:

```
CodeQL gate       success  app=15368 (github-actions)
Analyze (go)      success  app=15368
Analyze (actions) success  app=15368
CodeQL            success  app=57789 (github-advanced-security)   <- still produced
```

So the reverse order's exposure is a bounded re-run gap on commits whose analysis predates the switch, not a guaranteed repo-wide freeze. The chosen order is still right, but for the honest reason: it does not *depend* on that app's check-run name continuing to match here, where the other order does. The doc now says that.

One consequence worth stating so nobody re-litigates it: this does **not** mean `CodeQL`/`57789` could have simply stayed required. It is pull-request-scoped and does not report on `merge_group` (`github/codeql-action#1537`), so requiring it would leave every merge queue entry hanging — the failure #322 needs avoided.

## Historical note: the checks were red, and why

They are green now. Keeping the finding because it is the reason the migration order is what it is.

The first two runs failed with all three CodeQL checks red. The analysis ran and uploaded fine; GitHub refused to **process** it:

```
##[error]Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when
the default setup is enabled
```

That invalidates both halves of the ticket's prescribed sequence — "wait until the workflow is green on `main`, *then* disable default setup" is circular, and "add the new context, confirm it reports, *then* remove `CodeQL`" cannot work either, because `CodeQL gate` cannot pass while `CodeQL`'s producer is enabled.

**The gate behaved correctly throughout.** It saw `analyze = failure` and failed closed with a specific message rather than passing on absence — the property `codeql-gate.test.sh` asserts against fixtures, observed under a real failure. On the green re-run it credited only the 2 fresh analyses out of 6 on the PR refs (4 stale ones default setup had left on `refs/pull/325/head`), which also means the gate cannot be satisfied by the configuration it replaces.

## Related Issues/PRs

- Unblocks #322 (SOL-152974, merge queue adoption), now merged — `CodeQL` was the one required context it could not cover
- Resolves the consequence of SOL-152858, whose step 3 closed unanswered
- Related to SOL-152960 (fork pull request workflow approval), SOL-153167 (cleared alert #1)

---

**For Reviewers**

**Focus Areas**

1. **The gate's decision logic** (`codeql-gate.sh`) — it will be the required check, so a bug here either blocks everyone or silently enforces nothing. The two-arm threshold and the `commit_sha` match are the parts I would read twice.
2. **Report mode on push.** Push/schedule are non-blocking deliberately, so a finding on `main` cannot wedge every open pull request. If you would rather `main` go red, it is a one-line change to the `env:` expression.
3. **New-findings-only scope.** Kept, comparing alert *numbers* against `refs/heads/main`. Dropping it would be strictly stronger and is free today at zero alerts, but a CodeQL query-pack update can introduce alerts on `main` with no code change, and that would block every merge until someone fixed or dismissed them.

**Open item**

The one acceptance criterion still not closed is a verdict on a **real fork** pull request against *this* repository — it needs a fork plus maintainer approval of the run (SOL-152960). The `cli/cli` evidence is strong but is another repository. Worth doing once `CodeQL gate` is registered.
