### PR TITLE
SOL-153355: Add the RDP tools to the performance harness fixture and teach loadgen their arguments

### DIFF
--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -249,6 +249,14 @@ The miss count is never reset — it feeds the shutdown gate.
 | `get-rdp-status` | 3 | object, then queue bindings and REST consumers in parallel |
 | `get-broker-status` | 5 | SEMPv1; the fifth (`show hardware details`) fires on appliances only, so this is 4 on a software broker |
 
+`semp-fanout.json` is keyed by **rule, not by tool**, and the two `list-rdps`
+rows above share rules. The gate calls `list-rdps` twice — once at default
+arguments, once at `maxResults=200` — so `sempv2 rdps page 1` reads 2 (one hit
+from each) and `sempv2 rdps page 2 (cursor)` reads 1, belonging only to the
+paginated call. The totals reconcile with the table (2 + 1 = 1 + 2), but the
+per-call numbers are the table's, not the file's. Every other row maps to its
+rules one-to-one.
+
 The default `maxResults` is **100**, so `followPages` never paginates at
 default arguments regardless of how much data the broker holds — the SEMP cost
 of a list tool is set by the caller's `maxResults`, not by broker size.
@@ -296,7 +304,12 @@ Doing them together matters: self-changing fields (uptime, memory percentages,
 disk usage) drift with wall-clock time, so canned and goldens taken hours
 apart cannot match exact-mode comparison even when replaying the same data.
 It finishes by writing `fixtures.manifest` — a sha256 per file plus the
-capture time, broker alias, and VPN.
+capture time, broker alias, VPN, and the RDP the capture pinned (`# rdp:`).
+That last one is not just provenance: `mock-semp` serves `get-rdp-status` for
+that RDP alone, so `run.sh` and `run-loadgen.sh` read it back
+(`./fixtures-manifest.sh rdp`) to pass `-rdp` to `fidelity` and `loadgen`. A
+manifest without it stops both scripts with a pointer to recapture, rather than
+letting them ask for an RDP the mock will 404.
 
 `run.sh` and `run-loadgen.sh` verify that manifest before starting anything
 (`./fixtures-manifest.sh check`, runnable on its own). The check fails when:

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -345,8 +345,13 @@ CONFIG_FILE=./broker-config.real.yaml ./regen-golden.sh
 ```
 
 Overrides: `BROKER_ALIAS` (default `my-broker`), `VPN` (default `default`),
-`RDP_NAME` (default `rdp_1` — the single RDP `get-rdp-status` is captured and
-replayed for).
+`RDP_NAME` (the single RDP `get-rdp-status` is captured and replayed for —
+defaults to the first RDP the VPN reports, derived from the captured
+collection). Setting `RDP_NAME` to a name the VPN does not hold fails before
+anything is captured; leaving it unset cannot name an RDP the broker lacks.
+Prefer an RDP with one queue binding and one REST consumer: `get-rdp-status`
+declares no `maxResults`, so a busier one is captured silently truncated at 100
+rather than caught.
 For example, to capture from a non-default VPN:
 
 ```

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -76,7 +76,7 @@ Artifacts land in `bin/runs/<timestamp>[-<tag>]/`.
 |---|---|---|
 | `9090` | MCP server | health at `/health`; `run.sh` refuses to start if occupied |
 | `18081..18081+N-1` | mock-semp broker ports | one per fake broker; default N=50 → `18081..18130`. In split-host mode Box A binds `0.0.0.0` so Box B can reach these over the LAN |
-| `19000` | mock-semp config endpoint | `POST /_mock/config` for per-port latency / error injection. Bound to localhost by default (separate from `-listen-addr`) so opening broker ports to the LAN doesn't also expose the injection knob |
+| `19000` | mock-semp control endpoint | `POST /_mock/config` for per-port latency / error injection; `GET /_mock/hits` reports per-rule SEMP counts and `POST /_mock/hits` reports and zeroes them. Bound to localhost by default (separate from `-listen-addr`) so opening broker ports to the LAN doesn't also expose the injection knob |
 
 ## Quick start (single host)
 
@@ -102,13 +102,14 @@ Key env knobs (full list in `run.sh` header):
 |---|---|---|
 | `CLIENTS` | 32 | MCP sessions in parallel |
 | `DURATION` | 60s | Go duration string |
-| `TOOLS` | `get-broker-status,list-queues` | subset of tools the mock can answer |
+| `TOOLS` | all four | `get-broker-status,list-queues,list-rdps,get-rdp-status`; set it to a subset to isolate one tool's cost. Validated in the step-0 preflight, before the mock starts — an unknown tool aborts the run immediately |
 | `LATENCY_MS` | 0 | per-response sleep in mock; use to force per-broker semaphore queueing inside MCP |
 | `ERROR_RATE` | 0 | probability each broker response is injected as an error |
 | `ERROR_COUNT` | 0 | cap on injected errors per broker port (0 = unlimited) |
 | `ERROR_STATUSES` | `503:70,429:20,500:10` | weighted status pool; only 429/500/502/503/504 accepted |
 | `BROKER_ALIAS` | `broker-01` | fidelity `-broker`; must exist in `broker-config.mock.yaml` |
 | `VPN` | from `fixtures.manifest` | fidelity `-vpn`; defaults to the VPN the goldens were captured against. Set it only to override |
+| `RDP` | from `fixtures.manifest` | fidelity/loadgen `-rdp`; the RDP the capture pinned. The mock serves `get-rdp-status` for that RDP only |
 
 ## Split-host run
 
@@ -138,7 +139,7 @@ firing loadgen.
 |---|---|---|
 | `CLIENTS` | 200 | `loadgen -clients` — MCP sessions in parallel |
 | `DURATION` | 60s | `loadgen -duration` |
-| `TOOLS` | `get-broker-status,list-queues` | `loadgen -tools` — subset of tools the mock can answer |
+| `TOOLS` | all four | `loadgen -tools`; `get-broker-status,list-queues,list-rdps,get-rdp-status`, or a subset to isolate one tool's cost. Validated in the step-0 preflight, so a typo fails before the mock binds and before the wait for Box B |
 | `BROKERS` | 50 | `loadgen -broker-count` |
 | `TOTAL_RPS` | 0 | `loadgen -total-rps` (0 = unlimited); paces aggregate req/s to break the release-barrier convoy |
 | `LATENCY_MS` | 0 | `mock-semp -default-latency-ms`; >0 piles requests on MCP's per-broker semaphore |
@@ -149,6 +150,7 @@ firing loadgen.
 | `ERROR_STATUSES` | `503:70,429:20,500:10` | weighted status pool; only 429/500/502/503/504 accepted |
 | `BROKER_ALIAS` | `broker-01` | fidelity `-broker`; must exist in `broker-config.mock.yaml` |
 | `VPN` | from `fixtures.manifest` | fidelity `-vpn`; defaults to the VPN the goldens were captured against. Set it only to override |
+| `RDP` | from `fixtures.manifest` | fidelity/loadgen `-rdp`; the RDP the capture pinned |
 
 ## Fidelity gate
 
@@ -164,6 +166,121 @@ jitter between the canned and golden captures (broker uptime, memory
 usage percent). Everything else must match byte-for-byte. Add a path
 here only when regen-golden.sh's coordinated recapture shows it truly
 drifts within the sub-second window between the two captures.
+
+The gate covers five checks:
+
+| check | arguments |
+|---|---|
+| `get-broker-status` | broker only |
+| `list-queues` | `msgVpnName` |
+| `list-rdps` | `msgVpnName` |
+| `list-rdps (maxResults=200, paginated)` | `msgVpnName`, `maxResults=200` |
+| `get-rdp-status` | `msgVpnName`, `restDeliveryPointName` |
+
+The paginated `list-rdps` check exists because the default `maxResults` of 100
+stops `followPages` before it asks for a second page — so the plain check never
+exercises pagination however many RDPs the broker holds. Asking for 200 drives
+the mock through its cursor rule, and since the golden records every RDP
+returned, exact-mode length comparison is what proves they all came back.
+
+That check is the only thing in the suite that walks a cursor chain, and it can
+only do so if the capture produced more than one RDP page. A capture from a VPN
+with 100 or fewer RDPs still passes it — a one-page golden against a one-page
+replay — so the coverage would vanish with nothing going red. Both
+`regen-golden.sh` (at capture time, where recapturing from a bigger VPN is still
+an option) and `mock-semp` (at every startup) warn when that happens.
+
+### Fixture durability
+
+The gate is exact, but its three exclusions are not evenly distributed, and
+that matters when you recapture from a busier broker.
+
+| fixture tool | stays exact on a realistic capture? | why |
+|---|---|---|
+| `list-rdps` | **yes** | Every field it selects is settled while the RDPs are disabled: `up:false`, `lastFailureTime` frozen at the moment each was shut down rather than advancing on retries. Two reads seconds apart are byte-identical |
+| `get-rdp-status` | **yes** | Same, plus `uptime:0` and all HTTP counters at `0` on a disabled REST consumer |
+| `list-queues` | **no** | Six of the thirteen fields it selects move under any traffic at all: `bindCount`, `msgSpoolUsage`, `spooledMsgCount`, `rxMsgRate`, `txMsgRate`, `txUnackedMsgCount`. It needs no exclusions today, but that is a property of the capture VPN being idle — not of the harness. On a loaded broker the only way to keep it green is to exclude those six, at which point the check stops verifying most of what the tool returns |
+| `get-broker-status` | **no** | Already the source of all three exclusions (uptime twice, memory percent) |
+
+So: realism and strictness are in tension for the two original fixture tools
+and not for the RDP pair. If you recapture against a broker under load and the
+gate goes red on `list-queues`, that is the expected outcome, not a
+regression — and adding those fields to `exclusions.txt` is a decision to stop
+checking them, which is worth making deliberately.
+
+### What this fixture cannot tell you
+
+Two limits are structural, not oversights:
+
+- **SEMPv2/JSON only.** `get-redundancy-status` — the one single-call SEMPv1
+  tool, and the natural same-cost cross-protocol comparator — is deliberately
+  not in the fixture. `get-broker-status` is SEMPv1 but fans out to 4–5 calls
+  and its count varies with broker type, so it cannot serve as a clean SEMPv1
+  denominator. Any throughput figure from this harness covers the SEMPv2/JSON
+  path; the SEMPv1 ceiling is unmeasured.
+- **Every RDP in the capture is disabled.** That is exactly right for
+  regression detection — nothing drifts — but it means the fixtures never
+  exercise a healthy RDP with live counters, and their values are short and
+  repetitive, so they are cheap to parse and allocate. A throughput ceiling
+  measured against them is an **upper bound, not a sizing figure**.
+
+### SEMP cost per tool call
+
+`loadgen` reports tool calls per second; the performance targets are written in
+SEMP requests per second. The conversion factor is each tool's fan-out, and
+`mock-semp` measures it directly: every rule counts the requests it served, and
+those counts are readable two ways. `GET /_mock/hits` reports them mid-run;
+`POST` reports and zeroes them.
+
+The run scripts use that to hand you the table without a calibration run. The
+fidelity gate makes exactly one call per check, so step `3b` POSTs `/_mock/hits`
+the moment it passes: the gate's own fan-out lands in `semp-fanout.json` beside
+the other artifacts, and the counters restart at zero so the shutdown summary in
+`mock.log` (`SEMP requests served per rule`) measures the load phase alone. Both
+places name the window they cover. Without that reset the two phases share one
+tally, which is invisible under load and the whole number in a low-volume run.
+The miss count is never reset — it feeds the shutdown gate.
+
+| call | SEMP requests | note |
+|---|---|---|
+| `list-rdps` (default args) | 1 | reported tool rate **is** the SEMP rate, no conversion |
+| `list-rdps maxResults=200` | 2 | page 1 + one cursor follow |
+| `list-queues` (default args) | 1 | same 1-call shape |
+| `get-rdp-status` | 3 | object, then queue bindings and REST consumers in parallel |
+| `get-broker-status` | 5 | SEMPv1; the fifth (`show hardware details`) fires on appliances only, so this is 4 on a software broker |
+
+The default `maxResults` is **100**, so `followPages` never paginates at
+default arguments regardless of how much data the broker holds — the SEMP cost
+of a list tool is set by the caller's `maxResults`, not by broker size.
+`loadgen` has no `maxResults` flag, so every list tool in a load run costs
+exactly 1 SEMP request.
+
+`TOOLS` defaults to all four, and each client rotates through them evenly, so
+the default workload averages `(5 + 1 + 1 + 3) / 4 = 2.5` SEMP requests per
+tool call (2.25 against a software broker, where `get-broker-status` is 4).
+There is no single conversion factor for a mixed rotation: read the per-rule
+counts out of `mock.log` rather than multiplying the reported tool rate. Set
+`TOOLS` to one tool when you want a rate that converts by a single number, or
+when you want to attribute a latency tail to a specific fan-out.
+
+One consequence worth knowing rather than discovering: a capture of a VPN with
+more than 100 queues produces `queues_page2.json` and beyond, and `mock-semp`
+registers a cursor rule for each — but nothing in the suite requests them,
+because every `list-queues` call it makes uses default arguments. The shutdown
+summary shows them as `(never fired)`. Exercising them would mean
+adding a paginated `list-queues` check, which changes how `list-queues` is
+gated; `list-rdps` carries the paginated check instead, and the cursor
+machinery is shared by both collections, so the code path is covered either
+way.
+
+`list-rdps` and `get-rdp-status` are in the fixture specifically as a 1-call
+and 3-call pair on the same protocol against the same objects in the same VPN,
+differing in nothing but fan-out. `get-rdp-status` also contributes two things
+no other fixture tool does: concurrent sub-requests inside a single tool call
+(its two collection steps are `parallel: true`, so one call holds up to two
+per-broker concurrency slots), and a small-payload datapoint — 2,135 bytes of
+tool output against `list-rdps`'s 26,274 on the same protocol and VPN, which
+separates per-request overhead from per-byte cost.
 
 ### Regenerating the fixtures
 
@@ -214,7 +331,9 @@ Consequences worth internalizing before you touch a fixture:
 CONFIG_FILE=./broker-config.real.yaml ./regen-golden.sh
 ```
 
-Overrides: `BROKER_ALIAS` (default `my-broker`), `VPN` (default `default`).
+Overrides: `BROKER_ALIAS` (default `my-broker`), `VPN` (default `default`),
+`RDP_NAME` (default `rdp_1` — the single RDP `get-rdp-status` is captured and
+replayed for).
 For example, to capture from a non-default VPN:
 
 ```
@@ -291,5 +410,25 @@ POSTing to `http://<mock-host>:19000/_mock/config`.
 and exits non-zero on shutdown. The wrapper scripts propagate that exit
 code, so an unrecognized SEMP call fails the run instead of hiding in a log
 file. If you extend the tool set, teach `capture.sh` to record the new
-response, update the handler, and re-run `regen-golden.sh` so the new fixture
-arrives from the same capture as the rest.
+response, update the handler, add the file to `sanitize.sh`'s list, and re-run
+`regen-golden.sh` so the new fixture arrives from the same capture as the rest.
+
+That gate is why `get-rdp-status` is pinned to one RDP by exact path match. The
+alternative shape — matching `/restDeliveryPoints/` by prefix — would answer a
+request for any of the VPN's 196 RDPs with the one RDP that was captured: a
+wrong answer that looks exactly like a right one, and that no other check in
+the harness would catch. Compare the five SEMPv1 rules, which all share the
+`/SEMP` path and are told apart by first-substring-match on the request body;
+that shape has the hazard, and the RDP rules deliberately don't inherit it.
+
+Shutdown (and `/_mock/hits` mid-run) also reports the requests each rule
+served, including a `(never fired)` marker. Use it to sanity-check a new rule: a
+SEMPv2 rule written against the public `/SEMP/v2/monitor/` path only will
+never fire, because MCP uses `/SEMP/v2/__private_monitor__/`.
+
+`sanitize.sh` closes with the RDP endpoint values from the capture
+(`remoteHost`, `remotePort`, `postRequestTarget`). Its residual scan matches
+192.168/16 and 172.16/12 addresses, so an RDP pointed at a real internal service
+*by hostname* passes it; printing those values every run puts the one thing a
+clean scan cannot vouch for in front of whoever ran it. Confirm none of them
+names something real before the capture is trusted.

--- a/test/performance/fidelity/main.go
+++ b/test/performance/fidelity/main.go
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // Command fidelity is the hard gate before any performance load run. It
-// connects to a live MCP server, invokes get-broker-status and list-queues,
-// and deep-equals the tool output against golden JSON captured earlier
-// (with MCP pointed at the real broker).
+// connects to a live MCP server, invokes every tool in buildChecks, and
+// deep-equals the tool output against golden JSON captured earlier (with MCP
+// pointed at the real broker).
 //
 // Exit codes:
 //
@@ -32,6 +32,7 @@
 //	  -mcp-url http://localhost:9090 \
 //	  -broker  my-broker \
 //	  -vpn     default \
+//	  -rdp     rdp_1 \
 //	  -golden-dir test/performance/fidelity/golden
 //
 // Auth: reads MCP_DEV_TOKEN from env and sends it as Bearer if set. Leave
