### PR TITLE
SOL-153582: reap idle MCP sessions instead of holding them forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Idle MCP sessions are now closed after two hours instead of being held for the lifetime of the process. The server passed no options to the SDK's streamable-HTTP handler, leaving `SessionTimeout` at its zero value — which the go-sdk documents as "idle sessions are never closed". A session was released only on an explicit `DELETE` or a transport close, so any client that connected and then vanished (a sleeping laptop, a killed container, a dropped network, or a client that simply never sends `DELETE`) left its session and the goroutines behind it in memory permanently. On a long-running server this grew without bound and no metric revealed it. Operator-visible effect: a client whose session has been idle for more than two hours receives `404 session not found` on its next request and re-initializes; spec-compliant clients do this transparently. Tracked under SOL-153582.
+
 ### Changed
 
 - The DEBUG logs for acquiring a broker token now trace the whole sequence, from `broker token needed` through to `broker token attached to request` or `broker token unavailable`. The old messages are replaced: `token cache get`, `token cache put` (both carried a `status` field of `0` or `1`), `token exchange succeeded`, `token exchange retried` and `token exchange retries exhausted` are gone. New fields on these lines: `http_status`, `attempts`, `reason`. Anything matching the old messages or reading `status` on the cache lines needs updating. Tracked under SOL-153363.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -406,6 +406,22 @@ func limitRequestBody(next http.Handler, maxBytes int64) http.Handler {
 	})
 }
 
+// newMCPStreamableOptions builds the options for the SDK's streamable-HTTP
+// handler. Passing nil here would leave every field at its zero value, which
+// for SessionTimeout means "never close an idle session" — see
+// defaults.DefaultMCPSessionIdleTimeout for why that leaks and why the value
+// is what it is.
+//
+// Deliberately NOT set here: CrossOriginProtection (deprecated; we wrap
+// instead — see crossOriginProtection), MaxRequestBodyBytes (we bound the
+// body ourselves in limitRequestBody, ahead of the SDK), and Stateless (the
+// stateful default is the only mode we have exercised against real clients).
+func newMCPStreamableOptions() *mcp.StreamableHTTPOptions {
+	return &mcp.StreamableHTTPOptions{
+		SessionTimeout: defaults.DefaultMCPSessionIdleTimeout,
+	}
+}
+
 // maxLoggedHeaderBytes bounds a client-supplied header value before it reaches
 // the log stream. The cross-origin deny path runs BEFORE auth, so an
 // unauthenticated caller controls these values; without a cap each rejected
@@ -1058,7 +1074,7 @@ func main() {
 	// Create MCP handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
 		return server
-	}, nil)
+	}, newMCPStreamableOptions())
 
 	// Wrap MCP handler with auth middleware. Cross-origin protection wraps
 	// this from the OUTSIDE, in buildMCPEndpoint — see that function for why

