### PR TITLE
SOL-153444: prove SEMP rate limits hold end to end in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -184,6 +184,7 @@ jobs:
         run: |
           go vet ./...
           (cd test/e2e-common/broker-driver && go vet ./...)
+          (cd test/e2e-common/semp-tap && go vet ./...)
 
       - name: Test
         # -race enables the Go race detector to catch data races on shared state (e.g. BrokerPool).
@@ -247,6 +248,32 @@ jobs:
           docker logs solace-e2e-a 2>&1 | tail -100
           echo "=== solace-e2e-b ==="
           docker logs solace-e2e-b 2>&1 | tail -100
+
+      # The throttling scenario's verdict is a claim about timing, so on failure
+      # the raw evidence has to come back with it. The records are the arrival
+      # and header-return timestamps the assertions were computed from, and the
+      # per-phase configs say which limits were actually in force (they carry
+      # only ${VAR} placeholders, never resolved credentials).
+      #
+      # Deliberately not the MCP server log. This step fires on ANY failure in
+      # the job, not just this scenario's, so tailing the server log here would
+      # publish it to the Actions log for scenarios that never asked for it, and
+      # the suite has not needed it until now.
+      - name: Throttling scenario evidence (on failure)
+        if: failure()
+        run: |
+          for f in test/e2e-basic-mcp/bin/throttle-record-*.csv; do
+            [ -e "$f" ] || continue
+            echo "=== $f ($(wc -l < "$f") requests) ==="
+            cat "$f"
+          done
+          for f in test/e2e-basic-mcp/bin/mcp-config-throttle-*.yaml; do
+            [ -e "$f" ] || continue
+            echo "=== $f ==="
+            cat "$f"
+          done
+          echo "=== semp-tap log ==="
+          tail -100 test/e2e-basic-mcp/bin/semp-tap.log 2>/dev/null || echo "no tap log"
 
       - name: Tear down brokers
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ product-chat.md
 
 # Built E2E agent binary.
 test/e2e/agent/agent
+
+# semp-tap builds into a suite's gitignored bin/ via build_semp_tap, but a bare
+# `go build` inside its own module drops the binary next to the source.
+test/e2e-common/semp-tap/semp-tap

--- a/docs/internal/e2e-testing.md
+++ b/docs/internal/e2e-testing.md
@@ -27,12 +27,14 @@ Unit tests mock the Solace broker entirely. E2E tests validate the full stack en
 HTTP transport → MCP protocol → SEMP API → live Solace broker
 ```
 
-Two scenarios are covered:
+Four scenarios are covered:
 
 1. **Standalone** — raw curl requests against the MCP server (no AI agent)
 2. **Agent** — a Go program using the MCP SDK client to connect and call tools
+3. **Negative paths** — tool-execution failures surface as clean MCP structured errors
+4. **Throttling** — the SEMP rate limiter and in-flight cap hold against a real broker
 
-Both scenarios run against **two independent brokers** (`broker-a`, `broker-b`) to verify multi-broker routing.
+Scenarios 1 and 2 run against **two independent brokers** (`broker-a`, `broker-b`) to verify multi-broker routing.
 
 ---
 
@@ -44,20 +46,27 @@ test/e2e-basic-mcp/
 ├── .env                     # Single source of truth: ports, credentials
 ├── docker-compose.yml       # Two Solace PubSub+ broker containers
 ├── helpers.sh               # Shared bash functions (broker wait, server start, MCP helpers, assertions)
-├── setup-brokers.sh         # Bring brokers up and wait until ready (idempotent)
-├── run-all.sh               # Master test runner (orchestrates both scenarios, prints summary table)
-├── start-server.sh          # Build and start a fresh MCP server from latest source
+├── run-all.sh               # Master test runner (orchestrates every scenario, prints summary table)
 ├── test-standalone.sh       # Scenario 1: raw curl MCP protocol tests
 ├── test-agent.sh            # Scenario 2: builds and runs the Go agent
-├── bin/                     # Built binaries (gitignored)
+├── test-negative-paths.sh   # Scenario 3: structured-error envelope contract
+├── test-throttling.sh       # Scenario 4: rate limiter + in-flight cap
+├── test-throttling-analysis.sh  # Self-test of scenario 4's record arithmetic (no Docker)
+├── bin/                     # Built binaries, generated configs, records (gitignored)
 │   ├── mcp-server
 │   ├── mcp-server.pid       # PID file when server is started with --bg
+│   ├── semp-tap             # recording reverse proxy (scenario 4)
+│   ├── mcp-config-throttle-*.yaml   # per-phase configs (scenario 4)
+│   ├── throttle-record-*.csv        # per-phase request records (scenario 4)
 │   └── agent
 └── agent/
     ├── main.go              # Go MCP SDK client agent program
     ├── go.mod
     └── go.sum
 ```
+
+Broker startup (`setup-brokers.sh`) and server startup (`start-server.sh`) are
+shared and live in `test/e2e-common/`, not in the suite directory.
 
 ---
 