@@ -60,7 +61,8 @@ import (
 func main() {
 	mcpURL := flag.String("mcp-url", "http://localhost:9090", "MCP server URL")
 	broker := flag.String("broker", "", "broker alias to invoke tools against (required)")
-	vpn := flag.String("vpn", "default", "msgVpnName for list-queues")
+	vpn := flag.String("vpn", "default", "msgVpnName for the tools that take one (list-queues, list-rdps, get-rdp-status)")
+	rdp := flag.String("rdp", "", "restDeliveryPointName for get-rdp-status (required). Must name the RDP the capture pinned — the run scripts read it from fixtures.manifest. Deliberately not defaulted: a default that disagreed with the capture would surface as a confusing diff or a mock miss instead of a clear error.")
 	goldenDir := flag.String("golden-dir", "test/performance/fidelity/golden", "directory containing golden JSON files")
 	exclusionsPath := flag.String("exclusions", "", "path to a plain-text file of dotted paths (one per line, # comments allowed) that exact-mode diff should skip — e.g. broker uptime, which advances between the canned and golden captures. Default: <golden-dir>/../exclusions.txt if it exists.")
 	capture := flag.Bool("capture", false, "capture mode: overwrite golden files with the tools' current output instead of comparing (use when MCP is pointed at the real broker)")
@@ -72,12 +74,16 @@ func main() {
 		fmt.Fprintln(os.Stderr, "fidelity: -broker is required")
 		os.Exit(1)
 	}
+	if *rdp == "" {
+		fmt.Fprintln(os.Stderr, "fidelity: -rdp is required (the RDP name the capture pinned; ./fixtures-manifest.sh rdp prints it)")
+		os.Exit(1)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 	defer cancel()
 
 	if *capture {
-		if err := captureGoldens(ctx, *mcpURL, *broker, *vpn, *goldenDir); err != nil {
+		if err := captureGoldens(ctx, *mcpURL, *broker, *vpn, *rdp, *goldenDir); err != nil {
 			fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
 			os.Exit(1)
 		}
@@ -91,7 +97,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(ctx, *mcpURL, *broker, *vpn, *goldenDir, *shape, exclusions); err != nil {
+	if err := run(ctx, *mcpURL, *broker, *vpn, *rdp, *goldenDir, *shape, exclusions); err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
 		os.Exit(1)
 	}
@@ -160,25 +166,14 @@ func loadExclusions(explicit, goldenDir string, shape bool) (map[string]bool, er
 // Overwrites existing files. Recapturing at the same moment as
 // mock-semp/canned/capture.sh keeps live-metric drift (memory usage,
 // message rates) below noise threshold in the subsequent diff.
-func captureGoldens(ctx context.Context, mcpURL, broker, vpn, goldenDir string) error {
+func captureGoldens(ctx context.Context, mcpURL, broker, vpn, rdp, goldenDir string) error {
 	session, err := connect(ctx, mcpURL)
 	if err != nil {
 		return fmt.Errorf("connecting to MCP: %w", err)
 	}
 	defer session.Close()
 
-	checks := []toolCheck{
-		{
-			tool:       "get-broker-status",
-			goldenFile: filepath.Join(goldenDir, "get-broker-status.json"),
-			args:       map[string]any{"broker": broker},
-		},
-		{
-			tool:       "list-queues",
-			goldenFile: filepath.Join(goldenDir, "list-queues.json"),
-			args:       map[string]any{"broker": broker, "msgVpnName": vpn},
-		},
-	}
+	checks := buildChecks(broker, vpn, rdp, goldenDir)
 
 	// Two-phase write so a mid-recapture failure never leaves one golden
 	// updated and another stale: first collect every tool's output and stage
@@ -199,17 +194,17 @@ func captureGoldens(ctx context.Context, mcpURL, broker, vpn, goldenDir string) 
 		out, err := callTool(ctx, session, c.tool, c.args)
 		if err != nil {
 			cleanupTemps()
-			return fmt.Errorf("%s: %w", c.tool, err)
+			return fmt.Errorf("%s: %w", c.name(), err)
 		}
 		data, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {
 			cleanupTemps()
-			return fmt.Errorf("%s: marshaling: %w", c.tool, err)
+			return fmt.Errorf("%s: marshaling: %w", c.name(), err)
 		}
 		tmp, err := stageTemp(c.goldenFile, data, 0o600)
 		if err != nil {
 			cleanupTemps()
-			return fmt.Errorf("%s: staging %s: %w", c.tool, c.goldenFile, err)
+			return fmt.Errorf("%s: staging %s: %w", c.name(), c.goldenFile, err)
 		}
 		stagedFiles = append(stagedFiles, staged{tmp: tmp, final: c.goldenFile, size: len(data)})
 	}
@@ -255,33 +250,20 @@ func stageTemp(finalPath string, data []byte, perm os.FileMode) (string, error) 
 	return tmp, nil
 }
 
-func run(ctx context.Context, mcpURL, broker, vpn, goldenDir string, shape bool, exclusions map[string]bool) error {
+func run(ctx context.Context, mcpURL, broker, vpn, rdp, goldenDir string, shape bool, exclusions map[string]bool) error {
 	session, err := connect(ctx, mcpURL)
 	if err != nil {
 		return fmt.Errorf("connecting to MCP: %w", err)
 	}
 	defer session.Close()
 
-	checks := []toolCheck{
-		{
-			tool:       "get-broker-status",
-			goldenFile: filepath.Join(goldenDir, "get-broker-status.json"),
-			args:       map[string]any{"broker": broker},
-		},
-		{
-			tool:       "list-queues",
-			goldenFile: filepath.Join(goldenDir, "list-queues.json"),
-			args:       map[string]any{"broker": broker, "msgVpnName": vpn},
-		},
-	}
-
 	var firstErr error
-	for _, c := range checks {
-		fmt.Printf("--- %s ---\n", c.tool)
+	for _, c := range buildChecks(broker, vpn, rdp, goldenDir) {
+		fmt.Printf("--- %s ---\n", c.name())
 		if err := verify(ctx, session, c, shape, exclusions); err != nil {
 			fmt.Printf("  DIFF: %v\n", err)
 			if firstErr == nil {
-				firstErr = fmt.Errorf("%s diverged", c.tool)
+				firstErr = fmt.Errorf("%s diverged", c.name())
 			}
 			continue
 		}
@@ -295,6 +277,61 @@ type toolCheck struct {
 	tool       string
 	goldenFile string
 	args       map[string]any
+	// label names the check in the output. Defaults to the tool name; set it
+	// when two checks call the same tool with different arguments, so a diff
+	// says which of them drifted.
+	label string
+}
+
+// name returns the label to print for this check.
+func (c toolCheck) name() string {
+	if c.label != "" {
+		return c.label
+	}
+	return c.tool
+}
+
+// buildChecks declares every tool the fidelity gate covers, with the exact
+// arguments to call it with and the golden it must match.
+//
+// One list, used by both capture and verify. They used to carry a copy each,
+// which meant a tool added to one and not the other would capture a golden
+// nothing ever checked, or check a golden nothing ever captured.
+func buildChecks(broker, vpn, rdp, goldenDir string) []toolCheck {
+	return []toolCheck{
+		{
+			tool:       "get-broker-status",
+			goldenFile: filepath.Join(goldenDir, "get-broker-status.json"),
+			args:       map[string]any{"broker": broker},
+		},
+		{
+			tool:       "list-queues",
+			goldenFile: filepath.Join(goldenDir, "list-queues.json"),
+			args:       map[string]any{"broker": broker, "msgVpnName": vpn},
+		},
+		{
+			tool:       "list-rdps",
+			goldenFile: filepath.Join(goldenDir, "list-rdps.json"),
+			args:       map[string]any{"broker": broker, "msgVpnName": vpn},
+		},
+		{
+			// The default maxResults of 100 stops followPages before it asks
+			// for a second page, so the check above never exercises
+			// pagination however many RDPs the broker holds. Asking for more
+			// than one page's worth drives the mock through its cursor rule,
+			// and because the golden records every RDP returned, exact-mode
+			// length comparison is the assertion that all of them came back.
+			tool:       "list-rdps",
+			label:      "list-rdps (maxResults=200, paginated)",
+			goldenFile: filepath.Join(goldenDir, "list-rdps-paged.json"),
+			args:       map[string]any{"broker": broker, "msgVpnName": vpn, "maxResults": 200},
+		},
+		{
+			tool:       "get-rdp-status",
+			goldenFile: filepath.Join(goldenDir, "get-rdp-status.json"),
+			args:       map[string]any{"broker": broker, "msgVpnName": vpn, "restDeliveryPointName": rdp},
+		},
+	}
 }
 
 // verify calls one tool, unmarshals the golden and the actual output as
@@ -303,6 +340,13 @@ type toolCheck struct {
 func verify(ctx context.Context, session *mcp.ClientSession, c toolCheck, shape bool, exclusions map[string]bool) error {
 	goldenBytes, err := os.ReadFile(c.goldenFile)
 	if err != nil {
+		// A capture taken before this check existed leaves the manifest and
+		// the golden dir agreeing with each other and simply lacking the file,
+		// so the fixture preflight passes and this is the first thing to
+		// notice. Without the pointer it reads as a regression in the tool.
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no golden at %s — this check is newer than the capture; recapture both fixture sets with ./regen-golden.sh", c.goldenFile)
+		}
 		return fmt.Errorf("reading golden: %w", err)
 	}
 	var golden map[string]any

--- a/test/performance/fixtures-manifest.sh
+++ b/test/performance/fixtures-manifest.sh
@@ -17,6 +17,7 @@
 #   ./fixtures-manifest.sh write              # after a capture (regen-golden.sh)
 #   ./fixtures-manifest.sh check [--no-canned]  # preflight (run.sh, run-loadgen.sh)
 #   ./fixtures-manifest.sh vpn                # print the VPN the capture used
+#   ./fixtures-manifest.sh rdp                # print the RDP the capture pinned
 #
 # check fails when:
 #   - the manifest is absent          → nothing has been captured here
@@ -35,7 +36,7 @@
 # Env:
 #   FIXTURE_AGE_WARN  age past which check prints a warning (default 7d;
 #                     accepts <N>d or <N>h). Warning only.
-#   BROKER_ALIAS/VPN  recorded by write as capture provenance.
+#   BROKER_ALIAS/VPN/RDP_NAME  recorded by write as capture provenance.
 
 set -euo pipefail
 
@@ -87,6 +88,7 @@ cmd_write() {
     echo "# captured_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "# broker_alias: ${BROKER_ALIAS:-unknown}"
     echo "# vpn: ${VPN:-unknown}"
+    echo "# rdp: ${RDP_NAME:-unknown}"
     ( cd "$here" && printf '%s\n' "$paths" | xargs sha256sum )
   } >"$manifest"
 
@@ -164,10 +166,11 @@ EOF
   if [[ -n "$captured_epoch" ]]; then
     age_s=$(( $(date +%s) - captured_epoch ))
     warn_s="$(age_seconds "${FIXTURE_AGE_WARN:-7d}")"
-    printf '   fixtures captured %s (%dh ago) broker=%s vpn=%s\n' \
+    printf '   fixtures captured %s (%dh ago) broker=%s vpn=%s rdp=%s\n' \
       "$captured_at" "$(( age_s / 3600 ))" \
       "$(sed -n 's/^# broker_alias: //p' "$manifest")" \
-      "$(sed -n 's/^# vpn: //p' "$manifest")"
+      "$(sed -n 's/^# vpn: //p' "$manifest")" \
+      "$(sed -n 's/^# rdp: //p' "$manifest")"
     if (( age_s > warn_s )); then
       echo "   WARNING: older than ${FIXTURE_AGE_WARN:-7d}. Still internally consistent, so the run proceeds," >&2
       echo "            but the broker it describes has moved on — recapture before trusting a regression." >&2
@@ -187,9 +190,20 @@ cmd_vpn() {
   sed -n 's/^# vpn: //p' "$manifest" | head -1
 }
 
+# cmd_rdp prints the RDP name the capture pinned, for the same reason cmd_vpn
+# exists: the mock pins one RDP (it reads the name out of the captured object),
+# so fidelity and loadgen must ask for that RDP and no other. Reading it from
+# the capture's own provenance is what keeps the two from drifting — a literal
+# default in each script is how they would.
+cmd_rdp() {
+  [[ -f "$manifest" ]] || return 0
+  sed -n 's/^# rdp: //p' "$manifest" | head -1
+}
+
 case "${1:-}" in
   write) shift; cmd_write "$@" ;;
   check) shift; cmd_check "$@" ;;
   vpn)   shift; cmd_vpn "$@" ;;
-  *) echo "usage: $0 {write|check [--no-canned]|vpn}" >&2; exit 2 ;;
+  rdp)   shift; cmd_rdp "$@" ;;
+  *) echo "usage: $0 {write|check [--no-canned]|vpn|rdp}" >&2; exit 2 ;;
 esac

--- a/test/performance/loadgen/main.go
+++ b/test/performance/loadgen/main.go
@@ -28,7 +28,13 @@
 //	  -brokers  my-broker \
 //	  -clients  32 \
 //	  -duration 60s \
-//	  -tools    get-broker-status,list-queues
+//	  -tools    get-broker-status,list-queues,list-rdps,get-rdp-status \
+//	  -rdp      rdp_1
+//
+// Every tool loadgen can call is listed in toolRecipes along with the
+// arguments it needs; a -tools list naming anything else stops the run at
+// startup. get-rdp-status additionally needs -rdp, which must name the RDP
+// the mock's fixture pinned (run.sh reads it from fixtures.manifest).
 //
 // Auth: reads MCP_DEV_TOKEN from env and sends it as Bearer if set.
 package main
@@ -58,24 +64,45 @@ func main() {
 	brokersCSV := flag.String("brokers", "", "comma-separated broker aliases; each client is pinned to one, round-robin. Mutually exclusive with -broker-count.")
 	brokerCount := flag.Int("broker-count", 0, "shortcut: generate <prefix>-01..<prefix>-N as the alias list. Zero means use -brokers instead.")
 	brokerPrefix := flag.String("broker-prefix", "broker", "prefix used with -broker-count (e.g. -broker-count=50 => broker-01..broker-50)")
-	vpn := flag.String("vpn", "default", "msgVpnName argument for tools that need it (e.g. list-queues)")
+	vpn := flag.String("vpn", "default", "msgVpnName argument for every tool whose recipe needs it (list-queues, list-rdps, get-rdp-status)")
+	rdp := flag.String("rdp", "", "restDeliveryPointName argument for get-rdp-status. Must name the RDP the fixture pinned — run.sh reads it from fixtures.manifest")
 	clients := flag.Int("clients", 32, "number of concurrent MCP sessions")
 	duration := flag.Duration("duration", 60*time.Second, "steady-state run duration")
 	warmup := flag.Duration("warmup", 0, "duration excluded from stats before steady state; useful for skipping session warmup jitter")
-	toolsCSV := flag.String("tools", "get-broker-status,list-queues", "comma-separated tool names; each client rotates through them")
+	toolsCSV := flag.String("tools", "get-broker-status,list-queues,list-rdps,get-rdp-status", "comma-separated tool names; each client rotates through them")
 	rps := flag.Float64("rps", 0, "per-client req/s cap; 0 = unlimited (client fires as fast as MCP responds). Mutually exclusive with -total-rps.")
 	totalRPS := flag.Float64("total-rps", 0, "aggregate req/s across all clients; divided evenly so per-client = total-rps/clients. Mutually exclusive with -rps.")
 	connectTimeout := flag.Duration("connect-timeout", 30*time.Second, "deadline for opening each MCP session before the run starts")
+	validateOnly := flag.Bool("validate-only", false, "check -tools against the argument recipes and exit, without opening any session. The run scripts call this in their preflight so a typo in TOOLS costs nothing instead of surfacing after the mock is up, the fidelity gate has run, and (split-host) MCP has been waited for.")
 	flag.Parse()
+
+	tools := splitCSV(*toolsCSV)
+	if len(tools) == 0 || *clients < 1 || *duration <= 0 {
+		fmt.Fprintln(os.Stderr, "loadgen: -tools, -clients, -duration are required and non-empty")
+		os.Exit(2)
+	}
+	// Refuse the run before a single session is dialled. A tool called with
+	// missing required arguments returns IsError, which lands in the same
+	// error count as broker unavailability and timeouts — so an argument gap
+	// would complete the run and read as a resilience finding rather than an
+	// operator mistake.
+	//
+	// Checked before the broker flags so -validate-only needs nothing but the
+	// tool list and its argument values — the preflight has those, and asking
+	// it for a broker count it doesn't use would be a wart.
+	argValues := map[string]string{argVPN: *vpn, argRDP: *rdp}
+	if err := validateTools(tools, argValues); err != nil {
+		fmt.Fprintf(os.Stderr, "loadgen: %v\n", err)
+		os.Exit(2)
+	}
+	if *validateOnly {
+		fmt.Printf("loadgen: -tools %v OK (arguments resolvable for every tool)\n", tools)
+		return
+	}
 
 	brokers, err := resolveBrokers(*brokersCSV, *brokerCount, *brokerPrefix)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "loadgen: %v\n", err)
-		os.Exit(2)
-	}
-	tools := splitCSV(*toolsCSV)
-	if len(tools) == 0 || *clients < 1 || *duration <= 0 {
-		fmt.Fprintln(os.Stderr, "loadgen: -tools, -clients, -duration are required and non-empty")
 		os.Exit(2)
 	}
 	perClientRPS, err := resolveRPS(*rps, *totalRPS, *clients)
@@ -92,7 +119,7 @@ func main() {
 	cfg := runConfig{
 		mcpURL:         *mcpURL,
 		brokers:        brokers,
-		vpn:            *vpn,
+		argValues:      argValues,
 		tools:          tools,
 		clients:        *clients,
 		duration:       *duration,
@@ -107,15 +134,95 @@ func main() {
 }
 
 type runConfig struct {
-	mcpURL         string
-	brokers        []string
-	vpn            string
+	mcpURL  string
+	brokers []string
+	// argValues maps an argument name from toolRecipes to the flag-supplied
+	// value for it. Validated against every named tool's recipe before the
+	// run starts, so buildCallSpecs can build arguments without a fallible
+	// lookup on the call path.
+	argValues      map[string]string
 	tools          []string
 	clients        int
 	duration       time.Duration
 	warmup         time.Duration
 	rps            float64
 	connectTimeout time.Duration
+}
+
+// Argument names the recipes below draw on. Constants rather than repeated
+// literals so a typo is a compile error instead of a tool-side IsError that
+// only shows up as a high error rate mid-run.
+const (
+	argVPN = "msgVpnName"
+	argRDP = "restDeliveryPointName"
+)
+
+// toolRecipes names the arguments each tool needs beyond "broker", which
+// every tool takes. Deliberately a literal per-tool list: deriving arguments
+// from the tool's input schema would couple loadgen to MCP's tool
+// registration path, which is a much bigger change than four entries justify.
+//
+// A tool absent from this map cannot be called at all — validateTools stops
+// the run at startup. That matters more than it looks: a tool invoked without
+// its required arguments returns IsError, and callOnce folds IsError into the
+// same error count as broker unavailability, timeouts, and MCP-side rate
+// limiting. A misconfigured workload would otherwise complete and report a
+// high error rate that reads as a finding about the system under test.
+var toolRecipes = map[string][]string{
+	"get-broker-status": {},
+	"get-rdp-status":    {argVPN, argRDP},
+	"list-queues":       {argVPN},
+	"list-rdps":         {argVPN},
+}
+
+// validateTools rejects a tool list naming anything loadgen cannot build
+// arguments for: a tool with no recipe, or a recipe whose argument has no
+// value (an empty flag). Both are operator mistakes, and both must stop the
+// run rather than be measured.
+func validateTools(tools []string, argValues map[string]string) error {
+	known := make([]string, 0, len(toolRecipes))
+	for name := range toolRecipes {
+		known = append(known, name)
+	}
+	sort.Strings(known)
+
+	for _, tool := range tools {
+		recipe, ok := toolRecipes[tool]
+		if !ok {
+			return fmt.Errorf("no argument recipe for tool %q — cannot call it. Known tools: %s",
+				tool, strings.Join(known, ", "))
+		}
+		for _, arg := range recipe {
+			if argValues[arg] == "" {
+				return fmt.Errorf("tool %q needs argument %q but no value was given (see the corresponding flag)", tool, arg)
+			}
+		}
+	}
+	return nil
+}
+
+// callSpec is one prebuilt tool invocation: the tool name and the exact
+// argument map to send. Built once per client before the clock starts, so the
+// steady-state loop neither allocates a map per call nor performs a lookup
+// that could fail.
+type callSpec struct {
+	tool string
+	args map[string]any
+}
+
+// buildCallSpecs prepares one callSpec per tool in the rotation, for one
+// broker. Requires validateTools to have passed: every tool named here has a
+// recipe and every argument in that recipe has a value.
+func buildCallSpecs(tools []string, broker string, argValues map[string]string) []callSpec {
+	out := make([]callSpec, 0, len(tools))
+	for _, tool := range tools {
+		args := map[string]any{"broker": broker}
+		for _, arg := range toolRecipes[tool] {
+			args[arg] = argValues[arg]
+		}
+		out = append(out, callSpec{tool: tool, args: args})
+	}
+	return out
 }
 
 // sample is one recorded tool call. Zero-value err means success. Kept as a
@@ -166,12 +273,14 @@ func run(ctx context.Context, cfg runConfig) error {
 
 	for i := 0; i < cfg.clients; i++ {
 		broker := cfg.brokers[i%len(cfg.brokers)]
+		// Arguments resolved here, off the clock. Each client gets its own
+		// specs because "broker" differs per client; nothing mutates them
+		// afterwards.
+		specs := buildCallSpecs(cfg.tools, broker, cfg.argValues)
 		wg.Go(func() {
 			perClient[i] = clientLoop(ctx, sessions[i], clientJob{
 				id:       i,
-				broker:   broker,
-				vpn:      cfg.vpn,
-				tools:    cfg.tools,
+				specs:    specs,
 				warmup:   cfg.warmup,
 				duration: cfg.duration,
 				rps:      cfg.rps,
@@ -216,10 +325,10 @@ func run(ctx context.Context, cfg runConfig) error {
 // clientJob is the immutable per-goroutine config; the mutable atomics for
 // live counters are passed alongside.
 type clientJob struct {
-	id       int
-	broker   string
-	vpn      string
-	tools    []string
+	id int
+	// specs is the rotation this client fires, in order, wrapping around.
+	// Prebuilt by buildCallSpecs; read-only for the lifetime of the loop.
+	specs    []callSpec
 	warmup   time.Duration
 	duration time.Duration
 	rps      float64
@@ -290,12 +399,12 @@ func clientLoop(ctx context.Context, session *mcp.ClientSession, j clientJob) []
 			}
 		}
 
-		tool := j.tools[callIdx%len(j.tools)]
+		spec := j.specs[callIdx%len(j.specs)]
 		callIdx++
 
 		callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		t0 := time.Now()
-		err := callOnce(callCtx, session, tool, j.broker, j.vpn)
+		err := callOnce(callCtx, session, spec)
 		latency := time.Since(t0)
 		cancel()
 
@@ -332,15 +441,14 @@ func clientLoop(ctx context.Context, session *mcp.ClientSession, j clientJob) []
 // test, not a fidelity check; that's what fidelity/main.go is for. Tool
 // error responses (IsError=true) surface as errors in the reported error
 // rate so the operator can see broker unavailability, timeouts, MCP-side
-// rate limits, etc. — but the number is observational, not a gate.
-func callOnce(ctx context.Context, session *mcp.ClientSession, tool, broker, vpn string) error {
-	args := map[string]any{"broker": broker}
-	if tool == "list-queues" {
-		args["msgVpnName"] = vpn
-	}
+// rate limits, etc. — but the number is observational, not a gate. That
+// reading only holds because validateTools has already ruled out the one
+// IsError cause that is an operator mistake rather than a system signal: a
+// tool called without its required arguments.
+func callOnce(ctx context.Context, session *mcp.ClientSession, spec callSpec) error {
 	res, err := session.CallTool(ctx, &mcp.CallToolParams{
-		Name:      tool,
-		Arguments: args,
+		Name:      spec.tool,
+		Arguments: spec.args,
 	})
 	if err != nil {
 		return err

--- a/test/performance/loadgen/main_test.go
+++ b/test/performance/loadgen/main_test.go
@@ -1,0 +1,158 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// fullArgs is a value for every argument name any recipe references. Tests
+// that care about a missing value override one entry.
+func fullArgs() map[string]string {
+	return map[string]string{argVPN: "vpn_2", argRDP: "rdp_1"}
+}
+
+// TestBuildCallSpecsArguments pins the exact argument map each tool is called
+// with. These are the values that reach the broker, so a wrong or missing one
+// would surface only as an IsError buried in the run's error rate.
+func TestBuildCallSpecsArguments(t *testing.T) {
+	tests := []struct {
+		tool string
+		want map[string]any
+	}{
+		{
+			tool: "get-broker-status",
+			want: map[string]any{"broker": "broker-01"},
+		},
+		{
+			tool: "list-queues",
+			want: map[string]any{"broker": "broker-01", "msgVpnName": "vpn_2"},
+		},
+		{
+			tool: "list-rdps",
+			want: map[string]any{"broker": "broker-01", "msgVpnName": "vpn_2"},
+		},
+		{
+			tool: "get-rdp-status",
+			want: map[string]any{
+				"broker":                "broker-01",
+				"msgVpnName":            "vpn_2",
+				"restDeliveryPointName": "rdp_1",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.tool, func(t *testing.T) {
+			specs := buildCallSpecs([]string{tc.tool}, "broker-01", fullArgs())
+			if len(specs) != 1 {
+				t.Fatalf("buildCallSpecs returned %d specs, want 1", len(specs))
+			}
+			if specs[0].tool != tc.tool {
+				t.Errorf("tool = %q, want %q", specs[0].tool, tc.tool)
+			}
+			if !reflect.DeepEqual(specs[0].args, tc.want) {
+				t.Errorf("args = %v, want %v", specs[0].args, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildCallSpecsPreservesRotationOrder guards the round-robin: clientLoop
+// indexes specs modulo their length, so the order must match -tools.
+func TestBuildCallSpecsPreservesRotationOrder(t *testing.T) {
+	tools := []string{"list-rdps", "get-rdp-status", "list-queues"}
+	specs := buildCallSpecs(tools, "broker-07", fullArgs())
+
+	got := make([]string, 0, len(specs))
+	for _, s := range specs {
+		got = append(got, s.tool)
+	}
+	if !reflect.DeepEqual(got, tools) {
+		t.Errorf("spec order = %v, want %v", got, tools)
+	}
+}
+
+// TestBuildCallSpecsIsolatesBrokers checks each client's specs carry that
+// client's own broker — a shared map would pin every client to one broker and
+// silently invalidate the fan-out the run is measuring.
+func TestBuildCallSpecsIsolatesBrokers(t *testing.T) {
+	first := buildCallSpecs([]string{"list-rdps"}, "broker-01", fullArgs())
+	second := buildCallSpecs([]string{"list-rdps"}, "broker-02", fullArgs())
+
+	if first[0].args["broker"] != "broker-01" {
+		t.Errorf("first broker = %v, want broker-01", first[0].args["broker"])
+	}
+	if second[0].args["broker"] != "broker-02" {
+		t.Errorf("second broker = %v, want broker-02", second[0].args["broker"])
+	}
+}
+
+// TestValidateToolsRejectsUnknownTool is the acceptance case for "loadgen
+// refuses to start when -tools names a tool it has no argument recipe for,
+// with a message naming the tool".
+func TestValidateToolsRejectsUnknownTool(t *testing.T) {
+	err := validateTools([]string{"list-rdps", "list-widgets"}, fullArgs())
+	if err == nil {
+		t.Fatal("validateTools accepted an unknown tool; the run must not start")
+	}
+	if !strings.Contains(err.Error(), "list-widgets") {
+		t.Errorf("error does not name the offending tool: %v", err)
+	}
+	// The message has to be actionable — an operator who typo'd a tool name
+	// needs to see what the valid names are.
+	for _, known := range []string{"get-broker-status", "get-rdp-status", "list-queues", "list-rdps"} {
+		if !strings.Contains(err.Error(), known) {
+			t.Errorf("error does not list known tool %q: %v", known, err)
+		}
+	}
+}
+
+// TestValidateToolsRejectsMissingArgValue covers the other half of the gap:
+// a known tool whose required argument was never supplied. Calling
+// get-rdp-status with an empty restDeliveryPointName returns IsError, which
+// is indistinguishable from a broker problem in the reported error rate.
+func TestValidateToolsRejectsMissingArgValue(t *testing.T) {
+	args := fullArgs()
+	args[argRDP] = ""
+
+	err := validateTools([]string{"get-rdp-status"}, args)
+	if err == nil {
+		t.Fatal("validateTools accepted get-rdp-status with no -rdp value")
+	}
+	if !strings.Contains(err.Error(), argRDP) {
+		t.Errorf("error does not name the missing argument: %v", err)
+	}
+
+	// A tool that doesn't need the empty argument is unaffected.
+	if err := validateTools([]string{"list-rdps"}, args); err != nil {
+		t.Errorf("list-rdps rejected for an argument it does not use: %v", err)
+	}
+}
+
+// TestValidateToolsAcceptsEveryRecipe keeps the recipe table and the default
+// -tools value honest: everything declared must be callable with the flags
+// loadgen offers.
+func TestValidateToolsAcceptsEveryRecipe(t *testing.T) {
+	all := make([]string, 0, len(toolRecipes))
+	for name := range toolRecipes {
+		all = append(all, name)
+	}
+	if err := validateTools(all, fullArgs()); err != nil {
+		t.Fatalf("validateTools rejected a declared recipe: %v", err)
+	}
+}

--- a/test/performance/mock-semp/canned/README.md
+++ b/test/performance/mock-semp/canned/README.md
@@ -38,6 +38,14 @@ why you want just one side.
 | `show_version.xml`, `show_system.xml`, `show_memory.xml`, `show_message_spool.xml` | SEMPv1 `<show>` commands behind `get-broker-status` |
 | `show_hardware_details.xml` | SEMPv1, appliance-only path of `get-broker-status` |
 | `queues_page<N>.json` | SEMPv2 `list-queues`, one file per page; pages must be contiguous from 1. However many the broker's queue count produces — `sanitize.sh` globs them |
+| `rdps_page<N>.json` | SEMPv2 `list-rdps`, same per-page scheme |
+| `rdp_object.json`, `rdp_queue_bindings.json`, `rdp_rest_consumers.json` | SEMPv2 `get-rdp-status`, for the single RDP `RDP_NAME` pinned at capture time |
+
+`mock-semp` reads the pinned RDP's name out of `rdp_object.json` rather than
+taking it as a flag, so the fixture and the rule cannot name different RDPs. A
+request for any other RDP name is a miss: 404, a `MISS` line, and a non-zero
+exit at shutdown. `fixtures.manifest` records the name (`# rdp:`), and the run
+scripts read it from there to pass `-rdp` to `fidelity` and `loadgen`.
 
 `mock-semp` reads them from disk at startup — no `go:embed`, no rebuild
 after a recapture. Anything unmatched is a logged miss and a non-zero exit.

--- a/test/performance/mock-semp/canned/README.md
+++ b/test/performance/mock-semp/canned/README.md
@@ -39,7 +39,7 @@ why you want just one side.
 | `show_hardware_details.xml` | SEMPv1, appliance-only path of `get-broker-status` |
 | `queues_page<N>.json` | SEMPv2 `list-queues`, one file per page; pages must be contiguous from 1. However many the broker's queue count produces — `sanitize.sh` globs them |
 | `rdps_page<N>.json` | SEMPv2 `list-rdps`, same per-page scheme |
-| `rdp_object.json`, `rdp_queue_bindings.json`, `rdp_rest_consumers.json` | SEMPv2 `get-rdp-status`, for the single RDP `RDP_NAME` pinned at capture time |
+| `rdp_object.json`, `rdp_queue_bindings.json`, `rdp_rest_consumers.json` | SEMPv2 `get-rdp-status`, for the single RDP pinned at capture time (`RDP_NAME`, or the first the VPN reports) |
 
 `mock-semp` reads the pinned RDP's name out of `rdp_object.json` rather than
 taking it as a flag, so the fixture and the rule cannot name different RDPs. A

--- a/test/performance/mock-semp/canned/capture.sh
+++ b/test/performance/mock-semp/canned/capture.sh
@@ -17,12 +17,14 @@
 #   BROKER_USERNAME=... \
 #   BROKER_PASSWORD=... \
 #   MSG_VPN=default \
-#   RDP_NAME=rdp_1 \
+#   [RDP_NAME=rdp_1] \
 #   ./capture.sh
 #
-# RDP_NAME pins the single RDP that get-rdp-status is replayed for. mock-semp
-# reads the pinned name back out of the captured object rather than taking a
-# flag, so the two cannot disagree; a request for any other RDP misses.
+# RDP_NAME pins the single RDP that get-rdp-status is replayed for, and is
+# optional: unset, this pins the first RDP the VPN reports. mock-semp reads the
+# pinned name back out of the captured object rather than taking a flag, so the
+# two cannot disagree; a request for any other RDP misses. Setting it to a name
+# the VPN does not hold fails before anything is captured.
 #
 # Exits non-zero on any HTTP failure — a missing response file is a build
 # mistake, not a runtime one.
@@ -32,7 +34,12 @@ set -euo pipefail
 : "${BROKER_USERNAME:?BROKER_USERNAME is required}"
 : "${BROKER_PASSWORD:?BROKER_PASSWORD is required}"
 MSG_VPN="${MSG_VPN:-default}"
-RDP_NAME="${RDP_NAME:-rdp_1}"
+# No literal default. Unset means "pin whichever RDP this VPN reports first",
+# derived from the collection captured below — see pin_rdp_name. A hardcoded
+# name would be the one place in this chain that can name an RDP the capture
+# does not contain, which is exactly what mock-semp reading the name back out
+# of rdp_object.json exists to prevent.
+RDP_NAME="${RDP_NAME:-}"
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"
@@ -81,6 +88,34 @@ curl_get() {
   echo "wrote $out ($(wc -c < "$out") bytes)"
 }
 
+# All SEMPv2 captures use the private monitor endpoint, because that is what
+# MCP uses: the monitor spec's basePath is /SEMP/v2/__private_monitor__, and
+# list-queues needs it for bindCount, a private-schema attribute the public
+# /SEMP/v2/monitor/... path rejects as "not a valid attribute". Capturing from
+# the private path keeps the fixture byte-comparable with what MCP sees
+# end-to-end.
+SEMP_BASE="/SEMP/v2/__private_monitor__/msgVpns/$MSG_VPN"
+
+# An explicitly requested RDP is checked before a single fixture is written.
+# Every capture below overwrites its file, and the per-RDP requests come last,
+# so without this a bad RDP_NAME replaces the five SEMPv1 captures and both
+# paginated collections and *then* fails on a bare curl 404 — leaving a tree
+# that no longer matches fixtures.manifest and a message that never mentions
+# RDP_NAME. One request up front buys a clear error and an untouched tree.
+#
+# Only needed for an explicit name: a derived one comes from the captured
+# collection and therefore cannot name an RDP the broker lacks.
+if [[ -n "$RDP_NAME" ]]; then
+  if ! curl -fsS --config - \
+      "$BROKER_URL$SEMP_BASE/restDeliveryPoints/$RDP_NAME?select=restDeliveryPointName" \
+      -o /dev/null <<<"$_curl_user_cfg"; then
+    echo "capture: RDP_NAME='$RDP_NAME' does not exist in VPN '$MSG_VPN' on $BROKER_URL." >&2
+    echo "         Nothing was captured. Leave RDP_NAME unset to pin the first RDP the VPN reports," >&2
+    echo "         or pass a name this VPN actually holds." >&2
+    exit 2
+  fi
+fi
+
 echo "--- SEMPv1: get-broker-status inputs ---"
 curl_semp show_version.xml       '<rpc><show><version/></show></rpc>'
 curl_semp show_system.xml        '<rpc><show><system/></show></rpc>'
@@ -93,14 +128,6 @@ curl_semp show_message_spool.xml '<rpc><show><message-spool><detail/></message-s
 # at all. On a software broker the broker answers with a SEMP failure rather
 # than an HTTP error, which is captured and simply never requested.
 curl_semp show_hardware_details.xml '<rpc><show><hardware><details/></hardware></show></rpc>'
-
-# All SEMPv2 captures use the private monitor endpoint, because that is what
-# MCP uses: the monitor spec's basePath is /SEMP/v2/__private_monitor__, and
-# list-queues needs it for bindCount, a private-schema attribute the public
-# /SEMP/v2/monitor/... path rejects as "not a valid attribute". Capturing from
-# the private path keeps the fixture byte-comparable with what MCP sees
-# end-to-end.
-SEMP_BASE="/SEMP/v2/__private_monitor__/msgVpns/$MSG_VPN"
 
 # capture_pages follows a collection's pagination chain into
 # <prefix><N>.json, one file per page.
@@ -143,15 +170,46 @@ echo "--- SEMPv2: list-rdps (page 1 + follow pagination) ---"
 RDPS_SELECT="clientName,enabled,lastFailureReason,lastFailureTime,msgVpnName,restDeliveryPointName,up"
 capture_pages rdps_page "$SEMP_BASE/restDeliveryPoints?count=100&select=$RDPS_SELECT"
 
+# pin_rdp_name prints the first restDeliveryPointName in the captured
+# collection. jq preferred, grep fallback, matching capture_pages' handling of
+# nextPageUri — this script cannot assume jq.
+pin_rdp_name() {
+  local page="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.data[0].restDeliveryPointName // ""' "$page"
+  else
+    grep -oE '"restDeliveryPointName"[[:space:]]*:[[:space:]]*"[^"]*"' "$page" |
+      head -1 | sed -E 's/.*"([^"]+)"$/\1/' || true
+  fi
+}
+
+# Pin the RDP from the data just captured rather than from a literal. mock-semp
+# reads the pinned name back out of rdp_object.json, so taking it from the
+# collection makes "the fixture and the rule name the same RDP" true by
+# construction on any broker, not just the lab VPN this was built against.
+if [[ -z "$RDP_NAME" ]]; then
+  RDP_NAME="$(pin_rdp_name rdps_page1.json)"
+  if [[ -z "$RDP_NAME" ]]; then
+    echo "capture: VPN '$MSG_VPN' on $BROKER_URL reports no RDPs, so get-rdp-status has nothing" >&2
+    echo "         to capture and mock-semp will not start. Capture from a VPN that has at least" >&2
+    echo "         one RDP (the fidelity gate needs one), or set RDP_NAME to pick a specific one." >&2
+    exit 2
+  fi
+  echo "pinned RDP '$RDP_NAME' (first in the captured collection; set RDP_NAME to override)"
+fi
+
 echo "--- SEMPv2: get-rdp-status for RDP '$RDP_NAME' (3 requests) ---"
 RDP_SELECT="clientName,clientProfileName,enabled,lastFailureReason,lastFailureTime,msgVpnName,restDeliveryPointName,timeConnectionsBlocked,up"
 BINDINGS_SELECT="lastFailureReason,lastFailureTime,postRequestTarget,queueBindingName,restDeliveryPointName,up,uptime"
 CONSUMERS_SELECT="authenticationScheme,enabled,httpRequestOutstandingTxMsgCount,httpRequestTimedOutTxMsgCount,httpRequestTxMsgCount,httpResponseErrorRxMsgCount,httpResponseSuccessRxMsgCount,lastConnectionFailureReason,lastConnectionFailureTime,lastFailureReason,lastFailureTime,outgoingConnectionCount,remoteHost,remotePort,restConsumerName,restDeliveryPointName,up"
 
-# get-rdp-status asks for count=100 on both sub-collections. One page each is
-# all this captures; an RDP with more than 100 queue bindings or REST consumers
-# would need page files, and would announce itself as a mock miss rather than
-# quietly answering with a partial list.
+# get-rdp-status asks for count=100 on both sub-collections, and one page each
+# is all this captures. An RDP with more than 100 queue bindings or REST
+# consumers would be captured silently truncated, not caught: the tool declares
+# no maxResults, so it never requests a second page (fetchPaginated in
+# internal/composite/executor.go stops at the 100-item default), the golden
+# records the same first 100 with truncated: true, and the gate passes over a
+# partial answer. Pin an RDP with one binding and one consumer.
 rdp_path="$SEMP_BASE/restDeliveryPoints/$RDP_NAME"
 curl_get rdp_object.json         "$rdp_path?select=$RDP_SELECT"
 curl_get rdp_queue_bindings.json "$rdp_path/queueBindings?count=100&select=$BINDINGS_SELECT"

--- a/test/performance/mock-semp/canned/capture.sh
+++ b/test/performance/mock-semp/canned/capture.sh
@@ -3,10 +3,10 @@
 #
 # capture.sh — record real broker responses for the mock's canned/ dir.
 #
-# Fires the exact SEMP requests MCP would send for get-broker-status and
-# list-queues, and saves the raw response bodies alongside this script.
-# Overwrites any existing files, which are gitignored — see README.md in this
-# directory. mock-semp replays them straight from disk.
+# Fires the exact SEMP requests MCP would send for get-broker-status,
+# list-queues, list-rdps and get-rdp-status, and saves the raw response bodies
+# alongside this script. Overwrites any existing files, which are gitignored —
+# see README.md in this directory. mock-semp replays them straight from disk.
 #
 # Prefer ../../regen-golden.sh: it drives this script AND the golden capture in
 # one pass, so the two fixture sets describe the same instant. Running this
@@ -17,7 +17,12 @@
 #   BROKER_USERNAME=... \
 #   BROKER_PASSWORD=... \
 #   MSG_VPN=default \
+#   RDP_NAME=rdp_1 \
 #   ./capture.sh
+#
+# RDP_NAME pins the single RDP that get-rdp-status is replayed for. mock-semp
+# reads the pinned name back out of the captured object rather than taking a
+# flag, so the two cannot disagree; a request for any other RDP misses.
 #
 # Exits non-zero on any HTTP failure — a missing response file is a build
 # mistake, not a runtime one.
@@ -27,6 +32,7 @@ set -euo pipefail
 : "${BROKER_USERNAME:?BROKER_USERNAME is required}"
 : "${BROKER_PASSWORD:?BROKER_PASSWORD is required}"
 MSG_VPN="${MSG_VPN:-default}"
+RDP_NAME="${RDP_NAME:-rdp_1}"
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"
@@ -80,39 +86,76 @@ curl_semp show_version.xml       '<rpc><show><version/></show></rpc>'
 curl_semp show_system.xml        '<rpc><show><system/></show></rpc>'
 curl_semp show_memory.xml        '<rpc><show><memory/></show></rpc>'
 curl_semp show_message_spool.xml '<rpc><show><message-spool><detail/></message-spool></show></rpc>'
+# The appliance-only fifth call. get-broker-status fires it when show-version
+# identifies the broker as an appliance (internal/tools/sempv1/brokerstatus:
+# hardwareXML), and mock-semp registers its rule unconditionally, reading the
+# file at startup — so without this line a fresh capture cannot start the mock
+# at all. On a software broker the broker answers with a SEMP failure rather
+# than an HTTP error, which is captured and simply never requested.
+curl_semp show_hardware_details.xml '<rpc><show><hardware><details/></hardware></show></rpc>'
 
-echo "--- SEMPv2: list-queues (page 1 + follow pagination) ---"
-# select= matches the tools.yaml declaration for list-queues, comma-joined
-# (SEMP wire format — verified in internal/semp/sempv2/client_test.go).
+# All SEMPv2 captures use the private monitor endpoint, because that is what
+# MCP uses: the monitor spec's basePath is /SEMP/v2/__private_monitor__, and
+# list-queues needs it for bindCount, a private-schema attribute the public
+# /SEMP/v2/monitor/... path rejects as "not a valid attribute". Capturing from
+# the private path keeps the fixture byte-comparable with what MCP sees
+# end-to-end.
+SEMP_BASE="/SEMP/v2/__private_monitor__/msgVpns/$MSG_VPN"
+
+# capture_pages follows a collection's pagination chain into
+# <prefix><N>.json, one file per page.
 #
-# bindCount is a private-schema attribute (see
-# semp-v2-swagger-private-monitor-extended.json). It lives at
-# /SEMP/v2/__private_monitor__/... — that's the endpoint MCP uses. The
-# public /SEMP/v2/monitor/... path rejects bindCount as "not a valid
-# attribute". We hit the private path here so the captured body carries
-# bindCount and matches what MCP sees end-to-end.
-SELECT="accessType,bindCount,egressEnabled,ingressEnabled,lowPriorityMsgCongestionState,maxMsgSpoolUsage,msgSpoolUsage,msgVpnName,queueName,rxMsgRate,spooledMsgCount,txMsgRate,txUnackedMsgCount"
-SEMP_BASE="/SEMP/v2/__private_monitor__"
+# Stale pages are deleted first. A previous capture with more pages than this
+# one would otherwise leave its tail behind, and mock-semp chains pages by the
+# cursor each one advertises — so the leftover would be recorded in the
+# manifest and served as part of a chain it never belonged to.
+capture_pages() {
+  local prefix="$1" next="$2" page=1
+  rm -f "${prefix}"[0-9]*.json
+  while [[ -n "$next" ]]; do
+    local out="${prefix}${page}.json"
+    curl_get "$out" "$next"
+    # Extract nextPageUri from meta.paging (may be absent on last page).
+    # jq is preferred; fall back to grep for environments without it.
+    if command -v jq >/dev/null 2>&1; then
+      next=$(jq -r '.meta.paging.nextPageUri // ""' "$out")
+    else
+      next=$(grep -oE '"nextPageUri"[[:space:]]*:[[:space:]]*"[^"]*"' "$out" | sed -E 's/.*"([^"]+)"$/\1/' || true)
+    fi
+    # SEMPv2's nextPageUri may be absolute or root-relative; curl_get handles both.
+    page=$((page + 1))
+    if [[ $page -gt 20 ]]; then
+      echo "aborting: >20 pages of $prefix, likely a bug" >&2
+      exit 1
+    fi
+  done
+}
 
-page=1
-next="$SEMP_BASE/msgVpns/$MSG_VPN/queues?count=100&select=$SELECT"
-while [[ -n "$next" ]]; do
-  out="queues_page${page}.json"
-  curl_get "$out" "$next"
-  # Extract nextPageUri from meta.paging (may be absent on last page).
-  # jq is preferred; fall back to grep for environments without it.
-  if command -v jq >/dev/null 2>&1; then
-    next=$(jq -r '.meta.paging.nextPageUri // ""' "$out")
-  else
-    next=$(grep -oE '"nextPageUri"[[:space:]]*:[[:space:]]*"[^"]*"' "$out" | sed -E 's/.*"([^"]+)"$/\1/' || true)
-  fi
-  # SEMPv2's nextPageUri may be absolute or root-relative; curl_get handles both.
-  page=$((page + 1))
-  if [[ $page -gt 20 ]]; then
-    echo "aborting: >20 pages, likely a bug" >&2
-    exit 1
-  fi
-done
+# Every select= below is the comma-joined field list from that tool's step in
+# internal/composite/definitions/tools.yaml (SEMP wire format — verified in
+# internal/semp/sempv2/client_test.go). A field captured that the tool does not
+# select, or the reverse, breaks the exact-mode gate.
+echo "--- SEMPv2: list-queues (page 1 + follow pagination) ---"
+QUEUES_SELECT="accessType,bindCount,egressEnabled,ingressEnabled,lowPriorityMsgCongestionState,maxMsgSpoolUsage,msgSpoolUsage,msgVpnName,queueName,rxMsgRate,spooledMsgCount,txMsgRate,txUnackedMsgCount"
+capture_pages queues_page "$SEMP_BASE/queues?count=100&select=$QUEUES_SELECT"
+
+echo "--- SEMPv2: list-rdps (page 1 + follow pagination) ---"
+RDPS_SELECT="clientName,enabled,lastFailureReason,lastFailureTime,msgVpnName,restDeliveryPointName,up"
+capture_pages rdps_page "$SEMP_BASE/restDeliveryPoints?count=100&select=$RDPS_SELECT"
+
+echo "--- SEMPv2: get-rdp-status for RDP '$RDP_NAME' (3 requests) ---"
+RDP_SELECT="clientName,clientProfileName,enabled,lastFailureReason,lastFailureTime,msgVpnName,restDeliveryPointName,timeConnectionsBlocked,up"
+BINDINGS_SELECT="lastFailureReason,lastFailureTime,postRequestTarget,queueBindingName,restDeliveryPointName,up,uptime"
+CONSUMERS_SELECT="authenticationScheme,enabled,httpRequestOutstandingTxMsgCount,httpRequestTimedOutTxMsgCount,httpRequestTxMsgCount,httpResponseErrorRxMsgCount,httpResponseSuccessRxMsgCount,lastConnectionFailureReason,lastConnectionFailureTime,lastFailureReason,lastFailureTime,outgoingConnectionCount,remoteHost,remotePort,restConsumerName,restDeliveryPointName,up"
+
+# get-rdp-status asks for count=100 on both sub-collections. One page each is
+# all this captures; an RDP with more than 100 queue bindings or REST consumers
+# would need page files, and would announce itself as a mock miss rather than
+# quietly answering with a partial list.
+rdp_path="$SEMP_BASE/restDeliveryPoints/$RDP_NAME"
+curl_get rdp_object.json         "$rdp_path?select=$RDP_SELECT"
+curl_get rdp_queue_bindings.json "$rdp_path/queueBindings?count=100&select=$BINDINGS_SELECT"
+curl_get rdp_rest_consumers.json "$rdp_path/restConsumers?count=100&select=$CONSUMERS_SELECT"
 
 echo "--- done ---"
 ls -la *.xml *.json 2>/dev/null

--- a/test/performance/mock-semp/canned/sanitize.sh
+++ b/test/performance/mock-semp/canned/sanitize.sh
@@ -228,8 +228,15 @@ report_rdp_endpoints() {
   local values
   # -h suppresses the filename prefix: postRequestTarget values contain
   # slashes, so stripping a prefix after the fact would mangle them.
-  values="$(grep -ohaE '"(remoteHost|postRequestTarget)":"[^"]*"|"remotePort":[0-9]+' "${rdp_files[@]}" 2>/dev/null |
-    sort -u || true)"
+  #
+  # The pattern tolerates whitespace after the colon and the sed squeezes it
+  # back out, so the same value reported from two files collapses to one line.
+  # Canned bodies are compact broker output, but the goldens come from
+  # json.MarshalIndent — a pattern matching only "key":"value" reports nothing
+  # at all from get-rdp-status.json, which is the one file here captured
+  # independently rather than derived from the canned bytes.
+  values="$(grep -ohaE '"(remoteHost|postRequestTarget)":[[:space:]]*"[^"]*"|"remotePort":[[:space:]]*[0-9]+' "${rdp_files[@]}" 2>/dev/null |
+    sed -E 's/":[[:space:]]+/":/' | sort -u || true)"
   [[ -z "$values" ]] && return 0
 
   echo "sanitize: RDP endpoints in the capture — confirm none names a real internal service:"

--- a/test/performance/mock-semp/canned/sanitize.sh
+++ b/test/performance/mock-semp/canned/sanitize.sh
@@ -51,11 +51,16 @@ table="$here/sanitize.local.tsv"
 
 # --- files -------------------------------------------------------------------
 #
-# The SEMPv1 captures and the goldens are a fixed set. The queues pages are
-# not: capture.sh follows pagination, so their count tracks the broker's queue
-# count. Globbing them (rather than naming page 1..3, as this script once did)
-# is what keeps a broker with two pages from aborting the capture and a broker
-# with four from leaving page 4 unscrubbed.
+# The SEMPv1 captures, the per-RDP captures and the goldens are a fixed set.
+# The paginated collections are not: capture.sh follows pagination, so the page
+# count tracks how many queues or RDPs the broker holds. Globbing them (rather
+# than naming page 1..3, as this script once did) is what keeps a broker with
+# two pages from aborting the capture and a broker with four from leaving page 4
+# unscrubbed.
+#
+# Every capture must appear here. A file left off the list is not merely
+# unscrubbed — it is also invisible to the residual scan below, so the run
+# would report "clean" while carrying whatever the omitted file carries.
 #
 # Only capture output is listed. This script must never rewrite tracked source
 # files: a capture that edits scripts in the working tree is a surprise, and a
@@ -66,18 +71,29 @@ files=(
   "$canned_dir/show_memory.xml"
   "$canned_dir/show_message_spool.xml"
   "$canned_dir/show_hardware_details.xml"
+  "$canned_dir/rdp_object.json"
+  "$canned_dir/rdp_queue_bindings.json"
+  "$canned_dir/rdp_rest_consumers.json"
   "$golden_dir/get-broker-status.json"
   "$golden_dir/list-queues.json"
+  "$golden_dir/list-rdps.json"
+  "$golden_dir/list-rdps-paged.json"
+  "$golden_dir/get-rdp-status.json"
 )
 
-shopt -s nullglob
-pages=("$canned_dir"/queues_page*.json)
-shopt -u nullglob
-if (( ${#pages[@]} == 0 )); then
-  echo "sanitize: no queues_page*.json in $canned_dir — capture is incomplete" >&2
-  exit 2
-fi
-files+=("${pages[@]}")
+# Paginated collections, one glob each. An empty glob means the capture never
+# finished — the mock cannot serve that tool at all, so stop here rather than
+# scrubbing a partial tree.
+for prefix in queues_page rdps_page; do
+  shopt -s nullglob
+  pages=("$canned_dir/$prefix"*.json)
+  shopt -u nullglob
+  if (( ${#pages[@]} == 0 )); then
+    echo "sanitize: no ${prefix}*.json in $canned_dir — capture is incomplete" >&2
+    exit 2
+  fi
+  files+=("${pages[@]}")
+done
 
 # Guard against a partial capture — every named file must exist. A silent skip
 # would leave a real value behind on a broken tree.
@@ -141,6 +157,15 @@ fi
 #   build  non-GA build markers: the "+lo.NNN" suffix and the "NNNmain.N"
 #          main-branch form. GA versions never carry either.
 #
+# The RDP captures carry three fields that can name a real endpoint: a REST
+# consumer's remoteHost/remotePort and a queue binding's postRequestTarget. The
+# scan below only recognizes 192.168/16 and 172.16/12 addresses, so an RDP
+# pointed at a real internal service by hostname passes it. Rather than ask the
+# reader to know that, report_rdp_endpoints prints those values at the end of
+# every run: the one thing a clean scan cannot vouch for is put in front of
+# whoever ran the scrub. On the capture this harness was built against they were
+# "example.com", 80 and "/", which is why no table entries exist for them.
+#
 # A hit is fatal: regen-golden.sh runs under set -e, so the capture stops
 # before the manifest is written and before anything replays the fixture.
 # scan reports matches of $pattern that do not also match $allow. grep -E has
@@ -187,3 +212,27 @@ fi
 
 echo "sanitize: residual scan clean (MACs, lab IPs, WWPNs, build markers)"
 echo "sanitize: note — serials have no detectable shape; the scan cannot vouch for them."
+
+# report_rdp_endpoints prints the RDP endpoint fields the scan cannot judge, so
+# the human check does not depend on anyone remembering it exists. Reported, not
+# gated: "example.com" and a real internal hostname are indistinguishable by
+# shape, and only a reader can tell which one is on screen.
+report_rdp_endpoints() {
+  local rdp_files=() f
+  for f in "$canned_dir/rdp_rest_consumers.json" "$canned_dir/rdp_queue_bindings.json" \
+           "$golden_dir/get-rdp-status.json"; do
+    [[ -f "$f" ]] && rdp_files+=("$f")
+  done
+  (( ${#rdp_files[@]} )) || return 0
+
+  local values
+  # -h suppresses the filename prefix: postRequestTarget values contain
+  # slashes, so stripping a prefix after the fact would mangle them.
+  values="$(grep -ohaE '"(remoteHost|postRequestTarget)":"[^"]*"|"remotePort":[0-9]+' "${rdp_files[@]}" 2>/dev/null |
+    sort -u || true)"
+  [[ -z "$values" ]] && return 0
+
+  echo "sanitize: RDP endpoints in the capture — confirm none names a real internal service:"
+  while IFS= read -r v; do echo "            $v"; done <<<"$values"
+}
+report_rdp_endpoints

--- a/test/performance/mock-semp/handler.go
+++ b/test/performance/mock-semp/handler.go
@@ -75,17 +75,24 @@ var canned fs.FS
 type handler struct {
 	cfg    *configStore
 	misses atomic.Int64
-	rules  []rule
+	rules  []*rule
+	// windowReset records that the counters were zeroed mid-run via
+	// POST /_mock/hits, so the shutdown summary can say which window its
+	// numbers cover instead of implying they cover the whole process.
+	windowReset atomic.Bool
 }
 
 // rule is a single "if the request looks like X, serve response Y" mapping.
-// Match is intentionally loose: for SEMPv1 we substring-match the XML body
-// (SEMP requests are small enough that a substring is unambiguous). For
-// SEMPv2 we path-prefix + query-param match.
+// Matching is as tight as the protocol allows, and no tighter: SEMPv1
+// substring-matches the XML body because all five <show> commands POST to the
+// same /SEMP path, while SEMPv2 matches on path and query parameters, which
+// are unambiguous. Held by pointer so hits can be counted without copying an
+// atomic.
 type rule struct {
 	name    string
 	match   func(r *http.Request, body []byte) bool
 	respond func(w http.ResponseWriter, r *http.Request, body []byte)
+	hits    atomic.Int64
 }
 
 func newHandler(cfg *configStore) *handler {
@@ -121,6 +128,101 @@ func (h *handler) withInjection(port int) http.Handler {
 
 func (h *handler) missCount() int64 { return h.misses.Load() }
 
+// logHitSummary prints how many requests each rule served, in registration
+// order. This is the harness's own measurement of SEMP fan-out: a known number
+// of tool calls reports exactly how many SEMP requests they cost, which is
+// what converts loadgen's tool-calls/s into the SEMP requests/s the
+// performance targets are written in.
+//
+// The window matters and is stated in the header. One mock process serves both
+// the fidelity gate and the load run, so without a mid-run reset these totals
+// are the sum of the two — a fixed dozen requests from the gate, which is
+// nothing next to a load run and everything next to a calibration one. The run
+// scripts POST /_mock/hits after the gate to bank its counts and zero the
+// counters, and this says so rather than leaving the reader to know it.
+//
+// Zero-hit rules are called out because a rule that never fires is a real
+// hazard — a predicate matching only the public monitor path would look
+// perfectly healthy otherwise. It is reported, never gating: a run with
+// -tools list-rdps legitimately never touches the queues or SEMPv1 rules.
+func (h *handler) logHitSummary() {
+	window := "this run"
+	if h.windowReset.Load() {
+		window = "since the last POST /_mock/hits reset"
+	}
+	log.Printf("mock-semp: SEMP requests served per rule (%s):", window)
+	for _, rl := range h.rules {
+		n := rl.hits.Load()
+		note := ""
+		if n == 0 {
+			note = "   (never fired)"
+		}
+		log.Printf("mock-semp:   %-44s %8d%s", rl.name, n, note)
+	}
+}
+
+// ruleHits is one rule's served-request count, as reported by /_mock/hits.
+type ruleHits struct {
+	Rule string `json:"rule"`
+	Hits int64  `json:"hits"`
+}
+
+// hitsSnapshot returns every rule's count in registration order. When reset is
+// true the counters are zeroed as they are read, so the returned snapshot is
+// the tally for the window that just ended and the next window starts at zero.
+//
+// Swap-per-rule is not one atomic operation across all rules, which is fine
+// for the only caller: the scripts snapshot between phases, when nothing is
+// driving the mock. A snapshot taken under load may split a request or two
+// across the boundary.
+func (h *handler) hitsSnapshot(reset bool) []ruleHits {
+	out := make([]ruleHits, 0, len(h.rules))
+	for _, rl := range h.rules {
+		n := rl.hits.Load()
+		if reset {
+			n = rl.hits.Swap(0)
+		}
+		out = append(out, ruleHits{Rule: rl.name, Hits: n})
+	}
+	if reset {
+		h.windowReset.Store(true)
+	}
+	return out
+}
+
+// hitsHandler serves /_mock/hits on the config port. GET reports the per-rule
+// counts; POST reports them and zeroes the counters, which is how a caller
+// separates one phase's SEMP fan-out from the next's. It lives on the config
+// port rather than the broker ports for the same reason /_mock/config does:
+// broker ports may be open to the LAN, and a path under /_mock there would
+// also be one more predicate every real SEMP request has to fall through.
+//
+// The miss count is reported for context but never reset: it feeds the
+// shutdown gate, and a phase boundary is no reason to forgive a 404.
+func (h *handler) hitsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodPost:
+		default:
+			http.Error(w, "GET (report) or POST (report and reset) only", http.StatusMethodNotAllowed)
+			return
+		}
+		snapshot := h.hitsSnapshot(r.Method == http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(struct {
+			Reset  bool       `json:"reset"`
+			Misses int64      `json:"misses"`
+			Rules  []ruleHits `json:"rules"`
+		}{
+			Reset:  r.Method == http.MethodPost,
+			Misses: h.missCount(),
+			Rules:  snapshot,
+		})
+	})
+}
+
 // serve reads the body once (rules need it), then dispatches to the first
 // matching rule. On miss, logs the request line and returns 404.
 func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
@@ -133,6 +235,7 @@ func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
 
 	for _, rl := range h.rules {
 		if rl.match(r, body) {
+			rl.hits.Add(1)
 			rl.respond(w, r, body)
 			return
 		}
@@ -146,16 +249,16 @@ func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
 
 // buildRules declares the exact set of SEMP requests this mock knows how
 // to answer. Ordering matters: first match wins, so more specific rules
-// (e.g. queues pagination cursor) come before broader ones.
+// (e.g. a pagination cursor, or one pinned RDP) come before broader ones.
 //
-// list-queues pagination auto-discovers pages: any canned/queues_page<N>.json
+// List pagination auto-discovers pages: any canned/<prefix>_page<N>.json
 // present on disk becomes a rule keyed on the cursor value MCP will
 // send to reach that page (extracted from page N-1's meta.paging.nextPageUri).
 // So a fresh capture with more pages Just Works — no matching handler edit
-// needed. A capture with only page 1 (queue count <= page size) works too:
+// needed. A capture with only page 1 (object count <= page size) works too:
 // no cursor rules registered, just the page-1 rule.
-func (h *handler) buildRules() []rule {
-	rules := []rule{
+func (h *handler) buildRules() []*rule {
+	rules := []*rule{
 		// SEMPv1 — get-broker-status issues four <show> commands in
 		// parallel. Order here is stylistic; SEMPv1 dispatch is body-based.
 		{
@@ -189,16 +292,54 @@ func (h *handler) buildRules() []rule {
 		},
 	}
 
-	rules = append(rules, buildQueuesRules()...)
+	// Per-RDP rules precede the restDeliveryPoints collection rules. Suffix
+	// matching already keeps /restDeliveryPoints/<name> out of the collection
+	// rule, but the ordering makes that structural rather than a property of
+	// how the predicates happen to be written today.
+	rules = append(rules, buildPinnedRDPRules()...)
+	rules = append(rules, buildPagedRules(queuesCollection)...)
+	rules = append(rules, buildPagedRules(rdpsCollection)...)
 	return rules
 }
 
-// buildQueuesRules discovers canned/queues_page<N>.json files and returns
-// one rule per page. Pages 2..N are matched by the cursor MCP will send,
-// which is the cursor embedded in page N-1's nextPageUri (MCP passes the
-// URI back verbatim). Cursor rules are registered before the page-1 rule
-// so a cursor-bearing request is matched specifically.
-func buildQueuesRules() []rule {
+// pagedCollection describes one paginated SEMPv2 collection the mock
+// replays. Both collections behave identically — page files on disk, a cursor
+// chain between them — so they share one builder rather than each carrying a
+// copy of the discovery logic.
+type pagedCollection struct {
+	label      string            // appears in rule names and startup errors
+	filePrefix string            // canned/<filePrefix><N>.json
+	tool       string            // the MCP tool that cannot be served without it
+	isListPath func(string) bool // does this request path address the collection?
+	// ownsPaginationCheck marks the collection the fidelity gate's paginated
+	// check runs against. Exactly one collection carries it, and a capture
+	// that yields a single page for that one leaves the cursor chain
+	// unexercised suite-wide — see the warning in buildPagedRules.
+	ownsPaginationCheck bool
+}
+
+var (
+	queuesCollection = pagedCollection{
+		label:      "queues",
+		filePrefix: "queues_page",
+		tool:       "list-queues",
+		isListPath: isQueuesListPath,
+	}
+	rdpsCollection = pagedCollection{
+		label:               "rdps",
+		filePrefix:          "rdps_page",
+		tool:                "list-rdps",
+		isListPath:          isRdpsListPath,
+		ownsPaginationCheck: true,
+	}
+)
+
+// buildPagedRules discovers canned/<prefix><N>.json files and returns one
+// rule per page. Pages 2..N are matched by the cursor MCP will send, which is
+// the cursor embedded in page N-1's nextPageUri (MCP passes the URI back
+// verbatim). Cursor rules are registered before the page-1 rule so a
+// cursor-bearing request is matched specifically.
+func buildPagedRules(c pagedCollection) []*rule {
 	entries, err := fs.ReadDir(canned, ".")
 	if err != nil {
 		log.Fatalf("mock-semp: reading canned dir: %v", err)
@@ -210,10 +351,10 @@ func buildQueuesRules() []rule {
 	var pages []page
 	for _, e := range entries {
 		n := e.Name()
-		if e.IsDir() || !strings.HasPrefix(n, "queues_page") || !strings.HasSuffix(n, ".json") {
+		if e.IsDir() || !strings.HasPrefix(n, c.filePrefix) || !strings.HasSuffix(n, ".json") {
 			continue
 		}
-		numStr := strings.TrimSuffix(strings.TrimPrefix(n, "queues_page"), ".json")
+		numStr := strings.TrimSuffix(strings.TrimPrefix(n, c.filePrefix), ".json")
 		num, err := strconv.Atoi(numStr)
 		if err != nil {
 			log.Fatalf("mock-semp: canned/%s: cannot parse page number: %v", n, err)
@@ -221,7 +362,8 @@ func buildQueuesRules() []rule {
 		pages = append(pages, page{num: num, file: n})
 	}
 	if len(pages) == 0 {
-		log.Fatalf("mock-semp: no queues_page*.json in the canned dir — list-queues cannot be served; capture fixtures with ./regen-golden.sh")
+		log.Fatalf("mock-semp: no %s*.json in the canned dir — %s cannot be served; capture fixtures with ./regen-golden.sh",
+			c.filePrefix, c.tool)
 	}
 	sort.Slice(pages, func(i, j int) bool { return pages[i].num < pages[j].num })
 	// Require contiguous 1..N. A gap means the recapture failed partway
@@ -229,11 +371,24 @@ func buildQueuesRules() []rule {
 	// would break silently at runtime — fail fast at startup instead.
 	for i, p := range pages {
 		if p.num != i+1 {
-			log.Fatalf("mock-semp: canned/queues_page*.json not contiguous: expected page %d, got %d", i+1, p.num)
+			log.Fatalf("mock-semp: canned/%s*.json not contiguous: expected page %d, got %d", c.filePrefix, i+1, p.num)
 		}
 	}
 
-	var out []rule
+	// A single page means no cursor rule is registered, so nothing in the
+	// suite exercises the pagination chain — and the fidelity check that
+	// exists to cover it still passes, because it compares a one-page golden
+	// against a one-page replay. Green, and covering less than it says. The
+	// capture is the only place to fix it, so say so loudly at startup rather
+	// than leaving it to be inferred from the hit summary.
+	if len(pages) == 1 && c.ownsPaginationCheck {
+		log.Printf("mock-semp: WARNING: canned/%s1.json is the only %s page, so no cursor rules exist. "+
+			"The paginated %s fidelity check cannot exercise pagination against this capture — "+
+			"recapture from a VPN holding more than one page (>100 objects) to restore that coverage.",
+			c.filePrefix, c.label, c.tool)
+	}
+
+	var out []*rule
 	// Pages 2..N — cursor match. The cursor MCP sends for page N is the one
 	// baked into page (N-1)'s nextPageUri.
 	for i := 1; i < len(pages); i++ {
@@ -241,19 +396,87 @@ func buildQueuesRules() []rule {
 		if cursor == "" {
 			log.Fatalf("mock-semp: %s has no nextPageUri cursor but %s exists", pages[i-1].file, pages[i].file)
 		}
-		out = append(out, rule{
-			name:    fmt.Sprintf("sempv2 queues page %d (cursor)", pages[i].num),
-			match:   sempv2QueuesCursorEquals(cursor),
+		out = append(out, &rule{
+			name:    fmt.Sprintf("sempv2 %s page %d (cursor)", c.label, pages[i].num),
+			match:   sempv2ListCursorEquals(c.isListPath, cursor),
 			respond: staticFile(pages[i].file, "application/json"),
 		})
 	}
 	// Page 1 — no cursor.
-	out = append(out, rule{
-		name:    "sempv2 queues page 1",
-		match:   sempv2QueuesFirstPage,
+	out = append(out, &rule{
+		name:    fmt.Sprintf("sempv2 %s page 1", c.label),
+		match:   sempv2ListFirstPage(c.isListPath),
 		respond: staticFile(pages[0].file, "application/json"),
 	})
 	return out
+}
+
+// Sub-resources of a single RDP that get-rdp-status reads. Named constants
+// because the strings appear in both the rule set and its tests.
+const (
+	rdpSubQueueBindings = "queueBindings"
+	rdpSubRestConsumers = "restConsumers"
+)
+
+// buildPinnedRDPRules returns the three exact-path rules behind
+// get-rdp-status: the RDP object, its queue bindings, and its REST consumers.
+//
+// The RDP name is taken from the captured object itself, not from a flag or a
+// literal, so the mock's pin cannot disagree with what was captured. Every
+// other name matches no rule at all and lands in the MISS log with a 404 —
+// deliberately unlike the five SEMPv1 rules, which share the /SEMP path and
+// are told apart by first-substring-match on the request body. That shape
+// answers a request for the wrong thing with a plausible body; this one
+// fails loudly.
+//
+// One page per sub-resource is enough while the pinned RDP has a single queue
+// binding and a single REST consumer (get-rdp-status asks for count=100).
+// A pinned RDP with more than 100 of either would need page files here, and
+// would announce itself as a miss rather than a truncated answer.
+func buildPinnedRDPRules() []*rule {
+	const objectFile = "rdp_object.json"
+	pinned := pinnedRDPName(objectFile)
+
+	return []*rule{
+		{
+			name:    fmt.Sprintf("sempv2 rdp %q object", pinned),
+			match:   sempv2RDPPath(pinned, ""),
+			respond: staticFile(objectFile, "application/json"),
+		},
+		{
+			name:    fmt.Sprintf("sempv2 rdp %q queueBindings", pinned),
+			match:   sempv2RDPPath(pinned, rdpSubQueueBindings),
+			respond: staticFile("rdp_queue_bindings.json", "application/json"),
+		},
+		{
+			name:    fmt.Sprintf("sempv2 rdp %q restConsumers", pinned),
+			match:   sempv2RDPPath(pinned, rdpSubRestConsumers),
+			respond: staticFile("rdp_rest_consumers.json", "application/json"),
+		},
+	}
+}
+
+// pinnedRDPName returns the restDeliveryPointName carried in the captured RDP
+// object. Fatals when the file is missing, unparseable, or carries no name:
+// a mock that pinned "" would answer for an RDP nobody asked about, and a bad
+// capture is a startup problem, not a runtime one.
+func pinnedRDPName(file string) string {
+	data, err := fs.ReadFile(canned, file)
+	if err != nil {
+		log.Fatalf("mock-semp: reading %s: %v — get-rdp-status cannot be served; capture fixtures with ./regen-golden.sh", file, err)
+	}
+	var parsed struct {
+		Data struct {
+			RestDeliveryPointName string `json:"restDeliveryPointName"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		log.Fatalf("mock-semp: %s: bad JSON: %v", file, err)
+	}
+	if parsed.Data.RestDeliveryPointName == "" {
+		log.Fatalf("mock-semp: %s: no data.restDeliveryPointName — recapture with ./regen-golden.sh", file)
+	}
+	return parsed.Data.RestDeliveryPointName
 }
 
 // cursorFromNextPageURI returns the cursor query parameter carried in the
@@ -299,34 +522,96 @@ func sempv1Body(needle string) func(*http.Request, []byte) bool {
 	}
 }
 
-// isQueuesListPath matches both the public monitor path and the private
-// monitor path. MCP uses the private endpoint for list-queues because it
-// exposes bindCount (a private-schema attribute); direct curl against the
-// public path silently drops it. Both paths are shape-compatible for the
-// fields we replay, so a single rule serves both.
-func isQueuesListPath(p string) bool {
-	if !strings.HasSuffix(p, "/queues") {
-		return false
-	}
+// isMonitorMsgVpnPath reports whether p addresses something under a message
+// VPN on either monitor endpoint. MCP uses the private one in practice — the
+// monitor spec's basePath is /SEMP/v2/__private_monitor__, and list-queues
+// needs it for bindCount, a private-schema attribute the public path rejects.
+// A rule matching only the public path would therefore never fire, so every
+// SEMPv2 predicate here goes through this function rather than naming one
+// prefix. Both paths are shape-compatible for the fields we replay.
+func isMonitorMsgVpnPath(p string) bool {
 	return strings.HasPrefix(p, "/SEMP/v2/monitor/msgVpns/") ||
 		strings.HasPrefix(p, "/SEMP/v2/__private_monitor__/msgVpns/")
 }
 
-func sempv2QueuesFirstPage(r *http.Request, _ []byte) bool {
-	return r.Method == http.MethodGet &&
-		isQueuesListPath(r.URL.Path) &&
-		r.URL.Query().Get("cursor") == ""
+func isQueuesListPath(p string) bool {
+	return isMonitorMsgVpnPath(p) && strings.HasSuffix(p, "/queues")
 }
 
-// sempv2QueuesCursorEquals returns a predicate that fires when the request
-// is a list-queues GET whose cursor query parameter matches exactly. Cursor
-// values are opaque broker state (URL-encoded XML), so exact match is the
-// only correct comparison.
-func sempv2QueuesCursorEquals(want string) func(*http.Request, []byte) bool {
+// isRdpsListPath matches the restDeliveryPoints collection. Suffix-matching
+// (not prefix) is what keeps /restDeliveryPoints/<name> and its sub-resources
+// out of this rule — those belong to the pinned-RDP rules.
+func isRdpsListPath(p string) bool {
+	return isMonitorMsgVpnPath(p) && strings.HasSuffix(p, "/restDeliveryPoints")
+}
+
+// sempv2ListFirstPage returns a predicate for the cursor-free first page of a
+// collection.
+func sempv2ListFirstPage(isListPath func(string) bool) func(*http.Request, []byte) bool {
 	return func(r *http.Request, _ []byte) bool {
 		return r.Method == http.MethodGet &&
-			isQueuesListPath(r.URL.Path) &&
+			isListPath(r.URL.Path) &&
+			r.URL.Query().Get("cursor") == ""
+	}
+}
+
+// sempv2ListCursorEquals returns a predicate that fires when the request is a
+// GET for the collection whose cursor query parameter matches exactly. Cursor
+// values are opaque broker state (URL-encoded XML), so exact match is the
+// only correct comparison.
+func sempv2ListCursorEquals(isListPath func(string) bool, want string) func(*http.Request, []byte) bool {
+	return func(r *http.Request, _ []byte) bool {
+		return r.Method == http.MethodGet &&
+			isListPath(r.URL.Path) &&
 			r.URL.Query().Get("cursor") == want
+	}
+}
+
+// rdpsSegment is the path element that introduces a single RDP.
+const rdpsSegment = "/restDeliveryPoints/"
+
+// rdpSubResource splits a monitor path of the form
+//
+//	<monitor-prefix>/msgVpns/<vpn>/restDeliveryPoints/<name>[/<sub>]
+//
+// into the RDP name and its sub-resource ("" for the object itself). ok is
+// false for anything that is not such a path, including a deeper path than
+// this mock replays — an unrecognized shape must miss, not be approximated.
+//
+// The VPN segment is deliberately not compared: the mock replays one capture
+// on every port regardless of the alias or VPN in the request, exactly as the
+// queues rules do. The RDP name is what gets pinned.
+func rdpSubResource(p string) (name, sub string, ok bool) {
+	if !isMonitorMsgVpnPath(p) {
+		return "", "", false
+	}
+	_, tail, found := strings.Cut(p, rdpsSegment)
+	if !found {
+		return "", "", false
+	}
+	name, sub, hasSub := strings.Cut(tail, "/")
+	switch {
+	case name == "":
+		return "", "", false
+	case !hasSub:
+		return name, "", true
+	case sub == "" || strings.Contains(sub, "/"):
+		return "", "", false
+	default:
+		return name, sub, true
+	}
+}
+
+// sempv2RDPPath returns a predicate matching a GET for exactly one RDP name
+// and one sub-resource. A request naming any other RDP matches nothing and is
+// answered as a miss.
+func sempv2RDPPath(pinned, sub string) func(*http.Request, []byte) bool {
+	return func(r *http.Request, _ []byte) bool {
+		if r.Method != http.MethodGet {
+			return false
+		}
+		name, gotSub, ok := rdpSubResource(r.URL.Path)
+		return ok && name == pinned && gotSub == sub
 	}
 }
 

--- a/test/performance/mock-semp/handler.go
+++ b/test/performance/mock-semp/handler.go
@@ -431,8 +431,17 @@ const (
 //
 // One page per sub-resource is enough while the pinned RDP has a single queue
 // binding and a single REST consumer (get-rdp-status asks for count=100).
-// A pinned RDP with more than 100 of either would need page files here, and
-// would announce itself as a miss rather than a truncated answer.
+//
+// A pinned RDP with more than 100 of either would NOT announce itself. The
+// tool declares no maxResults parameter, so resolveMaxResults returns
+// defaultMax (100) and fetchPaginated stops on the first page without ever
+// issuing a cursor request — see internal/composite/executor.go. Fixture and
+// golden would each hold the first 100 of N with truncated: true, they would
+// match, and the gate would stay green over a partial answer. Nothing misses,
+// and sempv2RDPPath ignores the cursor parameter anyway (unlike
+// sempv2ListCursorEquals), so a cursor request would re-serve page 1 rather
+// than fail. Pinning a busy RDP is therefore a capture-time judgement the
+// harness cannot make for you: prefer one with a single binding and consumer.
 func buildPinnedRDPRules() []*rule {
 	const objectFile = "rdp_object.json"
 	pinned := pinnedRDPName(objectFile)

--- a/test/performance/mock-semp/handler_test.go
+++ b/test/performance/mock-semp/handler_test.go
@@ -1,0 +1,368 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// The real fixtures are lab captures kept out of git, so these tests build a
+// miniature canned/ in memory: same file names, same shapes, enough of
+// meta.paging to drive the cursor chain.
+//
+// canned is a package-level fs.FS read by staticFile and the rule builders at
+// newHandler time, so every test sets it before constructing a handler and
+// none of them run in parallel.
+const (
+	testRDPName    = "rdp_1"
+	testRDPCursor  = "rdp-cursor-page2"
+	testQCursor    = "queue-cursor-page2"
+	privateVPNBase = "/SEMP/v2/__private_monitor__/msgVpns/vpn_2"
+	publicVPNBase  = "/SEMP/v2/monitor/msgVpns/vpn_2"
+)
+
+func testFixtures() fstest.MapFS {
+	// meta.paging.nextPageUri is where the cursor chain lives — the same
+	// place cursorFromNextPageURI reads it from in a real capture.
+	page := func(body, nextCursor string) *fstest.MapFile {
+		meta := `{}`
+		if nextCursor != "" {
+			meta = `{"paging":{"nextPageUri":"/SEMP/v2/__private_monitor__/next?cursor=` + nextCursor + `&count=100"}}`
+		}
+		return &fstest.MapFile{Data: []byte(`{"data":[` + body + `],"meta":` + meta + `}`)}
+	}
+	return fstest.MapFS{
+		// list-queues needs at least one page or the mock refuses to start.
+		"queues_page1.json": page(`{"queueName":"q1"}`, testQCursor),
+		"queues_page2.json": page(`{"queueName":"q2"}`, ""),
+
+		"rdps_page1.json": page(`{"restDeliveryPointName":"`+testRDPName+`"}`, testRDPCursor),
+		"rdps_page2.json": page(`{"restDeliveryPointName":"rdp_196"}`, ""),
+
+		"rdp_object.json":         {Data: []byte(`{"data":{"restDeliveryPointName":"` + testRDPName + `","up":false},"meta":{}}`)},
+		"rdp_queue_bindings.json": page(`{"queueBindingName":"`+testRDPName+`_queue"}`, ""),
+		"rdp_rest_consumers.json": page(`{"restConsumerName":"consumer_1"}`, ""),
+
+		// SEMPv1 rules read these at rule-build time.
+		"show_version.xml":          {Data: []byte(`<rpc-reply/>`)},
+		"show_system.xml":           {Data: []byte(`<rpc-reply/>`)},
+		"show_memory.xml":           {Data: []byte(`<rpc-reply/>`)},
+		"show_message_spool.xml":    {Data: []byte(`<rpc-reply/>`)},
+		"show_hardware_details.xml": {Data: []byte(`<rpc-reply/>`)},
+	}
+}
+
+// newTestHandler points canned at the in-memory fixtures and builds a handler
+// over them.
+func newTestHandler(t *testing.T) *handler {
+	t.Helper()
+	canned = testFixtures()
+	return newHandler(newConfigStore([]int{8081}))
+}
+
+// get issues a GET through the handler and returns the recorder.
+func get(t *testing.T, h *handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.serve(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil))
+	return rec
+}
+
+// TestRdpsListPagination walks the cursor chain the composite executor
+// follows: page 1 carries no cursor, and the cursor it advertises in
+// nextPageUri is the one that must fetch page 2.
+func TestRdpsListPagination(t *testing.T) {
+	h := newTestHandler(t)
+
+	rec := get(t, h, privateVPNBase+"/restDeliveryPoints?count=100")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first page: status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"`+testRDPName+`"`) {
+		t.Errorf("first page body does not look like page 1: %s", rec.Body.String())
+	}
+
+	rec = get(t, h, privateVPNBase+"/restDeliveryPoints?count=100&cursor="+testRDPCursor)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second page: status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "rdp_196") {
+		t.Errorf("cursor request did not return page 2: %s", rec.Body.String())
+	}
+
+	if h.missCount() != 0 {
+		t.Errorf("missCount = %d, want 0", h.missCount())
+	}
+}
+
+// TestRdpsListUnknownCursorMisses proves the cursor is compared exactly.
+// Cursors are opaque broker state; serving page 2 for a cursor the capture
+// never produced would be a wrong answer dressed as a right one.
+func TestRdpsListUnknownCursorMisses(t *testing.T) {
+	h := newTestHandler(t)
+
+	rec := get(t, h, privateVPNBase+"/restDeliveryPoints?cursor=not-a-real-cursor")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+	if h.missCount() != 1 {
+		t.Errorf("missCount = %d, want 1", h.missCount())
+	}
+}
+
+// TestRdpsListMatchesBothMonitorPrefixes covers the AC directly: MCP uses the
+// private endpoint, so a rule matching only the public path would never fire.
+func TestRdpsListMatchesBothMonitorPrefixes(t *testing.T) {
+	for _, base := range []string{privateVPNBase, publicVPNBase} {
+		t.Run(base, func(t *testing.T) {
+			h := newTestHandler(t)
+			if rec := get(t, h, base+"/restDeliveryPoints?count=100"); rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200", rec.Code)
+			}
+			if h.missCount() != 0 {
+				t.Errorf("missCount = %d, want 0", h.missCount())
+			}
+		})
+	}
+}
+
+// TestPinnedRDPSubResources checks all three requests get-rdp-status issues
+// are served for the RDP the capture pinned, on both monitor prefixes.
+func TestPinnedRDPSubResources(t *testing.T) {
+	paths := map[string]string{
+		"object":        "",
+		"queueBindings": "/" + rdpSubQueueBindings,
+		"restConsumers": "/" + rdpSubRestConsumers,
+	}
+	for name, sub := range paths {
+		t.Run(name, func(t *testing.T) {
+			h := newTestHandler(t)
+			rec := get(t, h, privateVPNBase+"/restDeliveryPoints/"+testRDPName+sub)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if h.missCount() != 0 {
+				t.Errorf("missCount = %d, want 0", h.missCount())
+			}
+		})
+	}
+}
+
+// TestUnpinnedRDPNameMisses is the negative case the story calls for: a
+// request for any RDP other than the pinned one must miss and 404, never be
+// served the pinned RDP's body. Serving it would make every measurement of
+// get-rdp-status silently valid-looking for RDPs that were never captured.
+func TestUnpinnedRDPNameMisses(t *testing.T) {
+	subs := []string{"", "/" + rdpSubQueueBindings, "/" + rdpSubRestConsumers}
+	for _, sub := range subs {
+		t.Run("sub="+sub, func(t *testing.T) {
+			h := newTestHandler(t)
+			path := privateVPNBase + "/restDeliveryPoints/rdp_999" + sub
+
+			rec := get(t, h, path)
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("status = %d, want 404 (body=%q)", rec.Code, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), testRDPName) {
+				t.Errorf("served the pinned RDP's body for an unpinned name: %s", rec.Body.String())
+			}
+			if h.missCount() != 1 {
+				t.Errorf("missCount = %d, want 1", h.missCount())
+			}
+		})
+	}
+}
+
+// TestPerRDPPathNotSwallowedByCollectionRule guards the rule ordering. If the
+// collection predicate ever became a prefix match, /restDeliveryPoints/<name>
+// would be answered with the whole-collection body — a wrong answer that
+// nothing else in the harness would catch.
+func TestPerRDPPathNotSwallowedByCollectionRule(t *testing.T) {
+	h := newTestHandler(t)
+
+	if isRdpsListPath(privateVPNBase + "/restDeliveryPoints/" + testRDPName) {
+		t.Error("isRdpsListPath matched a single-RDP path")
+	}
+	if isRdpsListPath(privateVPNBase + "/restDeliveryPoints/" + testRDPName + "/" + rdpSubQueueBindings) {
+		t.Error("isRdpsListPath matched an RDP sub-resource path")
+	}
+
+	// The object rule serves the object, not the collection.
+	rec := get(t, h, privateVPNBase+"/restDeliveryPoints/"+testRDPName)
+	if body := rec.Body.String(); !strings.Contains(body, `"data":{`) {
+		t.Errorf("single-RDP request did not get the object body: %s", body)
+	}
+}
+
+// TestRdpSubResourceRejectsUnknownShapes pins the splitter's boundaries. An
+// unrecognized path shape must be reported as not-an-RDP-path so it misses,
+// rather than being approximated to the nearest rule.
+func TestRdpSubResourceRejectsUnknownShapes(t *testing.T) {
+	bad := []string{
+		privateVPNBase + "/restDeliveryPoints",                            // the collection
+		privateVPNBase + "/restDeliveryPoints/",                           // no name
+		privateVPNBase + "/restDeliveryPoints/" + testRDPName + "/",       // empty sub
+		privateVPNBase + "/restDeliveryPoints/" + testRDPName + "/a/b",    // deeper than we replay
+		"/SEMP/v2/config/msgVpns/vpn_2/restDeliveryPoints/" + testRDPName, // config, not monitor
+	}
+	for _, p := range bad {
+		if _, _, ok := rdpSubResource(p); ok {
+			t.Errorf("rdpSubResource(%q) = ok, want not ok", p)
+		}
+	}
+
+	name, sub, ok := rdpSubResource(privateVPNBase + "/restDeliveryPoints/" + testRDPName + "/" + rdpSubRestConsumers)
+	if !ok || name != testRDPName || sub != rdpSubRestConsumers {
+		t.Errorf("rdpSubResource = (%q, %q, %v), want (%q, %q, true)", name, sub, ok, testRDPName, rdpSubRestConsumers)
+	}
+}
+
+// TestHitCountsPerRule checks the per-rule accounting the SEMP-cost
+// measurement reads: three requests for one RDP land on three distinct rules,
+// one each, and a miss increments nothing.
+func TestHitCountsPerRule(t *testing.T) {
+	h := newTestHandler(t)
+
+	base := privateVPNBase + "/restDeliveryPoints/" + testRDPName
+	get(t, h, base)
+	get(t, h, base+"/"+rdpSubQueueBindings)
+	get(t, h, base+"/"+rdpSubRestConsumers)
+	get(t, h, privateVPNBase+"/restDeliveryPoints/rdp_999")
+
+	var served int64
+	for _, rl := range h.rules {
+		if n := rl.hits.Load(); n > 0 {
+			served += n
+			if n != 1 {
+				t.Errorf("rule %q served %d requests, want 1", rl.name, n)
+			}
+		}
+	}
+	if served != 3 {
+		t.Errorf("rules served %d requests in total, want 3", served)
+	}
+	if h.missCount() != 1 {
+		t.Errorf("missCount = %d, want 1", h.missCount())
+	}
+}
+
+// TestHitsSnapshotResetSeparatesPhases covers what /_mock/hits exists for: one
+// mock process serves the fidelity gate and then the load run, so the counts
+// have to be separable or the gate's dozen requests are folded into the load
+// phase's fan-out measurement.
+func TestHitsSnapshotResetSeparatesPhases(t *testing.T) {
+	h := newTestHandler(t)
+	object := privateVPNBase + "/restDeliveryPoints/" + testRDPName
+
+	get(t, h, object)
+	get(t, h, object+"/"+rdpSubQueueBindings)
+
+	banked := totalHits(h.hitsSnapshot(true))
+	if banked != 2 {
+		t.Fatalf("banked %d hits, want 2", banked)
+	}
+	if got := totalHits(h.hitsSnapshot(false)); got != 0 {
+		t.Errorf("counters still hold %d hits after reset, want 0", got)
+	}
+	if !h.windowReset.Load() {
+		t.Error("windowReset not set; the shutdown summary would claim to cover the whole run")
+	}
+
+	// The next phase's counts stand alone.
+	get(t, h, object)
+	if got := totalHits(h.hitsSnapshot(false)); got != 1 {
+		t.Errorf("second window = %d hits, want 1", got)
+	}
+}
+
+// TestHitsEndpointGETDoesNotReset keeps GET observational: reading the counts
+// mid-run must not silently move the boundary the reset is meant to draw.
+func TestHitsEndpointGETDoesNotReset(t *testing.T) {
+	h := newTestHandler(t)
+	get(t, h, privateVPNBase+"/restDeliveryPoints/"+testRDPName)
+
+	rec := httptest.NewRecorder()
+	h.hitsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/_mock/hits", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var got struct {
+		Reset  bool  `json:"reset"`
+		Misses int64 `json:"misses"`
+		Rules  []struct {
+			Rule string `json:"rule"`
+			Hits int64  `json:"hits"`
+		} `json:"rules"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not JSON: %v (body=%s)", err, rec.Body.String())
+	}
+	if got.Reset {
+		t.Error("GET reported reset=true")
+	}
+	if len(got.Rules) != len(h.rules) {
+		t.Errorf("reported %d rules, want %d — every rule must appear, including zero-hit ones", len(got.Rules), len(h.rules))
+	}
+	if total := totalHits(h.hitsSnapshot(false)); total != 1 {
+		t.Errorf("GET cleared the counters: %d hits remain, want 1", total)
+	}
+}
+
+// TestHitsEndpointRejectsOtherMethods — anything but GET/POST is a caller bug,
+// and answering it 200 would hand back a snapshot nobody can interpret.
+func TestHitsEndpointRejectsOtherMethods(t *testing.T) {
+	h := newTestHandler(t)
+	rec := httptest.NewRecorder()
+	h.hitsHandler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/_mock/hits", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+}
+
+// TestHitsResetLeavesMissesAlone — misses feed the shutdown gate, and a phase
+// boundary is no reason to forgive a 404.
+func TestHitsResetLeavesMissesAlone(t *testing.T) {
+	h := newTestHandler(t)
+	get(t, h, privateVPNBase+"/restDeliveryPoints/rdp_999")
+
+	h.hitsSnapshot(true)
+	if h.missCount() != 1 {
+		t.Errorf("missCount = %d after reset, want 1", h.missCount())
+	}
+}
+
+func totalHits(snapshot []ruleHits) int64 {
+	var total int64
+	for _, r := range snapshot {
+		total += r.Hits
+	}
+	return total
+}
+
+// TestPinnedRDPNameComesFromTheCapture is why there is no -rdp flag on the
+// mock: the pin is whatever was captured, so the mock and the fixture cannot
+// disagree.
+func TestPinnedRDPNameComesFromTheCapture(t *testing.T) {
+	canned = testFixtures()
+	if got := pinnedRDPName("rdp_object.json"); got != testRDPName {
+		t.Errorf("pinnedRDPName = %q, want %q", got, testRDPName)
+	}
+}

--- a/test/performance/mock-semp/handler_test.go
+++ b/test/performance/mock-semp/handler_test.go
@@ -169,24 +169,50 @@ func TestPinnedRDPSubResources(t *testing.T) {
 // request for any RDP other than the pinned one must miss and 404, never be
 // served the pinned RDP's body. Serving it would make every measurement of
 // get-rdp-status silently valid-looking for RDPs that were never captured.
+//
+// The names are chosen for their string relationship to the pinned "rdp_1",
+// because the regression to guard against is the name comparison in
+// sempv2RDPPath degrading from == to a prefix or substring match — an easy
+// refactor slip, and the one wrong answer nothing else in the harness would
+// catch. An unrelated name cannot detect that: HasPrefix("rdp_999", "rdp_1")
+// is false, so rdp_999 alone would keep passing. Each case below fails under
+// one such degradation, in both directions.
 func TestUnpinnedRDPNameMisses(t *testing.T) {
-	subs := []string{"", "/" + rdpSubQueueBindings, "/" + rdpSubRestConsumers}
-	for _, sub := range subs {
-		t.Run("sub="+sub, func(t *testing.T) {
-			h := newTestHandler(t)
-			path := privateVPNBase + "/restDeliveryPoints/rdp_999" + sub
+	names := map[string]string{
+		// Shares no prefix with the pinned name: the plain wrong-RDP case.
+		"unrelated": "rdp_999",
+		// The pinned name is a prefix of this one, so HasPrefix(name, pinned)
+		// or Contains(name, pinned) would serve it. The VPN this fixture was
+		// captured from holds rdp_1 through rdp_196, so these neighbours are
+		// real names a caller can ask for, not synthetic ones.
+		"pinned-is-prefix": "rdp_10",
+		// The mirror image: this is a prefix of the pinned name, catching
+		// HasPrefix(pinned, name) — which rdp_10 does not.
+		"prefix-of-pinned": "rdp_",
+	}
+	subs := map[string]string{
+		"object":        "",
+		"queueBindings": "/" + rdpSubQueueBindings,
+		"restConsumers": "/" + rdpSubRestConsumers,
+	}
+	for nameLabel, rdpName := range names {
+		for subLabel, sub := range subs {
+			t.Run(nameLabel+"/"+subLabel, func(t *testing.T) {
+				h := newTestHandler(t)
+				path := privateVPNBase + "/restDeliveryPoints/" + rdpName + sub
 
-			rec := get(t, h, path)
-			if rec.Code != http.StatusNotFound {
-				t.Errorf("status = %d, want 404 (body=%q)", rec.Code, rec.Body.String())
-			}
-			if strings.Contains(rec.Body.String(), testRDPName) {
-				t.Errorf("served the pinned RDP's body for an unpinned name: %s", rec.Body.String())
-			}
-			if h.missCount() != 1 {
-				t.Errorf("missCount = %d, want 1", h.missCount())
-			}
-		})
+				rec := get(t, h, path)
+				if rec.Code != http.StatusNotFound {
+					t.Errorf("%s: status = %d, want 404 (body=%q)", path, rec.Code, rec.Body.String())
+				}
+				if strings.Contains(rec.Body.String(), testRDPName) {
+					t.Errorf("%s: served the pinned RDP's body for an unpinned name: %s", path, rec.Body.String())
+				}
+				if h.missCount() != 1 {
+					t.Errorf("%s: missCount = %d, want 1", path, h.missCount())
+				}
+			})
+		}
 	}
 }
 

--- a/test/performance/mock-semp/main.go
+++ b/test/performance/mock-semp/main.go
@@ -20,10 +20,10 @@
 //	-listen-addr         interface to bind for broker ports (localhost or 0.0.0.0)  default localhost
 //	-listen-start        first broker port (inclusive)             default 8081
 //	-listen-count        number of broker ports to bind             default 50
-//	-config-listen-addr  interface to bind for /_mock/config        default localhost
+//	-config-listen-addr  interface to bind for /_mock/*             default localhost
 //	                     (kept separate from -listen-addr so opening broker ports
 //	                     to the LAN doesn't also expose the injection knob).
-//	-config-port         /_mock/config endpoint port                default 9000
+//	-config-port         /_mock/config and /_mock/hits port         default 9000
 //	-default-latency-ms  fixed sleep before every response, all ports (default 0).
 //	                     Overridden per-port by POST /_mock/config.
 //	-canned-dir          directory of captured SEMP responses to replay.
@@ -44,14 +44,25 @@
 // built to observe (backpressure behavior, timeout handling, memory under
 // contention) — the flag is how you make it appear on demand.
 //
-// The mock serves two tools' worth of canned responses:
-//   - get-broker-status  (4 SEMPv1 POSTs to /SEMP)
-//   - list-queues        (SEMPv2 GET, 2 pages)
+// The mock serves four tools' worth of canned responses:
+//   - get-broker-status  (4 SEMPv1 POSTs to /SEMP, 5 on an appliance)
+//   - list-queues        (SEMPv2 GET, paginated)
+//   - list-rdps          (SEMPv2 GET, paginated)
+//   - get-rdp-status     (SEMPv2 GET x3, for one pinned RDP only)
 //
 // Any request that matches no rule returns 404 and logs a miss. The process
 // exits non-zero at shutdown if any miss was logged — a silent 404 in a log
 // file is easy to skim past; a failed exit code is a hard gate. See plan
-// step 3.
+// step 3. That gate is what makes the pinned-RDP rules safe: a request for an
+// RDP the capture doesn't cover fails the run instead of being answered with
+// the pinned RDP's body.
+//
+// Shutdown also logs how many requests each rule served. That is the harness's
+// own measurement of per-tool SEMP fan-out — the factor that converts
+// loadgen's tool calls/s into the SEMP requests/s the performance targets are
+// written in. GET /_mock/hits reports the same counts mid-run; POST reports
+// and zeroes them, which is how the run scripts keep the fidelity gate's dozen
+// requests out of the load phase's totals.
 package main
 
 import (
@@ -130,6 +141,9 @@ func main() {
 
 	configMux := http.NewServeMux()
 	configMux.Handle("/_mock/config", cfg.handler())
+	// Same port as /_mock/config: both are operator knobs, and neither should
+	// be reachable from the LAN when broker ports are.
+	configMux.Handle("/_mock/hits", handler.hitsHandler())
 	configSrv := &http.Server{
 		Addr:              net.JoinHostPort(*configListenAddr, strconv.Itoa(*configPort)),
 		Handler:           configMux,
@@ -166,6 +180,10 @@ func main() {
 	}
 	_ = configSrv.Shutdown(shutdownCtx)
 	wg.Wait()
+
+	// Per-rule counts before the gate: on a failing run they say which rules
+	// did fire, which is the first thing you want next to the MISS lines.
+	handler.logHitSummary()
 
 	// Hard gate: if any request matched no rule, exit non-zero. The plan
 	// spells this out explicitly — a silent miss looks identical to success

--- a/test/performance/regen-golden.sh
+++ b/test/performance/regen-golden.sh
@@ -30,6 +30,10 @@ bin="$here/bin"
 config="${CONFIG_FILE:-$repo_root/broker-config.yaml}"
 broker_alias="${BROKER_ALIAS:-my-broker}"
 vpn="${VPN:-default}"
+# The RDP that get-rdp-status is captured and replayed for. mock-semp reads
+# the name back out of the captured object, and the manifest records it here,
+# so the fixture, the mock and the run scripts all name the same RDP.
+rdp_name="${RDP_NAME:-rdp_1}"
 runs="$bin/runs/$(date +%Y%m%d-%H%M%S)-regen"
 mkdir -p "$runs"
 
@@ -164,15 +168,16 @@ if [[ -z "$broker_url" ]]; then
   exit 2
 fi
 
-echo "== 3. canned/*: direct SEMP capture from $broker_url (vpn=$vpn)"
+echo "== 3. canned/*: direct SEMP capture from $broker_url (vpn=$vpn rdp=$rdp_name)"
 BROKER_URL="$broker_url" \
   BROKER_USERNAME="$BROKER_USERNAME" \
   BROKER_PASSWORD="$BROKER_PASSWORD" \
   MSG_VPN="$vpn" \
+  RDP_NAME="$rdp_name" \
   "$here/mock-semp/canned/capture.sh" 2>&1 | tee "$runs/canned.log"
 
-echo "== 4. fidelity -capture (alias=$broker_alias vpn=$vpn)"
-"$bin/fidelity" -mcp-url http://localhost:9090 -broker "$broker_alias" -vpn "$vpn" \
+echo "== 4. fidelity -capture (alias=$broker_alias vpn=$vpn rdp=$rdp_name)"
+"$bin/fidelity" -mcp-url http://localhost:9090 -broker "$broker_alias" -vpn "$vpn" -rdp "$rdp_name" \
   -golden-dir "$here/fidelity/golden" -capture 2>&1 | tee "$runs/regen.log"
 
 echo "== 5. sanitize canned and golden — strip lab-identifying values"
@@ -182,11 +187,24 @@ echo "== 5. sanitize canned and golden — strip lab-identifying values"
 # a no-op.
 "$here/mock-semp/canned/sanitize.sh" 2>&1 | tee "$runs/sanitize.log"
 
+# The paginated list-rdps fidelity check is the only thing in the suite that
+# walks a cursor chain, and it can only do that if this capture produced more
+# than one RDP page. With a single page it still passes — a one-page golden
+# against a one-page replay — so the coverage would disappear without anything
+# turning red. Warn here, where recapturing from a bigger VPN is still an
+# option; mock-semp repeats the warning at every startup.
+rdps_pages=$(find "$here/mock-semp/canned" -maxdepth 1 -name 'rdps_page*.json' | wc -l)
+if (( rdps_pages < 2 )); then
+  echo "!! WARNING: this VPN yielded $rdps_pages RDP page(s) (<=100 RDPs), so the paginated" >&2
+  echo "   list-rdps check has no cursor chain to walk and pagination goes uncovered." >&2
+  echo "   Capture from a VPN with more than 100 RDPs to keep that coverage." >&2
+fi
+
 echo "== 6. record fixtures.manifest (hashes + capture time for both sets)"
 # One manifest per capture is what lets run.sh prove canned and golden came
 # from the same pass. Written last, after sanitization, so it describes
 # exactly the bytes the mock will replay.
-BROKER_ALIAS="$broker_alias" VPN="$vpn" "$here/fixtures-manifest.sh" write
+BROKER_ALIAS="$broker_alias" VPN="$vpn" RDP_NAME="$rdp_name" "$here/fixtures-manifest.sh" write
 
 echo "== canned regenerated at $here/mock-semp/canned"
 echo "== goldens regenerated at $here/fidelity/golden"

--- a/test/performance/regen-golden.sh
+++ b/test/performance/regen-golden.sh
@@ -30,10 +30,14 @@ bin="$here/bin"
 config="${CONFIG_FILE:-$repo_root/broker-config.yaml}"
 broker_alias="${BROKER_ALIAS:-my-broker}"
 vpn="${VPN:-default}"
-# The RDP that get-rdp-status is captured and replayed for. mock-semp reads
-# the name back out of the captured object, and the manifest records it here,
-# so the fixture, the mock and the run scripts all name the same RDP.
-rdp_name="${RDP_NAME:-rdp_1}"
+# The RDP that get-rdp-status is captured and replayed for. Optional, and
+# deliberately not defaulted to a literal: capture.sh pins the first RDP the
+# VPN reports when this is unset, and step 3 below reads the name back out of
+# the captured object — the same source mock-semp resolves it from. So the
+# fixture, the mock, the manifest and the run scripts all name the same RDP
+# because they all read it from one place, rather than because a default
+# happened to match the lab.
+rdp_name="${RDP_NAME:-}"
 runs="$bin/runs/$(date +%Y%m%d-%H%M%S)-regen"
 mkdir -p "$runs"
 
@@ -168,13 +172,31 @@ if [[ -z "$broker_url" ]]; then
   exit 2
 fi
 
-echo "== 3. canned/*: direct SEMP capture from $broker_url (vpn=$vpn rdp=$rdp_name)"
+echo "== 3. canned/*: direct SEMP capture from $broker_url (vpn=$vpn rdp=${rdp_name:-<first in VPN>})"
 BROKER_URL="$broker_url" \
   BROKER_USERNAME="$BROKER_USERNAME" \
   BROKER_PASSWORD="$BROKER_PASSWORD" \
   MSG_VPN="$vpn" \
   RDP_NAME="$rdp_name" \
   "$here/mock-semp/canned/capture.sh" 2>&1 | tee "$runs/canned.log"
+
+# Read the pinned name back out of the capture, exactly as mock-semp does at
+# startup (pinnedRDPName in mock-semp/handler.go). capture.sh may have derived
+# it, so this — not $RDP_NAME — is what the golden capture and the manifest
+# must use. Parsing the fixture rather than the capture log keeps the manifest
+# describing the bytes on disk.
+rdp_object="$here/mock-semp/canned/rdp_object.json"
+if command -v jq >/dev/null 2>&1; then
+  rdp_name="$(jq -r '.data.restDeliveryPointName // ""' "$rdp_object")"
+else
+  rdp_name="$(grep -oE '"restDeliveryPointName"[[:space:]]*:[[:space:]]*"[^"]*"' "$rdp_object" |
+    head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+fi
+if [[ -z "$rdp_name" ]]; then
+  echo "capture wrote no restDeliveryPointName into $rdp_object — cannot pin an RDP." >&2
+  exit 2
+fi
+echo "   pinned RDP: $rdp_name"
 
 echo "== 4. fidelity -capture (alias=$broker_alias vpn=$vpn rdp=$rdp_name)"
 "$bin/fidelity" -mcp-url http://localhost:9090 -broker "$broker_alias" -vpn "$vpn" -rdp "$rdp_name" \

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -9,7 +9,7 @@
 # Env overrides (same names as run.sh so the two scripts share vocabulary):
 #   CLIENTS      loadgen -clients                (default 200)
 #   DURATION     loadgen -duration               (default 60s)
-#   TOOLS        loadgen -tools                  (default get-broker-status,list-queues)
+#   TOOLS        loadgen -tools                  (default get-broker-status,list-queues,list-rdps,get-rdp-status)
 #   BROKERS      loadgen -broker-count           (default 50)
 #   LATENCY_MS   mock-semp -default-latency-ms   (default 0). Set >0 to make every
 #                broker response take that long — combined with the MCP config's
@@ -29,8 +29,10 @@
 #   ERROR_STATUSES weighted status pool "code:w,code:w,..."
 #                  (default "503:70,429:20,500:10")
 #   BROKER_ALIAS   fidelity -broker  (default broker-01; must exist in broker-config.mock.yaml)
-#   VPN            fidelity -vpn   (default: the VPN recorded in fixtures.manifest
-#                  at capture time — set this only to override that)
+#   VPN            fidelity/loadgen -vpn (default: the VPN recorded in
+#                  fixtures.manifest at capture time — set only to override)
+#   RDP            fidelity/loadgen -rdp (default: the RDP recorded in
+#                  fixtures.manifest; the mock serves get-rdp-status for it only)
 
 set -euo pipefail
 
@@ -40,7 +42,7 @@ bin="$here/bin"
 
 CLIENTS="${CLIENTS:-200}"
 DURATION="${DURATION:-60s}"
-TOOLS="${TOOLS:-get-broker-status,list-queues}"
+TOOLS="${TOOLS:-get-broker-status,list-queues,list-rdps,get-rdp-status}"
 BROKERS="${BROKERS:-50}"
 LATENCY_MS="${LATENCY_MS:-0}"
 TOTAL_RPS="${TOTAL_RPS:-0}"
@@ -95,6 +97,23 @@ if [[ -z "$VPN" || "$VPN" == "unknown" ]]; then
   echo "fixtures.manifest records no VPN — recapture with ./regen-golden.sh, or pass VPN=<name> explicitly." >&2
   exit 2
 fi
+
+# Same for the pinned RDP. The mock answers get-rdp-status for exactly one RDP
+# name — the one in the capture — and misses (404, non-zero exit) for any
+# other, so both fidelity and loadgen have to ask for that one.
+RDP="${RDP:-$("$here/fixtures-manifest.sh" rdp)}"
+if [[ -z "$RDP" || "$RDP" == "unknown" ]]; then
+  echo "fixtures.manifest records no RDP — recapture with ./regen-golden.sh, or pass RDP=<name> explicitly." >&2
+  exit 2
+fi
+
+# Validate TOOLS before anything starts. loadgen enforces this at its own
+# startup too, but by then the mock is listening, the fidelity gate has run,
+# and (split-host) we may have waited minutes for Box B — a typo in TOOLS
+# should cost nothing. The tool list lives in loadgen's own recipe map, so the
+# check is delegated rather than duplicated here: a bash copy of the valid
+# names would drift the first time a tool is added.
+"$bin/loadgen" -validate-only -tools "$TOOLS" -vpn "$VPN" -rdp "$RDP"
 
 # Convert Go duration to seconds for the sampler's -duration arg.
 sample_secs=$(awk -v d="$DURATION" 'BEGIN {
@@ -182,6 +201,26 @@ arm_injection() {
     http://localhost:19000/_mock/config >/dev/null
 }
 
+# snapshot_fanout banks the per-rule SEMP counts accumulated so far and zeroes
+# them: POST /_mock/hits reports the window it closes. Called between the
+# fidelity gate and the load run, so the gate's requests are recorded as the
+# fan-out table they are, and the shutdown summary in mock.log covers only the
+# load phase. Skipped under NO_MOCK=1 for the same reason arm_injection is: the
+# mock isn't ours. Never fatal.
+snapshot_fanout() {
+  [[ "$NO_MOCK" == "1" ]] && { echo "   (NO_MOCK=1: read /_mock/hits on the host that owns the mock)"; return 0; }
+  local out="$runs/semp-fanout.json"
+  if ! curl -fsS -X POST http://localhost:19000/_mock/hits -o "$out"; then
+    echo "   WARNING: could not read /_mock/hits; mock.log's shutdown summary will include the gate's requests" >&2
+    return 0
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.rules[] | select(.hits > 0) | "   \(.hits) \(.rule)"' "$out"
+  else
+    echo "   counts in $out (install jq to see them tabulated here)"
+  fi
+}
+
 wait_for_tcp() {
   local host=$1 port=$2 name=$3 timeout_s=${4:-12}
   local end=$((SECONDS + timeout_s))
@@ -253,18 +292,24 @@ fi
 # Fidelity gate: exact-mode diff of MCP tool output vs golden captures.
 # Runs BEFORE arm_injection so the check isn't flaked by a 1% error roll.
 # BROKER_ALIAS + VPN must match how the goldens were captured; see run.sh.
-echo "== 3b. fidelity gate (exact mode; broker=$BROKER_ALIAS vpn=$VPN; exclusions in fidelity/exclusions.txt)"
-if ! "$bin/fidelity" -mcp-url "$mcp_url" -broker "$BROKER_ALIAS" -vpn "$VPN" \
+echo "== 3b. fidelity gate (exact mode; broker=$BROKER_ALIAS vpn=$VPN rdp=$RDP; exclusions in fidelity/exclusions.txt)"
+if ! "$bin/fidelity" -mcp-url "$mcp_url" -broker "$BROKER_ALIAS" -vpn "$VPN" -rdp "$RDP" \
       -golden-dir "$here/fidelity/golden" | tee "$runs/fidelity.log"; then
   echo "!! fidelity FAILED — aborting before load run" >&2
   exit 1
 fi
 
+# The gate makes exactly one call per check, so the counters now hold each
+# tool's SEMP fan-out. Bank that table and zero the counters so mock.log's
+# shutdown summary measures the load phase alone.
+echo "== 3c. SEMP fan-out per tool call (from the gate's one-call-per-check pass)"
+snapshot_fanout
+
 extra_args=()
 [[ "$TOTAL_RPS" != "0" ]] && extra_args+=(-total-rps "$TOTAL_RPS")
 
 if awk -v r="$ERROR_RATE" 'BEGIN { exit !(r+0 > 0) }'; then
-  echo "== 3c. arming error injection (rate=$ERROR_RATE count=$ERROR_COUNT/port statuses=$ERROR_STATUSES)"
+  echo "== 3d. arming error injection (rate=$ERROR_RATE count=$ERROR_COUNT/port statuses=$ERROR_STATUSES)"
   arm_injection
   inject_note="inject rate=$ERROR_RATE count=$ERROR_COUNT/port statuses=$ERROR_STATUSES"
 else
@@ -274,6 +319,7 @@ fi
 echo "== 4. loadgen against $mcp_url ($CLIENTS clients, $DURATION, tools=$TOOLS${TOTAL_RPS:+, total-rps=$TOTAL_RPS}; $inject_note)"
 "$bin/loadgen" -mcp-url "$mcp_url" -broker-count "$BROKERS" \
   -clients "$CLIENTS" -duration "$DURATION" -tools "$TOOLS" \
+  -vpn "$VPN" -rdp "$RDP" \
   "${extra_args[@]}" \
   > >(tee "$runs/loadgen.log") 2>&1 &
 lg_pid=$!

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -299,9 +299,13 @@ if ! "$bin/fidelity" -mcp-url "$mcp_url" -broker "$BROKER_ALIAS" -vpn "$VPN" -rd
   exit 1
 fi
 
-# The gate makes exactly one call per check, so the counters now hold each
-# tool's SEMP fan-out. Bank that table and zero the counters so mock.log's
+# The gate makes exactly one call per check, so the counters now hold the SEMP
+# cost of those five calls. Bank that table and zero the counters so mock.log's
 # shutdown summary measures the load phase alone.
+#
+# Read it per rule, not per tool: two of the five checks are list-rdps (default
+# args, and maxResults=200 for the paginated one), so "rdps page 1" shows 2 —
+# one hit from each. README's per-call table has the split.
 echo "== 3c. SEMP fan-out per tool call (from the gate's one-call-per-check pass)"
 snapshot_fanout
 

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -255,11 +255,16 @@ if ! "$bin/fidelity" -mcp-url http://localhost:9090 -broker "$BROKER_ALIAS" -vpn
   exit 1
 fi
 
-# The gate makes exactly one call per check, so the counters now hold each
-# tool's SEMP fan-out — the factor that turns loadgen's tool calls/s into SEMP
-# requests/s. Bank that table, then zero the counters so the shutdown summary
-# in mock.log measures the load phase alone instead of the load phase plus
-# these dozen requests.
+# The gate makes exactly one call per check, so the counters now hold the SEMP
+# cost of those five calls — the factor that turns loadgen's tool calls/s into
+# SEMP requests/s. Bank that table, then zero the counters so the shutdown
+# summary in mock.log measures the load phase alone instead of the load phase
+# plus these dozen requests.
+#
+# Read it per rule, not per tool: two of the five checks are list-rdps (default
+# args, and maxResults=200 for the paginated one), so "rdps page 1" shows 2 —
+# one hit from each — and only "rdps page 2 (cursor)" is unique to the
+# paginated call. README's per-call table has the split.
 echo "== 3b. SEMP fan-out per tool call (from the gate's one-call-per-check pass)"
 snapshot_fanout
 

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -11,7 +11,7 @@
 # Env overrides:
 #   CLIENTS      loadgen -clients      (default 32)
 #   DURATION     loadgen -duration     (default 60s)
-#   TOOLS        loadgen -tools        (default get-broker-status,list-queues)
+#   TOOLS        loadgen -tools        (default get-broker-status,list-queues,list-rdps,get-rdp-status)
 #   LATENCY_MS   mock-semp -default-latency-ms (default 0). Set >0 to make every
 #                broker response take that long — with max_concurrent_per_broker=10
 #                in the MCP config, this is what causes requests to queue up on
@@ -27,8 +27,10 @@
 #                   overload signals and exercises the MCP retry chain.
 #                   Only 429/500/502/503/504 are accepted (retryable codes).
 #   BROKER_ALIAS fidelity -broker  (default broker-01; must exist in broker-config.mock.yaml)
-#   VPN          fidelity -vpn     (default: the VPN recorded in fixtures.manifest
+#   VPN          fidelity/loadgen -vpn (default: the VPN recorded in fixtures.manifest
 #                at capture time — set this only to override that)
+#   RDP          fidelity/loadgen -rdp (default: the RDP recorded in fixtures.manifest;
+#                the mock serves get-rdp-status for that RDP only)
 #   BROKER_USERNAME / BROKER_PASSWORD  (default perf/perf; mock accepts anything non-empty)
 
 set -euo pipefail
@@ -41,7 +43,7 @@ mkdir -p "$runs"
 
 CLIENTS="${CLIENTS:-32}"
 DURATION="${DURATION:-60s}"
-TOOLS="${TOOLS:-get-broker-status,list-queues}"
+TOOLS="${TOOLS:-get-broker-status,list-queues,list-rdps,get-rdp-status}"
 LATENCY_MS="${LATENCY_MS:-0}"
 ERROR_RATE="${ERROR_RATE:-0}"
 ERROR_COUNT="${ERROR_COUNT:-0}"
@@ -87,6 +89,23 @@ if [[ -z "$VPN" || "$VPN" == "unknown" ]]; then
   echo "fixtures.manifest records no VPN — recapture with ./regen-golden.sh, or pass VPN=<name> explicitly." >&2
   exit 2
 fi
+
+# Same for the pinned RDP. The mock answers get-rdp-status for exactly one RDP
+# name — the one in the capture — and misses (404, non-zero exit) for any
+# other, so both fidelity and loadgen have to ask for that one.
+RDP="${RDP:-$("$here/fixtures-manifest.sh" rdp)}"
+if [[ -z "$RDP" || "$RDP" == "unknown" ]]; then
+  echo "fixtures.manifest records no RDP — recapture with ./regen-golden.sh, or pass RDP=<name> explicitly." >&2
+  exit 2
+fi
+
+# Validate TOOLS before anything starts. loadgen enforces this at its own
+# startup too, but by then the mock is listening, the fidelity gate has run,
+# and (split-host) we may have waited minutes for Box B — a typo in TOOLS
+# should cost nothing. The tool list lives in loadgen's own recipe map, so the
+# check is delegated rather than duplicated here: a bash copy of the valid
+# names would drift the first time a tool is added.
+"$bin/loadgen" -validate-only -tools "$TOOLS" -vpn "$VPN" -rdp "$RDP"
 
 mock_pid= mcp_pid= mem_pid= top_pid=
 # kill_tree signals a pid (and its process group if reachable) and waits for
@@ -198,6 +217,25 @@ arm_injection() {
     http://localhost:19000/_mock/config >/dev/null
 }
 
+# snapshot_fanout banks the per-rule SEMP counts accumulated so far and zeroes
+# them: POST /_mock/hits reports the window it closes. Called between the
+# fidelity gate and the load run, so the gate's requests are recorded as the
+# fan-out table they are, and the shutdown summary in mock.log covers only the
+# load phase. Never fatal — a missing fan-out table is worth a warning, not a
+# dead run, and mock.log still carries the (combined) totals.
+snapshot_fanout() {
+  local out="$runs/semp-fanout.json"
+  if ! curl -fsS -X POST http://localhost:19000/_mock/hits -o "$out"; then
+    echo "   WARNING: could not read /_mock/hits; mock.log's shutdown summary will include the gate's requests" >&2
+    return 0
+  fi
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.rules[] | select(.hits > 0) | "   \(.hits) \(.rule)"' "$out"
+  else
+    echo "   counts in $out (install jq to see them tabulated here)"
+  fi
+}
+
 echo "== 2. MCP server on :9090 (config: broker-config.mock.yaml)"
 # Exec the prebuilt binary, not `go run`: `go run` runs the compiled program
 # as a child process, so $mcp_pid would be the toolchain wrapper and the
@@ -207,18 +245,26 @@ setsid bash -c "cd '$repo_root' && CONFIG_FILE='$here/broker-config.mock.yaml' e
 mcp_pid=$!
 wait_for_http "http://localhost:9090/health" mcp-server
 
-echo "== 3. fidelity gate (exact mode; broker=$BROKER_ALIAS vpn=$VPN; exclusions in fidelity/exclusions.txt)"
+echo "== 3. fidelity gate (exact mode; broker=$BROKER_ALIAS vpn=$VPN rdp=$RDP; exclusions in fidelity/exclusions.txt)"
 # BROKER_ALIAS + VPN must match how the goldens were captured; the mock
 # replays canned bytes regardless of the alias in the request path, so
 # BROKER_ALIAS just picks which mock broker MCP dials.
-if ! "$bin/fidelity" -mcp-url http://localhost:9090 -broker "$BROKER_ALIAS" -vpn "$VPN" \
+if ! "$bin/fidelity" -mcp-url http://localhost:9090 -broker "$BROKER_ALIAS" -vpn "$VPN" -rdp "$RDP" \
       -golden-dir "$here/fidelity/golden" | tee "$runs/fidelity.log"; then
   echo "!! fidelity FAILED — aborting before load run" >&2
   exit 1
 fi
 
+# The gate makes exactly one call per check, so the counters now hold each
+# tool's SEMP fan-out — the factor that turns loadgen's tool calls/s into SEMP
+# requests/s. Bank that table, then zero the counters so the shutdown summary
+# in mock.log measures the load phase alone instead of the load phase plus
+# these dozen requests.
+echo "== 3b. SEMP fan-out per tool call (from the gate's one-call-per-check pass)"
+snapshot_fanout
+
 if awk -v r="$ERROR_RATE" 'BEGIN { exit !(r+0 > 0) }'; then
-  echo "== 3b. arming error injection (rate=$ERROR_RATE count=$ERROR_COUNT/port statuses=$ERROR_STATUSES)"
+  echo "== 3c. arming error injection (rate=$ERROR_RATE count=$ERROR_COUNT/port statuses=$ERROR_STATUSES)"
   arm_injection
 fi
 
@@ -247,6 +293,7 @@ fi
 echo "== 5. loadgen ($CLIENTS clients, $DURATION, tools=$TOOLS; $inject_note)"
 "$bin/loadgen" -mcp-url http://localhost:9090 -broker-count 50 \
   -clients "$CLIENTS" -duration "$DURATION" -tools "$TOOLS" \
+  -vpn "$VPN" -rdp "$RDP" \
   | tee "$runs/loadgen.log"
 
 echo "== done"


### PR DESCRIPTION
## Summary

Adds the two RDP tools (`list-rdps`, `get-rdp-status`) to the performance harness fixture and teaches `loadgen` their arguments, giving the harness a 1-call / 3-call SEMPv2 pair whose fields stay byte-stable under real broker load. No product code changes — everything is under `test/performance/`.

Implements SOL-153355 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Dependency update

## Motivation and Context

The harness from SOL-150813 could replay two tools, and both are weak instruments. The fidelity gate is exact but fragile: all three entries in `fidelity/exclusions.txt` come from `get-broker-status`, and `list-queues` needs none only because the capture VPN is idle — six of the thirteen fields it selects (`bindCount`, `msgSpoolUsage`, `spooledMsgCount`, `rxMsgRate`, `txMsgRate`, `txUnackedMsgCount`) move under any traffic at all. The moment fixtures are captured from a loaded broker, keeping the gate green means excluding those six, at which point the check stops verifying most of what the tool returns. Today's clean result is a property of the capture VPN being quiet, not of the harness being robust.

The RDP tools are not subject to that trade. Every RDP in the capture VPN is `enabled: false`, so every field both tools select is settled — `up: false`, `uptime: 0`, all HTTP counters `0`, `lastFailureTime` frozen at the moment each RDP was disabled rather than advancing on retries. These stay exact on a busy broker.

They also close two measurement gaps. `loadgen` reports tool calls per second while the performance targets are written in SEMP requests per second, and converting between them needs a fan-out factor the old fixture made ambiguous (`get-broker-status` is 4 or 5 depending on broker type, `list-queues` 1 or 3 depending on `maxResults`, and nothing recorded which). `list-rdps` at default arguments is exactly 1 SEMP call, so the reported rate *is* the SEMP rate. `get-rdp-status` is a stable 3 on the same protocol against the same objects in the same VPN — a 1-call and a 3-call tool differing in nothing but fan-out — and its steps 2 and 3 are `parallel: true`, which is the only concurrent-sub-request shape in the fixture.

Separately, `loadgen` could not call either tool, and the failure mode was worse than "it doesn't work". A tool invoked without its required arguments returns `IsError`, and `callOnce` folded that into the same error count as broker unavailability, timeouts, and MCP-side rate limiting — so a misconfigured workload would complete, report a high error rate, and read as a resilience finding rather than an operator mistake. An argument gap must not be able to masquerade as a measurement.

## Changes Made

- `loadgen`: replaced `callOnce`'s hardcoded `if tool == "list-queues"` branch with `toolRecipes`, a static per-tool argument map. Deliberately a literal list, not schema introspection — deriving arguments from the tool's input schema would couple `loadgen` to MCP's registration path.
- `loadgen`: `validateTools` refuses to start when `-tools` names a tool with no recipe (message lists the known tools) or a recipe whose argument has no value. Checked before any session is dialled and before the broker flags are resolved.
- `loadgen`: new `-rdp` flag for `restDeliveryPointName`; `-vpn` help updated; `-tools` now defaults to all four tools.
- `loadgen`: new `-validate-only` mode that checks the tool list and exits without opening a session, so both run scripts can validate `TOOLS` in their step-0 preflight — before the mock binds, before the fidelity gate, and (split-host) before the wait for Box B. The valid tool list stays in `loadgen`; a bash copy would drift the first time a tool is added.
- `loadgen`: arguments are now prebuilt into per-client `callSpec` values before the clock starts, so the steady-state loop neither allocates a map per call nor performs a lookup that can fail.
- `mock-semp`: `isRdpsListPath` mirroring `isQueuesListPath`, and both are routed through a new `isMonitorMsgVpnPath` that matches the public `/SEMP/v2/monitor/` and private `/SEMP/v2/__private_monitor__/` prefixes. MCP uses the private one, so a rule matching only the public path never fires.
- `mock-semp`: three exact-path rules for the pinned RDP's object, queue bindings, and REST consumers, registered ahead of the collection rules. The pinned name is read out of `rdp_object.json` at startup rather than taken as a flag, so the fixture and the rule cannot name different RDPs. A request for any other name matches nothing, logs a `MISS`, answers 404, and fails the run at shutdown.
- `mock-semp`: pagination discovery generalized into `buildPagedRules(pagedCollection)`, shared by queues and RDPs instead of each carrying a copy. Startup now fatals on a non-contiguous page set and warns when the collection that owns the paginated fidelity check yielded a single page.
- `mock-semp`: per-rule hit counters, a shutdown summary that flags rules which never fired, and `GET`/`POST /_mock/hits` on the config port (GET reports, POST reports and zeroes). This is the harness measuring its own SEMP fan-out.
- `fidelity`: `buildChecks` is now one list used by both capture and verify — they previously carried a copy each, so a tool added to one and not the other would capture a golden nothing checked, or check a golden nothing captured. Added `list-rdps`, a paginated `list-rdps (maxResults=200)` check, and `get-rdp-status`; added a `-rdp` flag; a missing golden now points at `regen-golden.sh` instead of reading as a tool regression.
- `capture.sh`: captures `restDeliveryPoints` (following pagination), the pinned RDP's object, its queue bindings and its REST consumers, plus the appliance-only `show hardware details` that the mock's rule set requires at startup. Pagination extracted into `capture_pages`, which deletes stale page files first so a shorter capture cannot leave a previous run's tail to be served as part of a chain it never belonged to.
- `sanitize.sh`: the new captures and goldens added to the scrub list; both paginated collections globbed; and `report_rdp_endpoints` prints `remoteHost`, `remotePort` and `postRequestTarget` at the end of every run, because the residual scan matches only 192.168/16 and 172.16/12 and would pass an RDP pointed at a real internal service by hostname.
- `regen-golden.sh` / `fixtures-manifest.sh`: `RDP_NAME` threaded through capture, recorded as `# rdp:` provenance, and readable back via `fixtures-manifest.sh rdp`; both run scripts read it from there to pass `-rdp`. A capture yielding fewer than two RDP pages warns at capture time, where recapturing from a bigger VPN is still an option.
- `run.sh` / `run-loadgen.sh`: `RDP` env knob, `TOOLS` preflight validation, and a `snapshot_fanout` step that POSTs `/_mock/hits` the moment the fidelity gate passes — banking the gate's one-call-per-check pass as the fan-out table and zeroing the counters so the shutdown summary measures the load phase alone.
- `README.md`: the five gate checks and why the paginated one exists; a fixture-durability table saying which tools stay exact on a realistic capture and which pass only because the capture VPN is quiet; the two structural limits (SEMPv2/JSON only, and all-disabled RDPs make any ceiling an upper bound rather than a sizing figure); and the measured SEMP cost per tool call.

## Testing

**Test Environment:**
- Go version: go1.25.12 linux/amd64
- OS: Fedora Linux (kernel 7.0.10)
- Broker version (if applicable): fixtures captured from a Solace 3560 appliance on a main-branch build; harness runs replay those captures through `mock-semp`

**Tests Performed:**
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Tested locally with `go test -race ./...`
- [x] Tested with real Solace broker

**Test Coverage:**
- 20 new unit tests across `loadgen/main_test.go` (6) and `mock-semp/handler_test.go` (14); 31 tests pass across the three harness packages. `make check` green — build, vet, lint, race-enabled tests, total coverage 89.3% against the 85% floor.
- Argument map: every recipe resolves against its flags; rotation order preserved; per-broker specs isolated.
- Startup validation: an unknown tool and a recipe with an unset flag each abort with exit 2 and a message naming the tool. Verified against the built binary — `-tools list-rdps,frobnicate` reports `no argument recipe for tool "frobnicate" … Known tools: get-broker-status, get-rdp-status, list-queues, list-rdps`, and `-tools get-rdp-status` without `-rdp` reports the missing `restDeliveryPointName`.
- Pagination: `list-rdps` page 1 then the cursor-matched page 2; an unknown cursor misses rather than falling back to page 1.
- Both monitor prefixes match the same rule.
- Negative case: `/restDeliveryPoints/rdp_999` and both of its sub-resources miss and increment the miss counter, for the object, `queueBindings` and `restConsumers` alike; a per-RDP path is not swallowed by the collection rule; `rdpSubResource` rejects deeper and malformed shapes.
- Pinned name comes from the capture, not a literal.
- Hit counters: per-rule counts, `POST` reset separating phases, `GET` not resetting, non-GET/POST rejected, and a reset leaving the miss count alone.
- Integration, exact mode, exclusions untouched: full run with all four tools, then `TOOLS=list-rdps` alone (1644 requests, 0 errors) and `TOOLS=get-rdp-status` alone (1672 requests, 0 errors). All five fidelity checks matched their golden in every run, and every run reported zero misses.
- Fan-out reproduced and recorded: `list-rdps` 1, `list-rdps maxResults=200` 2, `list-queues` 1, `get-rdp-status` 3, `get-broker-status` 5 on the appliance capture — matching the counts measured through a logging reverse proxy against the real broker.

## Breaking Changes

None. Every change is under `test/performance/`; no production code, config schema, or tool definition is touched.

**Impact:** n/a

**Migration Guide:** n/a

## Checklist

### Code Quality
- [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (checked all files, commits, and logs)
- [x] Followed [secure logging rules](../docs/internal/secure-logging-rules.md)
- [x] Credential-carrying types implement `slog.LogValuer`
- [x] No security vulnerabilities introduced (checked with golangci-lint/gosec)

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

### Documentation
- [x] README.md updated (if user-facing changes)
- [ ] docs/ updated (if architecture/design changes)
- [x] godoc comments added/updated for exported functions
- [ ] CHANGELOG.md updated (if applicable)
- [ ] Examples updated (if applicable)

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

### Breaking Changes (if applicable)
- [ ] Breaking changes documented in commit message
- [ ] Breaking changes documented in PR description
- [ ] Migration guide provided
- [ ] Deprecated functionality marked with comments and deprecation notices

## Screenshots (if applicable)
n/a

## Additional Notes

**No CHANGELOG entry.** The change is confined to `test/performance/` and touches no production surface — not `internal/config/`, not `tools.yaml`, not a native tool package.

**One deliberate deviation from the story.** SOL-153355 asks for `-rdp` to default to the RDP name the fixture pins. It has no default here: both `loadgen` and `fidelity` require it, and the run scripts read it from `fixtures.manifest`. A literal default in each script is exactly how the mock's pin and the caller's request would come to disagree, and a disagreement surfaces as a confusing diff or a mock miss rather than a clear error. The out-of-the-box run works, which is what the AC is protecting — `run.sh` with no environment set passes.

**Two rows of the story's SEMP-cost table are not reproduced.** `list-rdps maxResults=500` (2 calls) and `list-queues maxResults=500` (3 calls) are absent from the README table, for different reasons. For `list-rdps`, 500 is redundant: the capture VPN holds 196 RDPs, so `fetchPaginated` runs out of objects before it reaches either limit and 500 returns exactly what the 200 check already asserts — a second 50 KB golden to capture, sanitize and hash for no additional coverage. For `list-queues` it is not redundant: at 291 queues, 200 stops on page 2 with `truncated: true` and 500 is the only value that requests page 3, which is why `sempv2 queues page 2/3 (cursor)` read `(never fired)` in every hit summary. 500 also crosses `capMax`, selecting a different `truncatedMessage` that no check currently covers. That is a `list-queues` gating change, which this story explicitly excludes, so it is filed as a follow-up on the SOL-150813 pagination thread rather than smuggled in here.

**`loadgen` has no `maxResults` flag,** per the story's exclusion list. That is what keeps the denominator stable: every list tool in a load run costs exactly 1 SEMP request, so the reported tool rate converts to a SEMP rate by a known factor instead of an operator variable.

**Read the fixture-durability section before recapturing.** If fixtures are recaptured from a broker under load and the gate goes red on `list-queues`, that is the expected outcome and not a regression — and adding those six fields to `exclusions.txt` is a decision to stop checking most of what the tool returns, worth making deliberately.


**For Reviewers:**

**Focus Areas**: The exact-path RDP matching in `mock-semp/handler.go` is the load-bearing decision — the alternative shape, a prefix match on `/restDeliveryPoints/`, would answer a request for any of the VPN's 196 RDPs with the one that was captured, and nothing else in the harness would catch it. Compare the five SEMPv1 rules, which share the `/SEMP` path and are told apart by first-substring-match on the body; that shape has the hazard and these rules deliberately do not inherit it. Also worth a close read: `validateTools` running before the broker flags are resolved (so `-validate-only` needs nothing it does not use), and `capture_pages` deleting stale page files before capture (a leftover page would otherwise be manifest-recorded and served as part of a chain it never belonged to).


