### PR TITLE
ci: reassign e2e-llm scheduled-run failure emails to lkiri

### DIFF
--- a/.github/workflows/llm-eval.yml
+++ b/.github/workflows/llm-eval.yml
@@ -34,7 +34,7 @@ on:
     # local. If the schedule ever outlives the window into EST it drifts to 01:00
     # local and needs 07:00 UTC — one more reason not to let it outlive the
     # window.
-    - cron: '0 6 * * *'
+    - cron: '0 6 * * *' # schedule owner: lkiri (reassigned from helen-zhu-solace)
   workflow_dispatch:
     inputs:
       target_branch:


### PR DESCRIPTION
## What
Touches the \`cron:\` line in \`llm-eval.yml\` so it's not just a comment.

## Why
GitHub emails scheduled-workflow failures to whoever last committed the
\`cron:\` line — currently @helen-zhu-solace via 72e822c (SOL-153184). She's
no longer the one watching the daily e2e-llm experiment, so this reassigns
notifications to me for the rest of the collection window (ends 2026-09-03).

No behavior change — same schedule, same trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)