### PR TITLE
SOL-153937: pin inventory closure computation to GOOS=linux

### DIFF
--- a/.github/scripts/build-test-licenses-check.sh
+++ b/.github/scripts/build-test-licenses-check.sh
@@ -215,9 +215,13 @@ while read -r gomod; do
     # so the closure silently empties and the reverse-direction check then
     # reports every real component as unused — telling a maintainer to delete
     # legitimate rows from a compliance artifact.
+    #
+    # GOOS pinned to linux for the same reason as licenses-check.sh: the
+    # closure is platform-dependent, and linux (what CI runs on) is the ground
+    # truth this inventory documents — not the maintainer's laptop.
     list_out=""
     list_rc=0
-    list_out=$(cd "$sub" && go list -deps -test -f '{{with .Module}}{{.Path}} {{.Version}}{{end}}' ./... 2>&1) || list_rc=$?
+    list_out=$(cd "$sub" && GOOS=linux go list -deps -test -f '{{with .Module}}{{.Path}} {{.Version}}{{end}}' ./... 2>&1) || list_rc=$?
     if [ "$list_rc" -ne 0 ]; then
         err "$DOC" "'go list' failed in $sub, so its dependency closure is unknown. Fix that before trusting this check. Output: $(head -3 <<<"$list_out" | tr '\n' ' ')"
         continue

--- a/.github/scripts/licenses-check.sh
+++ b/.github/scripts/licenses-check.sh
@@ -69,9 +69,16 @@ done
 ROOT_MODULE=$(go list -m)
 
 # Expected: "<module path> <version> <dir>" for every module in the binary's