--- a/cmd/server/session_timeout_test.go
+++ b/cmd/server/session_timeout_test.go
@@ -1,0 +1,162 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/SolaceProducts/solace-broker-mcp/internal/defaults"
+)
+
+// testSessionIdleTimeout keeps the reaping tests fast. The SDK's behavior is
+// independent of the value (production wires
+// defaults.DefaultMCPSessionIdleTimeout in newMCPStreamableOptions).
+const testSessionIdleTimeout = 100 * time.Millisecond
+
+// initializeBody is a minimal MCP initialize request. The SDK issues an
+// Mcp-Session-Id in response, which is what the reaping tests then track.
+const initializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{` +
+	`"protocolVersion":"2025-11-25","capabilities":{},` +
+	`"clientInfo":{"name":"session-timeout-test","version":"0.0.1"}}}`
+
+// newSessionTestHandler builds a genuine StreamableHTTPHandler with a short
+// idle timeout, so tests observe the real SDK's session lifecycle rather than
+// a mimic of it.
+func newSessionTestHandler(timeout time.Duration) *mcp.StreamableHTTPHandler {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "session-timeout-test",
+		Version: "0.0.1",
+	}, nil)
+	return mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return server
+	}, &mcp.StreamableHTTPOptions{SessionTimeout: timeout})
+}
+
+// newSessionRequest builds a POST /mcp request carrying the Accept and
+// Content-Type headers the SDK validates, optionally bearing a session ID.
+func newSessionRequest(body, sessionID string) *http.Request {
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	return req
+}
+
+// initializeSession drives one initialize exchange and returns the session ID
+// the SDK minted for it.
+func initializeSession(t *testing.T, handler *mcp.StreamableHTTPHandler) string {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSessionRequest(initializeBody, ""))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("initialize status = %d, want %d; body: %s",
+			rec.Code, http.StatusOK, rec.Body.String())
+	}
+	sessionID := rec.Header().Get("Mcp-Session-Id")
+	if sessionID == "" {
+		t.Fatal("initialize returned no Mcp-Session-Id; the stateful handler must issue one")
+	}
+	return sessionID
+}
+
+// sessionStatus replays a request under sessionID and reports the status the
+// SDK answers with. 404 means the session is gone.
+func sessionStatus(handler *mcp.StreamableHTTPHandler, sessionID string) int {
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSessionRequest(initializeBody, sessionID))
+	return rec.Code
+}
+
+// TestNewMCPStreamableOptions_SetsSessionIdleTimeout guards the whole point of
+// SOL-153582: a zero SessionTimeout means the SDK never closes an idle
+// session, so an abandoned session and its goroutines survive for the lifetime
+// of the process. Passing nil options — the pre-fix state — reintroduces
+// exactly that, which is why this asserts the field is populated rather than
+// merely that the options are non-nil.
+func TestNewMCPStreamableOptions_SetsSessionIdleTimeout(t *testing.T) {
+	opts := newMCPStreamableOptions()
+
+	if opts == nil {
+		t.Fatal("newMCPStreamableOptions returned nil; idle sessions would never be reaped")
+	}
+	if opts.SessionTimeout <= 0 {
+		t.Fatalf("SessionTimeout = %v, want > 0; zero means idle sessions are never closed",
+			opts.SessionTimeout)
+	}
+	if opts.SessionTimeout != defaults.DefaultMCPSessionIdleTimeout {
+		t.Errorf("SessionTimeout = %v, want %v",
+			opts.SessionTimeout, defaults.DefaultMCPSessionIdleTimeout)
+	}
+}
+
+// TestSessionTimeout_ReapsIdleSession pins the client-observable contract that
+// SessionTimeout actually buys us: once the timeout elapses, the SDK closes
+// the session and a request bearing its ID gets 404 "session not found". If an
+// SDK upgrade changes when or whether idle sessions are reaped, this fails and
+// the leak analysis can be re-verified against the new behavior.
+func TestSessionTimeout_ReapsIdleSession(t *testing.T) {
+	handler := newSessionTestHandler(testSessionIdleTimeout)
+	sessionID := initializeSession(t, handler)
+
+	// Wait without touching the session. Polling would defeat the test: every
+	// request resets the idle timer (the SDK pauses it for the duration of an
+	// in-flight request and restarts it on completion), so a poll loop keeps
+	// the session alive forever and the assertion never fires.
+	//
+	// A fixed wait is safe here despite the usual flakiness objection: the
+	// timer is armed for testSessionIdleTimeout regardless of machine load, so
+	// a slow box makes reaping later in wall-clock terms but never earlier
+	// than the deadline below. The margin is 20x.
+	time.Sleep(20 * testSessionIdleTimeout)
+
+	if status := sessionStatus(handler, sessionID); status != http.StatusNotFound {
+		t.Fatalf("session %s still alive (status %d) well after the %v idle timeout; "+
+			"idle sessions are not being reaped",
+			sessionID, status, testSessionIdleTimeout)
+	}
+}
+
+// TestSessionTimeout_KeepsActiveSession proves the timeout is an IDLE timeout,
+// not a session lifetime cap. A session used more often than the timeout must
+// survive indefinitely — otherwise the fix would cut off working clients mid
+// conversation, which is the failure mode the 2-hour production value is
+// chosen to avoid.
+func TestSessionTimeout_KeepsActiveSession(t *testing.T) {
+	handler := newSessionTestHandler(testSessionIdleTimeout)
+	sessionID := initializeSession(t, handler)
+
+	// Exercise the session across a span several times its idle timeout,
+	// touching it more frequently than the timeout throughout.
+	for range 10 {
+		time.Sleep(testSessionIdleTimeout / 4)
+		if status := sessionStatus(handler, sessionID); status != http.StatusOK {
+			t.Fatalf("actively used session %s was closed (status %d); "+
+				"SessionTimeout must bound idleness, not total lifetime",
+				sessionID, status)
+		}
+	}
+}

--- a/cmd/server/session_timeout_test.go
+++ b/cmd/server/session_timeout_test.go
@@ -85,6 +85,12 @@ func initializeSession(t *testing.T, handler *mcp.StreamableHTTPHandler) string 
 
 // sessionStatus replays a request under sessionID and reports the status the
 // SDK answers with. 404 means the session is gone.
+//
+// It reuses the initialize body rather than a more lifelike follow-up such as
+// tools/list because these tests assert only on the session-lookup outcome
+// (200 vs 404), which the SDK decides before it dispatches the method. Reusing
+// initialize keeps the probe independent of which tools happen to be
+// registered — this handler deliberately registers none.
 func sessionStatus(handler *mcp.StreamableHTTPHandler, sessionID string) int {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, newSessionRequest(initializeBody, sessionID))
@@ -150,9 +156,16 @@ func TestSessionTimeout_KeepsActiveSession(t *testing.T) {
 	sessionID := initializeSession(t, handler)
 
 	// Exercise the session across a span several times its idle timeout,
-	// touching it more frequently than the timeout throughout.
-	for range 10 {
-		time.Sleep(testSessionIdleTimeout / 4)
+	// touching it far more frequently than the timeout throughout.
+	//
+	// The touch interval is timeout/10, not timeout/4: this test fails when a
+	// gap between touches exceeds the timeout, so the margin has to absorb a
+	// GC pause or CI scheduling lag. At timeout/4 a single 100ms stall would
+	// reap the session and fail the test against correct code. 30 touches at
+	// timeout/10 keeps a 10x margin while still spanning 3x the timeout, so
+	// the assertion remains meaningful.
+	for range 30 {
+		time.Sleep(testSessionIdleTimeout / 10)
 		if status := sessionStatus(handler, sessionID); status != http.StatusOK {
 			t.Fatalf("actively used session %s was closed (status %d); "+
 				"SessionTimeout must bound idleness, not total lifetime",

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -117,6 +117,27 @@ const MaxSEMPResponseBytes = 16 * 1024 * 1024
 // surfaces as 400. No known MCP client produces one.
 const MaxMCPRequestBytes = 4 * 1024 * 1024
 
+// DefaultMCPSessionIdleTimeout bounds how long a streamable-HTTP MCP session
+// may sit idle before the SDK closes it. It backs
+// mcp.StreamableHTTPOptions.SessionTimeout.
+//
+// Left at the SDK's zero value, idle sessions are NEVER closed: a session
+// leaves the handler's map only on an explicit DELETE or a transport close,
+// so any client that initializes and then disappears (laptop sleep, container
+// kill, network drop, or a client that simply never sends DELETE) leaks its
+// session and the goroutines behind it for the lifetime of the process.
+//
+// Decided: 2 hours.
+// Reasoning: long enough to survive a meeting, a lunch break, or an idle
+// afternoon on a desktop client, while still bounding session growth on a
+// long-running pod to a couple of hours' worth of abandoned connections.
+// Trade-off: when the timeout fires, the next request bearing that session ID
+// gets 404 "session not found". A spec-compliant client re-initializes and
+// the user sees nothing; a client that does not will surface an error. Do NOT
+// shorten this without weighing that — the value is chosen for client
+// tolerance, not for how fast memory is reclaimed.
+const DefaultMCPSessionIdleTimeout = 2 * time.Hour
+
 // DefaultMaxConcurrentPerBroker is the maximum number of in-flight SEMP
 // requests allowed per broker, enforced by a semaphore shared across the
 // broker's SEMPv1 and SEMPv2 clients (see resilience.Semaphore and


### PR DESCRIPTION
## Summary

The MCP server never released idle sessions: `SessionTimeout` was left at the SDK's zero value, which the go-sdk documents as *"idle sessions are never closed"*. This sets a 2-hour idle timeout so abandoned sessions are reaped.

[SOL-153582](https://sol-jira.atlassian.net/browse/SOL-153582)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`cmd/server/main.go` passed `nil` options to `mcp.NewStreamableHTTPHandler`, so every field of `StreamableHTTPOptions` took its zero value — including `SessionTimeout`.

With the timeout at zero the SDK never arms `sessInfo.timer` (`streamable.go:721-725`), so a session leaves the handler's map only via `onClose` (`streamable.go:688-696`) — an explicit `DELETE` or a transport close. Any client that initializes and then vanishes (sleeping laptop, killed container, dropped network, or a client that simply never sends `DELETE`) left a live `sessionInfo` and its `ServerSession` behind for the lifetime of the process.

On a long-running pod that grew monotonically, and no metric exposed it. This affects the shipping default configuration.

Found while investigating the separate stateless-transport question (SOL-150761); it is independent of that work and shouldn't wait on it.

## Changes Made

- `internal/defaults/defaults.go` — new `DefaultMCPSessionIdleTimeout = 2 * time.Hour`, documented in the Decided/Reasoning/Trade-off form used by the neighbouring constants.
- `cmd/server/main.go` — new `newMCPStreamableOptions()` helper replacing the `nil` at the handler construction site. Its doc comment also records what is deliberately *not* set there (`CrossOriginProtection`, `MaxRequestBodyBytes`, `Stateless`) and why, so the next reader doesn't re-litigate it.
- `cmd/server/session_timeout_test.go` — new tests.
- `CHANGELOG.md` — entry under `[Unreleased]` → `Fixed`.

## Why two hours

The value is a trade-off, not a formality. When the timeout fires the session closes, and the next request bearing that ID gets `404 session not found` (`lookupSession`, `streamable.go:564`). A spec-compliant client re-initializes transparently; one that doesn't will surface an error to the user.

Two hours survives a meeting or a lunch break while still bounding growth. A desktop client idle overnight gets cut, but it is reconnecting in the morning regardless. The constant carries this reasoning inline so it isn't later "tidied" to a shorter value on reclamation grounds alone.

Hardcoded rather than configurable on purpose: the natural home for a configurable value is a `transport:` config block, which only earns its place alongside a `stateless` setting — work that is currently parked. Promoting the constant to a config key later is easy and non-breaking.

## Testing

**Test Environment:**
- Go version: as pinned in `go.mod` (go-sdk v1.7.0)
- OS: Linux (WSL2)
- Broker version: n/a — no broker involved

**Tests Performed:**
- [x] Unit tests added/updated
- [x] Tested locally with `go test -race ./...`

**Test Coverage:**

Three tests, all against a genuine `StreamableHTTPHandler` rather than a mimic:

- `TestNewMCPStreamableOptions_SetsSessionIdleTimeout` — asserts the field is populated, not merely that options are non-nil. Passing `nil` (the pre-fix state) reintroduces exactly the bug.
- `TestSessionTimeout_ReapsIdleSession` — pins the client-observable contract: after the idle timeout, a request bearing the session ID gets `404`. Guards against an SDK change to the session lifecycle.
- `TestSessionTimeout_KeepsActiveSession` — proves the timeout bounds *idleness*, not total lifetime. Without this, a future change could cut off working clients mid-conversation and still pass the reaping test.

Ran `-race -count=3` to check for flakes: 9/9 pass. `make build-all vet test-cover` green, total coverage 89.3% against the 85% floor.

**One caveat, stated plainly:** I could not verify `make lint` locally. `main` itself fails it here with 61 staticcheck findings, in files this PR does not touch, on the CI-pinned golangci-lint v2.11.4 — a local environment quirk. CI's lint job is the real check on this.

## Breaking Changes

None. No config schema change, so no migration note.

**Operator-visible behaviour change:** a session idle for more than two hours now returns `404 session not found` on its next request instead of resuming. This is the intended MCP re-initialize path and is documented in the CHANGELOG entry.

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code
- [x] Followed secure logging rules — this diff adds no logging statements
- [x] No credential-carrying types involved
- [ ] golangci-lint/gosec — see the lint caveat above; CI covers it

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests (active session must survive)
- [x] Error paths tested (404 after reaping)
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md — not user-facing configuration
- [ ] docs/ — no architecture change
- [x] godoc comments added for the new constant and helper
- [x] CHANGELOG.md updated
- [ ] Examples — n/a

### Git & CI
- [x] All commits are signed off (DCO)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main
- [x] No merge conflicts

## Additional Notes

Two related items found in the same investigation, deliberately **not** in this PR:

1. **SOL-152089** ("Default to 2 replicas with a PodDisruptionBudget", epic SOL-150253) says *"Dependencies. None. This story stands alone."* That looks wrong. Sessions live in one pod's memory, and `service.yaml` is a ClusterIP Service with no `sessionAffinity`, so raising `replicas` to 2 sends roughly half of every client's follow-up requests to a pod that has never heard of them — a flat `404`. Worth resolving before that story is picked up.
2. No scaling or session-affinity guidance exists in the docs today.

## Related Issues/PRs

- Related to SOL-150761 (MCP conformance / stateless transport investigation, where this was found)
- Blocks SOL-152089 (see Additional Notes)

---

**For Reviewers:**

**Focus Areas**: The 2-hour value. It is the one judgement call here, and it trades memory reclamation against client tolerance of a `404`. If you think it should be shorter or longer, that's the discussion worth having.

**Questions**: Do you want this configurable now rather than later? I argued against it above — a lone `session_timeout` key without a `stateless` sibling doesn't justify a new config block — but it's a reasonable counter-position.
