### PR TITLE
SOL-153463: Prepare release v0.8.0

### DIFF
--- a/.github/release-notes/v0.8.0.md
+++ b/.github/release-notes/v0.8.0.md
@@ -1,0 +1,76 @@
+## What's new in 0.8.0
+
+Stricter output contracts on the write tools, a faster `CallTool` path, four security
+hardening fixes, and the embedded SEMPv2 specs moved to the 10.26.4 rolling release.
+
+The full, verbose entry for each item is in [CHANGELOG.md](../../CHANGELOG.md).
+
+### Added
+
+- `make refresh-third-party-inventory` regenerates `THIRD_PARTY_LICENSES.md` and
+  `THIRD_PARTY_BUILD_TEST.md` from what the repository actually uses, instead of
+  hand-deriving the dependency closure. It rewrites only the rows that actually
+  changed and refuses outright — leaving the files untouched — on anything it
+  doesn't recognize. Still a manual step on Dependabot PRs.
+
+### Changed
+
+- Embedded SEMPv2 OpenAPI specs updated to the 10.26.4 rolling release
+  (`10.26.4.10725`), so tool schemas track current broker attributes.
+- The eight create/update composite tools (`create-message-vpn`, `update-message-vpn`,
+  `create-queue`, `update-queue`, `create-topic-endpoint`, `update-topic-endpoint`,
+  `create-rdp`, `update-rdp`) now declare strict, spec-derived output schemas that
+  reject undeclared fields and require the resource's own identifier. A future SEMP
+  release that reshapes a response field now fails validation instead of silently
+  passing through. Read-only tools are unchanged.
+- Each tool's input/output JSON Schema is now compiled once at registration rather
+  than re-compiled on every `CallTool`. Internal change only — the on-the-wire MCP
+  schemas, tool behavior, and response bytes are unchanged.
+- A `/mcp` request body over the 4 MiB cap that doesn't declare an oversized
+  `Content-Length` now returns `413` instead of `400`. The negotiated protocol
+  revisions are unchanged by the underlying `go-sdk` v1.7.0 bump.
+- `THIRD_PARTY_LICENSES.md`'s source of truth is now documented as the Go module
+  graph, replacing the standing instruction to hand-reconcile it against the FOSSA
+  scan. FOSSA remains the authoritative policy gate.
+- The release pipeline now executes every matrix leg's archived binary before it can
+  publish, asserting a clean exit and a version matching the tag — closing a gap
+  where cross-compiled `darwin/arm64` and `linux/arm64` archives were never run.
+
+### Fixed
+
+- The token-exchange circuit breaker's `consecutive_failure_threshold` rule now trips
+  on a slow, low-traffic IdP outage, not only a fast-failing one. Its state-change
+  `WARN` also now carries a `consecutive_failures` attribute, so an operator can tell
+  which rule opened the breaker from the log line alone.
+- OAuth Protected Resource Metadata is now also served at the RFC 9728 canonical path
+  `/.well-known/oauth-protected-resource/mcp`. Clients that follow the
+  `WWW-Authenticate` challenge verbatim are unaffected; clients that build the
+  canonical path directly now get a 200 instead of a 404.
+- `CallTool` now returns a structured tool result (`isError: true`, with `retryable`)
+  instead of a bare JSON-RPC protocol error on every local failure path — unknown
+  `broker`, schema validation, nil/invalid result, marshal failure. This matters most
+  for destructive tools, where the broker-side action may already have succeeded by
+  the time the failure is caught.
+
+### Security
+
+- Cross-origin protection on `/mcp` now runs outside the auth middleware. A
+  browser-initiated cross-origin POST or DELETE gets the `403` it earned — before any
+  JWT or JWKS work — instead of a `401` that masked a CSRF-shaped probe as an ordinary
+  auth failure. What passes on the wire is otherwise unchanged; protection stays on by
+  default with no new configuration.
+- Broker URLs logged at four runtime sites now go through the same sanitizer
+  `BrokerConfig.LogValue` already applied, rather than being logged raw.
+  Defense-in-depth: config-load validation already rejects embedded userinfo.
+- Token exchange now logs a diagnostic `WARN` when the IdP-issued token's `aud` claim
+  doesn't include the audience this process requested, surfacing an inert per-broker
+  audience config. It never fails the exchange. The exchange dedup/cache key now
+  includes the requested audience.
+- The container health check (`--health`) now verifies the server's TLS certificate
+  instead of accepting any certificate, closing CWE-295.
+
+  **Upgrading a TLS-enabled container:** the probe now reports unhealthy — while the
+  server keeps serving TLS correctly — if the certificate at `tls_cert_file` is
+  unreadable from the probe's process, carries no DNS or IP SAN, has expired, or is not
+  the one the server presents. Failure reasons go to stderr, which Docker records in
+  `State.Health.Log`.

