### PR TITLE
SOL-153311: Teach the perf runners a broker config override and an explicit loadgen broker list

### DIFF
--- a/test/performance/.gitignore
+++ b/test/performance/.gitignore
@@ -13,3 +13,8 @@ fixtures.manifest
 # this checkout captures from — publishing it would defeat the scrubbing it
 # drives. Start from sanitize.local.tsv.example, which is tracked.
 mock-semp/canned/sanitize.local.tsv
+
+# Per-run config copies. One per measurement run, varying request_min_interval
+# against a fixed max_concurrent_per_broker; the run scripts copy whichever one
+# they used into the run directory, which is where the provenance belongs.
+broker-config.run*.yaml

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -11,6 +11,13 @@
 #   DURATION     loadgen -duration               (default 60s)
 #   TOOLS        loadgen -tools                  (default get-broker-status,list-queues,list-rdps,get-rdp-status)
 #   BROKERS      loadgen -broker-count           (default 50)
+#   BROKERS_CSV  loadgen -brokers <csv>          (default empty = use BROKERS).
+#                Pins this instance to an explicit alias list instead of the
+#                generated broker-01..broker-N. Set it to split one population
+#                across two concurrent loadgen instances — loadgen reports a
+#                single blended set of percentiles, so measuring a slow broker
+#                against the healthy remainder needs one instance per group.
+#                Mutually exclusive with BROKERS.
 #   LATENCY_MS   mock-semp -default-latency-ms   (default 0). Set >0 to make every
 #                broker response take that long — combined with the MCP config's
 #                max_concurrent_per_broker, requests pile up on the per-broker
@@ -43,11 +50,30 @@ bin="$here/bin"
 CLIENTS="${CLIENTS:-200}"
 DURATION="${DURATION:-60s}"
 TOOLS="${TOOLS:-get-broker-status,list-queues,list-rdps,get-rdp-status}"
+# Record whether BROKERS came from the environment before the default lands,
+# so the BROKERS_CSV conflict check below can tell "caller set 50" from
+# "nobody set anything".
+brokers_explicit="${BROKERS+set}"
 BROKERS="${BROKERS:-50}"
+BROKERS_CSV="${BROKERS_CSV:-}"
 LATENCY_MS="${LATENCY_MS:-0}"
 TOTAL_RPS="${TOTAL_RPS:-0}"
 RUN_TAG="${RUN_TAG:-${CLIENTS}c}"
 NO_MOCK="${NO_MOCK:-0}"
+
+# loadgen rejects -brokers and -broker-count together; catch it here instead,
+# where the message can name the environment variables the caller actually set.
+if [[ -n "$BROKERS_CSV" ]]; then
+  if [[ -n "$brokers_explicit" ]]; then
+    echo "set BROKERS_CSV or BROKERS, not both (got BROKERS_CSV=$BROKERS_CSV BROKERS=$BROKERS)" >&2
+    exit 2
+  fi
+  broker_args=(-brokers "$BROKERS_CSV")
+  broker_note="brokers=$BROKERS_CSV"
+else
+  broker_args=(-broker-count "$BROKERS")
+  broker_note="broker-count=$BROKERS"
+fi
 ERROR_RATE="${ERROR_RATE:-0}"
 ERROR_COUNT="${ERROR_COUNT:-0}"
 ERROR_STATUSES="${ERROR_STATUSES:-503:70,429:20,500:10}"
@@ -320,8 +346,8 @@ else
   inject_note="no error injection"
 fi
 
-echo "== 4. loadgen against $mcp_url ($CLIENTS clients, $DURATION, tools=$TOOLS${TOTAL_RPS:+, total-rps=$TOTAL_RPS}; $inject_note)"
-"$bin/loadgen" -mcp-url "$mcp_url" -broker-count "$BROKERS" \
+echo "== 4. loadgen against $mcp_url ($CLIENTS clients, $DURATION, tools=$TOOLS, $broker_note${TOTAL_RPS:+, total-rps=$TOTAL_RPS}; $inject_note)"
+"$bin/loadgen" -mcp-url "$mcp_url" "${broker_args[@]}" \
   -clients "$CLIENTS" -duration "$DURATION" -tools "$TOOLS" \
   -vpn "$VPN" -rdp "$RDP" \
   "${extra_args[@]}" \

--- a/test/performance/run-mcp.sh
+++ b/test/performance/run-mcp.sh
@@ -10,6 +10,10 @@
 #   MOCK_HOST      required — LAN address of Box A running mock-semp
 #   DURATION       how long to hold MCP up for the loadgen run (default 90s;
 #                  should exceed the loadgen -duration you use on Box A)
