### PR TITLE
SOL-153693: gate against a third tool registering without input validation

### DIFF
--- a/cmd/server/conformance_test.go
+++ b/cmd/server/conformance_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -1213,4 +1214,279 @@ func TestToolsCall_ValidationOutsideToolManagerIsNotConformant(t *testing.T) {
 				env.Result)
 		}
 	})
+}
+
+// toolsWithoutInputValidation records the tools that do NOT validate their
+// arguments against their own declared input schema, because they are
+// registered outside the ToolManager pipeline (tools.RegisterListBrokers and
+// tools.RegisterDescribeSempSchema call mcp.Server.AddTool directly). The
+// untyped AddTool contract puts unmarshalling and schema validation on the
+// caller, and neither of these two does it — see
+// TestToolsCall_ValidationOutsideToolManagerIsNotConformant for the exact
+// failure mode of each. Tracked as SOL-153693.
+//
+// This is an allow-list, not an excuse. TestToolsCall_EveryToolValidatesItsInput
+// is a two-way gate over it, in the same shape as toolsWithoutOutputSchema:
+// a tool NOT listed here that accepts schema-invalid arguments fails the test
+// (the point of the gate — a third tool must not join these two unnoticed),
+// and a tool listed here that starts validating also fails it, so whoever
+// fixes SOL-153693 is told to delete the entry rather than leave a stale
+// allow-list behind.
+//
+// One caveat, deliberately not papered over: list-brokers declares no
+// properties at all, so no schema-invalid argument set can be derived from its
+// schema and the gate can only skip it. Its entry is still load-bearing —
+// every name here must match a registered tool, so the entry cannot rot after
+// a rename — but the "started validating" direction cannot fire for it until
+// its schema declares something to violate.
+var toolsWithoutInputValidation = map[string]bool{
+	"list-brokers":         true,
+	"describe-semp-schema": true,
+}
+
+// TestToolsCall_EveryToolValidatesItsInput is a gate, not a behaviour test: it
+// fails when a newly registered tool accepts schema-invalid arguments.
+//
+// Input validation on this server lives in ToolManager.CallTool
+// (internal/tools/manager.go), which checks arguments against the tool's
+// compiled input schema before dispatching to the handler. It does NOT live in
+// the SDK: production registers every tool with the untyped mcp.Server.AddTool,
+// whose contract explicitly leaves validation to the caller. So a tool
+// registered outside ToolManager silently gets none — which is exactly how the
+// two tools in toolsWithoutInputValidation ended up unvalidated (SOL-153693).
+//
+// This test does not fix those two. It stops a third joining them unnoticed:
+// every tool on the wire whose schema allows an invalid probe to be derived is
+// called with arguments derived from its OWN input schema (see
+// deriveInvalidArguments; the tools that allow none are logged and counted),
+// and must answer with a tool result carrying isError:true — the
+// MCP 2025-11-25 classification for an input-validation failure, which the
+// model can read and correct itself from, as opposed to a JSON-RPC error.
+//
+// No broker is contacted. Validation runs before handler.Handle, and the
+// broker alias sent is "dev" from budgetTestConfig, which resolves offline
+// (the pool builds SEMP clients lazily) — a bogus alias would fail broker
+// resolution first and this test would then be asserting the wrong thing.
+func TestToolsCall_EveryToolValidatesItsInput(t *testing.T) {
+	handler := conformanceHandler(t)
+	sessionID := initializeSessionFor(t, handler)
+
+	allTools := listToolsOverWire(t, handler, sessionID)
+	if len(allTools) == 0 {
+		t.Fatal("tools/list returned no tools; the registration pipeline is broken")
+	}
+
+	registered := make(map[string]bool, len(allTools))
+	probed, skipped := 0, 0
+	for _, tool := range allTools {
+		registered[tool.Name] = true
+
+		arguments, victim, ok := deriveInvalidArguments(t, tool.InputSchema)
+		if !ok {
+			// Not a pass. A gate that quietly probes nothing is worse than no
+			// gate, so every skip is named and the total is reported below.
+			skipped++
+			t.Logf("SKIP %s: no schema-invalid probe can be derived — its input schema "+
+				"declares no required string property other than the injected broker",
+				tool.Name)
+			continue
+		}
+		probed++
+
+		t.Run(tool.Name, func(t *testing.T) {
+			env := callToolOverWire(t, handler, sessionID, tool.Name, arguments)
+			validated := isErrorToolResult(t, env)
+
+			if toolsWithoutInputValidation[tool.Name] {
+				if validated {
+					t.Fatalf("%s now returns an isError tool result for a schema-invalid %q — "+
+						"it is validating its input. The SOL-153693 gap is closed for this "+
+						"tool: delete its entry from toolsWithoutInputValidation.", tool.Name, victim)
+				}
+				return
+			}
+			if !validated {
+				t.Fatalf("%s accepted a schema-invalid %q (an integer where its own input "+
+					"schema declares a string) without returning isError:true.\n"+
+					"arguments: %s\nresponse: %s\n"+
+					"Every tool must validate its arguments against its declared input "+
+					"schema. The SDK does not do this for untyped Server.AddTool "+
+					"registrations — ToolManager.CallTool does, so a tool registered "+
+					"outside that pipeline gets no validation at all (SOL-153693). "+
+					"Route the tool through ToolManager, or validate in its handler and "+
+					"return an isError result.",
+					tool.Name, victim, arguments, responseForLog(env))
+			}
+		})
+	}
+
+	// Staleness guard for the allow-list itself: an entry naming a tool that no
+	// longer exists (renamed, removed) would otherwise sit here forever,
+	// silently excusing nothing.
+	for name := range toolsWithoutInputValidation {
+		if !registered[name] {
+			t.Errorf("toolsWithoutInputValidation names %q, which is not a registered "+
+				"tool; remove the stale entry", name)
+		}
+	}
+
+	t.Logf("input-validation gate: %d tools probed, %d skipped (of %d registered)",
+		probed, skipped, len(allTools))
+	if probed == 0 {
+		t.Fatal("the gate probed no tools at all; the probe derivation is broken")
+	}
+}
+
+// isErrorToolResult reports whether a tools/call response is a tool result
+// with isError:true — MCP's classification for an input-validation failure.
+// A JSON-RPC error is deliberately NOT counted as validation: the model cannot
+// act on a protocol error, and describe-semp-schema's rejection-by-protocol-
+// error is precisely one of the gaps this gate exists to keep from spreading.
+func isErrorToolResult(t *testing.T, env jsonRPCEnvelope) bool {
+	t.Helper()
+	if env.Error != nil {
+		return false
+	}
+	var result wireToolResult
+	if err := json.Unmarshal(env.Result, &result); err != nil {
+		t.Fatalf("decoding tools/call result: %v; result: %s", err, env.Result)
+	}
+	return result.IsError != nil && *result.IsError
+}
+
+// responseForLog renders whichever half of the envelope arrived, so a failure
+// message shows what actually came back rather than an empty Result.
+func responseForLog(env jsonRPCEnvelope) string {
+	if env.Error != nil {
+		return fmt.Sprintf("JSON-RPC error (code %s): %s", env.Error.Code, env.Error.Message)
+	}
+	return string(env.Result)
+}
+
+// deriveInvalidArguments builds one schema-invalid argument set for a tool from
+// nothing but that tool's own input schema, so the gate carries no per-tool
+// knowledge and covers any tool added later for free.
+//
+// The single violation introduced is a type error: a required property the
+// schema declares as a string is sent as an integer. Every other required
+// property is filled with a plausible valid value, so a tool that rejects the
+// call is rejecting the one violation and not something incidental.
+//
+// The injected broker parameter is never the victim. It is read out and
+// stripped by ToolManager.CallTool BEFORE validation runs, so a non-string
+// broker would be answered with a broker-resolution error instead of a
+// validation error — a pass for the wrong reason. It is always sent as "dev".
+//
+// Returns ok=false when the schema declares no required string property other
+// than broker, which is the only case the caller may skip.
+func deriveInvalidArguments(t *testing.T, raw json.RawMessage) (arguments, victim string, ok bool) {
+	t.Helper()
+	var schema struct {
+		Required   []string                   `json:"required"`
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("decoding inputSchema: %v; schema: %s", err, raw)
+	}
+
+	// Sorted so the chosen victim is stable across runs — Go map iteration is
+	// not, and a gate that probes a different parameter each run reports
+	// failures that are hard to reproduce.
+	required := append([]string(nil), schema.Required...)
+	sort.Strings(required)
+
+	for _, name := range required {
+		if name == brokerParamName {
+			continue
+		}
+		if declaredType(t, schema.Properties[name]) == "string" {
+			victim = name
+			break
+		}
+	}
+	if victim == "" {
+		return "", "", false
+	}
+
+	args := make(map[string]any, len(required))
+	for _, name := range required {
+		switch {
+		case name == brokerParamName:
+			args[name] = validBrokerAlias
+		case name == victim:
+			// The one violation: an integer where a string is declared.
+			args[name] = 42
+		default:
+			args[name] = plausibleValue(t, schema.Properties[name])
+		}
+	}
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("encoding probe arguments: %v", err)
+	}
+	return string(encoded), victim, true
+}
+
+const (
+	// brokerParamName is the parameter injectBrokerParam adds to every
+	// ToolManager-registered tool's schema (internal/tools/register.go).
+	brokerParamName = "broker"
+	// validBrokerAlias is the only alias in budgetTestConfig. It must resolve,
+	// because broker resolution precedes input validation.
+	validBrokerAlias = "dev"
+)
+
+// declaredType returns a property schema's "type" keyword, or "" if the
+// property is absent or declares no single type.
+func declaredType(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	if raw == nil {
+		return ""
+	}
+	var prop struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &prop); err != nil {
+		// A union type ("type": ["string","null"]) lands here. Treat it as
+		// untyped rather than failing: it is simply not a usable probe target.
+		return ""
+	}
+	return prop.Type
+}
+
+// plausibleValue produces a value that satisfies a property schema, so the
+// probe's only schema violation is the one deriveInvalidArguments introduced
+// deliberately. It covers the JSON Schema types this server's tools actually
+// declare; an enum is honoured because an arbitrary string would violate it.
+func plausibleValue(t *testing.T, raw json.RawMessage) any {
+	t.Helper()
+	var prop struct {
+		Type string `json:"type"`
+		Enum []any  `json:"enum"`
+	}
+	if raw != nil {
+		if err := json.Unmarshal(raw, &prop); err != nil {
+			t.Fatalf("decoding property schema: %v; schema: %s", err, raw)
+		}
+	}
+	if len(prop.Enum) > 0 {
+		return prop.Enum[0]
+	}
+	switch prop.Type {
+	case "string":
+		// Non-empty, so a minLength:1 constraint (which every named string
+		// parameter in tools.yaml carries) is satisfied.
+		return "conformance-probe"
+	case "integer", "number":
+		return 1
+	case "boolean":
+		return true
+	case "array":
+		return []any{}
+	default:
+		// "object" and anything undeclared. An empty object satisfies a schema
+		// with no required sub-properties, which is what the *Config parameters
+		// on the update tools declare.
+		return map[string]any{}
+	}
 }