--- a/.github/release-notes/v0.8.0.md
+++ b/.github/release-notes/v0.8.0.md
@@ -3,7 +3,8 @@
 Stricter output contracts on the write tools, a faster `CallTool` path, four security
 hardening fixes, and the embedded SEMPv2 specs moved to the 10.26.4 rolling release.
 
-The full, verbose entry for each item is in [CHANGELOG.md](../../CHANGELOG.md).
+The full, verbose entry for each item is in
+[CHANGELOG.md](https://github.com/SolaceProducts/solace-broker-mcp/blob/v0.8.0/CHANGELOG.md).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-20
+
 ### Added
 
 - `make refresh-third-party-inventory` regenerates `THIRD_PARTY_LICENSES.md`
@@ -414,7 +416,8 @@ This project uses [Semantic Versioning](https://semver.org/):
 
 ## Links
 
-- [Unreleased]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.7.1...HEAD
+- [Unreleased]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.8.0...HEAD
+- [0.8.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.7.1...v0.8.0
 - [0.7.1]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.7.0...v0.7.1
 - [0.7.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.6.0...v0.7.0
 - [0.6.0]: https://github.com/SolaceProducts/solace-broker-mcp/compare/v0.5.0...v0.6.0


### PR DESCRIPTION
## Prepare release v0.8.0

Promotes the `[Unreleased]` CHANGELOG block into a dated `## [0.8.0] - 2026-08-20`
block, repoints the compare links, and adds the curated GitHub Release summary.

> [!IMPORTANT]
> **Merging this PR tags and publishes `v0.8.0` automatically.** The release
> pipeline fires on the pushed `v0.8.0` tag and creates an **immutable public
> GitHub Release** (four binary archives + checksums) plus a `ghcr.io` image with
> its moving `:latest` and `0.8` pointers. Tags cannot be reused — recovery from a
> bad release is roll-forward to `0.8.1`, never a retag. Merging this PR is the
> release go-ahead, not just a docs edit.

### What changed

| | |
|---|---|
| Version | `0.7.1` → `0.8.0` (MINOR — new **Added**, no BREAKING, pre-1.0 per `RELEASING.md`) |
| Categories promoted | **Added** (1), **Changed** (6), **Fixed** (4), **Security** (4) — 15 entries |
| Gap entries drafted | None — see below |
| Files touched | `CHANGELOG.md` (heading + 2 link lines only), new `.github/release-notes/v0.8.0.md` |

No existing CHANGELOG bullet was rewritten, and the `## Release Process` /
`## Versioning` sections are untouched.

### Gap detection

All 39 PRs merged since `v0.7.1` were checked; 7 touched production surface
(`.github/scripts/production-surface.sh`). Six are already represented in the
promoted block (SOL-152979, SOL-152286, SOL-153167, SOL-152980, SOL-152947,
SOL-153334). The seventh — #300 (SOL-151996) — matched the surface pattern only
through `internal/tools/sempv1/redundancy/testdata/*.xml` test fixtures, with no
production behavior change, so it is correctly changelog-exempt. **No gap entries
needed drafting.**

### Curated release notes

`.github/release-notes/v0.8.0.md` is new — the first curated summary in the repo.
`extract-release-notes.sh` prefers it over the verbatim block, and was verified to
pick it up. It condenses each promoted entry to 1–2 sentences and introduces no
facts absent from the CHANGELOG, which remains the verbose source of truth. The
TLS health-check upgrade note is carried through, since it is operator-actionable.

### Third-party inventory

`go.mod`/`go.sum` did change since `v0.7.1` — `kin-openapi` 0.145.0 → 0.146.0,
`modelcontextprotocol/go-sdk` 1.6.1 → 1.7.0, and a new indirect `golang.org/x/time`
v0.15.0. `licenses-check.sh` was run against this branch and **passes** (29 modules,
30 rows), so `THIRD_PARTY_LICENSES.md` is already current — the dep-bump PRs kept it
in sync and no regeneration is needed here.

### Reviewer checklist

- [ ] The `## [0.8.0] - 2026-08-20` block reads correctly and completely for this release
- [ ] `.github/release-notes/v0.8.0.md` is accurate and skimmable — this is the public release body
- [ ] `0.8.0` is the right version for what shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