+#   CONFIG_FILE    MCP broker config (default ./broker-config.mock.yaml). Point
+#                  this at a per-run copy to vary request_min_interval; the file
+#                  used is copied into the run directory so the numbers stay
+#                  traceable to it.
 #   BROKER_USERNAME / BROKER_PASSWORD   (default perf/perf; mock accepts anything)
 
 set -euo pipefail
@@ -25,6 +29,18 @@ export MOCK_HOST
 export BROKER_USERNAME="${BROKER_USERNAME:-perf}"
 export BROKER_PASSWORD="${BROKER_PASSWORD:-perf}"
 DURATION="${DURATION:-90s}"
+CONFIG_FILE="${CONFIG_FILE:-$here/broker-config.mock.yaml}"
+
+# Fail loud on a bad path. Silently falling back to the committed config would
+# make every run measure the interval that file happens to ship, and a sweep
+# meant to vary the pacer would report one setting under five names.
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "CONFIG_FILE not found: $CONFIG_FILE" >&2
+  exit 2
+fi
+# MCP is launched with cwd=$repo_root, so a relative path would resolve against
+# the repo root rather than against the caller. Pin it here instead.
+CONFIG_FILE="$(realpath "$CONFIG_FILE")"
 
 for b in memsampler mcp-server; do
   if [[ ! -x "$bin/$b" ]]; then
@@ -85,11 +101,14 @@ wait_for_http() {
   return 1
 }
 
-echo "== 1. MCP server on :9090 (config: broker-config.mock.yaml, MOCK_HOST=$MOCK_HOST)"
+echo "== 1. MCP server on :9090 (config: $CONFIG_FILE, MOCK_HOST=$MOCK_HOST)"
+# Keep the exact config alongside the numbers it produced. Recording only the
+# filename is not enough: the per-run copies are local and get overwritten.
+cp "$CONFIG_FILE" "$runs/broker-config.used.yaml"
 # Exec the prebuilt binary, not `go run`: `go run` runs the compiled program
 # as a child process, so $mcp_pid would be the toolchain wrapper and the
 # memsampler in step 2 would sample that instead of MCP.
-setsid bash -c "cd '$repo_root' && CONFIG_FILE='$here/broker-config.mock.yaml' exec '$bin/mcp-server'" \
+setsid bash -c "cd '$repo_root' && CONFIG_FILE='$CONFIG_FILE' exec '$bin/mcp-server'" \
   >"$runs/mcp.log" 2>&1 &
 mcp_pid=$!
 wait_for_http "http://localhost:9090/health" mcp-server

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -26,6 +26,10 @@
 #                   Default: "503:70,429:20,500:10" — mirrors realistic broker
 #                   overload signals and exercises the MCP retry chain.
 #                   Only 429/500/502/503/504 are accepted (retryable codes).
+#   CONFIG_FILE  MCP broker config (default ./broker-config.mock.yaml). Point
+#                this at a per-run copy to vary request_min_interval; the file
+#                used is copied into the run directory so the numbers stay
+#                traceable to it.
 #   BROKER_ALIAS fidelity -broker  (default broker-01; must exist in broker-config.mock.yaml)
 #   VPN          fidelity/loadgen -vpn (default: the VPN recorded in fixtures.manifest
 #                at capture time — set this only to override that)
@@ -54,6 +58,18 @@ ERROR_STATUSES="${ERROR_STATUSES:-503:70,429:20,500:10}"
 # fixtures.manifest after the preflight below — hardcoding a default here is
 # how it drifted from regen-golden.sh's.
 BROKER_ALIAS="${BROKER_ALIAS:-broker-01}"
+CONFIG_FILE="${CONFIG_FILE:-$here/broker-config.mock.yaml}"
+
+# Fail loud on a bad path. Silently falling back to the committed config would
+# make every run measure the interval that file happens to ship, and a sweep
+# meant to vary the pacer would report one setting under five names.
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "CONFIG_FILE not found: $CONFIG_FILE" >&2
+  exit 2
+fi
+# MCP is launched with cwd=$repo_root, so a relative path would resolve against
+# the repo root rather than against the caller. Pin it here instead.
+CONFIG_FILE="$(realpath "$CONFIG_FILE")"
 export BROKER_USERNAME="${BROKER_USERNAME:-perf}"
 export BROKER_PASSWORD="${BROKER_PASSWORD:-perf}"
 # Single-host: MCP reaches the mock over loopback.
