### PR TITLE
Update SEMP schemas to latest rolling release (10.26.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the embedded SEMPv2 OpenAPI specs to the 10.26.4 rolling release (`10.26.4.10725`), so tool schemas track current broker attributes. The three spec files are renamed to `semp-v2-swagger-{action,config,monitor}.10.26.4.json` and continue to be sourced from the private-extended variant.
+
 ### Fixed
 
 - The token-exchange circuit breaker's `consecutive_failure_threshold` rule now trips a slow, low-traffic IdP outage, not only a fast-failing one — it previously read gobreaker's own `ConsecutiveFailures`, which decays as its rolling window ages out and could leave the count permanently below threshold at low traffic even though every exchange failed. The rule now reads a separate, undecayed counter this package owns, reset only on an observed success. No config or behavior change for the fast-failing case this rule always caught; `consecutive_failure_threshold: 0` still disables it. Tracked under SOL-152286.

--- a/internal/semp/sempv2/specs/semp-v2-swagger-action.10.26.4.json
+++ b/internal/semp/sempv2/specs/semp-v2-swagger-action.10.26.4.json
@@ -4703,7 +4703,7 @@
     },
     "description": "SEMP (starting in `v2`) is a RESTful API for configuring, monitoring, and administering a Solace Event Broker. This specification defines the following API:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate action|/SEMP/v2/\\_\\_private\\_action\\_\\_|Internal use only\n\n\n\nThe following APIs are also available:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate configuration|/SEMP/v2/\\_\\_private\\_config\\_\\_|Internal use only\nPrivate monitoring|/SEMP/v2/\\_\\_private\\_monitor\\_\\_|Internal use only\n\n\n\nFor tutorials, architectural and protocol design documentation, and other information about the SEMP API, consult the [SEMP documentation](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) on the Solace website. The SEMP API specifications are also [available for download](https://solace.com/downloads/).\n\nIf you need additional support, please contact us at [support@solace.com](mailto:support@solace.com).",
     "title": "SEMP (Solace Element Management Protocol)",