### PR DESCRIPTION
## Summary

Adds a test gate that fails when a newly registered MCP tool accepts schema-invalid arguments. Tests only — no production code touched.

[SOL-153693](https://sol-jira.atlassian.net/browse/SOL-153693)

## Type of Change

- [x] New feature (non-breaking change which adds functionality) — test coverage only

## Motivation and Context

Input validation on this server lives in `ToolManager.CallTool` (`internal/tools/manager.go:243`), **not** in the SDK. Production registers tools with the untyped `mcp.Server.AddTool`, whose contract puts unmarshalling and schema validation on the caller (`mcp/server.go:263`).

Two tools bypass `ToolManager` and are unvalidated today:

- `list-brokers` — accepts undeclared arguments silently, no error at all.
- `describe-semp-schema` — rejects bad input, but as a JSON-RPC error rather than an `isError` tool result.

Those two are SOL-153693's subject and are **not** fixed here. This PR stops a *third* joining them unnoticed, which is the part that gets worse with time.

They didn't bypass the pipeline by accident, incidentally: they're the two tools that take no `broker` parameter, so they can't use the path that injects it. That's why the real fix (a single registration entry point that supports "no broker param" as a first-class case) is design work, and why this gate is worth having in the meantime.

## Changes Made

`TestToolsCall_EveryToolValidatesItsInput` in `cmd/server/conformance_test.go`. It lists every registered tool over the wire, derives a schema-invalid argument set **from that tool's own `inputSchema`**, calls it, and asserts an `isError` tool result.

Probe derivation: take the first `required` property declaring `type: "string"` that isn't `broker`, send `42` for it, and fill every other required property with a plausible valid value so the injected violation is the only one.

**Deriving the probe from the schema rather than hard-coding per-tool knowledge is what makes this a gate** — a tool added tomorrow is covered without anyone remembering to extend a list.

`broker` is excluded as the victim on purpose: `ToolManager` reads and strips it *before* validation, so a non-string broker returns a resolution error and would pass for the wrong reason.

## The allow-list is a three-way gate

`toolsWithoutInputValidation` names the two known-bad tools and fails in three directions:

1. An **unlisted** tool that doesn't validate fails — the point of the gate.
2. A **listed** tool that starts validating fails, so whoever closes SOL-153693 is told to delete the entry rather than leave a stale allow-list.
3. An entry naming a tool **no longer registered** fails as stale.

## Coverage — 35 probed, 5 skipped, of 40

Skips are logged individually with their reason and counted in a summary line, because a gate that silently probes nothing is worse than no gate.

- Four (`get-broker-status`, `get-discard-stats`, `get-redundancy-status`, `list-vpns`) have only `broker` to get wrong.
- **`list-brokers` cannot be probed at all** — it declares no properties, so no argument set violates its schema. Recorded plainly in the allow-list comment rather than left looking like coverage. Its real gap stays pinned by `TestToolsCall_ValidationOutsideToolManagerIsNotConformant`. Making that half live needs `additionalProperties: false` on its schema, which is a production change belonging to SOL-153693.

All 20 write tools are covered — `conformanceHandler` uses `registeredServer(t, true)`.

## Testing

```
gofmt -l cmd/server/                  clean
go build ./...                        Success
go vet ./...                          No issues
go test -race -count=3 ./cmd/server/  738 passed
make test-cover                       Total coverage 89.3% (85% floor)
```

The new test costs ~0.65s — it reuses the shared `conformanceHandler` and one session across all 35 probes.

**Mutation-tested, because a gate that only passes proves nothing.** Removing `describe-semp-schema` from the allow-list:

```
--- FAIL: TestToolsCall_EveryToolValidatesItsInput/describe-semp-schema
    describe-semp-schema accepted a schema-invalid "operation" (an integer where its own
    input schema declares a string) without returning isError:true.
    response: JSON-RPC error (code 0): missing required parameter 'operation'
```

That one failure line independently reproduces all three known `describe-semp-schema` defects — the misclassification, the invalid `code: 0` (SOL-153692), and the wrong-type-reported-as-missing.

**No network.** Validation runs before `handler.Handle`, so a schema-invalid call never reaches SEMP; 34 of 35 probes end in `error_type=validation_error` and the 35th never reaches `ToolManager`. Nothing listens on the broker port during the run.

## Breaking Changes

None. Tests only.

## Checklist

### Code Quality
- [x] Matches the house idiom in `conformance_test.go`
- [x] Self-review completed
- [x] Comments explain "why", not "what"
- [x] No commented-out code or debug statements

### Security
- [x] No credentials in code
- [x] No logging statements added

### Testing
- [x] `go test -race ./...` passes
- [x] No flakes across `-count=3`
- [x] Gate verified by mutation, not just by passing
- [x] Test names describe what is being tested

### Documentation
- [ ] README/docs — no user-facing change
- [x] godoc comments on the new helpers and allow-list
- [ ] CHANGELOG.md — no production surface touched

### Git & CI
- [x] Commit signed off (DCO)
- [x] Branch up to date with main
- [x] No merge conflicts

## Related Issues/PRs

- Guards SOL-153693; does not fix it
- The `code: 0` in the mutation output is SOL-153692
- Builds on the suite added in #346 (SOL-150761)

---

**For Reviewers:**

**Focus Areas**: Whether the schema-derived probe is the right strategy — it is what makes this a gate rather than a list, but it also means the 5 skips are structural rather than oversights. And whether 5/40 skipped is acceptable, given four of them have only `broker` to get wrong.

**Questions**: Should `list-brokers` get `additionalProperties: false` now so its half of the gate goes live, or does that belong with SOL-153693's design work?
