### PR TITLE
Calibrate the changelog skill's length guidance, and check the draft

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -44,18 +44,19 @@ the PR like any other change.
 ### Step 2: Learn the house voice
 
 Read `CHANGELOG.md` before drafting: the `[Unreleased]` section for what is
-pending, and the recent version blocks for the fullest voice examples — the detailed
-breaking-change paragraphs in `[0.5.0]` and `[0.3.0]`, and the migration **tables** in
-`[0.3.0]`. Match what you see, do not impose a generic style:
+pending, and `[0.5.0]` and `[0.3.0]` for the **structure** of a breaking-change entry
+and the **form** of a migration table. Take structure from them, not length — see the
+length bullet below. Match the conventions here, do not impose a generic style:
 
 - Keep a Changelog categories, in this order: **Added**, **Changed**, **Deprecated**,
   **Removed**, **Fixed**, **Security**. Added/Changed/Removed/Fixed are the common
   ones; use Deprecated and Security when the change is genuinely one (see Step 3).
-- Each entry is **one list item (bullet) per logical change**, and most are one or
-  two sentences. Length scales with impact, but the bar for a full paragraph is
-  high: it is for a breaking change that genuinely needs old behavior, new behavior,
-  and a migration path. Calibrate against the file as a whole — a typical entry is
-  far shorter than the longest ones, which are outliers rather than the voice.
+- Each entry is **one list item (bullet) per logical change**. Target one or two
+  sentences (~50 words); reserve a full paragraph for a breaking change that needs
+  old behavior, new behavior, and a migration path. **This is a deliberate change
+  from what the file currently shows.** The `[0.6.0]`–`[0.8.0]` entries run to a
+  median of 93–191 words — do not match their length. The older blocks (`[0.1.0]`
+  through `[0.5.0]`, medians 4–16) are the target.
 - Say what changed and what breaks. **Why** it changed belongs in the commit message,
   and **how** it works belongs in a code comment; an entry that runs long is usually
   carrying one of those. A reader of this file is updating their queries, dashboards,
@@ -120,7 +121,7 @@ into one sentence.
   version blocks — that is the release process's job (today it is the manual
   `## Release Process` in `CHANGELOG.md` / `RELEASING.md`; automating the
   release-notes link is tracked separately). Do not commit, push, or tag.
-- Print the resulting diff and stop for human review.
+- Print the resulting diff.
 
 ### Step 6: Check the draft against the tree
 
@@ -131,11 +132,16 @@ rather than as shipped, after a later revision moved it.
 - **Every identifier the entry names must exist as written** — log message, field,
   config key, flag, tool name. Grep each one. A name that no longer exists sends a
   reader looking for something that was renamed mid-branch.
-- **Anything observable in the diff that the entry omits.** Re-read the diff for
+- **Nothing observable in the diff may be silently omitted.** Re-read the branch
+  diff (`git diff main...HEAD`, from Step 1) for
   changed strings and fields and confirm each is either covered or deliberately out
   of scope. Where an entry claims a category — "the old messages are replaced" —
   list **all** of them: a partial list reads as complete, which is worse than a
   vague sentence.
+- If an identifier is not found, correct it from the tree; if you cannot resolve it,
+  flag it to the human rather than guessing.
+
+Then stop for human review.
 
 ## Rules
 
@@ -143,7 +149,8 @@ rather than as shipped, after a later revision moved it.
 - Never invent a SOL ticket number — use the `SOL-????.` placeholder and flag it.
 - One bullet per logical change; omit pure test/refactor/docs churn.
 - An entry describes the branch's whole diff against `main`, not any single commit.
-  If commits land after the entry is drafted, **re-derive from `main..HEAD` and
-  rewrite** rather than patching the existing text — patching assumes you already
-  know what those commits changed, which is the assumption Step 1 exists to avoid.
+  If commits land after the entry is drafted, **re-derive and rewrite** — `git diff
+  main...HEAD` for the files and `git log main..HEAD` for the commits, as in Step 1 —
+  rather than patching the existing text. Patching assumes you already know what
+  those commits changed, which is the assumption Step 1 exists to avoid.
 - If nothing user- or operator-visible changed, say so and write nothing.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -51,10 +51,15 @@ breaking-change paragraphs in `[0.5.0]` and `[0.3.0]`, and the migration **table
 - Keep a Changelog categories, in this order: **Added**, **Changed**, **Deprecated**,
   **Removed**, **Fixed**, **Security**. Added/Changed/Removed/Fixed are the common
   ones; use Deprecated and Security when the change is genuinely one (see Step 3).