@@ -289,6 +298,42 @@ Because LiteLLM exposes an OpenAI-compatible API, a Go OpenAI client (for exampl
 
 ---
 
+## Scenario 4: Throttling (SEMP rate limiter and in-flight cap)
+
+`test-throttling.sh` (SOL-153444) proves that `semp.request_min_interval` and `semp.max_concurrent_per_broker` are honored end to end against a real Dockerized broker. Both were previously covered only by unit tests against an `httptest` server (`internal/semp/resilience/ratelimiter_test.go`, `internal/semp/rate_limiter_shared_test.go`).
+
+### How it measures
+
+One MCP tool call is not one SEMP request — composites fan out, pagination adds more, retries add attempts the client never sees — so client-side timing cannot say what rate the broker experienced. Instead `semp-tap` (`test/e2e-common/semp-tap`, own `go.mod`, stdlib only) is placed between the MCP server and broker-a, and a dedicated `broker-throttle` alias points at it. The broker is real and does the real work; the tap forwards everything and records one CSV line per request. Because the rate limiter and the in-flight semaphore are keyed by broker alias, the record contains exactly this scenario's traffic.
+
+**The measurement window matters.** `Sender.Do` releases its semaphore slot when the response *headers* arrive, with the body still open (`internal/semp/resilience/sender.go`). The tap therefore measures in-flight over `[request received → response headers returned]` via `ModifyResponse`, not over full body-proxy completion. Measuring the wider window would report a correct cap of 2 as an occasional 3. For the same reason the tap counts requests, never connections: `max_concurrent_per_broker` also sizes the transport's `MaxConnsPerHost` per protocol client, so up to 2x the cap in TCP connections can legitimately exist.
+
+### Phases
+
+`semp:` is a single global block, and the two limits mask each other — with the pacer at 200ms and a local broker answering in tens of milliseconds, in-flight count never reaches 2, so a cap of 2 could never be shown to bind. Each limit gets a phase where it is the only constraint, plus a shared control. The MCP server is restarted between phases (the `e2e-oauth` pattern).
+
+| Phase | `request_min_interval` | `max_concurrent_per_broker` | Tap delay | Asserts |
+|---|---|---|---|---|
+| pacer | `200ms` | `10` | 0 | every gap ≥ 100ms, and the aggregate span ≥ gaps × 200ms − 200ms |
+| cap | `0s` | `2` | 150ms | peak in-flight == 2 |
+| pacer-control | `0s` | `10` | 0 | the inverse of the pacer phase |
+| cap-control | `0s` | `10` | 150ms | the inverse of the cap phase |
+
+The two control phases are the answer to "sanity-check that the assertion can actually fail". Each runs the identical load with its limit off and asserts the inverse. They are real, always-on CI assertions rather than commented-out or manual steps, so if the tap ever stops being able to see a violation, the control goes red and names the assertion that has gone blind.
+
+Each control differs from the phase it validates in exactly one variable. A single shared control would differ from the pacer phase in both the interval and the tap delay at once. That is also empirically the wrong shape: with no tap delay the same load peaks at only ~5 in flight rather than 10, so a delay-free run is a poor control for the cap even though it is the right control for the pacer.
+
+### Keeping it deterministic
+
+- Every assertion is count-based or a generous lower bound. A loaded CI runner makes gaps longer and requests overlap more, which is the safe direction for all of them.
+- Pacing is asserted twice, mirroring `rate_limiter_shared_test.go`. The per-pair minimum gap carries a deliberately wide floor (half the interval) because transit jitter can shorten a single gap, and widening costs nothing: every defect this guards against produces gaps near zero, not gaps a few milliseconds short. The aggregate span is the precise check, because that jitter cancels over a run.
+- The record arithmetic itself is self-tested against synthetic records by `test-throttling-analysis.sh`, which runs first in the scenario and also standalone in about a second with no Docker. Every numeric result passes a `require_int` guard first, because `[ "" -lt 13 ]` exits 2 and would otherwise fall through an `if` and return success.
+- `retries: 0` in the throttle config. Retries are explicitly *not* paced (they run inside one limiter tick and one semaphore slot), so a transient blip would otherwise inject arrivals no gap assertion accounts for.
+- The scenario warms the broker client up and then skips the first arrivals. `RateLimiter` is a bare `time.Ticker`, not a token bucket: its channel buffers one tick, so idle time is credit and the first request after an idle period is admitted with no wait. The warm-up makes that behavior deterministic rather than accidental.
+- Phases with a concurrency assertion hold each response an identical extra 150ms at the tap, so overlap is arithmetic rather than a race against how fast the broker answers. Both limits are still enforced by the real server against a real broker; only the measurement window is widened, and identically in the phase and its control.
+
+The scenario runs last in `run-all.sh` because it takes over port `9090` from the shared server the earlier scenarios use.
+
 ## Test Output
 
 `run-all.sh` prints a summary table at the end:
@@ -299,8 +344,10 @@ Because LiteLLM exposes an OpenAI-compatible API, a Go OpenAI client (for exampl
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━╋━━━━━━━━━╋━━━━━━━━━┫
 ┃ Standalone tests        ┃     9 ┃       9 ┃       0 ┃
 ┃ Agent tests             ┃     1 ┃       1 ┃       0 ┃
+┃ Negative-path tests     ┃     3 ┃       3 ┃       0 ┃
+┃ Throttling tests        ┃     4 ┃       4 ┃       0 ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━╋━━━━━━━━━╋━━━━━━━━━┫
-┃ TOTAL                   ┃    10 ┃      10 ┃       0 ┃
+┃ TOTAL                   ┃    17 ┃      17 ┃       0 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━┻━━━━━━━━━┻━━━━━━━━━┛
 ```
 

--- a/docs/internal/e2e-testing.md
+++ b/docs/internal/e2e-testing.md
@@ -310,7 +310,7 @@ One MCP tool call is not one SEMP request — composites fan out, pagination add
 
 ### Phases
 
-`semp:` is a single global block, and the two limits mask each other — with the pacer at 200ms and a local broker answering in tens of milliseconds, in-flight count never reaches 2, so a cap of 2 could never be shown to bind. Each limit gets a phase where it is the only constraint, plus a shared control. The MCP server is restarted between phases (the `e2e-oauth` pattern).
+`semp:` is a single global block, and the two limits mask each other — with the pacer at 200ms and a local broker answering in tens of milliseconds, in-flight count never reaches 2, so a cap of 2 could never be shown to bind. Each limit gets a phase where it is the only constraint, plus its own control phase. The MCP server is restarted between phases (the `e2e-oauth` pattern).
 
 | Phase | `request_min_interval` | `max_concurrent_per_broker` | Tap delay | Asserts |
 |---|---|---|---|---|

--- a/test/e2e-basic-mcp/.env
+++ b/test/e2e-basic-mcp/.env
@@ -5,6 +5,12 @@
 BROKER_A_SEMP_PORT=8080
 BROKER_B_SEMP_PORT=8082
 
+# Recording reverse proxy used by the throttling scenario (test-throttling.sh).
+# It forwards to broker-a and records what the broker actually receives, so the
+# rate limiter and in-flight cap can be asserted end to end. Host-side only —
+# no container listens here.
+SEMP_TAP_PORT=8084
+
 # Broker credentials (shared by both brokers)
 BROKER_USERNAME=admin
 BROKER_PASSWORD=admin

--- a/test/e2e-basic-mcp/README.md
+++ b/test/e2e-basic-mcp/README.md
@@ -27,7 +27,7 @@ docker compose -f test/e2e-basic-mcp/docker-compose.yml down -v
 ```
 
 `run-all.sh` builds the MCP server and the Go agent, applies the base fixtures to
-both brokers, runs all three scenarios, and cleans up the fixtures and server on
+both brokers, runs all four scenarios, and cleans up the fixtures and server on
 exit (via an `EXIT` trap). It assumes the brokers are already up — run the
 `setup-brokers.sh` step above first.
 
@@ -43,6 +43,8 @@ test/e2e-basic-mcp/
 ├── test-standalone.sh      # Scenario 1: raw curl MCP protocol tests
 ├── test-agent.sh           # Scenario 2: builds and runs the Go MCP-SDK agent
 ├── test-negative-paths.sh  # Scenario 3: structured-error envelope contract (SOL-150767)
+├── test-throttling.sh      # Scenario 4: rate limiter + in-flight cap (SOL-153444)
+├── test-throttling-analysis.sh  # Self-test of scenario 4's record arithmetic (no Docker, ~1s)
 ├── agent/                  # Go MCP-SDK client program (own go.mod)
 └── bin/                    # Built binaries + pidfile (gitignored)
 ```
@@ -74,6 +76,33 @@ The extras are local to this suite — other suites' server configs stay minimal
   itself is unit-tested in
   `internal/semp/resilience/` — this scenario is the "we drove it once" smoke
   on the envelope contract, not a comprehensive negative matrix.
+- **Scenario 4 — Throttling (`test-throttling.sh`).** SOL-153444. Proves
+  `semp.request_min_interval` and `semp.max_concurrent_per_broker` are honored
+  end to end against a real broker, which until now was covered only by unit
+  tests against an `httptest` server. It runs four phases, restarting the MCP
+  server with different limits each time, and measures what the broker actually
+  receives through `semp-tap` (a recording reverse proxy, sources in
+  `../e2e-common/semp-tap`) placed in front of broker-a behind a dedicated
+  `broker-throttle` alias:
+
+  | Phase | `request_min_interval` | `max_concurrent_per_broker` | Tap delay | Asserts |
+  | --- | --- | --- | --- | --- |
+  | pacer | `200ms` | `10` (slack) | 0 | every gap ≥ floor, and the aggregate span matches the interval |
+  | cap | `0s` | `2` | 150ms | peak in-flight == 2 |
+  | pacer-control | `0s` | `10` (slack) | 0 | the inverse of the pacer phase |
+  | cap-control | `0s` | `10` (slack) | 150ms | the inverse of the cap phase |
+
+  Each control differs from the phase it validates in exactly one variable, so a
+  green control means that specific assertion is live. They are the ticket's
+  "sanity-check the assertion" step, kept as real always-on CI assertions rather
+  than manual ones, so they cannot rot. Read
+  `semp-tap`'s package comment before touching an assertion: the measurement
+  window is `[request received → response headers returned]`, matching where
+  `Sender.Do` drops its semaphore slot, and it is not the same as full
+  body-proxy completion.
+
+  This scenario runs last because it takes over port `9090` from the shared
+  server the earlier scenarios use.
 
 ## Fixtures
 
@@ -118,8 +147,12 @@ Distinct from `e2e-monitoring` so both suites can run concurrently:
 | ------------- | ------------- | -------------- |
 | SEMP broker-a | 8080          | 8090           |
 | SEMP broker-b | 8082          | 8092           |
+| semp-tap      | 8084          | (not used)     |
 | SMF broker-a  | (not exposed) | 55655          |
 | SMF broker-b  | (not exposed) | 55656          |
+
+`semp-tap` is a host-side process, not a container: the throttling scenario's
+recording reverse proxy (`SEMP_TAP_PORT` in `.env`).
 
 The MCP server listens on `9090` (override with `MCP_PORT`). All broker ports are
 override-able via `.env` (`BROKER_A_SEMP_PORT`, `BROKER_B_SEMP_PORT`).

--- a/test/e2e-basic-mcp/helpers.sh
+++ b/test/e2e-basic-mcp/helpers.sh
@@ -74,3 +74,48 @@ cleanup_fixtures() {
     cleanup_fixtures_on "$BROKER_A_SEMP_CONFIG" "broker-a"
     cleanup_fixtures_on "$BROKER_B_SEMP_CONFIG" "broker-b"
 }
+
+# Config generator for the throttling scenario (SOL-153444, test-throttling.sh).
+#
+# Deliberately NOT the suite's write_config above: that one appends its own semp
+# block (a retry budget for the negative-path aliases), and semp is a single
+# global block, so appending a second one would leave the phase's limits at the
+# mercy of YAML key ordering. This builds the base broker set with
+# _lib_write_config and then owns the whole semp block itself.
+#
+# broker-throttle points at the tap rather than at the broker. The per-broker
+# rate limiter and in-flight semaphore are keyed by broker alias, so this alias
+# gets its own pair and the tap's record contains only traffic this scenario
+# generated. broker-a/broker-b stay pointed straight at their brokers.
+#
+# retries: 0 is load-bearing, not tidiness. Retries are explicitly not paced —
+# retryablehttp performs them inside the one limiter tick and the one semaphore
+# slot (see the comment on Sender.Do) — so a single transient blip would inject
+# arrivals at the tap that no gap assertion accounts for.
+#
+#   $1 config_file          path to write the generated YAML to
+#   $2 request_min_interval e.g. "200ms", or "0" to disable the pacer
+#   $3 max_concurrent       e.g. 2, or 10 to leave the cap provably slack
+write_throttle_config() {
+    local config_file="$1"
+    local min_interval="$2"
+    local max_concurrent="$3"
+
+    _lib_write_config "$config_file"
+    cat >> "$config_file" <<EOF
+  broker-throttle:
+    # Points at semp-tap, which forwards to broker-a and records what the
+    # broker actually receives. Same credentials — the tap is transparent.
+    url: "${SEMP_TAP_URL}"
+    auth:
+      mode: basic
+      username: "\${E2E_A_USERNAME}"
+      password: "\${E2E_A_PASSWORD}"
+
+semp:
+  request_min_interval: ${min_interval}
+  max_concurrent_per_broker: ${max_concurrent}
+  retries: 0
+EOF
+    log_info "Throttle config written to $config_file (request_min_interval=$min_interval, max_concurrent_per_broker=$max_concurrent)"
+}

--- a/test/e2e-basic-mcp/run-all.sh
+++ b/test/e2e-basic-mcp/run-all.sh
@@ -68,13 +68,28 @@ else
     NEGATIVE_EXIT=$?
 fi
 
-# 6. Summary table
+# 6. Run Scenario 4: SEMP throttling (SOL-153444)
+#
+# Last on purpose. It restarts the MCP server three times with different
+# `semp:` limits, so it takes over port 9090 from the shared server the earlier
+# scenarios used. Anything added after it would find that server gone.
+log_info ""
+log_info "=== Scenario 4: Throttling (rate limiter + in-flight cap) ==="
+log_info ""
+if bash "$SCRIPT_DIR/test-throttling.sh"; then
+    THROTTLING_EXIT=0
+else
+    THROTTLING_EXIT=$?
+fi
+
+# 7. Summary table
 TOTAL_RUN=0
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 SAW_STANDALONE=0
 SAW_AGENT=0
 SAW_NEGATIVE=0
+SAW_THROTTLING=0
 
 echo ""
 echo "┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓"
@@ -91,6 +106,7 @@ if [ -f "$E2E_RESULTS_DIR/results.txt" ]; then
             "Standalone tests")     SAW_STANDALONE=1 ;;
             "Agent tests")          SAW_AGENT=1      ;;
             "Negative-path tests")  SAW_NEGATIVE=1   ;;
+            "Throttling tests")     SAW_THROTTLING=1 ;;
         esac
     done < "$E2E_RESULTS_DIR/results.txt"
 fi
@@ -106,18 +122,22 @@ fi
 if [ "$SAW_NEGATIVE" -eq 0 ] && [ "$NEGATIVE_EXIT" -ne 0 ]; then
     printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "Negative-path tests" "CRASH" "--" "--"
 fi
+if [ "$SAW_THROTTLING" -eq 0 ] && [ "$THROTTLING_EXIT" -ne 0 ]; then
+    printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "Throttling tests" "CRASH" "--" "--"
+fi
 
 echo "┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━╋━━━━━━━━━╋━━━━━━━━━┫"
 printf "┃ %-23s ┃ %5s ┃ %7s ┃ %7s ┃\n" "TOTAL" "$TOTAL_RUN" "$TOTAL_PASSED" "$TOTAL_FAILED"
 echo "┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━┻━━━━━━━━━┻━━━━━━━━━┛"
 echo ""
 
-if [ "$STANDALONE_EXIT" -eq 0 ] && [ "$AGENT_EXIT" -eq 0 ] && [ "$NEGATIVE_EXIT" -eq 0 ]; then
+if [ "$STANDALONE_EXIT" -eq 0 ] && [ "$AGENT_EXIT" -eq 0 ] && [ "$NEGATIVE_EXIT" -eq 0 ] && [ "$THROTTLING_EXIT" -eq 0 ]; then
     log_ok "All E2E scenarios passed"
     exit 0
 else
     [ "$STANDALONE_EXIT" -ne 0 ] && log_fail "Standalone scenario failed"
     [ "$AGENT_EXIT" -ne 0 ] && log_fail "Agent scenario failed"
     [ "$NEGATIVE_EXIT" -ne 0 ] && log_fail "Negative-path scenario failed"
+    [ "$THROTTLING_EXIT" -ne 0 ] && log_fail "Throttling scenario failed"
     exit 1
 fi

--- a/test/e2e-basic-mcp/test-throttling-analysis.sh
+++ b/test/e2e-basic-mcp/test-throttling-analysis.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Self-test for the record-analysis arithmetic in test-throttling.sh.
+#
+# The throttling scenario's verdict is only as good as the four helpers that
+# turn a request record into numbers. Those helpers need neither a broker nor
+# Docker to exercise, so they are checked here against synthetic records with
+# known answers. test-throttling.sh runs this first, before spending four
+# server restarts on a measurement it has not verified; it also runs standalone
+# in about a second:
+#
+#   bash test/e2e-basic-mcp/test-throttling-analysis.sh
+#
+# Sourcing test-throttling.sh returns at its own guard before any phase runs,
+# so this only picks up the helpers.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./test-throttling.sh
+source "$SCRIPT_DIR/test-throttling.sh"
+
+# test-throttling.sh sets -e for its own run. This file deliberately keeps
+# going after a failed check so one broken helper does not hide the other
+# fifteen results, and it reports the tally at the end instead.
+set +e
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+FAILURES=0
+check() { # label expected actual
+    if [ "$2" = "$3" ]; then
+        log_ok "  $1 => $3"
+    else
+        log_fail "  $1 => got '$3', want '$2'"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+MS=1000000
+row() { # seq start_ms end_ms status
+    printf '%d,%d,%d,%d,GET,/SEMP/v2/monitor/msgVpns/default\n' "$1" $(( $2 * MS )) $(( $3 * MS )) "$4"
+}
+
+log_info "Record-analysis self-test"
+
+# ── A paced record, shaped exactly like phase A's ────────────────────────────
+# Arrival 1 is the warm-up. Arrival 2 spends the ticker's buffered tick and so
+# sits only 80ms after it. Arrivals 3+ are paced at 200ms. This is the shape the
+# skip-2 in phase A exists for, and the skip-0 case below is what it prevents.
+paced="$TMP/paced.csv"
+: > "$paced"
+row 1 0 5 200 >> "$paced"
+row 2 700 705 200 >> "$paced"
+row 3 780 785 200 >> "$paced"
+t=780
+for i in 4 5 6 7 8 9 10 11 12 13; do
+    t=$((t + 200))
+    row "$i" "$t" $((t + 5)) 200 >> "$paced"
+done
+
+check "paced: count"                13        "$(record_count "$paced")"
+check "paced: bad statuses"         0         "$(record_bad_status "$paced")"
+check "paced: min gap, skip 2"      200       "$(record_min_gap_ms "$paced" 2)"
+check "paced: min gap, skip 0"      80        "$(record_min_gap_ms "$paced" 0)"
+check "paced: span, skip 2"         "2000 10" "$(record_span_ms "$paced" 2)"
+check "paced: span, skip 0"         "2780 12" "$(record_span_ms "$paced" 0)"
+check "paced: peak in-flight"       1         "$(record_max_inflight "$paced")"
+
+# ── An unpaced record, shaped like a pacer-control run ───────────────────────
+unpaced="$TMP/unpaced.csv"
+: > "$unpaced"
+row 1 0 150 200 >> "$unpaced"
+t=500
+for i in 2 3 4 5 6 7 8 9 10 11 12 13; do
+    row "$i" "$t" $((t + 150)) 200 >> "$unpaced"
+    t=$((t + 2))
+done
+check "unpaced: min gap, skip 1"    2         "$(record_min_gap_ms "$unpaced" 1)"
+check "unpaced: peak in-flight"     12        "$(record_max_inflight "$unpaced")"
+
+# ── A capped record: strictly two at a time ──────────────────────────────────
+capped="$TMP/capped.csv"
+: > "$capped"
+row 1 0 150 200 >> "$capped"
+n=1
+for wave in 0 1 2 3 4 5; do
+    s=$((500 + wave * 150))
+    n=$((n + 1)); row "$n" "$s" $((s + 150)) 200 >> "$capped"
+    n=$((n + 1)); row "$n" "$s" $((s + 150)) 200 >> "$capped"
+done
+check "capped: peak in-flight"      2         "$(record_max_inflight "$capped")"
+
+# ── Touching intervals are not an overlap ────────────────────────────────────
+# The sweep line must apply the -1 before the +1 on a tie, or a correct cap of
+# N reads as N+1 whenever one request ends exactly as the next begins.
+tie="$TMP/tie.csv"
+{ row 1 0 100 200; row 2 100 200 200; } > "$tie"
+check "touching intervals: peak"    1         "$(record_max_inflight "$tie")"
+
+triple="$TMP/triple.csv"
+{ row 1 0 100 200; row 2 10 90 200; row 3 20 80 200; } > "$triple"
+check "nested intervals: peak"      3         "$(record_max_inflight "$triple")"
+
+# ── Completion order is not arrival order ────────────────────────────────────
+# The tap appends as requests finish, so a slow early request lands after a fast
+# later one. Everything positional must sort by arrival first.
+ooo="$TMP/out-of-order.csv"
+{ row 1 300 310 200; row 2 0 900 200; row 3 600 610 200; } > "$ooo"
+check "out-of-order: min gap"       300       "$(record_min_gap_ms "$ooo" 0)"
+check "out-of-order: peak"          2         "$(record_max_inflight "$ooo")"
+
+# ── Degenerate inputs must not read as success ───────────────────────────────
+empty="$TMP/empty.csv"; : > "$empty"
+check "empty: count"                0         "$(record_count "$empty")"
+check "empty: min gap"              -1        "$(record_min_gap_ms "$empty" 2)"
+check "empty: span"                 "-1 0"    "$(record_span_ms "$empty" 2)"
+check "empty: peak"                 0         "$(record_max_inflight "$empty")"
+
+single="$TMP/single.csv"
+{ row 1 0 1 200; row 2 5 6 200; } > "$single"
+check "one arrival past skip: span" "-1 0"    "$(record_span_ms "$single" 1)"
+check "one arrival past skip: gap"  -1        "$(record_min_gap_ms "$single" 1)"
+
+errs="$TMP/errors.csv"
+{ row 1 0 1 502; row 2 1 2 200; row 3 2 3 0; } > "$errs"
+check "errors counted"              2         "$(record_bad_status "$errs")"
+
+# ── require_int rejects everything a broken helper could emit ────────────────
+# This is the guard that stops `[ "" -lt 13 ]` (which exits 2, not 1) from
+# falling through an `if` and returning success from an assertion function.
+int_guard_errors=0
+for bad in "" "abc" "1 2" "-" "1.5"; do
+    if require_int "$bad" "self-test" 2>/dev/null; then
+        int_guard_errors=$((int_guard_errors + 1))
+    fi
+done
+for good in 0 7 -1 12345; do
+    if ! require_int "$good" "self-test" 2>/dev/null; then
+        int_guard_errors=$((int_guard_errors + 1))
+    fi
+done
+check "require_int accept/reject"   0         "$int_guard_errors"
+
+if [ "$FAILURES" -ne 0 ]; then
+    log_fail "Record-analysis self-test: $FAILURES check(s) failed"
+    exit 1
+fi
+log_ok "Record-analysis self-test: all checks passed"

--- a/test/e2e-basic-mcp/test-throttling.sh
+++ b/test/e2e-basic-mcp/test-throttling.sh
@@ -1,0 +1,536 @@
+#!/usr/bin/env bash
+# Scenario 4: SEMP throttling held end to end against a real broker (SOL-153444).
+#
+# Rate limiting is one of the concrete protections we tell customers about, and
+# until now it was proven only by unit tests against an httptest server. This
+# scenario proves it against the Dockerized broker the rest of the suite uses.
+#
+# ── How it measures ──────────────────────────────────────────────────────────
+#
+# Client-side timing of tool calls cannot answer the question: one tool call is
+# not one SEMP request. So semp-tap, a recording reverse proxy, is placed
+# between the MCP server and broker-a, and a dedicated `broker-throttle` alias
+# is pointed at it. The broker is real and does the real work; the tap forwards
+# everything and records one line per request. Because the rate limiter and the
+# in-flight semaphore are keyed by broker alias, the record holds exactly this
+# scenario's traffic and nothing else.
+#
+# The measurement window is [request received -> response headers returned],
+# not full body-proxy completion, because Sender.Do drops its semaphore slot at
+# header time with the body still open. The tap's package comment explains this
+# at length; read it before touching an assertion here.
+#
+# ── Why four phases ──────────────────────────────────────────────────────────
+#
+# `semp:` is a single global block, and the two limits mask each other: with the
+# pacer at 200ms and a local broker answering in tens of milliseconds, in-flight
+# count never reaches 2, so a cap of 2 could never be shown to bind. Each limit
+# therefore gets a phase in which it is the only constraint, and its own control
+# that differs from it in exactly one variable:
+#
+#   label           interval  cap  delay   asserts
+#   A pacer          200ms     10    0     min gap >= floor, and span matches interval
+#   B cap            0s         2  150ms   max in-flight == 2
+#   C pacer-control  0s        10    0     min gap < floor AND span < floor   (A can fail)
+#   D cap-control    0s        10  150ms   max in-flight > 2                  (B can fail)
+#
+# C and D are the answer to "sanity-check that the assertion can actually fail".
+# They are real, always-on CI assertions rather than commented-out steps, so if
+# the tap ever stops being able to see a violation, the control goes red and
+# names the assertion that has gone blind.
+#
+# One shared control would have been cheaper, and wrong: it would differ from
+# the pacer phase in two variables at once (the interval AND the tap delay).
+# The pacing metrics happen to read only the arrival column, which the delay
+# never touches, but that is an argument rather than a guarantee and it would
+# quietly stop holding the first time LOAD_CALLS or HOLD_DELAY is tuned. The
+# split also has an empirical justification: with no tap delay the same load
+# peaks at ~5 in flight, not 10, so a delay-free run is a poor control for the
+# cap even though it is the right control for the pacer.
+#
+# ── Determinism ──────────────────────────────────────────────────────────────
+#
+# Every assertion is count-based or a generous lower bound. Nothing races a
+# wall clock:
+#
+#   * The pacer floor is half the interval, and the span tolerance is 10% of the
+#     span. Both are far wider than any jitter measured, and cost nothing —
+#     see the reasoning at GAP_FLOOR_MS below.
+#   * A CI runner under load makes gaps longer and requests overlap more. Both
+#     are the safe direction for every assertion here.
+#   * B and D hold each response an identical extra 150ms at the tap, so overlap
+#     is arithmetic instead of depending on how fast the broker answers. Both
+#     limits are still enforced by the server against a real broker; only the
+#     measurement window is widened, and identically in the phase and in its
+#     control.
+
+set -euo pipefail
+# BASH_SOURCE rather than $0 (the convention the executed-only scenario scripts
+# use), so the path still resolves when this file is sourced for the helper
+# tests described at the Main section below.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+# ── Knobs ────────────────────────────────────────────────────────────────────
+
+# The pacer interval under test, and the floor assertions are made against.
+# 200ms is tight enough to be unmistakable in a 12-request sample and loose
+# enough that no plausible scheduling delay manufactures a violation.
+THROTTLE_INTERVAL="200ms"
+THROTTLE_INTERVAL_MS=200
+# Pacing is asserted two ways, for the reason the unit test in
+# internal/semp/rate_limiter_shared_test.go asserts it two ways.
+#
+# Per-pair (GAP_FLOOR_MS) catches a single unpaced admission. It is the jittery
+# one: request k's transit from the limiter to the tap can be slower than
+# k+1's, which shortens an observed gap even when pacing is perfect. The floor
+# is therefore set at half the interval — a deliberately huge budget, because
+# widening it costs nothing. Every defect this guards against (limiter
+# disabled, limiter per protocol client instead of per broker, limiter not
+# shared) produces gaps near ZERO, not gaps a few milliseconds short, so a
+# 100ms floor is exactly as damning as a 190ms one. The measured spread on an
+# idle machine was 187-199ms; the target is a 2-vCPU CI runner sharing cores
+# with two broker containers, which is the case that cannot be measured here,
+# so the budget is sized for it rather than for the machine it was written on.
+#
+# Aggregate (SPAN_TOLERANCE_MS) is the precise one: per-pair jitter cancels out
+# over a run, so the total span is stable and a tight tolerance is safe there.
+# It is what actually catches systematic under-pacing that the generous
+# per-pair floor waves through — an interval quietly applied at half its
+# configured value shows up as ~1000ms against a ~1900ms floor.
+GAP_FLOOR_MS=$((THROTTLE_INTERVAL_MS / 2))
+SPAN_TOLERANCE_MS=200
+
+# The cap under test, and the slack value used where the cap must provably not
+# be the constraint (mirrors the reasoning in rate_limiter_shared_test.go).
+THROTTLE_CAP=2
+SLACK_CAP=10
+
+# Concurrent tool calls per phase. Comfortably above THROTTLE_CAP so the cap
+# binds in phase B, and large enough that phase A yields ten asserted gaps.
+LOAD_CALLS=12
+
+# Per-response hold at the tap in phases B and C. See "Determinism" above.
+HOLD_DELAY="150ms"
+
+# get-vpn-status is a single-step composite with no pagination and no fan-out:
+# exactly one SEMP request per tool call. That keeps the record trivially
+# interpretable and needs no fixture beyond the default VPN.
+LOAD_TOOL="get-vpn-status"
+
+# ── State ────────────────────────────────────────────────────────────────────
+
+# Installed at the bottom of the file, after the sourcing guard — see there.
+cleanup() {
+    stop_server
+    stop_semp_tap
+    return 0
+}
+
+# ── Record analysis ──────────────────────────────────────────────────────────
+# Record lines are appended in completion order, so anything positional must
+# sort by start timestamp first. Format: seq,start_ns,end_ns,status,method,path
+
+# Every numeric comparison below goes through this first.
+#
+# `[ "" -lt 13 ]` exits 2, not 1, and an `if` whose condition exits non-zero
+# takes the else branch — so an assertion function that only ever tests
+# `if [ "$n" -lt X ]; then fail; fi` falls off the end and RETURNS SUCCESS when
+# its input is empty. Arithmetic is worse: $(( )) silently reads an empty
+# string as 0, which turned a missing span into a negative floor that every
+# value cleared. A scenario whose whole thesis is "no assertion may pass
+# without evidence" cannot have guards that pass on no evidence.
+#   $1 value   $2 label for the failure message
+require_int() {
+    if [[ ! "$1" =~ ^-?[0-9]+$ ]]; then
+        log_fail "$2: expected a number from the record analysis, got '${1}' — treating as a failure"
+        return 1
+    fi
+    return 0
+}
+
+record_count() { wc -l < "$1" | tr -d ' '; }
+
+# Count of requests the broker did not answer with 200. A phase where every call
+# errored would otherwise show a beautifully paced record of nothing, and every
+# "gap >= floor" assertion would pass vacuously.
+record_bad_status() { awk -F, '$4 != 200 { n++ } END { print n + 0 }' "$1"; }
+
+# Smallest gap between consecutive arrivals, in milliseconds, after ignoring the
+# first $2 arrivals. -1 when there are too few arrivals left to form a gap.
+#
+# The skip exists because RateLimiter is a bare time.Ticker, not a token bucket.
+# Its channel buffers one tick, so idle time is credit and the first request
+# after an idle period is admitted with no wait at all. Phase A skips 2: the
+# warm-up call, and the one load request that spends the buffered tick. Phases
+# with the pacer off skip only the warm-up.
+record_min_gap_ms() {
+    sort -t, -k2,2n "$1" | awk -F, -v skip="$2" '
+        { n++; s[n] = $2 }
+        END {
+            min = -1
+            for (i = skip + 2; i <= n; i++) {
+                gap = s[i] - s[i-1]
+                if (min < 0 || gap < min) min = gap
+            }
+            if (min < 0) { print -1 } else { printf "%d\n", min / 1000000 }
+        }'
+}
+
+# Elapsed milliseconds from the first asserted arrival to the last, and the
+# number of gaps that span covers, as "span_ms gaps". Same $2 skip semantics as
+# record_min_gap_ms. Prints "-1 0" when there are too few arrivals to span.
+#
+# Aggregate pacing is checked against this rather than against the sum of the
+# individual gaps so that transit jitter cancels: one gap arriving 13ms early is
+# necessarily followed by one arriving 13ms late, and the span is unmoved.
+record_span_ms() {
+    sort -t, -k2,2n "$1" | awk -F, -v skip="$2" '
+        { n++; s[n] = $2 }
+        END {
+            first = skip + 1
+            if (n - first < 1) { print "-1 0"; exit }
+            printf "%d %d\n", (s[n] - s[first]) / 1000000, n - first
+        }'
+}
+
+# Peak number of requests in flight at the broker, by sweep line over the
+# [start, end) intervals. On a tie the -1 sorts before the +1, so a request that
+# ends exactly as another starts is not counted as an overlap.
+record_max_inflight() {
+    awk -F, '{ print $2 ",1"; print $3 ",-1" }' "$1" \
+        | sort -t, -k1,1n -k2,2n \
+        | awk -F, '{ cur += $2; if (cur > max) max = cur } END { print max + 0 }'
+}
+
+# ── Load driver ──────────────────────────────────────────────────────────────
+
+# One warm-up call, then $LOAD_CALLS concurrent tools/call on a single session.
+#
+# A single session is deliberate: go-sdk calls jsonrpc2.Async before dispatching
+# anything but `initialize`, so calls on one session genuinely overlap
+# server-side, and one session avoids the per-handshake stagger that N sessions
+# would add. If that ever regressed to serialised dispatch, phase C's
+# "max in-flight > 2" fails loudly rather than any phase passing quietly.
+#
+# The warm-up is what makes the ticker's buffered-tick behaviour deterministic
+# instead of accidental. It creates the BrokerClient (and starts the ticker),
+# and the sleep that follows guarantees exactly one buffered tick is waiting
+# when the load begins — the case record_min_gap_ms's skip accounts for.
+drive_load() {
+    local args
+    args=$(jq -nc '{broker:"broker-throttle",msgVpnName:"default"}')
+
+    log_info "  warm-up call (creates the broker client and starts the ticker) ..."
+    mcp_call_tool "$LOAD_TOOL" "$args" >/dev/null || {
+        log_fail "  warm-up call failed"
+        return 1
+    }
+    # Longer than the pacer interval, so the ticker has produced a tick and the
+    # channel holds exactly one (a Ticker drops ticks rather than queueing them).
+    sleep 0.5
+
+    local sid
+    sid=$(mcp_initialize) || return 1
+
+    log_info "  firing $LOAD_CALLS concurrent $LOAD_TOOL calls ..."
+    local pids=() i
+    for i in $(seq 1 "$LOAD_CALLS"); do
+        mcp_request "$sid" "$(jq -nc --argjson id "$i" --arg t "$LOAD_TOOL" --argjson a "$args" \
+            '{jsonrpc:"2.0",id:$id,method:"tools/call",params:{name:$t,arguments:$a}}')" \
+            >/dev/null 2>&1 &
+        pids+=("$!")
+    done
+    local p
+    for p in "${pids[@]}"; do
+        wait "$p" || true
+    done
+}
+
+# ── Phase runner ─────────────────────────────────────────────────────────────
+
+# Bring up a tap and a server configured for one phase, drive the load, then
+# tear both down so the record is complete before it is read.
+#   $1 phase label   $2 request_min_interval   $3 max_concurrent   $4 tap delay
+#   $5 record file
+run_phase() {
+    local label="$1" interval="$2" cap="$3" delay="$4" record="$5"
+
+    log_info "── Phase $label: request_min_interval=$interval max_concurrent_per_broker=$cap (tap delay=$delay)"
+
+    stop_server
+    stop_semp_tap
+
+    start_semp_tap "$BROKER_A_URL" "$record" "$delay" || return 1
+
+    # Configs live under bin/ rather than $TMPDIR, for the reason e2e-oauth
+    # keeps its own there: on a CI-only failure they are the only record of
+    # which limits were actually in force, and the workflow collects them.
+    local config="$BIN_DIR/mcp-config-throttle-$label.yaml"
+    write_throttle_config "$config" "$interval" "$cap"
+    start_server "$config" || return 1
+
+    drive_load || return 1
+
+    # Stop the server before the tap so no late request lands after the record
+    # has been read, and stop the tap before analysing so its last line is out.
+    stop_server
+    stop_semp_tap
+
+    log_info "  recorded $(record_count "$record") requests → $record"
+}
+
+# Shared guards: the load actually reached the broker, and the broker answered.
+# Both must hold before any pacing or concurrency number means anything.
+assert_record_sane() {
+    local record="$1" label="$2"
+    local n bad
+    n=$(record_count "$record")
+    bad=$(record_bad_status "$record")
+    require_int "$n" "$label (record count)" || return 1
+    require_int "$bad" "$label (bad-status count)" || return 1
+
+    # Warm-up plus the load. Greater-or-equal rather than equality so the check
+    # survives a tool gaining a step, while still catching a load that silently
+    # did not run.
+    if [ "$n" -lt $((LOAD_CALLS + 1)) ]; then
+        log_fail "$label: broker saw $n requests, want at least $((LOAD_CALLS + 1)) — the load did not reach the broker"
+        return 1
+    fi
+    if [ "$bad" -ne 0 ]; then
+        log_fail "$label: $bad of $n requests did not return 200 — a failed load cannot prove anything about pacing"
+        return 1
+    fi
+}
+
+# ── Phase A: the pacer ───────────────────────────────────────────────────────
+
+RECORD_A="$BIN_DIR/throttle-record-pacer.csv"
+
+test_pacer_spaces_requests() {
+    assert_record_sane "$RECORD_A" "pacer" || return 1
+
+    local min_gap
+    min_gap=$(record_min_gap_ms "$RECORD_A" 2)
+    require_int "$min_gap" "pacer (min gap)" || return 1
+    if [ "$min_gap" -lt 0 ]; then
+        log_fail "pacer: too few arrivals to form a gap"
+        return 1
+    fi
+    if [ "$min_gap" -lt "$GAP_FLOOR_MS" ]; then
+        log_fail "pacer: smallest gap between consecutive SEMP requests was ${min_gap}ms, want >= ${GAP_FLOOR_MS}ms"
+        log_fail "  semp.request_min_interval=$THROTTLE_INTERVAL is not being honored end to end against the broker"
+        return 1
+    fi
+
+    local span gaps span_floor
+    read -r span gaps < <(record_span_ms "$RECORD_A" 2)
+    require_int "$span" "pacer (span)" || return 1
+    require_int "$gaps" "pacer (gap count)" || return 1
+    # Without this, zero gaps would make the floor negative and the comparison
+    # below would pass on an empty sample — the exact vacuous pass this whole
+    # scenario exists to rule out.
+    if [ "$gaps" -lt 1 ]; then
+        log_fail "pacer: no paced gaps in the record to aggregate over"
+        return 1
+    fi
+    span_floor=$((gaps * THROTTLE_INTERVAL_MS - SPAN_TOLERANCE_MS))
+    if [ "$span" -lt "$span_floor" ]; then
+        log_fail "pacer: $gaps paced requests spanned ${span}ms, want >= ${span_floor}ms"
+        log_fail "  individual gaps cleared the floor but the aggregate rate is faster than semp.request_min_interval=$THROTTLE_INTERVAL"
+        return 1
+    fi
+
+    log_info "  smallest gap ${min_gap}ms >= floor ${GAP_FLOOR_MS}ms; $gaps gaps spanned ${span}ms >= ${span_floor}ms (interval $THROTTLE_INTERVAL)"
+}
+
+# ── Phase B: the in-flight cap ───────────────────────────────────────────────
+
+RECORD_B="$BIN_DIR/throttle-record-cap.csv"
+
+test_cap_bounds_inflight() {
+    assert_record_sane "$RECORD_B" "cap" || return 1
+
+    local peak
+    peak=$(record_max_inflight "$RECORD_B")
+    require_int "$peak" "cap (peak in-flight)" || return 1
+
+    if [ "$peak" -gt "$THROTTLE_CAP" ]; then
+        log_fail "cap: broker saw $peak concurrent SEMP requests, want at most $THROTTLE_CAP"
+        log_fail "  semp.max_concurrent_per_broker=$THROTTLE_CAP is not being honored end to end against the broker"
+        return 1
+    fi
+    # Equality, not just the bound: a peak below the cap would mean the load
+    # never pressed against it, and the upper bound above would have passed for
+    # the wrong reason.
+    if [ "$peak" -lt "$THROTTLE_CAP" ]; then
+        log_fail "cap: broker saw only $peak concurrent SEMP requests with $LOAD_CALLS calls in flight"
+        log_fail "  the cap of $THROTTLE_CAP was never pressed, so this phase proves nothing — check the tap delay and the load driver"
+        return 1
+    fi
+    log_info "  peak in-flight $peak == cap $THROTTLE_CAP"
+}
+
+# ── Phases C and D: the controls ─────────────────────────────────────────────
+#
+# Each control differs from the phase it validates in exactly ONE variable.
+# That matters more than it might look. A single shared control would differ
+# from the pacer phase in two variables at once (the interval AND the tap
+# delay), and while the pacing metrics happen to read only the arrival column
+# — which the delay never touches — that invariance is an argument, not a
+# guarantee, and it would quietly stop holding the first time LOAD_CALLS or
+# HOLD_DELAY is tuned. Two controls cost one extra server restart and remove
+# the argument entirely.
+#
+#   C  vs A: interval 200ms -> 0s     (cap 10 and delay 0 held constant)
+#   D  vs B: cap 2 -> 10              (interval 0s and delay 150ms held constant)
+
+RECORD_C="$BIN_DIR/throttle-record-pacer-control.csv"
+RECORD_D="$BIN_DIR/throttle-record-cap-control.csv"
+
+# Proves phase A's two pacing assertions can actually fail. If this passes while
+# A also passes, the pacer is doing real work. If this fails, the measurement has
+# gone blind and A's green is worthless — which is exactly what a self-checking
+# test should tell you.
+test_pacer_control_detects_unpaced() {
+    assert_record_sane "$RECORD_C" "pacer-control" || return 1
+
+    local min_gap
+    min_gap=$(record_min_gap_ms "$RECORD_C" 1)
+    require_int "$min_gap" "pacer-control (min gap)" || return 1
+    if [ "$min_gap" -lt 0 ]; then
+        log_fail "pacer-control: too few arrivals to form a gap"
+        return 1
+    fi
+    if [ "$min_gap" -ge "$GAP_FLOOR_MS" ]; then
+        log_fail "pacer-control: with request_min_interval=0s the smallest gap was still ${min_gap}ms (>= floor ${GAP_FLOOR_MS}ms)"
+        log_fail "  the per-pair assertion in phase A cannot tell a paced run from an unpaced one, so it is not testing anything"
+        return 1
+    fi
+
+    # Phase A asserts pacing twice, so its control has to trip both. Without
+    # this, the aggregate check in phase A would have no proof it can fail.
+    local span gaps span_floor
+    read -r span gaps < <(record_span_ms "$RECORD_C" 1)
+    require_int "$span" "pacer-control (span)" || return 1
+    require_int "$gaps" "pacer-control (gap count)" || return 1
+    if [ "$gaps" -lt 1 ]; then
+        log_fail "pacer-control: no gaps in the record to aggregate over"
+        return 1
+    fi
+    span_floor=$((gaps * THROTTLE_INTERVAL_MS - SPAN_TOLERANCE_MS))
+    if [ "$span" -ge "$span_floor" ]; then
+        log_fail "pacer-control: with request_min_interval=0s $gaps requests still spanned ${span}ms (>= ${span_floor}ms)"
+        log_fail "  the aggregate assertion in phase A cannot tell a paced run from an unpaced one"
+        return 1
+    fi
+
+    log_info "  unpaced run shows gap ${min_gap}ms < floor ${GAP_FLOOR_MS}ms and span ${span}ms < ${span_floor}ms"
+}
+
+# Proves phase B's cap assertion can actually fail. Identical to B in every
+# respect except the cap itself.
+test_cap_control_detects_uncapped() {
+    assert_record_sane "$RECORD_D" "cap-control" || return 1
+
+    local peak
+    peak=$(record_max_inflight "$RECORD_D")
+    require_int "$peak" "cap-control (peak in-flight)" || return 1
+
+    if [ "$peak" -le "$THROTTLE_CAP" ]; then
+        log_fail "cap-control: with max_concurrent_per_broker=$SLACK_CAP the peak in-flight was only $peak (<= $THROTTLE_CAP)"
+        log_fail "  the assertion in phase B cannot tell a capped run from an uncapped one, so it is not testing anything"
+        return 1
+    fi
+    log_info "  uncapped run shows peak in-flight $peak > cap $THROTTLE_CAP"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+# Sourcing this file yields the record-analysis helpers above without running
+# any phase. test-throttling-analysis.sh is the consumer: it exercises the gap
+# and sweep-line arithmetic on synthetic records, which is the one part of this
+# scenario that needs neither a broker nor Docker. run-all.sh executes this file,
+# so the suite is unaffected.
+#
+# The guard sits above the trap deliberately. Installing an EXIT trap in a
+# sourcing shell would silently replace whatever trap that shell already had.
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    return 0
+fi
+
+trap cleanup EXIT INT TERM HUP
+
+log_info "=== Scenario 4: SEMP throttling (SOL-153444) ==="
+log_info ""
+
+# Check the measurement before spending three server restarts on it. If the gap
+# or sweep-line arithmetic is wrong, every verdict below is meaningless, and
+# this says so in under a second instead of after a minute of phases.
+if ! bash "$SCRIPT_DIR/test-throttling-analysis.sh"; then
+    log_fail "Record-analysis self-test failed; the throttling assertions cannot be trusted"
+    exit 1
+fi
+
+check_build_deps
+wait_for_all_brokers 90
+build_server
+build_semp_tap
+
+# Scenarios 1-3 left a server on $MCP_PORT. Take it over deliberately rather
+# than letting start_server's port sweep do it silently, so a stale process is
+# never mistaken for one of this scenario's own phases. This scenario runs last
+# in run-all.sh precisely so it is free to do this.
+if [ -f "$BIN_DIR/mcp-server.pid" ]; then
+    log_info "Stopping the shared suite server before taking over port $MCP_PORT ..."
+    kill_gracefully "$(cat "$BIN_DIR/mcp-server.pid")"
+    rm -f "$BIN_DIR/mcp-server.pid"
+fi
+
+# Each phase runs even if an earlier one failed, so a pacer regression does not
+# hide the cap result and neither hides either control's verdict.
+#
+# Every control holds all but one variable constant against the phase it
+# validates: C changes only the interval against A, D changes only the cap
+# against B.
+PHASE_A_OK=0
+PHASE_B_OK=0
+PHASE_C_OK=0
+PHASE_D_OK=0
+
+#                label           interval             cap              delay          record
+if run_phase "pacer"         "$THROTTLE_INTERVAL" "$SLACK_CAP"    "0"           "$RECORD_A"; then
+    PHASE_A_OK=1
+fi
+if run_phase "cap"           "0s"                 "$THROTTLE_CAP" "$HOLD_DELAY" "$RECORD_B"; then
+    PHASE_B_OK=1
+fi
+if run_phase "pacer-control" "0s"                 "$SLACK_CAP"    "0"           "$RECORD_C"; then
+    PHASE_C_OK=1
+fi
+if run_phase "cap-control"   "0s"                 "$SLACK_CAP"    "$HOLD_DELAY" "$RECORD_D"; then
+    PHASE_D_OK=1
+fi
+
+log_info ""
+
+# A phase that could not even run (broker gone, port taken, tap failed to bind)
+# is a failure, not a skip. Counting it as a failure keeps the summary table's
+# arithmetic honest and stops a broken harness reading as a green suite.
+report_phase() {
+    local ok="$1" name="$2" func="$3"
+    if [ "$ok" -eq 1 ]; then
+        run_test "$name" "$func"
+        return
+    fi
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    log_fail "$name (phase did not complete — see the log above)"
+}
+
+report_phase "$PHASE_A_OK" "Pacer spaces SEMP requests by request_min_interval" test_pacer_spaces_requests
+report_phase "$PHASE_B_OK" "In-flight cap bounds concurrent SEMP requests"      test_cap_bounds_inflight
+report_phase "$PHASE_C_OK" "Control: pacer off trips both pacing assertions"    test_pacer_control_detects_unpaced
+report_phase "$PHASE_D_OK" "Control: cap slack trips the in-flight assertion"   test_cap_control_detects_uncapped
+
+print_summary "Throttling tests"

--- a/test/e2e-common/README.md
+++ b/test/e2e-common/README.md
@@ -11,6 +11,7 @@ Shared infrastructure for the E2E test suites (`e2e-monitoring`, `e2e-management
 | `lib.sh::MCP_PROTOCOL_VERSION` | The `protocolVersion` every suite pins in its `initialize` handshake (default `2025-11-25`), overridable from the environment. `mcp_initialize` fails if the server negotiates something else — see the comment at the definition for why the pin is not go-sdk's latest revision |
 | `setup-brokers.sh` | Bring a suite's brokers up and wait for readiness |
 | `start-server.sh` | Build the MCP server and start it against a suite's brokers |
+| `semp-tap/` | Recording reverse proxy (own `go.mod`, stdlib only). Sits between the MCP server and a real broker and records one line per SEMP request, so a suite can assert on the rate and in-flight concurrency the broker actually sees. Used by `e2e-basic-mcp`'s throttling scenario; lifecycle helpers are `build_semp_tap` / `start_semp_tap` / `stop_semp_tap` in `lib.sh`. Its package comment documents the measurement window — read it before writing an assertion on the record |
 
 ## Quickstart pattern
 

--- a/test/e2e-common/lib.sh
+++ b/test/e2e-common/lib.sh
@@ -359,6 +359,95 @@ stop_broker_drivers() {
     sleep 3
 }
 
+# ── semp-tap (recording reverse proxy in front of a real broker) ─────────────
+# semp-tap sits between the MCP server and a real Dockerized broker and records
+# one line per SEMP request, so a suite can assert on the request rate and
+# in-flight concurrency the broker actually sees rather than on client-side
+# wall-clock timing. The broker is still real; the tap only observes.
+#
+# Used by the throttling scenario (SOL-153444). Point one broker alias's url at
+# $SEMP_TAP_URL and leave every other alias pointed straight at its broker, and
+# the record holds exactly that alias's traffic — the per-broker rate limiter and
+# in-flight semaphore are keyed by alias, so nothing else pollutes the sample.
+#
+# Sources live in test/e2e-common/semp-tap with their own go.mod (stdlib only).
+# The measurement-window subtlety is documented at length in its package comment;
+# read that before changing an assertion built on the record.
+
+SEMP_TAP_PORT="${SEMP_TAP_PORT:-8084}"
+SEMP_TAP_URL="http://localhost:${SEMP_TAP_PORT}"
+SEMP_TAP_PID=""
+
+build_semp_tap() {
+    log_info "Building semp-tap binary (recording reverse proxy) ..."
+    mkdir -p "$BIN_DIR"
+    (cd "$REPO_ROOT/test/e2e-common/semp-tap" && go build -o "$BIN_DIR/semp-tap" .)
+    log_info "semp-tap binary built: $BIN_DIR/semp-tap"
+}
+
+# Start the tap and block until its socket is bound.
+#   $1 upstream    real broker base URL to forward to (e.g. $BROKER_A_URL)
+#   $2 record      path to write the CSV request record to
+#   $3 delay       optional per-response hold (default 0); see the package doc
+start_semp_tap() {
+    local upstream="$1"
+    local record="$2"
+    local delay="${3:-0}"
+    local readyfile="$BIN_DIR/semp-tap.ready"
+    local logfile="$BIN_DIR/semp-tap.log"
+
+    # Clear a tap left behind by a crashed run, the way start_server sweeps
+    # MCP_PORT. Without this a stale listener turns every phase into a
+    # bind failure whose real cause is one run ago.
+    local existing_pid
+    existing_pid=$(lsof -ti:"$SEMP_TAP_PORT" 2>/dev/null || true)
+    if [ -n "$existing_pid" ]; then
+        log_warn "Killing existing process on semp-tap port $SEMP_TAP_PORT (PID=$existing_pid)"
+        kill_gracefully $existing_pid
+    fi
+
+    rm -f "$readyfile"
+    "$BIN_DIR/semp-tap" \
+        -listen ":$SEMP_TAP_PORT" \
+        -upstream "$upstream" \
+        -record "$record" \
+        -delay "$delay" \
+        -ready-file "$readyfile" \
+        >"$logfile" 2>&1 &
+    SEMP_TAP_PID=$!
+
+    # Wait on the bound socket, not a sleep. The MCP server starts next and its
+    # first tool call would otherwise race the listener into a connection-refused
+    # flake at the start of a phase.
+    local attempt=0
+    while [ $attempt -lt 40 ] && [ ! -s "$readyfile" ]; do
+        sleep 0.25
+        attempt=$((attempt + 1))
+    done
+    if [ ! -s "$readyfile" ]; then
+        log_fail "semp-tap did not bind $SEMP_TAP_URL within 10s; last 20 lines of $logfile:"
+        tail -n 20 "$logfile" >&2 2>/dev/null || true
+        # Reap it before dropping the PID. A tap that bound the port but never
+        # wrote the ready file would otherwise survive as an orphan and make the
+        # next phase's bind fail for a reason that looks unrelated.
+        stop_semp_tap
+        return 1
+    fi
+    log_info "semp-tap ready on $SEMP_TAP_URL → $upstream (delay=$delay, record=$record)"
+}
+
+stop_semp_tap() {
+    if [ -z "$SEMP_TAP_PID" ] || ! kill -0 "$SEMP_TAP_PID" 2>/dev/null; then
+        SEMP_TAP_PID=""
+        return 0
+    fi
+    log_info "Stopping semp-tap (PID=$SEMP_TAP_PID) ..."
+    # Graceful: the tap flushes each record as it completes, but SIGTERM lets an
+    # in-flight request finish and be recorded rather than vanish from the sample.
+    kill_gracefully "$SEMP_TAP_PID"
+    SEMP_TAP_PID=""
+}
+
 # Generate the MCP server config from .env-derived values so ports stay in sync.
 # Credentials use ${VAR_NAME} substitution — resolved by the server via ENV_FILE.
 # enable_write_tools is on for every suite: all suites exercise one server with

--- a/test/e2e-common/semp-tap/go.mod
+++ b/test/e2e-common/semp-tap/go.mod
@@ -1,0 +1,3 @@
+module github.com/SolaceProducts/solace-broker-mcp/test/e2e-common/semp-tap
+
+go 1.25.0

--- a/test/e2e-common/semp-tap/main.go
+++ b/test/e2e-common/semp-tap/main.go
@@ -78,10 +78,12 @@
 //
 //	seq,start_unix_nanos,end_unix_nanos,status,method,path
 //
-// start is when the tap received the request; end is after any -delay, when the
-// headers are handed back downstream. A request whose upstream call failed is
-// recorded with status 0 so a run that silently errored cannot masquerade as a
-// well-paced one.
+// start is when the tap received the request; end is stamped inside
+// ModifyResponse: after any -delay, once the upstream headers are available, and
+// before ReverseProxy writes them downstream. The record line is written and
+// fsynced in between, so end always sits slightly before the downstream header
+// write, never after. A request whose upstream call failed is recorded with
+// status 0 so a run that silently errored cannot masquerade as a well-paced one.
 //
 // Usage:
 //
@@ -100,6 +102,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -110,6 +113,21 @@ import (
 // ModifyResponse. A context value is the only channel the two share, since
 // ReverseProxy gives ModifyResponse the *http.Response and nothing else.
 type startKey struct{}
+
+// userinfoPattern matches the "user:pass@" segment of a URL. httputil's
+// ReverseProxy hands ErrorHandler the raw dial/roundtrip error, and a
+// *url.Error prints its URL verbatim — this module is stdlib-only (own
+// go.mod) and can't reach internal/config's SanitizeURLString, so errors
+// get their own narrow scrub before they reach the log.
+var userinfoPattern = regexp.MustCompile(`://[^/@\s]*@`)
+
+// sanitizeErrForLog strips embedded userinfo from an error's message before
+// logging. The tap points at test brokers today, but the upstream URL is
+// operator-supplied (-upstream), so nothing here should assume it never
+// carries credentials.
+func sanitizeErrForLog(err error) string {
+	return userinfoPattern.ReplaceAllString(err.Error(), "://")
+}
 
 // recorder serialises record lines to the record file. Every line is written
 // and flushed as it completes, so a run that is killed mid-phase still leaves a
@@ -212,9 +230,10 @@ func main() {
 		*req = *req.WithContext(context.WithValue(req.Context(), startKey{}, time.Now()))
 	}
 
-	// End of the measurement window. Fires when the upstream response headers
-	// are available and before they are written downstream — the same instant
-	// the MCP server's Sender.Do returns and drops its semaphore slot.
+	// End of the measurement window. Fires once the upstream response headers are
+	// available and before they are written downstream, which is strictly before
+	// the MCP server's Sender.Do returns and drops its semaphore slot (see "The
+	// measurement window" above).
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if *delay > 0 {
 			select {
@@ -233,7 +252,7 @@ func main() {
 	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
 		start, _ := req.Context().Value(startKey{}).(time.Time)
 		rec.record(start, time.Now(), 0, req.Method, req.URL.Path)
-		log.Printf("semp-tap: upstream error for %s %s: %v", req.Method, req.URL.Path, err)
+		log.Printf("semp-tap: upstream error for %s %s: %s", req.Method, req.URL.Path, sanitizeErrForLog(err))
 		w.WriteHeader(http.StatusBadGateway)
 	}
 

--- a/test/e2e-common/semp-tap/main.go
+++ b/test/e2e-common/semp-tap/main.go
@@ -1,0 +1,287 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command semp-tap is a recording reverse proxy placed between the MCP server
+// and a real Solace broker, so an e2e test can measure the SEMP request rate
+// and in-flight concurrency the broker actually sees.
+//
+// The broker stays real: the tap forwards every request upstream unmodified and
+// returns the broker's own response. It only observes. Point a broker alias's
+// url at the tap and leave the rest of the suite pointed straight at the broker,
+// and the record contains exactly the traffic that alias generated.
+//
+// # Why not just time the tool calls
+//
+// One MCP tool call is not one SEMP request: a composite tool can fan out to
+// several, pagination adds more, and retries add attempts the client never sees.
+// Client-side timing therefore cannot say what rate the broker experienced. The
+// tap can, because it sits where the broker does.
+//
+// # The measurement window — this is the subtle part
+//
+// resilience.Sender releases its per-broker in-flight semaphore slot when Do
+// returns, and Do returns as soon as the response HEADERS are available; the
+// body is handed back to the caller still open (see the `defer func() { <-d.sem
+// }()` in internal/semp/resilience/sender.go). So a request stops occupying a
+// slot at header time, not when its body finishes streaming.
+//
+// The tap must therefore measure in-flight over
+//
+//	[request received  →  response headers handed back downstream]
+//
+// and NOT over the full body-proxying duration. Measuring the wider window
+// would report a correct cap of 2 as an occasional 3, because the server is
+// entitled to admit a new request while a previous body is still draining.
+// ModifyResponse fires at exactly the right moment, which is why the end
+// timestamp is taken there rather than after ServeHTTP returns.
+//
+// With the end timestamp taken there, the error can only run one way. The
+// server's Do does not return until it has read the response headers off the
+// wire, which is strictly after the tap stamped its end time and handed those
+// headers downstream. The semaphore slot is therefore held over a superset of
+// the window the tap measures, so the tap can only ever UNDER-count overlap
+// relative to the semaphore, never over-count it. A cap assertion built on this
+// record cannot produce a false violation; the worst it can do is miss one,
+// which is what the control phase exists to rule out.
+//
+// For the same reason the tap counts REQUESTS, never connections.
+// semp.max_concurrent_per_broker also sizes the HTTP transport's
+// MaxConnsPerHost per protocol client (internal/semp/resilience/transport.go),
+// so up to 2x the cap in TCP connections can legitimately exist against one
+// broker. Connections are not the enforced bound; the shared semaphore is.
+//
+// # -delay
+//
+// With no delay, whether N concurrent requests genuinely overlap depends on how
+// fast the broker answers, which makes a concurrency assertion luck-dependent on
+// a fast runner. -delay holds each response for a fixed period after the broker
+// has answered and before the headers go back downstream. That widens the
+// semaphore hold and the measured window by the same amount, so overlap becomes
+// arithmetic rather than luck. The broker still does the real work; only the
+// measurement window is stretched. Apply the same delay to a phase and its
+// control so the comparison stays honest.
+//
+// # Record format
+//
+// One CSV line per request, no header row, appended in completion order:
+//
+//	seq,start_unix_nanos,end_unix_nanos,status,method,path
+//
+// start is when the tap received the request; end is after any -delay, when the
+// headers are handed back downstream. A request whose upstream call failed is
+// recorded with status 0 so a run that silently errored cannot masquerade as a
+// well-paced one.
+//
+// Usage:
+//
+//	semp-tap -listen :8084 -upstream http://localhost:8080 -record /path/rec.csv [-delay 150ms]
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// startKey carries a request's arrival timestamp from the Director to
+// ModifyResponse. A context value is the only channel the two share, since
+// ReverseProxy gives ModifyResponse the *http.Response and nothing else.
+type startKey struct{}
+
+// recorder serialises record lines to the record file. Every line is written
+// and flushed as it completes, so a run that is killed mid-phase still leaves a
+// usable partial record for diagnosis rather than an empty file.
+type recorder struct {
+	mu  sync.Mutex
+	f   *os.File
+	seq atomic.Int64
+}
+
+func newRecorder(path string) (*recorder, error) {
+	// Truncate: each phase gets its own file and must not inherit a previous
+	// run's arrivals, which would corrupt every gap and overlap computation.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open record file: %w", err)
+	}
+	return &recorder{f: f}, nil
+}
+
+func (r *recorder) record(start, end time.Time, status int, method, path string) {
+	// A zero start means the arrival stamp did not survive to here. Most
+	// ErrorHandler call sites in net/http/httputil hand back the INBOUND request
+	// rather than the one the Director stamped, so this is reachable on some
+	// error paths. Left alone, time.Time{}.UnixNano() is a large negative number
+	// that would sort ahead of every real arrival and poison every gap and
+	// overlap computation for the phase. Collapse it to a zero-duration event at
+	// the right point in time instead, and say so.
+	if start.IsZero() {
+		log.Printf("semp-tap: no arrival timestamp for %s %s; recording it as zero-duration", method, path)
+		start = end
+	}
+	n := r.seq.Add(1)
+	line := fmt.Sprintf("%d,%d,%d,%d,%s,%s\n", n, start.UnixNano(), end.UnixNano(), status, method, path)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, err := r.f.WriteString(line); err != nil {
+		log.Printf("semp-tap: write record: %v", err)
+		return
+	}
+	// Sync rather than rely on process exit: the analysing shell reads this file
+	// immediately after the tap is signalled, and an unflushed tail would show up
+	// as missing arrivals — which reads as a passing pacer test.
+	if err := r.f.Sync(); err != nil {
+		log.Printf("semp-tap: sync record: %v", err)
+	}
+}
+
+func (r *recorder) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.f.Close()
+}
+
+func main() {
+	listen := flag.String("listen", "", "address to listen on, e.g. :8084 (required)")
+	upstream := flag.String("upstream", "", "real broker base URL to forward to, e.g. http://localhost:8080 (required)")
+	record := flag.String("record", "", "path to write the CSV request record to (required)")
+	delay := flag.Duration("delay", 0, "hold each response for this long after the broker answers and before returning headers downstream; widens the semaphore hold and the measured window identically so concurrency is arithmetic rather than luck")
+	ready := flag.String("ready-file", "", "optional path to write the listening address to once the socket is bound; the harness polls for it instead of sleeping")
+	flag.Parse()
+
+	if *listen == "" || *upstream == "" || *record == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *delay < 0 {
+		log.Fatalf("semp-tap: -delay must be >= 0, got %s", *delay)
+	}
+
+	// The suite always passes a credential-free broker URL, but nothing stops a
+	// future caller passing http://user:pass@host. Neither the raw flag value
+	// nor url.Parse's error (which embeds the URL it was given) is safe to log,
+	// and URL.String() prints userinfo in the clear — hence Redacted() at the
+	// one place the upstream is echoed, and no URL at all in these two errors.
+	// Rule C-05 in docs/internal/secure-logging-rules.md.
+	target, err := url.Parse(*upstream)
+	if err != nil {
+		log.Fatal("semp-tap: -upstream is not a valid URL")
+	}
+	if target.Scheme == "" || target.Host == "" {
+		log.Fatal("semp-tap: -upstream must be an absolute URL with scheme and host")
+	}
+
+	rec, err := newRecorder(*record)
+	if err != nil {
+		log.Fatalf("semp-tap: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	// Stamp the arrival time and rewrite Host. NewSingleHostReverseProxy sets
+	// URL.Scheme/Host but leaves req.Host as the tap's own address; forwarding
+	// the upstream's Host keeps the broker seeing what it would see directly.
+	inner := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		inner(req)
+		req.Host = target.Host
+		*req = *req.WithContext(context.WithValue(req.Context(), startKey{}, time.Now()))
+	}
+
+	// End of the measurement window. Fires when the upstream response headers
+	// are available and before they are written downstream — the same instant
+	// the MCP server's Sender.Do returns and drops its semaphore slot.
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		if *delay > 0 {
+			select {
+			case <-time.After(*delay):
+			case <-resp.Request.Context().Done():
+			}
+		}
+		start, _ := resp.Request.Context().Value(startKey{}).(time.Time)
+		rec.record(start, time.Now(), resp.StatusCode, resp.Request.Method, resp.Request.URL.Path)
+		return nil
+	}
+
+	// An upstream failure must still land in the record. Without this the
+	// request simply vanishes, and a phase where every call errored would show
+	// zero arrivals — which every "gap >= interval" assertion passes vacuously.
+	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		start, _ := req.Context().Value(startKey{}).(time.Time)
+		rec.record(start, time.Now(), 0, req.Method, req.URL.Path)
+		log.Printf("semp-tap: upstream error for %s %s: %v", req.Method, req.URL.Path, err)
+		w.WriteHeader(http.StatusBadGateway)
+	}
+
+	ln, err := net.Listen("tcp", *listen)
+	if err != nil {
+		log.Fatalf("semp-tap: listen on %s: %v", *listen, err)
+	}
+
+	srv := &http.Server{
+		Handler: proxy,
+		// No ReadHeaderTimeout would trip gosec G112. The suite's requests are
+		// local and immediate, so a short bound is safe and keeps a wedged peer
+		// from pinning a goroutine for the whole phase.
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	// Readiness is the bound socket, not a sleep: the harness starts the MCP
+	// server as soon as this file appears, and a race there shows up as a
+	// connection-refused flake in the first tool call of a phase.
+	if *ready != "" {
+		if err := os.WriteFile(*ready, []byte(ln.Addr().String()+"\n"), 0o600); err != nil {
+			log.Fatalf("semp-tap: write -ready-file: %v", err)
+		}
+	}
+	log.Printf("semp-tap: listening on %s, forwarding to %s, recording to %s (delay=%s)",
+		ln.Addr(), target.Redacted(), *record, *delay)
+
+	// SIGTERM is how the harness stops a phase. Shut down gracefully so an
+	// in-flight request still gets its record line written.
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		<-stop
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}()
+
+	if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("semp-tap: serve: %v", err)
+	}
+
+	// Serve returns the instant Shutdown is CALLED, not when it finishes.
+	// Returning here would end main, run the deferred file close, and kill every
+	// in-flight handler before it could write its record line — so a request
+	// still at the broker when the harness stopped the tap would vanish from the
+	// sample and show up as an unexplained short record. Wait for the drain.
+	<-drained
+}


### PR DESCRIPTION
Rate limiting is one of the concrete things we tell customers protects their broker, and until now it was proven only by unit tests against an `httptest` server. This adds a fourth scenario to `test/e2e-basic-mcp` that proves `semp.request_min_interval` and `semp.max_concurrent_per_broker` hold end to end against the Dockerized broker the suite already runs.

Test-only. No production code changes, so no CHANGELOG entry.

## The one thing worth understanding before reviewing

Client-side timing of tool calls cannot answer this question. One tool call is not one SEMP request: composites fan out, pagination adds more, retries add attempts the client never sees. So a recording reverse proxy (`test/e2e-common/semp-tap`, own go.mod, stdlib only) sits between the MCP server and broker-a, behind a dedicated `broker-throttle` alias. The broker is real and does the real work. The tap forwards everything and records one line per request.

**The measurement window is the subtle part.** `Sender.Do` releases its semaphore slot when the response *headers* arrive, with the body still open:

```go
// internal/semp/resilience/sender.go
defer func() { <-d.sem }()   // Do returns with resp.Body still open
```

So a request stops occupying a slot at header time, not when its body finishes streaming. The tap therefore measures in-flight over `[request received → response headers returned]` using `ModifyResponse`, and not over full body-proxy completion. Measuring the wider window would report a correct cap of 2 as an occasional 3, because the server is entitled to admit a new request while a previous body is still draining.

For the same reason the tap counts requests, never connections. `max_concurrent_per_broker` also sizes the transport's `MaxConnsPerHost` per protocol client, so up to twice the cap in TCP connections can legitimately exist against one broker.

## Four phases, because the two limits mask each other

`semp:` is a single global block. With the pacer at 200ms and a local broker answering in tens of milliseconds, in-flight count never reaches 2, so a cap of 2 could never be shown to bind. Each limit gets a phase where it is the only constraint, plus its own control. The server restarts between phases, following the `e2e-oauth` pattern.

| Phase | `request_min_interval` | `max_concurrent_per_broker` | Tap delay | Asserts |
| --- | --- | --- | --- | --- |
| pacer | `200ms` | `10` (slack) | 0 | every gap >= 100ms, and aggregate span >= gaps x 200ms - 200ms |
| cap | `0s` | `2` | 150ms | peak in-flight == 2 |
| pacer-control | `0s` | `10` (slack) | 0 | the inverse of the pacer phase |
| cap-control | `0s` | `10` (slack) | 150ms | the inverse of the cap phase |

The controls are the ticket's "sanity-check the assertion itself" step. Each runs the identical load with its limit off and asserts the inverse. Keeping them as real always-on CI assertions rather than manual steps means they cannot rot: if the tap ever stops being able to see a violation, the control goes red and names the assertion that has gone blind.

Each control differs from the phase it validates in exactly one variable. That is worth the extra restart. A single shared control would differ from the pacer phase in both the interval and the tap delay at once, and it is empirically the wrong shape too: with no tap delay the same load peaks at only ~5 in flight rather than 10, so a delay-free run is a poor control for the cap even though it is the right control for the pacer.

## Keeping it off the flake list

- Every assertion is count-based or a generous lower bound. A loaded runner makes gaps longer and requests overlap more. Both are the safe direction.
- Pacing is asserted twice, mirroring `rate_limiter_shared_test.go`. The per-pair floor is half the interval, a deliberately huge budget, because widening costs nothing: every defect it guards against produces gaps near zero, not gaps a few milliseconds short. The aggregate span is the precise check, because jitter cancels over a run. Measured on an idle machine: min gaps 187-199ms against a 100ms floor, spans 1999-2008ms against an 1800ms floor. The floors are sized for a 2-vCPU runner sharing cores with two broker containers, which is the case that cannot be measured here.
- Every numeric result from the record analysis passes a `require_int` guard before any comparison. `[ "" -lt 13 ]` exits 2, not 1, so an `if` that only tests for the failure case falls through and returns success. That is precisely the vacuous pass this scenario exists to rule out, so the guards cannot have one of their own.
- `retries: 0` in the throttle config. Retries are explicitly not paced, so a transient blip would otherwise inject arrivals no gap assertion accounts for.
- A warm-up call plus a skip of the first arrivals. `RateLimiter` is a bare `time.Ticker`, not a token bucket, so idle time is credit and the first request after idle is admitted free. The warm-up makes that deterministic instead of accidental. Observed directly: min gap is 199ms with the skip and 27-137ms without it.
- The cap phase and its control hold each response an identical extra 150ms at the tap, so overlap is arithmetic rather than a race against how fast the broker answers. Both limits are still enforced by the real server against a real broker. Only the measurement window widens, and it widens the same way in the phase and in its control.

## Verification

Docker was not available where I built this, so the local work was done against a SEMP stub. CI has since run the real thing three times against the Dockerized brokers, and all three are green with wide margins:

| Run | Pacer min gap (floor 100ms) | Pacer span (floor 1800ms) | Cap peak | Cap-control peak |
| --- | --- | --- | --- | --- |
| 1 | 194ms | 1994ms | 2 | 10 |
| 2 | 199ms | 1999ms | 2 | 10 |
| 3 | 199ms | 1999ms | 2 | 10 |

The scenario adds about 70 seconds to the job, which now runs in ~2m20s.

Also verified:

- `make check` passes. Coverage 89.4%.
- `go build` and `go vet` clean on the new module. Added to CI's vet step alongside `broker-driver`.
- The record-analysis arithmetic, against synthetic records: skip semantics, tie handling at interval boundaries, nested intervals, out-of-order completion, empty and single-arrival inputs, error statuses, and the `require_int` guard. 22 checks. This ships as `test-throttling-analysis.sh`: the scenario runs it first, before spending four server restarts on a measurement it has not verified, and it also runs standalone in about a second with no Docker.
- The full chain seventeen times against the local stub, stable every run.
- That each assertion fails on the wrong data, and on missing data. Feeding the pacer assertion the unpaced record fails it, feeding the cap assertion the uncapped record fails it, feeding each control its throttled counterpart fails it, and pointing any of the four at a nonexistent record fails it. Eight cases, each with an accurate diagnostic.
- That the tap does not drop records when signalled mid-request, and that a dead upstream is recorded as status 0 rather than vanishing.

Three runs is a small sample. Worth a re-run if you want more confidence before merging, though the margins above leave a lot of room.

## If it does flake

The knobs are three constants at the top of `test-throttling.sh`: `GAP_FLOOR_MS` (half the interval), `SPAN_TOLERANCE_MS` (200), and `HOLD_DELAY` (150ms). There is a lot of room left to widen without losing sensitivity, because every failure mode this guards against produces gaps near zero rather than gaps a few milliseconds short.

## Notes

- Runs under `make e2e-all` and the existing `e2e-basic-mcp` CI job. No new container, no new job, no manual step.
- Scenario 4 runs last because it takes over port 9090 from the shared server the earlier scenarios use.
- `SEMP_TAP_PORT=8084`, unused by any other suite.
- On failure, CI now dumps the per-phase records and configs, which are the evidence behind a timing verdict. Deliberately not the server log: that step fires on any failure in the job, including scenarios that never asked for it.
- Out of scope per the ticket: the fairness (SOL-153441) and fail-fast (SOL-153442) work. This covers the pacer and cap behavior as it exists today and does not depend on either.
- Worth a follow-up: if SOL-153443 lands a saturation metric, the cap phase could assert on that directly instead of inferring concurrency at the tap.