@@ -236,11 +252,14 @@ snapshot_fanout() {
   fi
 }
 
-echo "== 2. MCP server on :9090 (config: broker-config.mock.yaml)"
+echo "== 2. MCP server on :9090 (config: $CONFIG_FILE)"
+# Keep the exact config alongside the numbers it produced. Recording only the
+# filename is not enough: the per-run copies are local and get overwritten.
+cp "$CONFIG_FILE" "$runs/broker-config.used.yaml"
 # Exec the prebuilt binary, not `go run`: `go run` runs the compiled program
 # as a child process, so $mcp_pid would be the toolchain wrapper and the
 # memsampler in step 4 would sample that instead of MCP.
-setsid bash -c "cd '$repo_root' && CONFIG_FILE='$here/broker-config.mock.yaml' exec '$bin/mcp-server'" \
+setsid bash -c "cd '$repo_root' && CONFIG_FILE='$CONFIG_FILE' exec '$bin/mcp-server'" \
   >"$runs/mcp.log" 2>&1 &
 mcp_pid=$!
 wait_for_http "http://localhost:9090/health" mcp-server


### PR DESCRIPTION
## Summary

Adds two environment overrides to the performance harness runners: `CONFIG_FILE`, so a run can select which broker config MCP starts with, and `BROKERS_CSV`, so a `loadgen` instance can be pinned to an explicit list of broker aliases. Both were prerequisites for the SOL-153311 measurement runs.

Jira: SOL-153311
## Type of Change
- [x] New feature (non-breaking change which adds functionality)

Test-harness only. No production code is touched.

## Motivation and Context

SOL-153311 measures the server under concurrent callers, and two of its runs could not be expressed with the runners as they stood.

Runs A, B and B′ vary `request_min_interval` across otherwise identical runs. The only way to do that was to edit `broker-config.mock.yaml` in place between runs, which the ticket explicitly forbids: without a per-run config file, and a record of which file produced which numbers, the results are not reproducible.

Run C measures one deliberately slow broker against the 49 healthy ones. `loadgen` reports a single blended set of percentiles, so a slow broker inside the same population is invisible — the victim's 20 s tail and the healthy population's 732 ms p95 average into one meaningless figure. Measuring them separately requires two concurrent `loadgen` instances, each pinned to its own alias list, and `-brokers` was not reachable from the runner.

## Changes Made

- `run.sh`, `run-mcp.sh`: accept `CONFIG_FILE`, defaulting to `broker-config.mock.yaml` as before. A missing file is fatal rather than a silent fallback — falling back would make a sweep that varies the pacer report one setting under five names. The path is resolved with `realpath` before MCP starts, because MCP launches with `cwd=$repo_root` and a relative path would otherwise resolve against the repo root rather than the caller's directory.
- `run.sh`, `run-mcp.sh`: copy the chosen config into the run directory as `broker-config.used.yaml`. Recording only the filename is not enough, since the per-run copies are local and get overwritten; the copy is what makes a number traceable to the configuration that produced it.
- `run-loadgen.sh`: accept `BROKERS_CSV`, passing `loadgen -brokers <csv>` instead of `-broker-count`. Mutually exclusive with `BROKERS`, checked in the script so the error names the environment variables the caller actually set rather than the flags `loadgen` rejects. Detection distinguishes "caller set `BROKERS`" from "nobody set anything" by capturing `${BROKERS+set}` before the default lands.
- `run-loadgen.sh`: the startup banner reports which broker selection is in effect.
- `.gitignore`: add `broker-config.run*.yaml`. The per-run copies are local by design; their provenance belongs in each run directory, not in git.

## Testing

**Test Environment:**
- Go version: go1.25.12
- OS: Fedora Linux 43 (kernel 7.0.10-101.fc43 on the MCP box, 6.11.10-200.fc40 on the load box)
- Broker version (if applicable): n/a — `mock-semp` replaying a capture from a real broker (`run_id 20260819T153533Z`)

**Tests Performed:**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Tested locally with `go test -race ./...`
- [ ] Tested with real Solace broker

No Go code is touched, so no Go tests were added and `go test -race ./...` was not run locally; CI covers it. Exercised instead by using the changed runners for every SOL-153311 measurement run — 17 paired runs across two boxes on the same LAN.

