### PR TITLE
ci: record trunk merges in the release manifest

### DIFF
--- a/.github/workflows/guardian-scan.yaml
+++ b/.github/workflows/guardian-scan.yaml
@@ -8,7 +8,8 @@ name: Guardian Scan
 #
 # DAG: build (image) and the two FOSSA jobs run in parallel; prisma runs after
 # build; guardian-gate runs after fossa-vuln + prisma (trunk only); gate
-# aggregates everything.
+# aggregates everything; update-manifest records the merge in the release
+# manifest (trunk only).
 #
 # Convention: `setup` computes every derived value as a string output; each job
 # maps the ones it needs into `env:` and references `${{ env.* }}` rather than
@@ -353,3 +354,57 @@ jobs:
             echo "::error::guardian-gate = $R_GATE"; fail=1
           fi
           [ "$fail" -eq 0 ] && echo "Guardian scan passed." || exit 1
+
+  # Records the merge in the release manifest Guardian's scheduled scan reads to
+  # pick a revision and an image. A blocked gate leaves the row at the previous
+  # commit.
+  #
+  # The shared workflow owns the default-branch check and skips tag pushes unless
+  # asked otherwise, so the guard here only has to cover the event. It is still
+  # needed: a workflow_dispatch scans this workflow's `git_ref` input while
+  # `github.ref_name` is main, which would file that ref's version as trunk's.
+  #
+  # It grants `contents: read` and `id-token: write`, which is why
+  # release-readiness-check.yaml and release.yml carry the latter — a reusable
+  # workflow's permissions must be a subset of its caller's, enforced at run
+  # creation even though this job never runs on their path.
+  update-manifest:
+    name: Update release manifest
+    needs: [setup, gate]
+    if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: SolaceDev/solace-public-workflows/.github/workflows/update-manifest.yaml@7b54c55a744838b3105b74d283ba291a77261b9c
+    with:
+      table_name: solace-cloud-manifest
+      manifest_aws_role: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+      # `version` is read back as a FOSSA revision, so it must be the string the
+      # FOSSA jobs above stamp — a branch name resolves to nothing.
+      #
+      # `image_tag` is the moving `dev` tag from the scheduled unstable build, not
+      # a per-commit one. That build skips when its immutable per-commit tag
+      # already exists, so a tag derived from this merge's SHA would usually name
+      # something never pushed. The cost is that this row's version and its image
+      # can be up to a day apart.
+      #
+      # Both matter: without `prisma_cloud` the container scan is skipped, and
+      # without `image_tag` there is no image to resolve. A pull that 404s is not
+      # a partial result — the scan fetcher discards a product's FOSSA output too
+      # unless every enabled scanner succeeded.
+      #
+      # The write merges, but a map-valued attribute is replaced wholesale, so
+      # `dev` and `prisma_cloud` each have to be given complete.
+      item: |
+        {
+          "squad": "ebp-dax",
+          "repository": "${{ github.event.repository.name }}",
+          "prisma_cloud": {
+            "enabled": ["dev"]
+          },
+          "dev": {
+            "sha": "${{ github.sha }}",
+            "version": "${{ needs.setup.outputs.full_version }}",
+            "image_tag": "dev"
+          }
+        }

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -73,6 +73,10 @@ jobs:
       pull-requests: write
       checks: write
       statuses: write
+      # Ceiling for guardian-scan's `update-manifest` job (OIDC). It never runs
+      # on this path, but a reusable workflow's permissions must be a SUBSET of
+      # the caller's — under-granting fails at run creation.
+      id-token: write
     # Load-bearing — do not remove, and do not replace with named secrets.
     # `environment: guardian` on guardian-scan's jobs does not resolve their
     # secrets when the workflow is reached via `workflow_call`: the `secrets`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,9 @@ jobs:
       pull-requests: write
       checks: write
       statuses: write
+      # Same ceiling as release-readiness-check.yaml — the subset rule applies at
+      # every workflow_call hop. Not a capability this path uses.
+      id-token: write
     uses: ./.github/workflows/release-readiness-check.yaml # zizmor: ignore[secrets-inherit]
     # `secrets: inherit` is load-bearing on both hops of this chain. Do not
     # remove it, and do not replace it with explicitly named secrets.

--- a/THIRD_PARTY_BUILD_TEST.md
+++ b/THIRD_PARTY_BUILD_TEST.md
@@ -193,12 +193,14 @@ unusual.
 
 Not third-party. Listed so the inventory accounts for every `uses:` in the
 repository rather than silently skipping the ones that did not fit the table.
-All five come from one repository, pinned to a single commit.
+All six come from one repository. Five share a single pin; `update-manifest.yaml`
+is pinned separately, for the reason below the table.
 
 | Action | Ref | Owner |
 |---|---|---|
 | `SolaceDev/solace-public-workflows/.github/actions/fossa-guard` | `6527948` | Solace |
 | `SolaceDev/solace-public-workflows/.github/actions/sca/sca-scan` | `6527948` | Solace |
