### PR TITLE
SOL-153473: restore secrets: inherit on the Guardian scan call chain

### DIFF
--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -66,16 +66,24 @@ jobs:
   guardian:
     name: Guardian gate
     needs: authorize
-    uses: ./.github/workflows/guardian-scan.yaml
+    uses: ./.github/workflows/guardian-scan.yaml # zizmor: ignore[secrets-inherit]
     permissions:
       contents: read
       packages: read     # ceiling for guardian-scan's FOSSA jobs (private scan container)
       pull-requests: write
       checks: write
       statuses: write
-    # No `secrets: inherit` — guardian-scan.yaml's jobs carry
-    # `environment: guardian` and resolve the FOSSA/Guardian/Prisma secrets from
-    # that environment themselves. Nothing to pass down.
+    # Load-bearing — do not remove, and do not replace with named secrets.
+    # `environment: guardian` on guardian-scan's jobs does not resolve their
+    # secrets when the workflow is reached via `workflow_call`: the `secrets`
+    # context arrives empty unless the caller opens it, so all six come through
+    # as empty strings and every scan job fails. Five of them exist only in the
+    # `guardian` environment, which a `uses:` job cannot enter — so naming them
+    # here is impossible, not merely verbose. release.yml's call of this
+    # workflow carries the same directive and the long form of this note.
+    # Removing it broke v0.7.0 (fixed by #291) and v0.8.0 (5ca7de1 /
+    # SOL-152856, fixed by SOL-153473).
+    secrets: inherit
     with:
       git_ref: ${{ inputs.version }}
       product_full_version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,18 +174,38 @@ jobs:
       pull-requests: write
       checks: write
       statuses: write
-    # No `secrets: inherit`. Every `secrets.*` reference in guardian-scan.yaml
-    # sits in a job declaring `environment: guardian`, and all six names —
-    # FOSSA_API_KEY, GUARDIAN_URL, GUARDIAN_API_TOKEN, PRISMACLOUD_* — exist in
-    # that environment, which the job resolves itself. Nothing was reading
-    # through `inherit`.
+    uses: ./.github/workflows/release-readiness-check.yaml # zizmor: ignore[secrets-inherit]
+    # `secrets: inherit` is load-bearing on both hops of this chain. Do not
+    # remove it, and do not replace it with explicitly named secrets.
     #
-    # Worth stating because one of them, FOSSA_API_KEY, also exists as an org
-    # secret, so `inherit` looked load-bearing. It was not: environment secrets
-    # outrank org secrets, so the `guardian` copy is what those jobs already
-    # got. What `inherit` actually did was hand the scan every other org and
-    # repo secret (LLM_SERVICE_API_KEY, VAULT_URL) that it never references.
-    uses: ./.github/workflows/release-readiness-check.yaml
+    # A workflow reached via `workflow_call` starts with an EMPTY `secrets`
+    # context, and that emptiness extends to the called workflow's own
+    # `environment:` layer. `inherit` is what opens that context; once open,
+    # guardian-scan.yaml's `environment: guardian` jobs resolve their six
+    # secrets themselves. Without it they read every one as an empty string and
+    # all four scan jobs fail.
+    #
+    # Naming the secrets instead is not an option here, tempting as the zizmor
+    # finding makes it look. Five of the six (GUARDIAN_URL, GUARDIAN_API_TOKEN,
+    # PRISMACLOUD_*) live only in the `guardian` environment, and a job that
+    # calls a reusable workflow with `uses:` may not declare `environment:` —
+    # so this job cannot see them to pass them on. It would forward empty
+    # strings and reproduce the outage. Explicit passing would first require
+    # moving those secrets to repo or org scope, which .github/ADMIN_SETUP.md
+    # keeps environment-scoped on purpose.
+    #
+    # Hence the suppression rather than a fix. What `inherit` over-shares is
+    # LLM_SERVICE_API_KEY and VAULT_URL — neither referenced by the scan, and
+    # VAULT_URL is dead since the move off Vault.
+    #
+    # Removed once already, by 5ca7de1 (SOL-152856), to let the new zizmor gate
+    # start green. That blocked the v0.8.0 release exactly as it had blocked
+    # v0.7.0 before #291 (DATAGO-148031) added it. Nothing on PR CI catches the
+    # regression: guardian-scan.yaml's direct push/pull_request triggers have no
+    # `workflow_call` hop, so only a tag push exercises this path. Verify a
+    # change here with a workflow_dispatch of release-readiness-check.yaml
+    # against the branch. SOL-153473.
+    secrets: inherit
     with:
       version: ${{ github.ref_name }}
 