-# closure, minus this repository itself.
+# closure, minus this repository itself. GOOS is pinned to linux because the
+# closure is platform-dependent — github.com/prometheus/procfs is only pulled
+# in on linux (client_golang's process collector) — and linux is the ground
+# truth: it is what this check's CI job runs on and what the shipped container
+# image is. Unpinned, a macOS run computes a smaller closure and reports the
+# procfs row as "listed but not in the dependency closure; drop the row" —
+# advice that, followed, deletes a correct row from a compliance artifact
+# (PR #365 did exactly that via the refresh script).
 closure=$(
-    go list -deps -f '{{with .Module}}{{.Path}} {{.Version}} {{.Dir}}{{end}}' "$TARGET" |
+    GOOS=linux go list -deps -f '{{with .Module}}{{.Path}} {{.Version}} {{.Dir}}{{end}}' "$TARGET" |
         grep -v '^$' |
         grep -v "^${ROOT_MODULE} " |
         sort -u

--- a/.github/scripts/refresh-build-test-inventory.sh
+++ b/.github/scripts/refresh-build-test-inventory.sh
@@ -101,7 +101,11 @@ find_go_submodule_for() {
         # intermittently here and gets misreported as "should not happen" by
         # this function's caller. awk reads its input to EOF regardless of
         # when the match is found, so go list is never killed mid-write.
-        if (cd "$sub" && go list -deps -test -f '{{with .Module}}{{.Path}}{{end}}' ./... 2>/dev/null | awk -v m="$mod_path" '$0 == m { f = 1 } END { exit !f }'); then
+        #
+        # GOOS pinned to linux to match build-test-licenses-check.sh's own
+        # closure exactly — the refresh must resolve a module to the same
+        # submodule the check will look for it in.
+        if (cd "$sub" && GOOS=linux go list -deps -test -f '{{with .Module}}{{.Path}}{{end}}' ./... 2>/dev/null | awk -v m="$mod_path" '$0 == m { f = 1 } END { exit !f }'); then
             printf '%s' "$sub"
             return 0
         fi

--- a/.github/scripts/sbom-check.test.sh
+++ b/.github/scripts/sbom-check.test.sh
@@ -72,18 +72,31 @@ echo "-- real pipeline, end to end --"
 real_sbom_dir=$(mktemp -d)
 ALL_TMP_DIRS+=("$real_sbom_dir")
 real_sbom="$real_sbom_dir/sbom.json"
-# `go run ...@v1.10.0`, matching release.yml's real "Generate SBOM" step
-# exactly — that step never `go install`s the tool, so a pre-installed
-# $GOBIN/cyclonedx-gomod would pass here and not exist in real CI.
+# The SBOM must describe the linux build — that is what release.yml's ubuntu
+# runner generates and what the committed document is validated against — even
+# when this self-test runs on macOS, so GOOS=linux is exported to the tool's
+# module analysis. `GOOS=linux go run` cannot do that: it would cross-compile
+# cyclonedx-gomod itself into a linux executable this host can't exec ("exec
+# format error"). So the pinned tool version is built natively into a
+# throwaway GOBIN first, and GOOS applies only to its run. The throwaway GOBIN
+# keeps the property the previous plain-`go run` shape had: a stale
+# pre-installed cyclonedx-gomod on the host can't be picked up and mask what
+# real CI would do.
 #
 # A failure to even generate the SBOM counts as a failed case, not a skip —
 # a self-test that quietly skips its own most important case on tool trouble
 # is a vacuous pass waiting to happen, the exact failure mode every other
 # self-test in this directory is written to avoid.
+tool_dir=$(mktemp -d)
+ALL_TMP_DIRS+=("$tool_dir")
 gen_output=""
 gen_rc=0
-gen_output=$(go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0 \
-    app -json -licenses -main cmd/server -output "$real_sbom" "$REPO_ROOT" 2>&1) || gen_rc=$?
+gen_output=$(GOBIN="$tool_dir" go install \
+    github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0 2>&1) || gen_rc=$?
+if [ "$gen_rc" -eq 0 ]; then
+    gen_output=$(GOOS=linux "$tool_dir/cyclonedx-gomod" \
+        app -json -licenses -main cmd/server -output "$real_sbom" "$REPO_ROOT" 2>&1) || gen_rc=$?
+fi
 if [ "$gen_rc" -ne 0 ]; then
     echo "  NOT OK   could not generate a real SBOM to test against:"
     while IFS= read -r line; do echo "           $line"; done <<<"$gen_output"


### PR DESCRIPTION
## Summary

Pins every dependency-closure computation in the third-party inventory scripts to `GOOS=linux`, so a refresh or check run on macOS computes the same closure CI validates on ubuntu — instead of a smaller one that reports Linux-only rows as stale and tells the maintainer to delete them.

Jira: [SOL-153937](https://sol-jira.atlassian.net/browse/SOL-153937)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

The inventory scripts compute the binary's dependency closure with the host's `GOOS`, but linux is the ground truth: it's what the checks' CI jobs run on and what the shipped container image is. `github.com/prometheus/procfs` is only in the closure on linux (client_golang's process collector), so a macOS run of `licenses-check.sh` reported the correct procfs row as "listed but not in the dependency closure; drop the row." The refresh script followed that advice on #365 — deleting a valid row from a compliance artifact and turning `Third-party licenses current` and the SBOM self-test red on a commit meant to fix them.

## Changes Made

- **`.github/scripts/licenses-check.sh`** — pins the `go list -deps ./cmd/server` binary closure to `GOOS=linux`, with a comment recording the procfs failure mode.
- **`.github/scripts/build-test-licenses-check.sh`** — pins the per-submodule `go list -deps -test` closures the same way.
- **`.github/scripts/refresh-build-test-inventory.sh`** — pins submodule resolution to match the check's closure exactly.
- **`.github/scripts/sbom-check.test.sh`** — builds cyclonedx-gomod natively into a throwaway GOBIN, then runs it with `GOOS=linux`. `GOOS=linux go run` can't do this: it cross-compiles the tool itself into a binary the host can't exec. The throwaway GOBIN preserves the property the plain-`go run` shape had — a stale pre-installed tool can't mask what real CI would do.

Deliberately unchanged: go-licenses licence *resolution* for packages that don't build on the host. The refresh already refuses loudly and directs a hand-verified row, which is the right behavior for a compliance file.

`refresh-licenses-inventory.sh` needs no edit — it derives its work entirely from `licenses-check.sh`'s diagnostics, so pinning the check pins the refresh.

## Testing

**Test Environment:**
- Go version: go1.26.0
- OS: macOS (darwin/arm64) — the platform where the bug lived
- Broker version: n/a (CI scripts only)

**Tests Performed:**
- [x] All five self-test suites pass locally: licenses-check 10/10, sbom-check 10/10, build-test-licenses-check 26/26, refresh-build-test 15/15 (3 network cases skipped offline), refresh-licenses 11/11 (1 skipped)
- [x] Both real checks pass against the tree on macOS (47 modules, procfs included) — `licenses-check.sh` failed on macOS before this change
- [x] `make refresh-third-party-inventory` on macOS makes no changes — a Mac refresh can no longer delete Linux-only rows

**Test Coverage:**
- CI's ubuntu jobs are behaviorally unaffected (`GOOS=linux` was already the effective value there); the macos-latest self-test job now exercises the pinned path and should produce output identical to ubuntu.

## Breaking Changes

None.

## Additional Notes

Known residual gap, out of scope by design: adding a *new* Linux-only dependency still requires one hand-verified row when refreshing from macOS, because go-licenses can't inspect a package that doesn't build on the host. The script's refusal message directs exactly that.

## Related Issues/PRs

- Related to #365 (the Dependabot PR where the darwin refresh deleted the procfs row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
