### PR TITLE
SOL-153564: Publish a daily unstable dev container image from main

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -1,0 +1,172 @@
+name: Dev build (unstable)
+
+# Publishes an unstable image from `main` once a day for the dev instance of the
+# lab Broker MCP deployment (SOL-153564). Deploying is done by the lab's hourly
+# cron in the SolaceDev/dax repo (SOL-151979); nothing here deploys anything.
+#
+# Not a release: no git tag, no Release, no CHANGELOG, and `:latest` never moves.
+# Writes to a separate `-dev` package, so no tag name here can collide with one
+# release.yml pushes. `contents: read` means this cannot create a tag or Release
+# even if it tried. (It could technically push to the release package, since
+# `packages: write` is repo-scoped — that isolation is by construction, not by
+# permission.)
+
+on:
+  schedule:
+    # 10:17 PM EST. Off the hour because GitHub delays scheduled runs under load.
+    # A schedule only ever runs on the default branch, so "publishes from main
+    # only" is enforced by the trigger type rather than a filter. Daily, not
+    # per-merge: 5-6 merges/day would mean ~150MB/day on the lab host and would
+    # replace the dev container under anyone debugging against it. Cost is that
+    # the lab sees one commit per day and cannot be used to bisect.
+    - cron: '17 3 * * *'
+  # Forces a fix into the lab today. Also the only way to exercise this at all:
+  # both triggers require the file to be on the default branch.
+  workflow_dispatch:
+
+# release.yml declares no group, so this can never cancel a release run.
+concurrency:
+  group: dev-build
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dev-build:
+    name: dev-build
+    # A schedule fires on every fork with Actions enabled, handing each one a
+    # nightly failure on a push nobody there can make. Same guard as llm-eval.yml.
+    if: github.event_name != 'schedule' || github.repository == 'SolaceProducts/solace-broker-mcp'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # No id-token/attestations/artifact-metadata: no provenance attestation,
+      # since this is never distributed. That is also part of why the package is
+      # not public — an unattested image should not be casually pullable.
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Required: a shallow clone fetches no tags, so `git describe` below
+          # would degrade to a bare SHA with no release base.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve version and commit
+        id: ver
+        # `--long` matters: without it, `git describe` the morning after a
+        # release returns a bare `v0.8.2` (the tag sits on main's HEAD), so the
+        # dev image would report a version identical to the stable release and
+        # the two lab instances would be indistinguishable. Diverges from
+        # Makefile:9 on purpose. `--dirty` omitted — a CI checkout is clean.
+        # The regex is Makefile:7-9's filter: VERSION is spliced into -ldflags.
+        run: |
+          version=$(git describe --tags --always --long 2>/dev/null \
+            | grep -E '^[A-Za-z0-9._+-]+$' || echo dev)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          # cut, not `--short=7`: --short is a MINIMUM width and git widens it on
+          # ambiguity, which would make the skip check below compare a tag name
+          # that is never pushed — rebuilding every night.
+          echo "short_sha=$(git rev-parse HEAD | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          echo "Building ${version} from $(git rev-parse HEAD)"
+
+      - name: Skip if this commit is already built
+        id: skip
+        # Correctness, not optimisation: buildkit stamps a fresh `created`
+        # timestamp, so a fully cache-hit build still pushes a new digest for
+        # byte-identical content, and the lab (which compares image IDs) would
+        # redeploy nightly for nothing. Keyed on the immutable per-commit tag, so
+        # it fails open on the first run and self-corrects after a failed build.
+        env:
+          REF: ghcr.io/solaceproducts/solace-broker-mcp-dev:dev-${{ steps.ver.outputs.short_sha }}
+        run: |
+          if docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
+            echo "already-built=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::${REF} already exists — nothing merged to main since the last build. Pushing nothing."
+          else
+            echo "already-built=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Docker metadata
+        id: meta
+        if: steps.skip.outputs.already-built != 'true'
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/solaceproducts/solace-broker-mcp-dev
+          # No `latest` and no semver, deliberately: `:latest` keeps meaning
+          # "newest release", and a package with no `latest` makes a bare
+          # `docker pull` fail instead of silently serving an unstable build.
+          # `prefix=dev-` overrides the default `sha-` so the tag is
+          # self-describing away from its package name.
+          tags: |
+            type=raw,value=dev
+            type=sha,prefix=dev-
+          # metadata-action already emits `revision` and `created`. These two say
+          # the image is unsupported wherever someone meets it first.
+          labels: |
+            org.opencontainers.image.title=Solace Broker MCP (unstable dev build)
+            org.opencontainers.image.description=Unstable build from main. Not a release, not supported. See SOL-153564.
+
+      - name: Build and push
+        id: build
+        if: steps.skip.outputs.already-built != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          # One consumer, so the second architecture is waste. A wrong guess here
+          # fails safely: the container will not start and the lab's config probe
+          # catches that before touching the running instance.
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.ver.outputs.version }}
+          # Read the shared cache, never write it. release.yml:428 and
+          # build-image.yaml:71 already export mode=max into one ~10GB LRU
+          # budget; a third writer would evict entries the release build and every
+          # PR scan hit. That is the one way this could slow the release path
+          # without touching release.yml. The compile layer never cache-hits
+          # anyway — VERSION is in the `RUN go build` at Dockerfile:11-14.
+          cache-from: type=gha
+
+      - name: Summary
+        # success(), not always(): a skip is a success, so this covers both real
+        # outcomes. On a failure `$SKIPPED` is empty and always() would print a
+        # "Pushed" table with blank values.
+        if: success()
+        env:
+          SKIPPED: ${{ steps.skip.outputs.already-built }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          SHORT_SHA: ${{ steps.ver.outputs.short_sha }}
+        run: |
+          {
+            if [ "$SKIPPED" = "true" ]; then
+              echo "### No new image"
+              echo
+              echo "\`main\` has not moved since the last dev build, so nothing was pushed."
+              echo "The lab's next hourly poll is a silent no-op."
+            else
+              echo "### Pushed"
+              echo
+              echo "| | |"
+              echo "|---|---|"
+              echo "| Version | \`${VERSION}\` |"
+              echo "| Moving tag | \`ghcr.io/solaceproducts/solace-broker-mcp-dev:dev\` |"
+              echo "| Immutable tag | \`ghcr.io/solaceproducts/solace-broker-mcp-dev:dev-${SHORT_SHA}\` |"
+              echo
+              echo "The lab dev instance picks this up at the next :30 poll, on port 9091."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -13,7 +13,8 @@ name: Dev build (unstable)
 
 on:
   schedule:
-    # 10:17 PM EST. Off the hour because GitHub delays scheduled runs under load.
+    # 03:17 UTC year-round (cron is UTC), so 10:17 PM EST / 11:17 PM EDT — both
+    # overnight, drift accepted. Off the hour: GitHub delays runs under load.
     # A schedule only ever runs on the default branch, so "publishes from main
     # only" is enforced by the trigger type rather than a filter. Daily, not
     # per-merge: 5-6 merges/day would mean ~150MB/day on the lab host and would
@@ -24,10 +25,15 @@ on:
   # both triggers require the file to be on the default branch.
   workflow_dispatch:
 
-# release.yml declares no group, so this can never cancel a release run.
+# Serialize, don't cancel. A cancellation between the two tag pushes leaves
+# `dev-<sha>` published while `dev` still points at the old build — and the skip
+# check keys on `dev-<sha>`, so every later run skips and `dev` never catches up.
+# Nothing queues at one run a day, so cancelling can only cause that.
+# (llm-eval.yml:54, same call.) release.yml declares no group, so this cannot
+# cancel a release run.
 concurrency:
   group: dev-build
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -35,15 +41,19 @@ permissions:
 jobs:
   dev-build:
     name: dev-build
-    # A schedule fires on every fork with Actions enabled, handing each one a
-    # nightly failure on a push nobody there can make. Same guard as llm-eval.yml.
-    if: github.event_name != 'schedule' || github.repository == 'SolaceProducts/solace-broker-mcp'
+    # Upstream only, and unconditional rather than schedule-only: a fork's token
+    # cannot push to this org's package, so a dispatched run there would build
+    # for minutes and then fail. llm-eval.yml guards only its schedule because a
+    # manual run is useful on a fork; publishing to our package never is.
+    if: github.repository == 'SolaceProducts/solace-broker-mcp'
     runs-on: ubuntu-latest
+    # ~4 min build; uncapped, a hung one holds a runner for six hours.
+    timeout-minutes: 20
     permissions:
       contents: read
-      # No id-token/attestations/artifact-metadata: no provenance attestation,
-      # since this is never distributed. That is also part of why the package is
-      # not public — an unattested image should not be casually pullable.
+      # No id-token/attestations/artifact-metadata: no cosign-verifiable GitHub
+      # attestation, since this is never distributed — part of why the package is
+      # not public. Buildx's own provenance is disabled on the build step below.
       packages: write
     steps:
       - name: Checkout
@@ -88,7 +98,8 @@ jobs:
         # timestamp, so a fully cache-hit build still pushes a new digest for
         # byte-identical content, and the lab (which compares image IDs) would
         # redeploy nightly for nothing. Keyed on the immutable per-commit tag, so
-        # it fails open on the first run and self-corrects after a failed build.
+        # it fails open on the first run and self-corrects after a build that
+        # failed BEFORE pushing — see the concurrency note for the other case.
         env:
           REF: ghcr.io/solaceproducts/solace-broker-mcp-dev:dev-${{ steps.ver.outputs.short_sha }}
         run: |
@@ -113,11 +124,13 @@ jobs:
           tags: |
             type=raw,value=dev
             type=sha,prefix=dev-
-          # metadata-action already emits `revision` and `created`. These two say
-          # the image is unsupported wherever someone meets it first.
+          # metadata-action already emits `revision` and `created`. `version` is
+          # pinned because it would otherwise be derived from the tags and read
+          # `dev`, while the binary inside reports v0.8.0-0-g65fe9bf.
           labels: |
             org.opencontainers.image.title=Solace Broker MCP (unstable dev build)
             org.opencontainers.image.description=Unstable build from main. Not a release, not supported. See SOL-153564.
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
 
       - name: Build and push
         id: build
@@ -132,6 +145,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Stated, not defaulted: buildx attaches SLSA provenance on a registry
+          # push unless told otherwise, which also makes the artifact an image
+          # index. Nothing verifies this image, so keep it a plain manifest.
+          provenance: false
           build-args: |
             VERSION=${{ steps.ver.outputs.version }}
           # Read the shared cache, never write it. release.yml:428 and


### PR DESCRIPTION
## Summary

Adds a scheduled workflow that publishes an unstable container image from `main` once a day, into its own `solace-broker-mcp-dev` GHCR package, for the dev instance of the shared lab Broker MCP deployment.

Tracked in SOL-153564. (No GitHub issue — this repo tracks work in Jira.)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

The lab runs a stable instance that auto-upgrades on each release (SOL-152308). We want a second, unstable instance so regressions surface in the lab within a day instead of at the next release. That instance needs something to pull — this PR publishes it. The deploying half lives in the `dax` repo under SOL-151979; nothing here deploys anything.

Two decisions worth stating up front:

**Daily, not per-merge.** At 5–6 merged PRs per working day, building per-merge would put ~150 MB/day of permanent growth on a shared lab host and would replace the dev container under anyone debugging against it six times a day. Daily gives them a fixed target that only changes overnight. The cost is that the lab sees one commit per day and can't be used to bisect. Switching later is a one-line change to the trigger.

**Its own package, not a tag on the release package.** That way no tag name here can collide with one `release.yml` produces, and any future registry cleanup deletes from a different package entirely.

## Changes Made

- New file `.github/workflows/dev-build.yaml`. **No existing file is touched.**
- Triggers on `schedule` (03:17 UTC = 10:17 PM EST) plus `workflow_dispatch`. No `push:` trigger.
- Publishes `…/solace-broker-mcp-dev:dev` and `:dev-<short-sha>`. No `latest`, no semver tags.
- Skips entirely when `main` hasn't moved since the last build.
- Single-arch `linux/amd64`, confirmed against `uname -m` on the lab host.
- Reads the shared buildx cache but never writes it.
- Job guarded so a `schedule` event on a fork doesn't run.

## Testing

No Go code changed, so the Go test suite is unaffected and not a meaningful signal here. What was verified instead:

- **actionlint v1.7.12** — clean, with `shellcheck` present locally so the `run:` blocks were actually checked (actionlint silently skips those rules without it).
- **zizmor 1.29.0** — clean, run with the same flags `workflow-lint` uses (`--no-online-audits --persona=regular --min-severity=low`).
- **`git describe --long` behaviour, against the real tag.** At `v0.8.0`, plain `git describe --tags --always` returns `v0.8.0`; with `--long` it returns `v0.8.0-0-g65fe9bf`. Without `--long` the dev image would report a version identical to the stable release on the morning after every release, making the two lab instances indistinguishable.
- **`git diff --cached --stat`** confirms one file and zero lines of `release.yml`, `build-image.yaml`, `build-and-test.yml` or `ci-pr.yaml`.
- **Comment-only rewrite verified mechanically** — after shortening the comments I diffed the comment-stripped form against the previous version to prove the 101 config lines were untouched.

**What cannot be tested before merge:** both `schedule` and `workflow_dispatch` require the workflow to be on the default branch, so the trigger is unexercised until this lands. Acceptable because the blast radius is nil — `contents: read` cannot create a tag or Release, and the workflow names only its own package. Post-merge plan is in Additional Notes.

- [x] Tested locally with the linters CI pins
- [ ] Unit / integration / E2E tests — **N/A**, no Go code changed
- [ ] Tested with real Solace broker — **N/A**

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Comments explain "why", not "what" — the four non-obvious decisions each carry a short rationale
- [x] No commented-out code or debug statements

### Security
- [x] No credentials in code, commits or logs
- [x] Job permissions are `contents: read` + `packages: write` only — no `id-token`, `attestations` or `artifact-metadata`
- [x] Action versions pinned to full SHAs; `persist-credentials: false` on checkout
- [x] zizmor clean at `--min-severity=low`

### Documentation
- [ ] README / docs — **N/A**, not user-facing. The lab runbook lives in the `dax` repo and is updated under SOL-151979
- [ ] CHANGELOG — **N/A**, not user-facing. The gate is advisory; adding the `no-changelog` label to silence the warning

### Git & CI
- [x] Commit signed off (DCO)
- [x] Branch up to date with `main`
- [x] No merge conflicts
- [ ] CI checks passing — pending

## Additional Notes

**Post-merge sequence**, in order:

1. `gh workflow run dev-build.yaml`
2. Confirm `:dev` and `:dev-<sha>` exist, and that `:latest` in the **release** package is byte-identical before and after
3. Confirm no git tag and no Release were created
4. Set the new package's visibility, link it to the repo, add its description

**Package visibility:** intended to be `internal` if the org's plan offers it, otherwise `private` — not public. The repo is already public so anyone can build this image themselves; what publishing adds is discoverability, and an unstable, unattested artifact listed on the org's package page beside product artifacts is easy to mistake for something supported. Visibility is a package setting applied after the first push, so it isn't in this YAML.

**Noticed but deliberately not fixed here:** `codeql.yml` also carries a `schedule:` trigger and has no fork guard, so forks likely get a failing weekly run from it. Separate concern, worth its own ticket.

## Related Issues/PRs

- Tracked by **SOL-153564**
- Blocks **SOL-151979** — the lab-side deploy work has nothing to pull until this publishes
- Interacts with **SOL-153306** (merged) — its `--log-opt` caps are in the shared `start_container()`, so the dev container inherits the 30 MB cap for free