+| `SolaceDev/solace-public-workflows/.github/workflows/update-manifest.yaml` | `7b54c55` | Solace |
 | `SolaceDev/solace-public-workflows/guardian-db-sync` | `6527948` | Solace |
 | `SolaceDev/solace-public-workflows/guardian-vulnerability-gate` | `6527948` | Solace |
 | `SolaceDev/solace-public-workflows/prisma-cloud-scan` | `6527948` | Solace |
@@ -206,6 +208,10 @@ All five come from one repository, pinned to a single commit.
 `6527948` is a branch commit, not a tag, so there is no release to record beside
 it. The repository itself is Apache-2.0. Re-pinned 2026-09-08 by the Dependabot
 `github-actions` group update (#383); the prior pin was `ba836c7`.
+
+`7b54c55` is a branch commit on that same repository. It sits apart from the
+group only because `update-manifest.yaml` postdates `6527948` and so could not be
+pinned there; expect the next group update to collapse the two.
 
 Two entries have been dropped from this table, both by the reverse-direction
 check rather than by anyone remembering to look.
@@ -217,7 +223,7 @@ resolve a reusable workflow from an internal repository in another organization.
 `SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml`
 went when DATAGO-147232 moved FOSSA and Prisma scanning off the Vault-backed
 reusable workflow onto the preceding composite actions. This table previously held
-that one row; it now holds five, and the whole preceding third-party table changed
+that one row; it now holds six, and the whole preceding third-party table changed
 from tags to SHA pins in the same change. None of it was reflected here until
 this update, which is what SOL-152951 is about.
 


### PR DESCRIPTION
The scheduled Guardian scan reads a manifest row to decide which revision and image of this repo to scan. There was no row, so registering the product was not enough to get it picked up.

Rebased on current `main`, which now carries #340.

## What it adds

One job on `guardian-scan.yaml` — `update-manifest` — calling the shared `update-manifest.yaml` reusable workflow, gated behind a green `gate`. It writes the row: squad, repository, a `prisma_cloud` key, and `sha` / `version` / `image_tag`.

`version` carries the `git describe` string the FOSSA jobs already stamp, rather than the branch name. The field is read back as a revision, and a branch name is accepted as well-formed and then resolves to nothing — it fails silently rather than degrading.

`image_tag` is the moving `dev` tag published by #340, not a per-commit tag. That build runs on a schedule and skips when its immutable per-commit tag already exists, so a tag derived from this merge's SHA would usually name something never pushed.

Both fields are load-bearing. Without `prisma_cloud` the container scan is skipped; without `image_tag` there is no image to resolve. A pull that 404s is not a partial result — the scan fetcher keeps a product's output only when every enabled scanner succeeded, so a bad image reference would discard the FOSSA results too.

The shared workflow merges rather than replaces, so attributes written by other jobs survive — but a map-valued attribute is replaced wholesale, which is why `dev` and `prisma_cloud` are each given complete. It also owns the default-branch check and skips tag pushes, so the caller-side guard only has to cover the event.

Pinned to `7b54c55` rather than `@main`: `unpinned-uses` is enforced by the `workflow-lint` gate and fires at high severity on a branch ref. That commit is what `main` points at today.

## Deviation from the ticket

The ticket specified the `update-dynamodb-release-manifest` composite action, and stated that no OIDC role would be needed — true of that action, which authenticates by a different mechanism.

This PR uses the shared `update-manifest.yaml` reusable workflow instead, which assumes the role via OIDC. **That makes `id-token: write` required**, here and on `release.yml`. The ticket's "no OIDC role needed" line no longer holds and has been corrected, so the next repo onboarded from it does not omit the grant and hit a run-creation failure.

The substitution was requested during review and is the better trade: it puts the role assumption, the default-branch check, the tag exclusion and the write serialisation behind one versioned boundary, drops `aws-actions/configure-aws-credentials` from this repo's surface, and replaces long-lived credentials with a short-lived scoped token.

## Caller permission change

`release-readiness-check.yaml` and `release.yml` gain `id-token: write`, for the shared workflow's OIDC assume-role.

A reusable workflow's job permissions must be a subset of its caller's, and GitHub enforces that at **run creation** rather than by skipping the job, so under-granting fails the release before a single step executes — even though this job never runs on that path.

## Known limitations

The row's `version` is written per merge, while the `dev` image is from the last scheduled build, so the two can be up to a day apart and container findings get attributed to a revision whose image was not the one scanned.

Write ordering is not guaranteed — see the thread on the inline review comment. A blocked gate also leaves the row at the previous commit.

## Still needed outside this repo

The image name on the scanning side has to point at #340's package, which is a **different package from the release one**. Until that lands, the reference resolves to a path that does not exist.

No registry credentials are needed — that package is public and anonymously pullable.

## Verification

`actionlint` v1.7.12 and `zizmor` 1.29.0 with this repo's gate flags: clean across all workflows. `build-test-licenses-check.sh` passes (47 components, 47 rows).

Confirmed the tag this row names resolves: an unauthenticated manifest fetch for the `dev` tag returns HTTP 200, a single OCI manifest declaring linux/amd64 — matching the `ubuntu-latest` runner that performs the pull.

Not exercised end to end — the job only fires on a merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)