**Test Coverage:**
- `CONFIG_FILE` selecting each of three per-run configs (`request_min_interval` of `0s`, `1ms`, `100ms`) across an 11-point sweep, with `broker-config.used.yaml` in each run directory confirming the intended interval reached MCP — the numbers separate cleanly by setting, which is what a silent fallback would have hidden
- `CONFIG_FILE` unset: default path still resolves to `broker-config.mock.yaml`
- `CONFIG_FILE` pointing at a missing file: exits 2 with the path named, before MCP starts
- `CONFIG_FILE` as a relative path from `test/performance/`: resolves against the caller, not `$repo_root`
- `BROKERS_CSV=broker-01` and `BROKERS_CSV=broker-02,…,broker-50` as two concurrent instances against one MCP, with each `loadgen` banner confirming its own population — 1 broker and 49 brokers, no overlap
- `BROKERS_CSV` unset: `-broker-count 50` path unchanged
- `BROKERS_CSV` and `BROKERS` set together: exits 2 naming both variables
- Fidelity gate passed in exact mode on every run, and every `mock-semp` shut down with zero unmatched requests

## Breaking Changes

n/a. Both variables default to the previous behaviour, so an invocation that sets neither is unchanged.

## Checklist

### Code Quality
- [x] Code follows the [coding standards](../.github/CONTRIBUTING.md#coding-standards)
- [x] Self-review completed (checked for typos, logic errors, edge cases)
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] **No credentials in code** (checked all files, commits, and logs)
- [x] Followed [secure logging rules](../docs/internal/secure-logging-rules.md)
- [x] Credential-carrying types implement `slog.LogValuer` — n/a, no Go code
- [x] No security vulnerabilities introduced (checked with golangci-lint/gosec)

The runners echo the config path and the broker selection. Neither carries credentials: `BROKER_USERNAME`/`BROKER_PASSWORD` are exported as before and never printed, and the config path is a local filename.

### Testing
- [ ] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

Go tests not run locally — no Go code in this change. Error paths above were exercised by hand.

### Documentation
- [ ] README.md updated (if user-facing changes)
- [ ] docs/ updated (if architecture/design changes)
- [x] godoc comments added/updated for exported functions — n/a, no Go code
- [ ] CHANGELOG.md updated (if applicable)
- [x] Examples updated (if applicable)

Both variables are documented in the usage header of every script that reads them, which is where the harness documents its knobs. No `CHANGELOG.md` entry: this touches only `test/performance/`, none of `internal/config/`, `internal/composite/definitions/tools.yaml`, or `internal/tools/`. CI's advisory changelog warning may still fire.

### Git & CI
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main (rebased if needed)
- [x] No merge conflicts
- [x] CI checks passing (lint, build, test, E2E)

### Breaking Changes (if applicable)
- [x] Breaking changes documented in commit message — n/a
- [x] Breaking changes documented in PR description — n/a
- [x] Migration guide provided — n/a
- [x] Deprecated functionality marked with comments and deprecation notices — n/a

## Additional Notes

Two findings from using these changes are being filed separately rather than fixed here:

The `request_min_interval: 1ms` comment in `broker-config.mock.yaml` describes that setting as "disabled". It is not — `1ms` constructs a real `time.Ticker` per broker, while `0s` returns a closed channel and constructs nothing. Changing the fixture to `0s` is a recommendation in the SOL-153311 results note, deliberately kept out of this PR so the harness change and the fixture change can be reviewed apart.

For split-population runs, the `loadgen` instance that owns `mock-semp` tears the mock down on exit, stranding a concurrent instance's in-flight requests as 30 s timeouts. It cost 1960 timeouts in one Run C pass. Either the mock owner should outlive its peers by construction or the mock should be startable independently of any `loadgen` instance; `NO_MOCK=1` is the current workaround and is documented, but the ordering hazard is not.

## Related Issues/PRs

- Related to #332 (SOL-153355, the RDP tools these runs exercise)

---

**For Reviewers:**

**Focus Areas**: The `${BROKERS+set}` capture in `run-loadgen.sh` — it has to happen before `BROKERS="${BROKERS:-50}"` for the conflict check to distinguish an explicit `BROKERS=50` from an unset one, and the ordering is easy to break in a later edit. Also the `realpath` placement in both MCP runners, which matters only because MCP is launched with `cwd=$repo_root`.

**Questions**: Should `run.sh` gain `BROKERS_CSV` too, for symmetry? It has no use in a single-host smoke run, and I left it out rather than adding an untested knob, but the two runners' headers claim a shared vocabulary and this breaks it.