-    "version": "10.26.3.10320"
+    "version": "10.26.4.10725"
   },
   "parameters": {
     "countQuery": {

--- a/internal/semp/sempv2/specs/semp-v2-swagger-config.10.26.4.json
+++ b/internal/semp/sempv2/specs/semp-v2-swagger-config.10.26.4.json
@@ -42825,7 +42825,7 @@
     },
     "description": "SEMP (starting in `v2`) is a RESTful API for configuring, monitoring, and administering a Solace Event Broker. This specification defines the following API:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate configuration|/SEMP/v2/\\_\\_private\\_config\\_\\_|Internal use only\n\n\n\nThe following APIs are also available:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate action|/SEMP/v2/\\_\\_private\\_action\\_\\_|Internal use only\nPrivate monitoring|/SEMP/v2/\\_\\_private\\_monitor\\_\\_|Internal use only\n\n\n\nFor tutorials, architectural and protocol design documentation, and other information about the SEMP API, consult the [SEMP documentation](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) on the Solace website. The SEMP API specifications are also [available for download](https://solace.com/downloads/).\n\nIf you need additional support, please contact us at [support@solace.com](mailto:support@solace.com).",
     "title": "SEMP (Solace Element Management Protocol)",
-    "version": "10.26.3.10320"
+    "version": "10.26.4.10725"
   },
   "parameters": {
     "countQuery": {

--- a/internal/semp/sempv2/specs/semp-v2-swagger-monitor.10.26.4.json
+++ b/internal/semp/sempv2/specs/semp-v2-swagger-monitor.10.26.4.json
@@ -69798,7 +69798,7 @@
           "x-writeOnly": false
         },
         "failureReason": {
-          "description": "The failure reason for the virtual IP being down.\n\nThe minimum access scope/level required to retrieve this attribute is \"global/read-only\". The allowed values and their meaning are:\n\n<pre>\n\"platform-not-supported\" - Platform does not support IPAT.\n\"msg-backbone-not-enabled\" - Message backbone not enabled.\n\"active-standby-role-unexpected\" - Active/standby role is not primary or backup.\n\"redundancy-not-enabled-on-backup\" - Redundancy not enabled on backup.\n\"ipat-not-enabled\" - IPAT not enabled.\n\"not-enabled\" - Not enabled.\n\"interface-not-configured\" - No interface configured.\n\"interface-not-found\" - Interface not found.\n\"ip-interface-not-found\" - Primary/backup IP interface not found.\n\"interface-oversubscribed-ipv4\" - Configured interface oversubscribed for IPv4.\n\"interface-oversubscribed-ipv6\" - Configured interface oversubscribed for IPv6.\n\"ip-interface-down\" - IP Interface down.\n\"system-error\" - System error.\n\"none\" - N/A.\n</pre>\n (private API only)",
+          "description": "The failure reason for the virtual IP being down.\n\nThe minimum access scope/level required to retrieve this attribute is \"global/read-only\". The allowed values and their meaning are:\n\n<pre>\n\"platform-not-supported\" - Platform does not support IPAT.\n\"msg-backbone-not-enabled\" - Message backbone not enabled.\n\"active-standby-role-unexpected\" - Active/standby role is not primary or backup.\n\"redundancy-not-enabled-on-backup\" - Redundancy not enabled on backup.\n\"ipat-not-enabled\" - IPAT not enabled.\n\"not-enabled\" - Not enabled.\n\"interface-not-configured\" - No interface configured.\n\"interface-not-found\" - Interface not found.\n\"ip-interface-not-found\" - Primary/backup IP interface not found.\n\"interface-oversubscribed-ipv4\" - Configured interface oversubscribed for IPv4.\n\"interface-oversubscribed-ipv6\" - Configured interface oversubscribed for IPv6.\n\"ip-interface-down\" - IP Interface down.\n\"ip-interface-change-in-progress\" - IP interface change in progress.\n\"none\" - N/A.\n</pre>\n (private API only)",
           "type": "string",
           "x-accessLevels": {
             "get": "global/read-only"
@@ -69820,7 +69820,7 @@
             "interface-oversubscribed-ipv4",
             "interface-oversubscribed-ipv6",
             "ip-interface-down",
-            "system-error",
+            "ip-interface-change-in-progress",
             "none"
           ],
           "x-opaque": false,
@@ -71818,7 +71818,7 @@
     },
     "description": "SEMP (starting in `v2`) is a RESTful API for configuring, monitoring, and administering a Solace Event Broker. This specification defines the following API:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate monitoring|/SEMP/v2/\\_\\_private\\_monitor\\_\\_|Internal use only\n\n\n\nThe following APIs are also available:\n\n\nAPI|Base Path|Purpose\n:---|:---|:---\nPrivate action|/SEMP/v2/\\_\\_private\\_action\\_\\_|Internal use only\nPrivate configuration|/SEMP/v2/\\_\\_private\\_config\\_\\_|Internal use only\n\n\n\nFor tutorials, architectural and protocol design documentation, and other information about the SEMP API, consult the [SEMP documentation](https://docs.solace.com/Admin/SEMP/Using-SEMP.htm) on the Solace website. The SEMP API specifications are also [available for download](https://solace.com/downloads/).\n\nIf you need additional support, please contact us at [support@solace.com](mailto:support@solace.com).",
     "title": "SEMP (Solace Element Management Protocol)",
-    "version": "10.26.3.10320"
+    "version": "10.26.4.10725"
   },
   "parameters": {
     "countQuery": {


### PR DESCRIPTION
Automated bump of the embedded SEMPv2 specs to `10.26.4.10725` (10.26.4), sourced from the private-extended vm_schema variant. Generated by broker-mcp/semp-autoupdate/update-semp-schemas.sh.