-- Each entry is **one list item (bullet) per logical change**, whose length scales
-  with impact: a trivial Added item is one line (e.g. "Apache 2.0 LICENSE file"); a
-  breaking change is a full multi-sentence paragraph explaining old behavior, new
-  behavior, and why.
+- Each entry is **one list item (bullet) per logical change**, and most are one or
+  two sentences. Length scales with impact, but the bar for a full paragraph is
+  high: it is for a breaking change that genuinely needs old behavior, new behavior,
+  and a migration path. Calibrate against the file as a whole — a typical entry is
+  far shorter than the longest ones, which are outliers rather than the voice.
+- Say what changed and what breaks. **Why** it changed belongs in the commit message,
+  and **how** it works belongs in a code comment; an entry that runs long is usually
+  carrying one of those. A reader of this file is updating their queries, dashboards,
+  or config — not learning the design.
 - Breaking changes are prefixed `- **BREAKING**: `. `**BREAKING**` is orthogonal to
   the category — a breaking change still files under Changed/Removed/etc. by its
   nature, and signals a SemVer MAJOR bump for the release/version decision.
@@ -117,9 +122,28 @@ into one sentence.
   release-notes link is tracked separately). Do not commit, push, or tag.
 - Print the resulting diff and stop for human review.
 
+### Step 6: Check the draft against the tree
+
+Two checks, both against the code rather than against what the change was meant to
+do. They exist because the common failure is describing the design as intended
+rather than as shipped, after a later revision moved it.
+
+- **Every identifier the entry names must exist as written** — log message, field,
+  config key, flag, tool name. Grep each one. A name that no longer exists sends a
+  reader looking for something that was renamed mid-branch.
+- **Anything observable in the diff that the entry omits.** Re-read the diff for
+  changed strings and fields and confirm each is either covered or deliberately out
+  of scope. Where an entry claims a category — "the old messages are replaced" —
+  list **all** of them: a partial list reads as complete, which is worse than a
+  vague sentence.
+
 ## Rules
 
 - Never place secrets, tokens, or credentials in an example.
 - Never invent a SOL ticket number — use the `SOL-????.` placeholder and flag it.
 - One bullet per logical change; omit pure test/refactor/docs churn.
+- An entry describes the branch's whole diff against `main`, not any single commit.
+  If commits land after the entry is drafted, **re-derive from `main..HEAD` and
+  rewrite** rather than patching the existing text — patching assumes you already
+  know what those commits changed, which is the assumption Step 1 exists to avoid.
 - If nothing user- or operator-visible changed, say so and write nothing.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -56,7 +56,7 @@ length bullet below. Match the conventions here, do not impose a generic style:
   old behavior, new behavior, and a migration path. **This is a deliberate change
   from what the file currently shows.** The `[0.6.0]`–`[0.8.0]` entries run to a
   median of 93–191 words — do not match their length. The older blocks (`[0.1.0]`
-  through `[0.5.0]`, medians 4–16) are the target.
+  through `[0.5.0]`, medians 4–21) are the target.
 - Say what changed and what breaks. **Why** it changed belongs in the commit message,
   and **how** it works belongs in a code comment; an entry that runs long is usually
   carrying one of those. A reader of this file is updating their queries, dashboards,

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -51,12 +51,11 @@ length bullet below. Match the conventions here, do not impose a generic style:
 - Keep a Changelog categories, in this order: **Added**, **Changed**, **Deprecated**,
   **Removed**, **Fixed**, **Security**. Added/Changed/Removed/Fixed are the common
   ones; use Deprecated and Security when the change is genuinely one (see Step 3).
-- Each entry is **one list item (bullet) per logical change**. Target one or two
-  sentences (~50 words); reserve a full paragraph for a breaking change that needs
-  old behavior, new behavior, and a migration path. **This is a deliberate change
-  from what the file currently shows.** The `[0.6.0]`–`[0.8.0]` entries run to a
-  median of 93–191 words — do not match their length. The older blocks (`[0.1.0]`
-  through `[0.5.0]`, medians 4–21) are the target.
+- Each entry is **one list item (bullet) per logical change**. Most land in 15–30
+  words; ~50 words is the ceiling, reserved for a breaking change that needs old
+  behavior, new behavior, and a migration path. **This is a deliberate change from
+  what the file currently shows.** The `[0.6.0]`–`[0.8.0]` entries run to a median
+  of 93–191 words — do not match their length.
 - Say what changed and what breaks. **Why** it changed belongs in the commit message,
   and **how** it works belongs in a code comment; an entry that runs long is usually
   carrying one of those. A reader of this file is updating their queries, dashboards,
@@ -132,14 +131,15 @@ rather than as shipped, after a later revision moved it.
 - **Every identifier the entry names must exist as written** — log message, field,
   config key, flag, tool name. Grep each one. A name that no longer exists sends a
   reader looking for something that was renamed mid-branch.
-- **Nothing observable in the diff may be silently omitted.** Re-read the branch
-  diff (`git diff main...HEAD`, from Step 1) for
-  changed strings and fields and confirm each is either covered or deliberately out
-  of scope. Where an entry claims a category — "the old messages are replaced" —
-  list **all** of them: a partial list reads as complete, which is worse than a
-  vague sentence.
+- **Nothing observable in the diff may be silently omitted.** Re-read the Step 1
+  change set for changed strings and fields and confirm each is either covered or
+  deliberately out of scope. Where an entry claims a category — "the old messages
+  are replaced" — list **all** of them: a partial list reads as complete, which is
+  worse than a vague sentence.
 - If an identifier is not found, correct it from the tree; if you cannot resolve it,
   flag it to the human rather than guessing.
