### PR TITLE
SOL-153411: verify CodeQL reports on a fork pull request (test — do not merge)

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -477,3 +477,5 @@ cap is per broker.
 | **Test helpers** | `cachetest`, `postprocesstest` — test-only registration/setup with cleanup | Production paths (build-excluded from prod use) | `internal/oauth/cache/cachetest/`, `internal/composite/postprocess/postprocesstest/` |
 
 ---
+
+<!-- SOL-153411: temporary marker for the fork-pull-request CodeQL verification. This PR is a test and will be closed unmerged. -->


### PR DESCRIPTION
## Purpose

A deliberate test pull request **from a fork**, opened to settle SOL-153411's one outstanding acceptance criterion:

> A fork pull request receives a real CodeQL verdict before merge, demonstrated on an actual fork pull request rather than inferred.

No fork pull request has ever been opened against this repository, so until now the fork behaviour was established from GitHub's documentation plus proxies. Code-scanning **default setup** documentably excluded fork pull requests, which is why SOL-153411 migrated to advanced setup (`.github/workflows/codeql.yml` + the `CodeQL gate` job).

## What to watch

Whether `CodeQL gate` reports at all on a fork ref, and what it concludes. `GITHUB_TOKEN` is capped read-only for a pull request from a fork and `security-events: write` is unavailable, so the open question is whether the analysis uploads and produces a verdict.

Either outcome is informative:

- **Reports and concludes** — the criterion is met and SOL-153411 can close.
- **Absent, or refuses on a missing analysis** — advanced setup does not cover fork pull requests either, and the required `CodeQL gate` context would block every external contribution. That needs handling before the next fork pull request arrives.

## Notes

- The change is a single comment line in `docs/internal/architecture.md`, carrying no behaviour.
- Opened from a fork owned by an org member, so it does **not** exercise the outside-collaborator "Approve and run" gate — that path belongs to SOL-152960, not to this criterion. The read-only-token restriction is a property of the pull request originating from a fork rather than of who owns it, so the thing under test is still tested.
- **To be closed unmerged**, and the fork deleted, once the check runs have been recorded.