### PR TITLE
SOL-153180: Update sam-integration.md with Go-based SAM integration findings

### DIFF
--- a/docs/sam-integration.md
+++ b/docs/sam-integration.md
@@ -1,106 +1,117 @@
 # Connecting solace-broker-mcp to Solace Agent Mesh
 
-This guide shows how to integrate this MCP server with Agent Mesh. For general MCP support in Agent Mesh — connection types, tool filtering, TLS/SSL config, environment variable passing — see the upstream [MCP Integration tutorial](https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/docs/documentation/developing/tutorials/mcp-integration.md).
+This guide connects this MCP server to Solace Agent Mesh (the Go `sam` CLI, 2.x)
+by registering it as an **MCP connector** and assigning it to an agent from the
+Agent Mesh UI. For general MCP support in Agent Mesh — connection types, tool
+filtering, auth options, TLS — see the bundled docs (`sam docs`) or
+[docs.solace.com](https://docs.solace.com).
+
+> **This example runs Agent Mesh locally.** `sam run --embedded` starts an
+> in-process dev event broker that Agent Mesh uses for its own internal
+> agent-to-agent messaging. That dev broker is unrelated to the Solace brokers
+> this MCP server monitors — the MCP server still connects to your real
+> broker(s) over SEMP per `broker-config.yaml`. For a team or production
+> deployment you run Agent Mesh against your own broker (Kubernetes or Agent
+> Mesh Cloud); the connector and agent steps below are identical.
 
 ## Prerequisites
 
-- A working Agent Mesh project (`sam init` complete, agents start cleanly)
-- Ability to run this MCP server locally with configured `broker-config.yaml` and `.env` files. For instructions, see [Quickstart](../README.md#quickstart)
+- The Go `sam` CLI installed (`sam --version` reports 2.x).
+- Ability to run this MCP server locally with configured `broker-config.yaml`
+  and `.env` files. See [Quickstart](../README.md#quickstart).
 
 ## Steps
 
-**1. Set a static token on the MCP server** — `broker-config.yaml`:
+**1. Configure client auth on the MCP server** — `broker-config.yaml`. This
+local example uses no client auth (the server binds to loopback only):
 
 ```yaml
 mcp_client_auth:
-  mode: static
-  dev_token: "sam-mcp-dev-token-local-only"  # change for your environment
+  mode: disabled
 ```
 
-For production, use `mode: oauth` instead — see [authentication.md](authentication.md).
+For a shared or production deployment, use `mode: static` (a bearer token) or
+`mode: oauth`, and set the connector's **Authentication Type** in step 4 to
+match. See [authentication.md](authentication.md).
 
-**2. Create the Agent Mesh agent** — `<sam-project>/configs/agents/solace_broker_agent.yaml`:
-
-```yaml
-!include ../shared_config.yaml
-
-apps:
-  - name: solace_broker_agent_app
-    app_base_path: .
-    app_module: solace_agent_mesh.agent.sac.app
-    broker:
-      <<: *broker_connection
-
-    app_config:
-      namespace: ${NAMESPACE}
-      agent_name: "SolaceBrokerAgent"
-      display_name: "Solace Broker"
-      model: *general_model
-
-      instruction: |
-        You manage and inspect Solace event brokers via SEMP-backed MCP tools.
-
-      tools:
-        - tool_type: mcp
-          connection_params:
-            type: streamable-http
-            url: "${SOLACE_BROKER_MCP_URL, http://localhost:9090/mcp}"
-            headers:
-              Authorization: "Bearer ${SOLACE_BROKER_MCP_TOKEN}"
-
-      session_service: *default_session_service
-      artifact_service: *default_artifact_service
-      agent_card:
-        description: "Inspects Solace event brokers via solace-broker-mcp."
-        defaultInputModes: ["text"]
-        defaultOutputModes: ["text", "file"]
-      agent_card_publishing: { interval_seconds: 10 }
-      agent_discovery: { enabled: true }
-      inter_agent_communication:
-        allow_list: ["*"]
-        request_timeout_seconds: 60
-```
-
-**3. Add the matching token to the Agent Mesh `.env` file**:
-
-```env
-SOLACE_BROKER_MCP_URL="http://localhost:9090/mcp"
-SOLACE_BROKER_MCP_TOKEN="sam-mcp-dev-token-local-only"   # must equal dev_token above
-```
-
-**4. Run both in separate terminals**:
+**2. Start the MCP server** (listens on `:9090`, endpoint `/mcp`):
 
 ```bash
-# Terminal 1 — this MCP server
 go run ./cmd/server
-
-# Terminal 2 — Agent Mesh (auto-discovers the new agent)
-sam run
 ```
 
-**5. Verify** — the Agent Mesh logs should include:
+**3. Start Agent Mesh locally** — allow connectors to reach a loopback MCP URL:
 
-```
-Initialized MCPToolset for server: url='http://localhost:9090/mcp'
-Agent card tool manifest populated with 24 tools.
-Registered new agent 'SolaceBrokerAgent' in registry.
+```bash
+SAM_PLATFORM_ALLOW_PRIVATE_MCP=true sam run --embedded
 ```
 
-Open the Agent Mesh web UI (`http://localhost:8000`) and ask the orchestrator a broker-related question — the orchestrator delegates to the `SolaceBrokerAgent`, which calls the MCP tools.
+By default Agent Mesh blocks connectors pointing at loopback or private
+addresses (SSRF protection), so discovering `localhost:9090` fails without this
+flag. It is only needed for local development — a production MCP server has a
+routable URL.
+
+The embedded runtime starts an in-process broker and serves the web UI at
+**http://127.0.0.1:8800** by default (health probe on `:8090`). Open the UI and
+connect an LLM provider on first launch — this becomes the `general` model alias
+your agent uses.
+
+**4. Add the MCP server as a connector** — in the UI left nav, go to
+**Builder** > **Connectors** > **Create Connector**, then the **Custom** tab >
+**Remote MCP**. This opens the two-step **Create MCP Connector** wizard. On step
+1 (**Configure Connector**):
+
+| Field | Value |
+|---|---|
+| Connector Name | `Solace Broker MCP` |
+| Description | e.g. `SEMP-backed Solace event broker tools.` |
+| MCP Server URL | `http://localhost:9090/mcp` |
+| Connection Type | `Streamable HTTP` |
+| Authentication Type | `No Authentication` (matches `mode: disabled` in step 1) |
+
+Use `http://` for the local server — it serves plaintext on loopback; the
+field's `https://` example is for remote servers.
+
+On step 2 (**Select Tools**), Agent Mesh connects and discovers the server's
+tools; select the ones to expose (or all), then save.
+
+**5. Create and deploy an agent** — go to **Builder** > **Agent Management** >
+**Add Agent** > **Create New Agent** > **Create Manually**:
+
+- **Name**: `SolaceBrokerAgent`
+- **Description**: `Inspects and manages Solace event brokers via solace-broker-mcp.`
+- **Instructions** (min 100 characters):
+
+  ```text
+  You manage and inspect Solace event brokers via SEMP-backed MCP tools. Use the
+  broker tools to answer questions about broker status, queues, clients, and
+  redundancy, and to perform management actions when asked.
+  ```
+
+- In the **Connectors** section, select **Edit** and add the connector from
+  step 4 — it appears with its discovered tool count. (You can also attach it
+  later by editing an existing agent.)
+- Select **Create and Deploy**.
+
+**6. Verify** — start a new chat and ask a broker-related question. Select
+`SolaceBrokerAgent` directly, or ask the **Orchestrator**, which delegates to it.
+The agent calls the MCP tools, which query your configured broker over SEMP.
 
 ## Authentication Chain
 
 ```
-Agent Mesh agent ─(Bearer SOLACE_BROKER_MCP_TOKEN)→ MCP server ─(basic BROKER_USERNAME/PASSWORD)→ Solace event broker
+Agent (in Agent Mesh) ─(optional bearer token)→ MCP server ─(basic BROKER_USERNAME/PASSWORD)→ Solace event broker
 ```
 
-The bearer token in the Agent Mesh `.env` and the `dev_token` in the MCP server configuration must be identical.
+In this local example the agent-to-MCP hop is unauthenticated. When
+`mcp_client_auth` is `static` or `oauth`, the agent sends a bearer token that
+the connector's **Authentication Type** must supply — and it must equal the
+`dev_token` in the MCP server configuration.
 
-## Additional Agent Mesh MCP Configuration
+## Defining the integration as code
 
-The following topics are covered in the [Agent Mesh MCP Integration tutorial](https://github.com/SolaceLabs/solace-agent-mesh/blob/main/docs/docs/documentation/developing/tutorials/mcp-integration.md):
-
-- Other connection types (`stdio`, `sse`, Docker)
-- Tool filtering (`tool_name`, `allow_list`, `deny_list`)
-- TLS/SSL config for self-signed certs (`ssl_config`)
-- Passing environment variables to the MCP server process
+The UI flow above is the quickest path. You can also declare the connector and
+agent as YAML and apply them with `sam config apply` — the version-controllable
+path for GitOps and automation. That path targets the Platform service and
+requires `sam auth login` (Early Access; commands and schema may change). See
+the declarative config docs via `sam docs`.

--- a/docs/sam-integration.md
+++ b/docs/sam-integration.md
@@ -33,7 +33,8 @@ For a shared or production deployment, use `mode: static` (a bearer token) or
 `mode: oauth`, and set the connector's **Authentication Type** in step 4 to
 match. See [authentication.md](authentication.md).
 
-**2. Start the MCP server** (listens on `:9090`, endpoint `/mcp`):
+**2. Start the MCP server** — in non-OAuth modes it binds loopback by default,
+serving the MCP endpoint at `http://127.0.0.1:9090/mcp`:
 
 ```bash
 go run ./cmd/server
@@ -45,9 +46,9 @@ go run ./cmd/server
 SAM_PLATFORM_ALLOW_PRIVATE_MCP=true sam run --embedded
 ```
 
-By default Agent Mesh blocks connectors pointing at loopback or private
+By default, Agent Mesh blocks connectors pointing at loopback or private
 addresses (SSRF protection), so discovering `localhost:9090` fails without this
-flag. It is only needed for local development — a production MCP server has a
+flag. Note that this workaround is only needed for local development — a production MCP server has a
 routable URL.
 
 The embedded runtime starts an in-process broker and serves the web UI at
@@ -84,7 +85,7 @@ tools; select the ones to expose (or all), then save.
   ```text
   You manage and inspect Solace event brokers via SEMP-backed MCP tools. Use the
   broker tools to answer questions about broker status, queues, clients, and
-  redundancy, and to perform management actions when asked.
+  redundancy, and to perform configuration and action updates when asked.
   ```
 
 - In the **Connectors** section, select **Edit** and add the connector from
@@ -113,16 +114,6 @@ tools; select the ones to expose (or all), then save.
 Either way, the agent calls the MCP tools, which query your configured broker
 over SEMP.
 
-## Authentication Chain
-
-```
-Agent (in Agent Mesh) ─(optional bearer token)→ MCP server ─(basic BROKER_USERNAME/PASSWORD)→ Solace event broker
-```
-
-In this local example the agent-to-MCP hop is unauthenticated. When
-`mcp_client_auth` is `static` or `oauth`, the agent sends a bearer token that
-the connector's **Authentication Type** must supply — and it must equal the
-`dev_token` in the MCP server configuration.
 
 ## Defining the integration as code
 

--- a/docs/sam-integration.md
+++ b/docs/sam-integration.md
@@ -4,6 +4,9 @@ This guide shows how to connect this MCP server to the Solace Agent Mesh desktop
 app by registering it as an **MCP connector** and assigning it to an agent from
 the Agent Mesh UI.
 
+_Validated against Solace Agent Mesh v2.307.3 (macOS), 2026-08. UI navigation may
+differ in later versions._
+
 > **This example runs Agent Mesh locally.** The desktop app starts an in-process
 > dev event broker that Agent Mesh uses for its own internal agent-to-agent
 > messaging. That dev broker is unrelated to the Solace brokers this MCP server
@@ -13,7 +16,9 @@ the Agent Mesh UI.
 
 ## Prerequisites
 
-- The Solace Agent Mesh desktop app installed.
+- The Solace Agent Mesh desktop app installed. See the
+  [Solace Agent Mesh docs](https://docs.solace.com/Agent-Mesh/agent-mesh.htm) for
+  install and getting-started guides.
 - Ability to run this MCP server locally with configured `broker-config.yaml`
   and `.env` files. See [Quickstart](../README.md#quickstart).
 
@@ -55,8 +60,11 @@ launchctl setenv SAM_PLATFORM_ALLOW_PRIVATE_MCP true
 Then fully quit the app (Cmd+Q — closing the window isn't enough) and relaunch it;
 an already-running app keeps its old environment and won't pick up the new value.
 
-This workaround is only needed for local development — a production MCP server
-has a routable URL.
+This is needed whenever the MCP server's URL resolves to a loopback or private
+(RFC1918/RFC4193) address — local development, and also self-hosted deployments
+where Agent Mesh reaches the server over a cluster-internal or otherwise private
+address. It relaxes only private and loopback addresses; link-local (including
+cloud instance metadata) stays blocked.
 
 **4. Add the MCP server as a connector** — in the UI left nav, go to
 **Builder** > **Connectors** > **Create Connector**, then the **Custom** tab >

--- a/docs/sam-integration.md
+++ b/docs/sam-integration.md
@@ -1,21 +1,19 @@
 # Connecting solace-broker-mcp to Solace Agent Mesh
 
-This guide shows how to connect this MCP server to Solace Agent Mesh (the Go `sam` CLI, 2.x)
-by registering it as an **MCP connector** and assigning it to an agent from the
-Agent Mesh UI. For general MCP support in Agent Mesh — connection types, tool
-filtering, auth options, TLS — see the bundled docs (`sam docs`) or
-[docs.solace.com](https://docs.solace.com).
+This guide shows how to connect this MCP server to the Solace Agent Mesh desktop
+app by registering it as an **MCP connector** and assigning it to an agent from
+the Agent Mesh UI.
 
-> **This example runs Agent Mesh locally.** `sam run --embedded` starts an
-> in-process dev event broker that Agent Mesh uses for its own internal
-> agent-to-agent messaging. That dev broker is unrelated to the Solace brokers
-> this MCP server monitors — the MCP server still connects to your real
-> broker(s) over SEMP per `broker-config.yaml`. For a team or production
-> deployment you run Agent Mesh against your own broker; the connector and agent steps below are identical.
+> **This example runs Agent Mesh locally.** The desktop app starts an in-process
+> dev event broker that Agent Mesh uses for its own internal agent-to-agent
+> messaging. That dev broker is unrelated to the Solace brokers this MCP server
+> monitors — the MCP server still connects to your real broker(s) over SEMP per
+> `broker-config.yaml`. For a team or production deployment you point Agent Mesh
+> at your own broker; the connector and agent steps below are identical.
 
 ## Prerequisites
 
-- The Go `sam` CLI installed (`sam --version` reports 2.x).
+- The Solace Agent Mesh desktop app installed.
 - Ability to run this MCP server locally with configured `broker-config.yaml`
   and `.env` files. See [Quickstart](../README.md#quickstart).
 
@@ -40,21 +38,25 @@ serving the MCP endpoint at `http://127.0.0.1:9090/mcp`:
 go run ./cmd/server
 ```
 
-**3. Start Agent Mesh locally** — allow connectors to reach a loopback MCP URL:
+**3. Open the Agent Mesh desktop app** — the app auto-starts its in-process
+broker and runtime; no command to run. On first launch, connect an LLM provider —
+this becomes the `general` model alias your agent uses.
+
+To reach a loopback MCP server locally, set `SAM_PLATFORM_ALLOW_PRIVATE_MCP=true`
+in the environment the app launches from. By default Agent Mesh blocks connectors
+pointing at loopback or private addresses (SSRF protection), so discovering
+`localhost:9090` fails without it. On macOS, a GUI app launched from Finder won't
+see your shell env, so set it for the login session:
 
 ```bash
-SAM_PLATFORM_ALLOW_PRIVATE_MCP=true sam run --embedded
+launchctl setenv SAM_PLATFORM_ALLOW_PRIVATE_MCP true
 ```
 
-By default, Agent Mesh blocks connectors pointing at loopback or private
-addresses (SSRF protection), so discovering `localhost:9090` fails without this
-flag. Note that this workaround is only needed for local development — a production MCP server has a
-routable URL.
+Then fully quit the app (Cmd+Q — closing the window isn't enough) and relaunch it;
+an already-running app keeps its old environment and won't pick up the new value.
 
-The embedded runtime starts an in-process broker and serves the web UI at
-**http://127.0.0.1:8800** by default (health probe on `:8090`). Open the UI and
-connect an LLM provider on first launch — this becomes the `general` model alias
-your agent uses.
+This workaround is only needed for local development — a production MCP server
+has a routable URL.
 
 **4. Add the MCP server as a connector** — in the UI left nav, go to
 **Builder** > **Connectors** > **Create Connector**, then the **Custom** tab >
@@ -93,32 +95,6 @@ tools; select the ones to expose (or all), then save.
   later by editing an existing agent.)
 - Select **Create and Deploy**.
 
-**6. Verify** — from the UI or the terminal.
-
-- **UI:** start a new chat and ask a broker-related question. Select
-  `SolaceBrokerAgent` directly, or ask the **Orchestrator**, which delegates to it.
-
-- **CLI:** send a task from the terminal. `sam task send` targets
-  `http://localhost:8800` and the `orchestrator` by default; the orchestrator
-  delegates to your agent.
-
-  ```bash
-  sam task send "List the Solace brokers that are configured."
-  ```
-
-  Target a specific agent with `-a/--agent <agent-name>`. No auth token is
-  needed for this local no-auth instance. Note: if a tool is backed by an OAuth
-  connector, `sam task send` prints an authorization URL and waits for a browser
-  login — so OAuth-backed tools cannot complete a fully headless CLI run.
-
-Either way, the agent calls the MCP tools, which query your configured broker
-over SEMP.
-
-
-## Defining the integration as code
-
-The UI flow above is the quickest path. You can also declare the connector and
-agent as YAML and apply them with `sam config apply` — the version-controllable
-path for GitOps and automation. That path targets the Platform service and
-requires `sam auth login` (Early Access; commands and schema may change). See
-the declarative config docs via `sam docs`.
+**6. Verify** — start a new chat and ask a broker-related question. Select
+`SolaceBrokerAgent` directly, or ask the **Orchestrator**, which delegates to it.
+The agent calls the MCP tools, which query your configured broker over SEMP.

--- a/docs/sam-integration.md
+++ b/docs/sam-integration.md
@@ -1,6 +1,6 @@
 # Connecting solace-broker-mcp to Solace Agent Mesh
 
-This guide connects this MCP server to Solace Agent Mesh (the Go `sam` CLI, 2.x)
+This guide shows how to connect this MCP server to Solace Agent Mesh (the Go `sam` CLI, 2.x)
 by registering it as an **MCP connector** and assigning it to an agent from the
 Agent Mesh UI. For general MCP support in Agent Mesh — connection types, tool
 filtering, auth options, TLS — see the bundled docs (`sam docs`) or
@@ -11,8 +11,7 @@ filtering, auth options, TLS — see the bundled docs (`sam docs`) or
 > agent-to-agent messaging. That dev broker is unrelated to the Solace brokers
 > this MCP server monitors — the MCP server still connects to your real
 > broker(s) over SEMP per `broker-config.yaml`. For a team or production
-> deployment you run Agent Mesh against your own broker (Kubernetes or Agent
-> Mesh Cloud); the connector and agent steps below are identical.
+> deployment you run Agent Mesh against your own broker; the connector and agent steps below are identical.
 
 ## Prerequisites
 
@@ -93,9 +92,26 @@ tools; select the ones to expose (or all), then save.
   later by editing an existing agent.)
 - Select **Create and Deploy**.
 
-**6. Verify** — start a new chat and ask a broker-related question. Select
-`SolaceBrokerAgent` directly, or ask the **Orchestrator**, which delegates to it.
-The agent calls the MCP tools, which query your configured broker over SEMP.
+**6. Verify** — from the UI or the terminal.
+
+- **UI:** start a new chat and ask a broker-related question. Select
+  `SolaceBrokerAgent` directly, or ask the **Orchestrator**, which delegates to it.
+
+- **CLI:** send a task from the terminal. `sam task send` targets
+  `http://localhost:8800` and the `orchestrator` by default; the orchestrator
+  delegates to your agent.
+
+  ```bash
+  sam task send "List the Solace brokers that are configured."
+  ```
+
+  Target a specific agent with `-a/--agent <agent-name>`. No auth token is
+  needed for this local no-auth instance. Note: if a tool is backed by an OAuth
+  connector, `sam task send` prints an authorization URL and waits for a browser
+  login — so OAuth-backed tools cannot complete a fully headless CLI run.
+
+Either way, the agent calls the MCP tools, which query your configured broker
+over SEMP.
 
 ## Authentication Chain
 


### PR DESCRIPTION
## Summary

Rewrites `docs/sam-integration.md` for the **Go-based** Solace Agent Mesh (SAM) CLI. The previous guide targeted the Python SAM and no longer works on the Go implementation; this documents the current UI-connector flow, validated end-to-end against a local embedded SAM instance.

Jira: SOL-153180

## Type of Change

- [x] Documentation update

## Motivation and Context

The old guide assumed the Python SAM: `app_module`/`app_config` YAML dropped into `configs/agents/` and picked up by `sam run`. The Go SAM (v2.307.x) has a different architecture — agents are owned by a Platform service and authored via the UI (or `sam config apply`), and an MCP server is attached as an `mcp/remote` **connector**. Following the old steps on the Go CLI does not work, so the guide needed a full rewrite.

## Changes Made

- Rewrote the guide around the Go SAM UI-connector flow: `sam run --embedded` → add the Broker MCP server as a **Remote MCP** connector → attach it to an agent → deploy → chat.
- Documented the `SAM_PLATFORM_ALLOW_PRIVATE_MCP=true` requirement — SAM's SSRF guard blocks loopback/private MCP URLs, so local dev fails without it.
- Corrected UI navigation and field labels (Builder → Connectors → Create Connector → Custom → Remote MCP; MCP Server URL / Connection Type / Authentication Type) and the local UI URL (`http://127.0.0.1:8800`).
- Added a caveat that the embedded dev broker is SAM's internal bus, unrelated to the brokers the MCP server monitors over SEMP.
- Added a brief pointer to the declarative `sam config apply` path (Early Access) as an alternative.

## Testing

Documentation-only change; no code paths touched. The documented procedure was walked end-to-end on a local setup:

- Ran the Broker MCP server (`mcp_client_auth.mode: disabled`) and `sam run --embedded` (SAM v2.307.3).
- Created the Remote MCP connector in the UI — tool discovery succeeded.
- Created and deployed an agent with the connector; a live chat invoked a broker tool (`list-brokers`, success) against a real Solace broker over SEMP.

**Test Environment:**
- Go version: go1.26.3
- OS: macOS (Darwin 25.6)
- SAM: v2.307.3

**Tests Performed:**
- [x] Tested locally by walking the documented steps end-to-end
- [x] Tested with real Solace broker (broker tool call succeeded)

Unit/integration/E2E: N/A — documentation only. CHANGELOG: N/A — docs are not production surface per `CLAUDE.md`.

## Checklist

- [x] docs/ updated
- [x] Self-review completed
- [x] No credentials in code/docs
- [x] All commits signed off (DCO)
- [x] Clear, descriptive commit message
- [x] Branch up to date with main

## Additional Notes

The headless/Docker-Compose SAM path for the eval harness (which *does* require a non-interactive platform credential) is separate research tracked under SOL-150790 and is out of scope here.

## Related Issues/PRs

- Related to SOL-150790 (Go SAM for the Mode-2 eval harness — research)

---

**For Reviewers:**

**Focus Areas**: Accuracy of the UI steps and field labels against the current Go SAM (v2.307.x), and whether the `SAM_PLATFORM_ALLOW_PRIVATE_MCP` / no-auth framing is the right default for a public-facing guide.