+- If either check changed the entry, re-print the diff — the human must see the
+  corrected version, not the one from Step 5.
 
 Then stop for human review.
 
@@ -148,9 +148,8 @@ Then stop for human review.
 - Never place secrets, tokens, or credentials in an example.
 - Never invent a SOL ticket number — use the `SOL-????.` placeholder and flag it.
 - One bullet per logical change; omit pure test/refactor/docs churn.
-- An entry describes the branch's whole diff against `main`, not any single commit.
-  If commits land after the entry is drafted, **re-derive and rewrite** — `git diff
-  main...HEAD` for the files and `git log main..HEAD` for the commits, as in Step 1 —
+- An entry describes the whole Step 1 change set, not any single commit. If commits
+  land after the entry is drafted, **re-derive and rewrite** — redo Step 1 in full —
   rather than patching the existing text. Patching assumes you already know what
   those commits changed, which is the assumption Step 1 exists to avoid.
 - If nothing user- or operator-visible changed, say so and write nothing.

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -146,13 +146,13 @@ assert the rest by hand before proceeding:
 If any check fails, the promotion is malformed — fix before proceeding.
 
 **A6. Draft the human-readable release-notes summary.** The published GitHub Release should be
-*skimmable*, not the verbatim (deliberately verbose) CHANGELOG block. The pipeline runs on the tag
+*skimmable*, not the verbatim CHANGELOG block. The pipeline runs on the tag
 with no LLM available, so the summary must be authored here and committed in the release PR:
 `.github/scripts/extract-release-notes.sh` publishes `.github/release-notes/vX.Y.Z.md` when present
 and otherwise falls back to the raw block. Write that file:
 - Draft **from the promoted `## [X.Y.Z]` block only** — condense each entry to 1–2 sentences,
   grouped by the same categories (`Added`/`Changed`/`Fixed`/`Security`/…), dropping rationale and
-  implementation detail. The verbose CHANGELOG remains the source of truth.
+  implementation detail. The CHANGELOG remains the source of truth.
 - Do not introduce facts absent from the block; do not restate the release gate — the script still
   enforces "the CHANGELOG section exists and has real entries" independently of this file.
 


### PR DESCRIPTION
## Summary

Three changes to the `/changelog` skill, each from a mistake the current guidance either allowed or actively caused while writing the entries for #333.

## Type of Change

- [x] Documentation update

Tooling only. No production code.

## Motivation and Context

**The length guidance points the wrong way.** Step 2 says an entry's "length scales with impact" and directs the drafter to the longest paragraphs in the file as "the fullest voice examples." Followed literally, that produces entries several times longer than the file's own norm — the two written for #333 ran to 225 and 138 words, against a typical entry of well under fifty. Most of that was explaining *how* the change worked, which belongs in a code comment.

**Nothing told the drafter to check its own output.** One entry named a `result` field carrying `hit`/`miss` — a design a later revision had replaced. It survived until a reviewer caught it. A grep per named identifier would have found it immediately.

**Nothing said what to do when commits land after the entry.** The #333 entry was patched twice as later commits arrived, and still missed a fifth renamed message while promising that "anything matching the old messages needs updating." A partial list reads as complete, which is worse than a vague sentence.

## Changes Made

- **Step 2** — length guidance calibrates against the file as a whole rather than its longest examples, and states where *why* and *how* belong instead.
- **Step 6 (new)** — after drafting, grep every identifier the entry names to confirm it exists as written, and re-read the diff for anything observable the entry omits. Where an entry claims a category, list all of it.
- **Rules** — an entry describes the branch's whole diff against `main`, not one commit. Commits landing after it is drafted mean re-deriving from `main..HEAD`, not patching.

+28/−4 on one file.

## Testing

**Tests Performed:**
- [x] Self-review completed

No code paths touched, so nothing to run. The guidance was derived from the entries in #333 and checked against `CHANGELOG.md`'s actual contents rather than from recollection.

## Additional Notes

The Step 2 change **contradicts guidance that is there today**, so it is the part worth disagreeing with if you think the long paragraphs in `[0.5.0]` and `[0.3.0]` are the target rather than the exception. My read is that they are exceptional by design — both are breaking changes that genuinely need old behavior, new behavior, and a migration path — and that pointing every drafter at them as the voice is what produces bloat elsewhere.

An earlier revision of this change embedded an `awk` one-liner for measuring the median entry length. Removed: no other skill in this repo embeds a shell command, and `awk`/`sort` are not available on a stock Windows shell.

## Related Issues/PRs

- Prompted by the changelog entries in #333 (SOL-153363)
