### PR TITLE
SOL-152449: own the shutdown-flush budget in one place

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/SolaceProducts/solace-broker-mcp/internal/oauth/cache"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/correlation"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/health"
+	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/hooks"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/semp"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/semp/sempv2"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/semp/sempv2/specs"
@@ -568,7 +569,7 @@ func startServer(srv *http.Server, tlsCertFile, tlsKeyFile string) <-chan error 
 // skipping the graceful wait. Readiness has already flipped to 503 above, so a
 // forced exit still leaves /readyz correct. A nil forceSig (the startup-error
 // path, which never drains) simply never fires that select case.
-func drainAndShutdown(srv shutdowner, readiness *health.ReadinessState, drainDelay, shutdownTimeout time.Duration, forceSig <-chan os.Signal) error {
+func drainAndShutdown(srv shutdowner, readiness *health.ReadinessState, drainDelay, shutdownTimeout time.Duration, forceSig <-chan os.Signal, shutdownHooks *hooks.Registry) error {
 	readiness.SetShuttingDown()
 	slog.Info("draining before shutdown",
 		slog.String("reason", "signal"),
@@ -584,7 +585,7 @@ func drainAndShutdown(srv shutdowner, readiness *health.ReadinessState, drainDel
 			return nil
 		}
 	}
-	return gracefulShutdown(srv, shutdownTimeout, forceSig)
+	return gracefulShutdown(srv, shutdownTimeout, forceSig, shutdownHooks)
 }
 
 // forceClose is the shared "second signal" reaction (SOL-151437): a single WARN
@@ -646,7 +647,12 @@ type shutdowner interface {
 // returned via the force path — no goroutine leak. A nil forceSig (the
 // startup-error path) never fires that case, so that path keeps its exact
 // prior behavior, including the Shutdown-timed-out forced-close fallback.
-func gracefulShutdown(srv shutdowner, timeout time.Duration, forceSig <-chan os.Signal) error {
+//
+// shutdownHooks runs (SOL-152449) once srv.Shutdown has settled, success or
+// timed-out-then-forced-close alike — never while requests may still be
+// in-flight. A second signal returns before that point, so it skips hooks
+// entirely: "stop now" outranks a telemetry flush.
+func gracefulShutdown(srv shutdowner, timeout time.Duration, forceSig <-chan os.Signal, shutdownHooks *hooks.Registry) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -661,6 +667,9 @@ func gracefulShutdown(srv shutdowner, timeout time.Duration, forceSig <-chan os.
 				slog.Error("forced close failed", slog.String("error", closeErr.Error()))
 			}
 		}
+		hookCtx, hookCancel := context.WithTimeout(context.Background(), time.Duration(defaults.DefaultShutdownHookTimeoutSeconds)*time.Second)
+		defer hookCancel()
+		shutdownHooks.RunAll(hookCtx)
 		return err
 	case sig := <-forceSig:
 		forceClose(srv, sig)
@@ -1071,6 +1080,10 @@ func main() {
 	readiness := health.NewReadinessState()
 	mux := buildMux(readiness)
 
+	// shutdownHooks is empty until a later story (SOL-152091, SOL-152420,
+	// SOL-152418) registers an OTel provider flush against it.
+	shutdownHooks := hooks.NewRegistry()
+
 	// Create MCP handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
 		return server
@@ -1178,11 +1191,11 @@ func main() {
 		drainDelay := drainDelayForSignal(receivedSignal, time.Duration(cfg.Observability.ShutdownDrainDelayS)*time.Second)
 		// Pass the still-registered signal channel so a second SIGINT/SIGTERM
 		// during the drain or graceful wait forces an immediate close (SOL-151437).
-		_ = drainAndShutdown(httpServer, readiness, drainDelay, shutdownTimeout, done)
+		_ = drainAndShutdown(httpServer, readiness, drainDelay, shutdownTimeout, done, shutdownHooks)
 	} else {
 		// Startup-error path never began serving, so there is nothing to drain
 		// and no second-signal semantics: pass a nil force channel.
-		_ = gracefulShutdown(httpServer, shutdownTimeout, nil)
+		_ = gracefulShutdown(httpServer, shutdownTimeout, nil, shutdownHooks)
 	}
 
 	slog.Info("server stopped")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -650,8 +650,9 @@ type shutdowner interface {
 //
 // shutdownHooks runs (SOL-152449) once srv.Shutdown has settled, success or
 // timed-out-then-forced-close alike — never while requests may still be
-// in-flight. A second signal returns before that point, so it skips hooks
-// entirely: "stop now" outranks a telemetry flush.
+// in-flight. A second signal before that point skips hooks entirely; one
+// during the flush (runShutdownHooks) cuts it short instead. Either way,
+// "stop now" outranks a telemetry flush.
 func gracefulShutdown(srv shutdowner, timeout time.Duration, forceSig <-chan os.Signal, shutdownHooks *hooks.Registry) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -667,13 +668,34 @@ func gracefulShutdown(srv shutdowner, timeout time.Duration, forceSig <-chan os.
 				slog.Error("forced close failed", slog.String("error", closeErr.Error()))
 			}
 		}
-		hookCtx, hookCancel := context.WithTimeout(context.Background(), time.Duration(defaults.DefaultShutdownHookTimeoutSeconds)*time.Second)
-		defer hookCancel()
-		shutdownHooks.RunAll(hookCtx)
+		runShutdownHooks(shutdownHooks, forceSig)
 		return err
 	case sig := <-forceSig:
 		forceClose(srv, sig)
 		return nil
+	}
+}
+
+// runShutdownHooks flushes shutdownHooks within DefaultShutdownHookTimeoutSeconds.
+// A second signal (SOL-151437) mid-flush cancels it immediately instead of
+// waiting out the budget — the same "stop now" guarantee as the rest of
+// shutdown.
+func runShutdownHooks(shutdownHooks *hooks.Registry, forceSig <-chan os.Signal) {
+	hookCtx, hookCancel := context.WithTimeout(context.Background(), time.Duration(defaults.DefaultShutdownHookTimeoutSeconds)*time.Second)
+	defer hookCancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		shutdownHooks.RunAll(hookCtx)
+	}()
+
+	select {
+	case <-done:
+	case sig := <-forceSig:
+		slog.Warn("second signal received during shutdown-hook flush; abandoning remaining hooks",
+			slog.String("signal", sig.String()))
+		hookCancel()
 	}
 }
 

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SolaceProducts/solace-broker-mcp/internal/defaults"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/health"
 	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/hooks"
 )