### PR DESCRIPTION
## Summary

Restores `secrets: inherit` on both `workflow_call` hops of the Guardian scan chain, which is what makes the release path resolve its scan secrets. Without it the v0.8.0 release failed with all four Guardian jobs reading every secret as an empty string.

SOL-153473: https://sol-jira.atlassian.net/browse/SOL-153473

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

CI-only change; no production surface touched, so no `CHANGELOG.md` entry (per `CLAUDE.md`, entries are for `internal/config/`, `tools.yaml`, or `internal/tools/`).

## Motivation and Context

Release run [32420846500](https://github.com/SolaceProducts/solace-broker-mcp/actions/runs/32420846500) (tag `v0.8.0`) failed:

- FOSSA licensing / FOSSA vulnerability — `Error: A FOSSA API key was specified, but it is an empty string`
- Guardian gate — `guardian-url and guardian-key are required.`
- Prisma scan — console-URL request failed on empty `PRISMACLOUD_*`; no `pcc_scan_results.json`. The follow-on `422 details_url must use the http or https scheme` is a downstream symptom of the empty console URL.
- `Guardian scan gate` then aggregated `fossa-license/fossa-vuln/prisma/guardian-gate = failure`

This is the same failure that blocked v0.7.0 and was fixed by #291 (DATAGO-148031, `8db0f3e`, merged 2026-08-11). Commit `5ca7de1` (SOL-152856) removed that fix a day later, so the zizmor gate added in the very next commit (`33648a2`, same ticket) would start green with no ignore file — `secrets-inherit` was one of the five findings it cleared.

### The mechanism, precisely

A workflow reached via `workflow_call` starts with an **empty** `secrets` context, and that emptiness extends to the called workflow's own `environment:` layer. `secrets: inherit` opens that context; once open, `guardian-scan.yaml`'s `environment: guardian` jobs resolve their six secrets themselves.

This is **not** the caller forwarding them. Five of the six (`GUARDIAN_URL`, `GUARDIAN_API_TOKEN`, `PRISMACLOUD_*`) exist only in the `guardian` environment, which no caller in this chain can see. The dispatch below proves it: Guardian's DB sync and Prisma's upload both authenticated successfully using exactly those secrets.

### Why explicit secrets is not the fix here

Naming the secrets is what zizmor's `secrets-inherit` audit asks for, and it was the first shape considered. It is not available:

```
$ actionlint
when a reusable workflow is called with "uses", "environment" is not available.
only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", and "permissions"
```

Neither caller can enter the `guardian` environment, so neither can read those five secrets to pass them on — it would forward empty strings and reproduce the outage. Explicit passing would first require moving them to repo or org scope, which `.github/ADMIN_SETUP.md` keeps environment-scoped deliberately (it is what makes fork PRs skip scanning cleanly).

So the finding is suppressed at each call site with a comment recording why, rather than "fixed" by breaking the release a third time.

## Changes Made

- `release.yml` — restore `secrets: inherit` on the `release-readiness-check.yaml` call; replace the comment asserting it was not load-bearing with one explaining why it is, why named secrets are impossible, and what the previous removal cost
- `release-readiness-check.yaml` — same on the `guardian-scan.yaml` call
- `# zizmor: ignore[secrets-inherit]` on both `uses:` lines, so the required `workflow-lint` check stays green

## Testing

**Tests Performed:**

- [x] `actionlint` — clean
- [x] `zizmor 1.29.0`, the gate's exact invocation (`--no-online-audits --persona=regular --min-severity=low .github/workflows/`) — exit 0, "No findings to report"
- [x] YAML re-parsed to confirm the trailing `# zizmor:` comments do not corrupt the values (`uses` resolves to the clean path, `secrets` = `inherit` on both hops)
- [x] **`workflow_dispatch` of `release-readiness-check.yaml` against this branch** — the check `5ca7de1` prescribed and nobody ran
- [ ] Go unit / E2E tests — N/A, no Go code changed

**The verification that matters:** [run 32485836322](https://github.com/SolaceProducts/solace-broker-mcp/actions/runs/32485836322) — all eight jobs green.

```
Resolved: mode=trunk  event=workflow_dispatch  enforce=true  fossa_branch=main
Uses: .../guardian-scan.yaml@refs/heads/bczoma/sol-153473-restore-secrets-inherit (581e7c0)
ENFORCE: true
```

Trunk mode with `ENFORCE=true`, and the `Uses:` line confirms this branch's files were under test rather than `main`'s. Normal PR CI cannot verify this fix: `guardian-scan.yaml`'s direct `push`/`pull_request` triggers have no `workflow_call` hop, so only a tag push — or this dispatch — exercises the path.

A first dispatch ([32485521760](https://github.com/SolaceProducts/solace-broker-mcp/actions/runs/32485521760)) failed on `HTTP 400`/`HTTP 500` from Guardian because `version` doubles as both `git_ref` and `product_full_version`, and a branch name containing slashes is not a valid version string. Re-run with `version=main`, matching #291's verification. Both FOSSA jobs passed even on that attempt, and Prisma got far enough to scan and emit a console link — impossible with empty credentials.

## Breaking Changes

None.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what") — both comments record why the directive is load-bearing and why the previous removal broke two releases

### Security
- [x] No credentials in code
- [x] No secret values added; the six names were already present in `guardian-scan.yaml`, `release.yml` and `ADMIN_SETUP.md` in this public repo
- [x] Residual over-sharing accepted and documented: `inherit` also hands the scan `LLM_SERVICE_API_KEY` (used only by `llm-eval.yml`) and `VAULT_URL` (referenced by no workflow since the move off Vault). Deleting the dead `VAULT_URL` repo secret is worth a separate ticket.

### Git & CI
- [x] Commit signed off (DCO)
- [x] Branch up to date with `main` (0 behind, 1 ahead)
- [x] No merge conflicts
- [x] `workflow-lint` verified green locally

## Additional Notes

**`v0.8.0` cannot be released by merging this PR.** `release.yml` triggers only on `push: tags: v*`, and a local `./` reusable workflow resolves at the **triggering ref** — the failed run's log shows `guardian-scan.yaml@refs/tags/v0.8.0 (7a8f0e7)`. The tag still points at `7a8f0e7`, which lacks this fix, so re-running that run fails identically. After merge, `v0.8.0` needs re-pointing at the merge commit, and that tag push is what runs the release.

Nothing was published under 0.8.0, so it is a clean re-cut with nothing to unwind: `build-docker` and `release` were `skipped`, no GitHub release `v0.8.0` exists, ghcr holds only `0.7`, `0.7.1`, `latest`, and `latest` was never moved.

**Follow-ups worth filing:** delete the dead `VAULT_URL` secret; and consider a scheduled dispatch of `release-readiness-check.yaml` so this path is exercised between releases rather than only at one.

## Related Issues/PRs

- Restores the fix from #291 (DATAGO-148031)
- Reverts the `secrets: inherit` removal in `5ca7de1` (SOL-152856)

---

**For Reviewers:**

**Focus Areas**: whether suppressing `secrets-inherit` is the right call versus moving the five environment secrets to org scope to allow explicit passing. I argue against the move — `ADMIN_SETUP.md` relies on environment scoping for fork-PR behaviour — but that is the judgement to check.

**Questions**: should the `no-changelog` label be applied to silence the advisory CHANGELOG warning? The label does not currently exist in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
