### PR TITLE
SOL-153981: mkdir fidelity/golden before regen-golden.sh's capture step

### DIFF
--- a/test/performance/regen-golden.sh
+++ b/test/performance/regen-golden.sh
@@ -199,6 +199,11 @@ fi
 echo "   pinned RDP: $rdp_name"
 
 echo "== 4. fidelity -capture (alias=$broker_alias vpn=$vpn rdp=$rdp_name)"
+# A checkout that has never captured fixtures has no fidelity/golden/ yet —
+# that's the normal state of a fresh clone (see the fixtures-manifest.sh
+# preflight above), so create it rather than letting fidelity -capture fail
+# staging its first golden file into a directory that was never made.
+mkdir -p "$here/fidelity/golden"
 "$bin/fidelity" -mcp-url http://localhost:9090 -broker "$broker_alias" -vpn "$vpn" -rdp "$rdp_name" \
   -golden-dir "$here/fidelity/golden" -capture 2>&1 | tee "$runs/regen.log"
 


### PR DESCRIPTION
## What is the purpose of this change?
- `test/performance/regen-golden.sh` fails on a checkout that has never captured performance fixtures before, with a bare `no such file or directory` instead of a useful error.

## How is this accomplished?
- `fidelity -capture` (step 4) stages its first golden file into `fidelity/golden/`, but the script never creates that directory itself.
- `fidelity/golden/` only exists on a checkout that has captured before -- which the harness's own `fixtures-manifest.sh` preflight explicitly expects *not* to be the case on a fresh clone ("absent is the normal state of a fresh clone").
- Adds `mkdir -p "$here/fidelity/golden"` immediately before the `fidelity -capture` invocation.

## Anything reviewers should focus on/be aware of?
- Test-harness-only change (`test/performance/`), no production surface touched, so no CHANGELOG entry per repo convention.
- Found while replicating SOL-153311's performance runs against current `HEAD` on a from-scratch clone.

## What testing if any was performed?
- Reproduced the failure on a fresh clone, applied the one-line fix, and successfully ran `regen-golden.sh` end to end against a real lab broker (capture, sanitize, manifest write all completed) followed by a full single-host smoke run (`./run.sh`) that passed the fidelity gate against the resulting fixtures.