@@ -472,6 +473,57 @@ func TestGracefulShutdown_SecondSignalSkipsHooks(t *testing.T) {
 	}
 	if hookRan.Load() {
 		t.Error("registered hook ran despite a second-signal forced close; hooks must be skipped")
+	}
+}
+
+// TestGracefulShutdown_SecondSignalDuringHookFlushCutsItShort proves a second
+// signal WHILE hooks are running (SOL-152449) cancels the flush immediately
+// instead of waiting out the budget — same "stop now" guarantee as the rest
+// of shutdown.
+func TestGracefulShutdown_SecondSignalDuringHookFlushCutsItShort(t *testing.T) {
+	cs := &captureShutdowner{} // Shutdown returns nil immediately, no delay.
+	registry := hooks.NewRegistry()
+
+	hookStarted := make(chan struct{})
+	hookCanceled := make(chan struct{})
+	registry.Register("blocker", func(ctx context.Context) error {
+		close(hookStarted)
+		<-ctx.Done()
+		close(hookCanceled)
+		return ctx.Err()
+	})
+
+	forceSig := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() { done <- gracefulShutdown(cs, 30*time.Second, forceSig, registry) }()
+
+	select {
+	case <-hookStarted:
+	case <-time.After(time.Second):
+		t.Fatal("hook never started; test cannot exercise the mid-flush signal")
+	}
+
+	start := time.Now()
+	forceSig <- syscall.SIGTERM
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("gracefulShutdown returned %v on a second signal, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gracefulShutdown did not return after a second signal during hook flush")
+	}
+
+	hookBudget := time.Duration(defaults.DefaultShutdownHookTimeoutSeconds) * time.Second
+	if elapsed := time.Since(start); elapsed >= hookBudget {
+		t.Errorf("gracefulShutdown took %v after the second signal, want well under the %v hook budget", elapsed, hookBudget)
+	}
+
+	select {
+	case <-hookCanceled:
+	case <-time.After(time.Second):
+		t.Error("hook's context was never canceled after the second signal")
 	}
 }
 

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/health"
+	"github.com/SolaceProducts/solace-broker-mcp/internal/observability/hooks"
 )
 
 // TestDrainDelayForSignal proves the SIGINT-vs-SIGTERM drain policy (reviewer
@@ -104,7 +105,7 @@ func TestDrainAndShutdown_FlipsReadyzBeforeDelay(t *testing.T) {
 	}()
 
 	start := time.Now()
-	if err := drainAndShutdown(srv, readiness, drainDelay, 5*time.Second, nil); err != nil {
+	if err := drainAndShutdown(srv, readiness, drainDelay, 5*time.Second, nil, nil); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 	elapsed := time.Since(start)
@@ -135,7 +136,7 @@ func TestDrainAndShutdown_SetsShuttingDownEvenWithZeroDelay(t *testing.T) {
 	readiness := health.NewReadinessState()
 	readiness.SetInitialized()
 
-	if err := drainAndShutdown(srv, readiness, 0, 5*time.Second, nil); err != nil {
+	if err := drainAndShutdown(srv, readiness, 0, 5*time.Second, nil, nil); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 	if !readiness.IsShuttingDown() {
@@ -194,7 +195,7 @@ func TestDrainAndShutdown_ShutdownGetsFullBudgetAfterDrain(t *testing.T) {
 	readiness.SetInitialized()
 
 	start := time.Now()
-	if err := drainAndShutdown(cs, readiness, drainDelay, shutdownTimeout, nil); err != nil {
+	if err := drainAndShutdown(cs, readiness, drainDelay, shutdownTimeout, nil, nil); err != nil {
 		t.Fatalf("drainAndShutdown returned error: %v", err)
 	}
 
@@ -238,7 +239,7 @@ func TestGracefulShutdown_ForcedCloseFallback(t *testing.T) {
 	wantErr := context.DeadlineExceeded
 	cs := &captureShutdowner{shutdownErr: wantErr}
 
-	err := gracefulShutdown(cs, 50*time.Millisecond, nil)
+	err := gracefulShutdown(cs, 50*time.Millisecond, nil, nil)
 	if err != wantErr {
 		t.Errorf("gracefulShutdown returned %v, want the original Shutdown error %v", err, wantErr)
 	}
@@ -310,7 +311,7 @@ func TestDrainAndShutdown_SecondSignalDuringDrainForcesClose(t *testing.T) {
 	forceSig <- syscall.SIGTERM
 
 	start := time.Now()
-	if err := drainAndShutdown(srv, readiness, drainDelay, 30*time.Second, forceSig); err != nil {
+	if err := drainAndShutdown(srv, readiness, drainDelay, 30*time.Second, forceSig, nil); err != nil {
 		t.Fatalf("drainAndShutdown returned error on forced close: %v", err)
 	}
 	elapsed := time.Since(start)
@@ -343,7 +344,7 @@ func TestDrainAndShutdown_SecondSignalDuringGracefulForcesClose(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- drainAndShutdown(srv, readiness, 0, 30*time.Second, forceSig)
+		done <- drainAndShutdown(srv, readiness, 0, 30*time.Second, forceSig, nil)
 	}()
 
 	select {
@@ -428,6 +429,49 @@ func TestForceClose_LogsSingleWarnNamingSignal(t *testing.T) {
 	}
 	if got := srv.closeCount.Load(); got != 1 {
 		t.Errorf("forceClose invoked Close %d times, want exactly 1", got)
+	}
+}
+
+// TestGracefulShutdown_RunsHooksAfterShutdown proves shutdownHooks actually
+// gets invoked on a normal shutdown (SOL-152449) — the registry parameter
+// isn't just plumbed through and ignored.
+func TestGracefulShutdown_RunsHooksAfterShutdown(t *testing.T) {
+	cs := &captureShutdowner{}
+	registry := hooks.NewRegistry()
+	var hookRan atomic.Bool
+	registry.Register("test-hook", func(context.Context) error {
+		hookRan.Store(true)
+		return nil
+	})
+
+	if err := gracefulShutdown(cs, 50*time.Millisecond, nil, registry); err != nil {
+		t.Fatalf("gracefulShutdown returned error: %v", err)
+	}
+	if !hookRan.Load() {
+		t.Error("registered hook did not run after a normal shutdown")
+	}
+}
+
+// TestGracefulShutdown_SecondSignalSkipsHooks proves AC #3 (SOL-152449): a
+// second signal forcing an immediate close must skip registered hooks
+// entirely — "stop now" outranks a telemetry flush.
+func TestGracefulShutdown_SecondSignalSkipsHooks(t *testing.T) {
+	srv := newBlockingShutdowner()
+	registry := hooks.NewRegistry()
+	var hookRan atomic.Bool
+	registry.Register("test-hook", func(context.Context) error {
+		hookRan.Store(true)
+		return nil
+	})
+
+	forceSig := make(chan os.Signal, 1)
+	forceSig <- syscall.SIGTERM
+
+	if err := gracefulShutdown(srv, 30*time.Second, forceSig, registry); err != nil {
+		t.Errorf("gracefulShutdown returned %v on forced close, want nil", err)
+	}
+	if hookRan.Load() {
+		t.Error("registered hook ran despite a second-signal forced close; hooks must be skipped")
 	}
 }
 

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -118,10 +118,11 @@ until cold-start init finishes (~60s budget).
 
 `terminationGracePeriodSeconds: 45` is sized deliberately: on SIGTERM the
 server flips `/readyz` to 503, waits `obs.shutdown_drain_delay_s` (default 10s)
-for the endpoint to be deregistered, then drains in-flight requests for up to
-30s. The image is distroless with no shell, so this runs in-process and there
-is no `preStop` hook. **If you raise the drain delay, raise this value to
-match**, or Kubernetes will SIGKILL mid-drain.
+for the endpoint to be deregistered, drains in-flight requests for up to 30s,
+then flushes any registered shutdown hooks (OTel providers) for up to 3s more.
+The image is distroless with no shell, so this runs in-process and there is no
+`preStop` hook. **If you raise the drain delay, raise this value to match**,
+or Kubernetes will SIGKILL mid-drain.
 
 ## Configuration reference
 

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -40,16 +40,19 @@ spec:
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: solace-broker-mcp
-      # Graceful-shutdown budget (SOL-151288). On SIGTERM the server flips
-      # /readyz to 503, sleeps obs.shutdown_drain_delay_s (default 10s) so K8s
-      # deregisters the pod, then gracefully drains in-flight requests for up to
-      # DefaultShutdownTimeoutSeconds (30s). This drain runs IN-PROCESS: the
-      # distroless image has no shell, so there is NO preStop hook. The grace
-      # period must cover both phases plus a small buffer, or K8s SIGKILLs
-      # mid-drain and causes the 502s this design prevents:
+      # Graceful-shutdown budget (SOL-151288, SOL-152449). On SIGTERM the server
+      # flips /readyz to 503, sleeps obs.shutdown_drain_delay_s (default 10s) so
+      # K8s deregisters the pod, gracefully drains in-flight requests for up to
+      # DefaultShutdownTimeoutSeconds (30s), then flushes any registered
+      # shutdown hooks (OTel providers) for up to DefaultShutdownHookTimeoutSeconds
+      # (3s). This drain runs IN-PROCESS: the distroless image has no shell, so
+      # there is NO preStop hook. The grace period must cover all three phases
+      # plus a small buffer, or K8s SIGKILLs mid-drain and causes the 502s this
+      # design prevents:
       #   terminationGracePeriodSeconds = shutdown_drain_delay_s (10)
       #                                 + DefaultShutdownTimeoutSeconds (30)
-      #                                 + 5s buffer = 45
+      #                                 + DefaultShutdownHookTimeoutSeconds (3)
+      #                                 + 2s buffer = 45
       # If you raise obs.shutdown_drain_delay_s, raise this value to match.
       #
       # The readinessProbe below targets /readyz, so on SIGTERM the server's

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -65,17 +65,14 @@ const DefaultShutdownTimeoutSeconds = 30
 // deploy/kubernetes/deployment.yaml).
 const DefaultShutdownDrainDelayS = 10
 
-// DefaultShutdownHookTimeoutSeconds bounds the shutdown-hook registry's RunAll
-// (internal/observability/hooks), run after the HTTP server has finished its
-// own graceful shutdown. Hooks run concurrently, so this is the total time
-// budget regardless of how many are registered, not a per-hook allowance.
+// DefaultShutdownHookTimeoutSeconds bounds RunAll (internal/observability/hooks),
+// run after the HTTP server's own shutdown. Hooks run concurrently, so this is
+// the total budget regardless of hook count, not a per-hook allowance.
 //
-// Decided: 3 seconds, taken from the 5s of headroom already sitting between
-// DefaultShutdownDrainDelayS + DefaultShutdownTimeoutSeconds (40s) and the
-// deployed terminationGracePeriodSeconds (45s) — see deploy/kubernetes/deployment.yaml.
-// Trade-off: leaves only 2s of buffer before K8s SIGKILLs the pod, in exchange
-// for a real (if short) window to flush OTel providers against a slow or
-// unreachable collector. A hook that needs longer is abandoned, not waited on.
+// Decided: 3s, taken from the 5s slack between DefaultShutdownDrainDelayS +
+// DefaultShutdownTimeoutSeconds (40s) and terminationGracePeriodSeconds (45s,
+// see deploy/kubernetes/deployment.yaml) — leaving 2s of buffer before SIGKILL.
+// A hook that needs longer is abandoned, not waited on.
 const DefaultShutdownHookTimeoutSeconds = 3
 
 // DefaultSEMPRequestTimeoutDuration is the per-request timeout for individual

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -60,9 +60,23 @@ const DefaultShutdownTimeoutSeconds = 30
 // flight. Accepted as the cost of a 502-free rolling update.
 //
 // The pod's terminationGracePeriodSeconds must be at least
-// DefaultShutdownDrainDelayS + DefaultShutdownTimeoutSeconds plus a small buffer
-// so K8s does not SIGKILL the process mid-drain (see deploy/kubernetes/deployment.yaml).
+// DefaultShutdownDrainDelayS + DefaultShutdownTimeoutSeconds + DefaultShutdownHookTimeoutSeconds
+// plus a small buffer so K8s does not SIGKILL the process mid-drain (see
+// deploy/kubernetes/deployment.yaml).
 const DefaultShutdownDrainDelayS = 10
+
+// DefaultShutdownHookTimeoutSeconds bounds the shutdown-hook registry's RunAll
+// (internal/observability/hooks), run after the HTTP server has finished its
+// own graceful shutdown. Hooks run concurrently, so this is the total time
+// budget regardless of how many are registered, not a per-hook allowance.
+//
+// Decided: 3 seconds, taken from the 5s of headroom already sitting between
+// DefaultShutdownDrainDelayS + DefaultShutdownTimeoutSeconds (40s) and the
+// deployed terminationGracePeriodSeconds (45s) — see deploy/kubernetes/deployment.yaml.
+// Trade-off: leaves only 2s of buffer before K8s SIGKILLs the pod, in exchange
+// for a real (if short) window to flush OTel providers against a slow or
+// unreachable collector. A hook that needs longer is abandoned, not waited on.
+const DefaultShutdownHookTimeoutSeconds = 3
 
 // DefaultSEMPRequestTimeoutDuration is the per-request timeout for individual
 // SEMP API calls to a broker. Matches the story spec default and the Solace

--- a/internal/observability/hooks/hooks.go
+++ b/internal/observability/hooks/hooks.go
@@ -51,21 +51,14 @@ func (r *Registry) Register(name string, fn func(context.Context) error) {
 	r.hooks = append(r.hooks, namedHook{name: name, fn: fn})
 }
 
-// RunAll runs every registered hook concurrently and returns once they have
-// all finished or ctx's deadline passes, whichever comes first. Each hook
-// gets ctx directly, so every hook effectively gets the same full budget
-// regardless of how many others are registered — one slow or blocked hook
-// cannot shrink another's share. A hook still running when ctx expires is
-// abandoned, not waited on; RunAll returns anyway, bounding the total wall
-// time to ctx's deadline no matter how many hooks are registered. A failing
-// hook is logged and does not affect the caller's shutdown outcome.
+// RunAll runs every registered hook concurrently, returning once they all
+// finish or ctx's deadline passes. Each hook gets ctx directly, so every hook
+// gets the full budget regardless of how many others are registered. A slow
+// hook is abandoned rather than waited on; a panicking one is recovered (via
+// safego.Go) instead of crashing the process. Either way the rest keep
+// running, and a failing hook never changes the caller's shutdown outcome.
 //
-// RunAll is a no-op on a nil Registry or one with no hooks registered, so an
-// unused registry costs nothing.
-//
-// Each hook runs via safego.Go: a panicking hook is recovered and logged
-// rather than crashing the process mid-shutdown, the same guarantee
-// safego gives every other worker goroutine in this codebase.
+// A nil or empty Registry is a no-op — an unused registry costs nothing.
 func (r *Registry) RunAll(ctx context.Context) {
 	if r == nil || len(r.hooks) == 0 {
 		return
@@ -75,7 +68,10 @@ func (r *Registry) RunAll(ctx context.Context) {
 	for _, h := range r.hooks {
 		safego.Go(&g, func() error {
 			if err := h.fn(ctx); err != nil {
-				slog.Error("shutdown hook failed", slog.String("hook", h.name), slog.String("error", err.Error()))
+				// No err.Error(): hooks wrap external systems (an OTel
+				// collector), whose error text is unaudited (docs/internal/
+				// secure-logging-rules.md Rule 5).
+				slog.Error("shutdown hook failed", slog.String("hook", h.name))
 				return err
 			}
 			return nil

--- a/internal/observability/hooks/hooks.go
+++ b/internal/observability/hooks/hooks.go
@@ -1,0 +1,96 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hooks owns the shutdown-hook registry (SOL-152449): a place for
+// OTel providers to register a bounded flush without each editing
+// cmd/server's shutdown path.
+package hooks
+
+import (
+	"context"
+	"log/slog"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/SolaceProducts/solace-broker-mcp/internal/safego"
+)
+
+// namedHook pairs a hook with the name it logs under.
+type namedHook struct {
+	name string
+	fn   func(context.Context) error
+}
+
+// Registry holds shutdown hooks registered at startup and run once at
+// shutdown. The zero value has no hooks; a nil *Registry is also valid and
+// runs no hooks (see RunAll).
+type Registry struct {
+	hooks []namedHook
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{}
+}
+
+// Register adds a shutdown hook under name. Registration happens at startup,
+// before any shutdown can begin, so it is not safe for concurrent use with
+// RunAll.
+func (r *Registry) Register(name string, fn func(context.Context) error) {
+	r.hooks = append(r.hooks, namedHook{name: name, fn: fn})
+}
+
+// RunAll runs every registered hook concurrently and returns once they have
+// all finished or ctx's deadline passes, whichever comes first. Each hook
+// gets ctx directly, so every hook effectively gets the same full budget
+// regardless of how many others are registered — one slow or blocked hook
+// cannot shrink another's share. A hook still running when ctx expires is
+// abandoned, not waited on; RunAll returns anyway, bounding the total wall
+// time to ctx's deadline no matter how many hooks are registered. A failing
+// hook is logged and does not affect the caller's shutdown outcome.
+//
+// RunAll is a no-op on a nil Registry or one with no hooks registered, so an
+// unused registry costs nothing.
+//
+// Each hook runs via safego.Go: a panicking hook is recovered and logged
+// rather than crashing the process mid-shutdown, the same guarantee
+// safego gives every other worker goroutine in this codebase.
+func (r *Registry) RunAll(ctx context.Context) {
+	if r == nil || len(r.hooks) == 0 {
+		return
+	}
+
+	var g errgroup.Group
+	for _, h := range r.hooks {
+		safego.Go(&g, func() error {
+			if err := h.fn(ctx); err != nil {
+				slog.Error("shutdown hook failed", slog.String("hook", h.name), slog.String("error", err.Error()))
+				return err
+			}
+			return nil
+		})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = g.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		slog.Warn("shutdown hook budget exceeded; abandoning any hooks still running")
+	}
+}

--- a/internal/observability/hooks/hooks_test.go
+++ b/internal/observability/hooks/hooks_test.go
@@ -1,0 +1,151 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRunAll_NilRegistryIsNoop proves a nil *Registry (the common case before
+// any provider story registers a hook) costs nothing and never blocks.
+func TestRunAll_NilRegistryIsNoop(t *testing.T) {
+	var r *Registry
+	start := time.Now()
+	r.RunAll(context.Background())
+	if elapsed := time.Since(start); elapsed > 10*time.Millisecond {
+		t.Errorf("RunAll on a nil Registry took %v, want near-instant", elapsed)
+	}
+}
+
+// TestRunAll_EmptyRegistryIsNoop proves the same for a constructed but unused
+// Registry — the inert case Stories 14/25/46 leave behind until they register.
+func TestRunAll_EmptyRegistryIsNoop(t *testing.T) {
+	r := NewRegistry()
+	start := time.Now()
+	r.RunAll(context.Background())
+	if elapsed := time.Since(start); elapsed > 10*time.Millisecond {
+		t.Errorf("RunAll on an empty Registry took %v, want near-instant", elapsed)
+	}
+}
+
+// TestRunAll_BoundedTotalWithBlockingHooks proves the core budget guarantee:
+// three hooks that never return still leave RunAll bounded by ctx's deadline,
+// and a fourth registered hook does not push the wall-clock bound out further.
+func TestRunAll_BoundedTotalWithBlockingHooks(t *testing.T) {
+	r := NewRegistry()
+	block := func(ctx context.Context) error {
+		<-ctx.Done() // only returns when RunAll's budget expires
+		return nil
+	}
+	for i := 0; i < 4; i++ {
+		r.Register("blocker", block)
+	}
+
+	const budget = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	start := time.Now()
+	r.RunAll(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > budget+100*time.Millisecond {
+		t.Errorf("RunAll took %v with 4 blocking hooks, want bounded near the %v budget", elapsed, budget)
+	}
+}
+
+// TestRunAll_SlowHookDoesNotStarveFastHook proves one stuck hook cannot
+// prevent another registered hook from completing: both run concurrently, so
+// the fast hook's own effect is observed even though the slow one is
+// abandoned when the budget expires.
+func TestRunAll_SlowHookDoesNotStarveFastHook(t *testing.T) {
+	r := NewRegistry()
+	r.Register("slow", func(ctx context.Context) error {
+		<-ctx.Done()
+		return nil
+	})
+
+	var fastRan atomic.Bool
+	r.Register("fast", func(context.Context) error {
+		fastRan.Store(true)
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	r.RunAll(ctx)
+
+	if !fastRan.Load() {
+		t.Error("fast hook did not run; a slow hook must not starve the others")
+	}
+}
+
+// TestRunAll_PanickingHookDoesNotCrashProcess proves a panic in one hook is
+// recovered (via safego.Go) rather than escaping the goroutine and crashing
+// the process mid-shutdown — the panic equivalent of a failing hook must be
+// contained the same way an ordinary error is.
+func TestRunAll_PanickingHookDoesNotCrashProcess(t *testing.T) {
+	r := NewRegistry()
+	r.Register("panicker", func(context.Context) error {
+		panic("boom")
+	})
+
+	var fastRan atomic.Bool
+	r.Register("fast", func(context.Context) error {
+		fastRan.Store(true)
+		return nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.RunAll(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RunAll did not return after a hook panicked")
+	}
+	if !fastRan.Load() {
+		t.Error("fast hook did not run; a panicking hook must not prevent the others from running")
+	}
+}
+
+// TestRunAll_HookErrorDoesNotPropagate proves a failing hook is swallowed
+// (logged, not surfaced) — the shutdown exit-status decision belongs to the
+// HTTP server's own outcome, not to a lost telemetry flush.
+func TestRunAll_HookErrorDoesNotPropagate(t *testing.T) {
+	r := NewRegistry()
+	r.Register("failing", func(context.Context) error {
+		return errors.New("flush failed")
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.RunAll(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RunAll did not return after a hook error")
+	}
+}


### PR DESCRIPTION
Add a shutdown-hook registry (internal/observability/hooks) so Stories 14, 25, and 46 can each register a bounded OTel provider flush without editing cmd/server's shutdown path three separate times.

Hooks run concurrently and are bounded by a single new DefaultShutdownHookTimeoutSeconds budget (3s, carved from the 5s of previously-undocumented K8s grace-period slack) after the HTTP server's own graceful shutdown has settled - never while requests may still be in-flight, and never on a second-signal forced close. A panicking or failing hook is contained (via safego.Go) and logged, and never affects the process exit status. With no hooks registered the registry is a true no-op.

Updates the K8s terminationGracePeriodSeconds accounting in deployment.yaml and its README to include the new hook-budget line item.

## Summary

Adds a shutdown-hook registry (`internal/observability/hooks`) and a decided split of the shutdown timeout, so Stories 14, 25, and 46 each have a seam to register a bounded OTel provider flush without editing `cmd/server`'s shutdown path three separate times.

Fixes SOL-152449

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context

Three upcoming stories (meter provider, tracer provider, OTLP metrics reader) each need to flush an OTel provider on SIGTERM within a bounded timeout. Without a shared registry, three inline edits to the same shutdown function produce either three sequential full-budget waits (blowing `terminationGracePeriodSeconds`) or three uncoordinated fractions nobody reconciles. This is also the last comfortable moment to add the seam — `drainAndShutdown` is the same function SOL-151437's force-close path threads through, so after three provider stories touch it, adding this becomes a merge conflict instead of a story.

## Changes Made

- **`internal/observability/hooks/hooks.go`** — `Registry` with `Register(name, fn)` and `RunAll(ctx)`. Hooks run concurrently via `safego.Go` (panic-safe); `RunAll` returns within `ctx`'s deadline regardless of hook count, and one stuck/failing/panicking hook never blocks or affects the others. Nil/empty registry is a true no-op.
- **`internal/defaults/defaults.go`** — new `DefaultShutdownHookTimeoutSeconds = 3`, documented next to the existing shutdown-timeout/drain-delay constants.
- **`cmd/server/main.go`** — threads `*hooks.Registry` through `drainAndShutdown`/`gracefulShutdown` (the `shutdowner` interface itself is untouched). Hooks run only after the HTTP server's own shutdown has settled — never while requests may still be in-flight, and never on a second-signal forced close. `main()` builds one empty registry, inert until a later story registers against it.
- **`deploy/kubernetes/deployment.yaml`, `deploy/kubernetes/README.md`** — updated the `terminationGracePeriodSeconds` accounting comment to include the new hook budget (was 30s drain + 5s buffer; now 30s drain + 3s hooks + 2s buffer, still 45s total).
- **Tests** — new `hooks_test.go` (bounded total, no starvation, error/panic doesn't propagate, no-op when empty); two new `cmd/server/shutdown_test.go` tests (hooks run after a normal shutdown; hooks skipped on forced close). The 6 existing call sites needed a mechanical `nil` appended for the new parameter — no assertions changed.

## Testing

**Test Environment:**
- Go version: 1.25.0 (per `go.mod`)
- OS: darwin (local dev)
- Broker version (if applicable): N/A — no broker-facing code

**Tests Performed:**
- [x] Unit tests added/updated
- [ ] Integration tests added/updated — N/A
- [ ] E2E tests added/updated — N/A
- [x] Tested locally with `go test -race ./...`
- [ ] Tested with real Solace broker — N/A

**Test Coverage:**
- `make test-cover` — 89.5% total (85% gate)
- All 8 pre-existing `shutdown_test.go` tests still pass with identical assertions
- `/check-logs` — 1 MEDIUM (generic `err.Error()` logging on a caller-supplied hook function; not blocking, no hook is registered yet so nothing flows through it today)

## Breaking Changes

None. The registry is empty and inert until a later story calls `Register`.

## Checklist

### Code Quality
- [x] Code follows the coding standards
- [x] Self-review completed
- [x] Code is well-commented (explains "why", not "what")
- [x] Complex logic has explanatory comments
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code
- [x] Followed secure logging rules (`/check-logs`: 1 MEDIUM, non-blocking — see Testing)
- [ ] Credential-carrying types implement `slog.LogValuer` — N/A, none added
- [x] No security vulnerabilities introduced

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected
- [x] Edge cases covered by tests (bounded total, starvation, panic, error, empty/nil)
- [x] Error paths tested
- [x] Test names clearly describe what is being tested

### Documentation
- [ ] README.md updated — N/A, no user-facing change
- [x] docs/ updated — `deploy/kubernetes/README.md` grace-period accounting
- [x] godoc comments added/updated for exported functions
- [ ] CHANGELOG.md updated — N/A, no observable behavior change (registry is inert)
- [ ] Examples updated — N/A

### Git & CI
- [x] All commits are signed off (DCO)
- [x] Commits have clear, descriptive messages
- [x] Branch is up to date with main
- [x] No merge conflicts
- [ ] CI checks passing — pending first run

## Additional Notes

`make lint` locally reports 65 pre-existing staticcheck (SA5011) findings, none in files this PR touches — confirmed identical on a clean `main` via `git stash`. CI is the source of truth.
