### PR TITLE
SOL-154095: make performance-harness results comparable

### DIFF
--- a/test/performance/.gitignore
+++ b/test/performance/.gitignore
@@ -18,3 +18,8 @@ mock-semp/canned/sanitize.local.tsv
 # against a fixed max_concurrent_per_broker; the run scripts copy whichever one
 # they used into the run directory, which is where the provenance belongs.
 broker-config.run*.yaml
+
+# Generated N-broker configs from gen-mock-config.sh. One per broker count, and
+# nobody should commit a 200-broker broker list — regenerate it instead. The
+# generator refuses to write over the committed broker-config.mock.yaml.
+broker-config.gen*.yaml

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -108,7 +108,7 @@ Key env knobs (full list in `run.sh` header):
 | var | default | note |
 |---|---|---|
 | `CLIENTS` | 32 | MCP sessions in parallel |
-| `DURATION` | 60s | a number of `s`, `m` or `h`, greater than zero. Compound and sub-second forms (`1m30s`, `500ms`) are refused: the samplers count in whole seconds, and a duration they cannot express used to be silently replaced with 90. Zero is refused too — `memsampler -duration 0s` means "run until the process disappears" |
+| `DURATION` | 60s | a duration this harness can express exactly: a positive number of `s`, `m` or `h` landing on a whole second. `1.5m` (90s) is fine; `0.5s`, `1m30s` and `500ms` are refused, as is `0s` — `memsampler -duration 0s` means "run until the process disappears". Windows are sized in whole seconds and `stats_start_epoch` *is* one, so a value that had to be rounded would place the statistics window somewhere the load generator did not |
 | `WARMUP` | — | `loadgen -warmup`: time discarded from the **stats** at the head of the run. The run still lasts `WARMUP + DURATION` and the samplers are extended to match. See [Warm-up and mid-run events](#warm-up-and-mid-run-events) |
 | `TOOLS` | all four | `get-broker-status,list-queues,list-rdps,get-rdp-status`; set it to a subset to isolate one tool's cost. Validated in the step-0 preflight, before the mock starts — an unknown tool aborts the run immediately |
 | `LATENCY_MS` | 0 | per-response sleep in mock; use to force per-broker semaphore queueing inside MCP |
@@ -118,10 +118,11 @@ Key env knobs (full list in `run.sh` header):
 | `BROKER_ALIAS` | `broker-01` | fidelity `-broker`; must exist in `broker-config.mock.yaml` |
 | `VPN` | from `fixtures.manifest` | fidelity `-vpn`; defaults to the VPN the goldens were captured against. Set it only to override |
 | `RDP` | from `fixtures.manifest` | fidelity/loadgen `-rdp`; the RDP the capture pinned. The mock serves `get-rdp-status` for that RDP only |
-| `BROKERS` | 50 | mock broker count and `loadgen -broker-count`. Above 50 the committed config runs out of aliases — generate one with `gen-mock-config.sh` |
+| `BROKERS` | 50 | mock broker count and `loadgen -broker-count`, 919 max (18081 + 920 - 1 would collide with the mock's control port 19000). Above 50 the committed config runs out of aliases — generate one with `gen-mock-config.sh` |
+| `BROKER_PREFIX` | `broker` | alias prefix, passed to `loadgen -broker-prefix`. Must match the `-prefix` a generated config was built with, or every broker lookup misses. `BROKER_ALIAS` defaults to `<prefix>-01` |
 | `PORT_WAIT_SECS` | 60 | how long to wait for a port a previous run still holds |
 | `NOFILE` | 1048576 | descriptor limit to request; falls back to the hard limit. Both requested and granted are recorded |
-| `RIG_NOTE` | — | free-text note about this host, recorded verbatim in the run record |
+| `RIG_NOTE` | — | free-text note about this host. Recorded with control characters flattened to spaces, `=` replaced with `:` (both reported on stderr) and the value capped at 200 characters, so the record stays parseable by the documented `awk -F=` reader |
 
 ## Split-host run
 
@@ -153,7 +154,8 @@ firing loadgen.
 | `DURATION` | 60s | `loadgen -duration`; a number of `s`, `m` or `h` — see the `run.sh` table |
 | `WARMUP` | — | `loadgen -warmup`: time discarded from the **stats** at the head of the run. Extends this box's samplers, but **not Box B's** — see [Warm-up and mid-run events](#warm-up-and-mid-run-events) |
 | `TOOLS` | all four | `loadgen -tools`; `get-broker-status,list-queues,list-rdps,get-rdp-status`, or a subset to isolate one tool's cost. Validated in the step-0 preflight, so a typo fails before the mock binds and before the wait for Box B |
-| `BROKERS` | 50 | `loadgen -broker-count` |
+| `BROKERS` | 50 | `loadgen -broker-count`, 919 max — see the `run.sh` table |
+| `BROKER_PREFIX` | `broker` | `loadgen -broker-prefix`; must match a generated config's `-prefix` |
 | `TOTAL_RPS` | 0 | `loadgen -total-rps` (0 = unlimited); paces aggregate req/s to break the release-barrier convoy |
 | `LATENCY_MS` | 0 | `mock-semp -default-latency-ms`; >0 piles requests on MCP's per-broker semaphore |
 | `RUN_TAG` | `${CLIENTS}c` | tag appended to the runs dir |
@@ -166,7 +168,7 @@ firing loadgen.
 | `RDP` | from `fixtures.manifest` | fidelity/loadgen `-rdp`; the RDP the capture pinned |
 | `PORT_WAIT_SECS` | 60 | how long to wait for a mock port (or `:19000`) a previous run still holds |
 | `NOFILE` | 1048576 | descriptor limit to request; falls back to the hard limit. This is the box that needs it — one outbound socket per `CLIENTS` session |
-| `RIG_NOTE` | — | free-text note about this host, recorded verbatim in the run record |
+| `RIG_NOTE` | — | free-text note about this host. Recorded with control characters flattened to spaces, `=` replaced with `:` (both reported on stderr) and the value capped at 200 characters, so the record stays parseable by the documented `awk -F=` reader |
 
 `run-mcp.sh` (Box B) takes `PORT_WAIT_SECS`, `NOFILE`, `RIG_NOTE` and `WARMUP`
 too, with the same meanings and defaults, alongside its own `MOCK_HOST`,

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -48,13 +48,19 @@ and the per-command headers in `mock-semp/main.go`, `loadgen/main.go`,
 mock-semp/        replayer: pretends to be N brokers on 18081..18081+N-1
 loadgen/          concurrent MCP tool caller, prints throughput/latency/errors
 fidelity/         hard gate: compares tool output vs fidelity/golden/*.json
-memsampler/       polls /proc/<pid>/status, writes CSV
+memsampler/       polls /proc/<pid>/status + /proc/<pid>/fd, writes CSV
 sampler.sh        CPU + RSS/PSS/USS for MCP + mock + box totals, CSV
 loadgen-sampler.sh   loadgen-side connection/goroutine counters
 summary.sh        prints a one-page rollup of a run directory
+lib.sh            shared helpers: run record, load-phase stamps, port waits,
+                  descriptor limit (sourced by the run scripts, never run)
 
 broker-config.mock.yaml   MCP config pointing at mock-semp (50 brokers)
 broker-config.real.yaml   MCP config pointing at the real lab broker
+
+gen-mock-config.sh      generates an MCP config for N mock brokers (N > 50)
+gen-mock-config.test.sh self-test for the generator
+lib.test.sh             self-test for lib.sh + summary.sh's rollup
 
 build.sh          builds mock-semp, loadgen, fidelity, memsampler, mcp-server into ./bin/
 run.sh            single-host smoke run (mock + MCP + loadgen on one box)
@@ -68,13 +74,14 @@ fidelity/golden/      expected tool output     ─┘ regen-golden.sh writes bot
 fixtures.manifest     what the last capture produced (gitignored)
 ```
 
-Artifacts land in `bin/runs/<timestamp>[-<tag>]/`.
+Artifacts land in `bin/runs/<timestamp>[-<tag>]/`, including a `run-record.*`
+per role — see [The run record](#the-run-record).
 
 ## Ports
 
 | port | who | notes |
 |---|---|---|
-| `9090` | MCP server | health at `/health`; `run.sh` refuses to start if occupied |
+| `9090` | MCP server | health at `/health`; the run scripts wait up to `PORT_WAIT_SECS` (default 60) for a previous run to release it, then fail naming it |
 | `18081..18081+N-1` | mock-semp broker ports | one per fake broker; default N=50 → `18081..18130`. In split-host mode Box A binds `0.0.0.0` so Box B can reach these over the LAN |
 | `19000` | mock-semp control endpoint | `POST /_mock/config` for per-port latency / error injection; `GET /_mock/hits` reports per-rule SEMP counts and `POST /_mock/hits` reports and zeroes them. Bound to localhost by default (separate from `-listen-addr`) so opening broker ports to the LAN doesn't also expose the injection knob |
 
@@ -110,6 +117,10 @@ Key env knobs (full list in `run.sh` header):
 | `BROKER_ALIAS` | `broker-01` | fidelity `-broker`; must exist in `broker-config.mock.yaml` |
 | `VPN` | from `fixtures.manifest` | fidelity `-vpn`; defaults to the VPN the goldens were captured against. Set it only to override |
 | `RDP` | from `fixtures.manifest` | fidelity/loadgen `-rdp`; the RDP the capture pinned. The mock serves `get-rdp-status` for that RDP only |
+| `BROKERS` | 50 | mock broker count and `loadgen -broker-count`. Above 50 the committed config runs out of aliases — generate one with `gen-mock-config.sh` |
+| `PORT_WAIT_SECS` | 60 | how long to wait for a port a previous run still holds |
+| `NOFILE` | 1048576 | descriptor limit to request; falls back to the hard limit. Both requested and granted are recorded |
+| `RIG_NOTE` | — | free-text note about this host, recorded verbatim in the run record |
 
 ## Split-host run
 
@@ -151,6 +162,274 @@ firing loadgen.
 | `BROKER_ALIAS` | `broker-01` | fidelity `-broker`; must exist in `broker-config.mock.yaml` |
 | `VPN` | from `fixtures.manifest` | fidelity `-vpn`; defaults to the VPN the goldens were captured against. Set it only to override |
 | `RDP` | from `fixtures.manifest` | fidelity/loadgen `-rdp`; the RDP the capture pinned |
+| `PORT_WAIT_SECS` | 60 | how long to wait for a mock port (or `:19000`) a previous run still holds |
+| `NOFILE` | 1048576 | descriptor limit to request; falls back to the hard limit. This is the box that needs it — one outbound socket per `CLIENTS` session |
+| `RIG_NOTE` | — | free-text note about this host, recorded verbatim in the run record |
+
+`run-mcp.sh` (Box B) takes `PORT_WAIT_SECS`, `NOFILE` and `RIG_NOTE` too, with
+the same meanings and defaults, alongside its own `MOCK_HOST`, `DURATION` and
+`CONFIG_FILE` — full contract in the script header. `RIG_NOTE` matters most
+there: Box B is the rig whose CPU and RSS a campaign actually compares.
+
+## Running the self-tests
+
+None of these needs a broker, a server, fixtures or a network — they run in a
+`mktemp` dir in a couple of seconds:
+
+```
+./lib.test.sh              # lib.sh: run record, _source labels, port wait,
+                           # and summary.sh's load-phase windowing
+./gen-mock-config.test.sh  # the N-broker config generator
+go test ./memsampler/      # the /proc parse and the descriptor count
+```
+
+`lib.test.sh` is the one that covers the numbers a campaign is compared on. Its
+sampler fixture is deliberately bimodal — six idle samples, then six loaded
+ones — so a windowing bug cannot pass by accident: the whole-run and
+load-phase averages sit 25 points apart, and one assertion requires them to
+stay that way.
+
+## The run record
+
+Every run directory gets a machine-readable record of what produced it, one
+per role:
+
+```
+run-record.mcp        the box that ran MCP        (run.sh, run-mcp.sh)
+run-record.loadgen    the box that drove the load (run.sh, run-loadgen.sh)
+```
+
+One record per box, never a merged one. The two halves of a split-host run
+have different rigs — Box A carries the mock and the load generator, Box B the
+MCP server — and merging them would need a channel between the boxes that this
+harness deliberately does not have. `run.sh` writes both into its single run
+directory, so a consumer reads a single-host run the same way it reads the two
+halves of a split-host one.
+
+Format is one `key=value` per line with `#` comments, the same shape the
+`.info` sidecars use and `summary.sh` already parses with `awk -F=`. It carries:
+
+| group | fields |
+|---|---|
+| rig | `host`, `kernel`, `arch`, `cores_logical`, `cores_physical`, `cpu_model`, `mem_total_kb`, plus `instance_type` / `availability_zone` on EC2 and `rig_note` when `RIG_NOTE` is set |
+| code | `commit`, `commit_dirty`, and a `<binary>_sha256` for every binary the run executed |
+| fixtures | `fixtures_manifest_sha256`, `fixtures_files`, `fixtures_captured_at`, `fixtures_capture_commit`, `fixtures_capture_dirty`, `fixtures_vpn`, `fixtures_rdp`, `fixtures_broker_alias` |
+| admission | `semp_max_concurrent_per_broker`, `semp_request_min_interval`, `semp_max_queue_wait`, `semp_fair_scheduling`, each with a `_source` |
+| descriptors | `nofile_requested`, `nofile_granted`, `nofile_effective_soft`, `nofile_effective_hard`, `fd_peak`, `threads_peak` |
+| workload | `clients`, `duration`, `tools`, `broker_count`, `vpn`, `rdp`, `latency_ms`, `total_rps`, the error-injection knobs |
+| load phase | `load_start_epoch`, `load_end_epoch`, `load_window_source` |
+
+The governing rule is that **an absent field is honest and a guessed one is a
+trap**. Anything the harness cannot establish is either omitted (EC2 fields on
+a devserver: the metadata call simply fails there, which is the expected answer
+for "not EC2", not an error) or written as the literal `unknown`. A later
+comparison will trust whatever is written here.
+
+> **These records are internal.** The fixture fields name a real lab appliance
+> — `fixtures_vpn`, `fixtures_rdp` and `fixtures_broker_alias` are copied
+> straight out of `fixtures.manifest`, which is gitignored for exactly that
+> reason — and the rig fields name the host. The records live under the
+> gitignored `bin/runs/`, so nothing commits them, but they are meant to be
+> shared between engineers and archived: do not paste one into a public issue,
+> PR or page. Each record repeats this in its own header so a copied file
+> carries the warning with it.
+
+### Why the admission settings carry a `_source`
+
+Four settings move admission behaviour, and two of them post-date the first
+full measurement pass, so a run that does not record them cannot be compared
+with one that does: `semp.max_queue_wait` and `semp.fair_scheduling`.
+
+Recording them is not as simple as parsing the config, because **unset is not
+off**. The defaults are a 100 ms pacer, 10 in-flight slots, a 30 s admission
+bound, and fair scheduling **on**. A plain YAML parse of a config that relies
+on any of those would leave the field blank, which the next reader takes for
+"no throttle".
+
+So each field says where its value came from:
+
+| `_source` | meaning |
+|---|---|
+| `server-log` | the server reported its own effective value on its `config loaded` startup line |
+| `config-file` | the value was written explicitly in the config this run used (copied into the run directory as `broker-config.used.yaml`) |
+| `unreported-server-default` | not written down and not reported, so the server applied its default and the harness cannot prove which. The value reads `unknown` |
+| `server-log-absent` | the server never logged its `config loaded` line — it did not start, or it is an older build. Value reads `unknown` |
+| `server-log-schema-changed` | the line is there but the field is not on it. The harness's one coupling to the server's log output has broken and `lib.sh`'s reader needs updating; it warns on stderr as well. Value reads `unknown` |
+| `config-file-unparsed` | the key *is* in the config but `lib.sh`'s narrow reader could not extract it (a nesting or flow-style shape it does not handle). Value reads `unknown`, and it warns — recording `unreported-server-default` here would be a lie about provenance, which is in the same family as a wrong value |
+
+The last three exist so that a broken reader is distinguishable from an absent
+value. Collapsing them into one `unknown` would let a server log-schema change
+silently degrade every future run with no signal — and the whole reason this
+field is read from the log is that it *is* obtainable.
+
+Today only `fair_scheduling` reads `server-log` — it is published there
+deliberately, as a kill switch an operator has to be able to confirm took
+effect. The other three read `config-file` for any config that sets them (the
+committed `broker-config.mock.yaml` sets two of the three) and
+`unreported-server-default` otherwise. Putting all four on the `config loaded`
+line is a one-line server change that would make every run read `server-log`;
+it is production surface, so it is not in this harness.
+
+### The pacer setting changed with this suite
+
+`broker-config.mock.yaml` now sets `semp.request_min_interval: 0s`. It
+previously set `1ms` under a comment claiming the pacer was disabled, which was
+wrong: only `0s` disables it — `NewRateLimiter` returns a closed channel for a
+non-positive interval and builds no ticker, whereas **any** positive value
+builds a real ticker per broker. At `1ms` every broker carried a 1000 req/s
+admission ceiling that nobody knew was there.
+
+Two consequences worth knowing before comparing anything:
+
+- Throughput figures measured **before** this change were taken with that
+  1 ms per-broker pacer in place, and are not directly comparable with figures
+  taken after it. Those older runs also predate the run record, so nothing in
+  their artifacts reveals the setting — the only way to know is the commit they
+  were taken at.
+- The measured cost of `1ms` versus `0s` under load is below the noise floor,
+  so this is a correctness-of-description fix rather than a performance one.
+  Do not expect the numbers to move much; expect them to be *describable*.
+
+## Reading CPU: whole run vs load phase
+
+`summary.sh` reports MCP CPU twice:
+
+```
+  mcp   cpu:  min=  1.0%   avg= 26.8%   max= 55.0%   (out of 100% box)
+  mcp   cpu:  load-phase  avg= 52.5%   max= 55.0%   (6 of 12 samples, 10:33:50..10:34:15)
+```
+
+**Use the load-phase figure.** The whole-run average is diluted by however long
+the server sat idle before the load started — the fidelity gate, and in a
+split-host run the wait for the other box. That dilution is unstated and
+varies per run, so the whole-run average of two runs is not a comparison of
+anything. It is kept because older run directories only have that number.
+
+The window is *stamped*, not inferred: the runner that starts the load writes
+`load_start_epoch` and `load_end_epoch` into the record, and `summary.sh`
+windows the sampler CSV on `sampler.csv`'s `epoch` column. Inferring the
+boundary from a CPU threshold would use the metric to define the window it is
+measured over, and would break on exactly the runs that matter — an idle-pacer
+arm and a CPU-saturated arm look nothing alike.
+
+The split-host **MCP box cannot stamp its own window**: the load runs on the
+other box and the two share no channel. Its record says so
+(`load_window_source=split-host-load-on-other-box`) and its summary reports the
+whole-run figure only. `run-loadgen.sh` prints the command to window it after
+the fact, and both run directories are archived together anyway:
+
+```
+./summary.sh <box-b-run-dir> --window-from <box-a-run-dir>
+```
+
+`--window-from` takes the load box's run directory (or a path straight to its
+record), reads the window out of it, and names that record in the report — so a
+windowed figure in an archived summary stays traceable to the run that measured
+the window. A bare `<from_epoch> <to_epoch>` pair still works and is marked
+`unverified` in the output, because a mistyped epoch otherwise yields a
+plausible number rather than an error.
+
+## More than 50 brokers
+
+`broker-config.mock.yaml` hand-lists 50 aliases. `mock-semp -listen-count` and
+`loadgen -broker-count` both already scale well past that, so the config was
+the only thing capping the broker count. Generate one:
+
+```
+./gen-mock-config.sh -n 200 -o broker-config.gen200.yaml
+
+# split-host
+Box A:  BROKERS=200 ./run-loadgen.sh http://<box-b>:9090
+Box B:  CONFIG_FILE=./broker-config.gen200.yaml MOCK_HOST=<box-a> ./run-mcp.sh
+
+# single host
+BROKERS=200 CONFIG_FILE=./broker-config.gen200.yaml ./run.sh
+```
+
+The generated aliases are byte-identical to the ones `loadgen` generates —
+it builds `<prefix>-%02d`, which is a *minimum* width, so `broker-09` and
+`broker-200` both come out right and a "tidier" `%03d` would rename all 99 of
+the first brokers. That mismatch does not fail loudly: every call 404s at the
+mock and the run reads like a server fault. `gen-mock-config.test.sh` asserts
+it at one, two and three digits, checks the three `${...}` placeholders survive
+verbatim (MCP hard-fails on an unset one), and anchors the whole output shape
+against the committed 50-broker config, which it must reproduce byte for byte.
+
+Generated configs are gitignored (`broker-config.gen*.yaml`) and the generator
+refuses to write over the committed `broker-config.mock.yaml`.
+
+## Descriptor limits
+
+The run scripts raise `RLIMIT_NOFILE` to a flat generous value (`NOFILE`,
+default 1048576, falling back to the hard limit) before launching anything, and
+record what was requested, what the shell was granted, and what the server
+process itself ended up with — read from `/proc/<pid>/limits`, not from the
+launching shell, because the two diverge across a re-exec and the process's own
+view is the one that constrains the run.
+
+Nothing in this suite, `cmd/` or `deploy/` raised it before, which left the
+ceiling varying with whatever the operator's login shell handed it: a
+result-moving input that was invisible in the output.
+
+Where the descriptors go:
+
+- **MCP box.** Each broker gets two protocol clients, each with a transport
+  sized `MaxConnsPerHost` = `MaxIdleConnsPerHost` = `max_concurrent_per_broker`.
+  In-flight is capped per broker by the shared semaphore, so concurrent sockets
+  stay at or below the cap — but the two idle pools are separate and each holds
+  up to the cap for `IdleConnTimeout` (90 s), so open descriptors can reach
+  *twice* the cap per broker under a protocol-alternating workload.
+- **Load box.** Every `loadgen` session is one socket, which dominates a
+  2000-caller run. That is a property of the rig, not of the product, which is
+  why the two boxes keep separate records.
+
+The limit is deliberately flat rather than computed from the broker count and
+the concurrency cap: the arithmetic above is fragile and the descriptors are
+free. `memsampler` records the peak count actually reached (`fd_peak` in the
+record, `open_fds` per sample in `mem.csv`), so a run that came close to its
+ceiling is visible afterwards instead of being a mystery.
+
+### Sampler columns
+
+`mem.csv`, from `memsampler`, one row per second against the MCP process:
+
+```
+t_sec, wall_ts, rss_kb, vm_kb, threads, open_fds
+```
+
+`open_fds` counts the entries in `/proc/<pid>/fd`, and reads `NA` when that
+directory could not be read (another user's process, or the process exiting
+between the two reads) — `NA` rather than `0`, because "no descriptors" and "we
+could not look" are different facts and a `0` in a run record would be believed.
+
+Descriptors are sampled from `/proc` and **not** scraped off `/metrics`, for two
+reasons, the second being the stronger: the Go runtime and process collectors on
+`/metrics` carry no scrape test or golden-file exclusion yet, and collecting
+them at all requires running with `OBS_METRICS_ENABLED` on — which changes the
+thing under test (a histogram observation per tool invocation, plus a scrape
+listener) and makes the numbers non-comparable with every run measured so far,
+all of which had it off. Reading `/proc` costs nothing and perturbs nothing.
+What it does not give is the goroutine count and GC internals; the soak's pass
+criteria (RSS drift, threads flat, descriptors flat) do not need them, and
+`GODEBUG=gctrace=1` answers "was that memory collectable garbage?" for free.
+
+`sampler.csv`, from `sampler.sh`, every 5 s, covering both processes plus box
+totals:
+
+```
+t_sec, wall, mcp_cpu, mcp_cpu_pct_of_box, mcp_rss_kb, mcp_pss_kb, mcp_uss_kb,
+mock_cpu, mock_cpu_pct_of_box, mock_rss_kb, mock_pss_kb, mock_uss_kb,
+loadavg1, sys_mem_used_kb, epoch
+```
+
+`epoch` is the last column and is what `summary.sh` windows on: `t_sec` is
+relative to the sampler's own start and `wall` carries no date, so neither can
+be compared with a stamp taken by another process. It was appended rather than
+inserted, so every existing column index still holds.
+
+There is deliberately no descriptor column in `sampler.csv`. `memsampler` is
+already per-process and already carries `threads`, so the count belongs there;
+a second one here would be one nobody reconciles with the first.
 
 ## Fidelity gate
 
@@ -304,7 +583,11 @@ Doing them together matters: self-changing fields (uptime, memory percentages,
 disk usage) drift with wall-clock time, so canned and goldens taken hours
 apart cannot match exact-mode comparison even when replaying the same data.
 It finishes by writing `fixtures.manifest` — a sha256 per file plus the
-capture time, broker alias, VPN, and the RDP the capture pinned (`# rdp:`).
+capture time, the commit the capture was taken at (`# capture_commit:`, and
+`# capture_dirty:` for whether that tree was clean), the broker alias, the VPN,
+and the RDP the capture pinned (`# rdp:`). The run record copies that
+provenance forward, so a run can name both the fixture set and the code that
+produced it.
 That last one is not just provenance: `mock-semp` serves `get-rdp-status` for
 that RDP alone, so `run.sh` and `run-loadgen.sh` read it back
 (`./fixtures-manifest.sh rdp`) to pass `-rdp` to `fidelity` and `loadgen`. A

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -108,7 +108,8 @@ Key env knobs (full list in `run.sh` header):
 | var | default | note |
 |---|---|---|
 | `CLIENTS` | 32 | MCP sessions in parallel |
-| `DURATION` | 60s | Go duration string |
+| `DURATION` | 60s | a number of `s`, `m` or `h`. Compound and sub-second forms (`1m30s`, `500ms`) are refused: the samplers count in whole seconds, and a duration they cannot express used to be silently replaced with 90 |
+| `WARMUP` | — | `loadgen -warmup`: time discarded from the **stats** at the head of the run. The run still lasts `WARMUP + DURATION` and the samplers are extended to match. See [Warm-up and mid-run events](#warm-up-and-mid-run-events) |
 | `TOOLS` | all four | `get-broker-status,list-queues,list-rdps,get-rdp-status`; set it to a subset to isolate one tool's cost. Validated in the step-0 preflight, before the mock starts — an unknown tool aborts the run immediately |
 | `LATENCY_MS` | 0 | per-response sleep in mock; use to force per-broker semaphore queueing inside MCP |
 | `ERROR_RATE` | 0 | probability each broker response is injected as an error |
@@ -149,7 +150,8 @@ firing loadgen.
 | var | default | note |
 |---|---|---|
 | `CLIENTS` | 200 | `loadgen -clients` — MCP sessions in parallel |
-| `DURATION` | 60s | `loadgen -duration` |
+| `DURATION` | 60s | `loadgen -duration`; a number of `s`, `m` or `h` — see the `run.sh` table |
+| `WARMUP` | — | `loadgen -warmup`: time discarded from the **stats** at the head of the run. Extends this box's samplers, but **not Box B's** — see [Warm-up and mid-run events](#warm-up-and-mid-run-events) |
 | `TOOLS` | all four | `loadgen -tools`; `get-broker-status,list-queues,list-rdps,get-rdp-status`, or a subset to isolate one tool's cost. Validated in the step-0 preflight, so a typo fails before the mock binds and before the wait for Box B |
 | `BROKERS` | 50 | `loadgen -broker-count` |
 | `TOTAL_RPS` | 0 | `loadgen -total-rps` (0 = unlimited); paces aggregate req/s to break the release-barrier convoy |
@@ -166,22 +168,29 @@ firing loadgen.
 | `NOFILE` | 1048576 | descriptor limit to request; falls back to the hard limit. This is the box that needs it — one outbound socket per `CLIENTS` session |
 | `RIG_NOTE` | — | free-text note about this host, recorded verbatim in the run record |
 
-`run-mcp.sh` (Box B) takes `PORT_WAIT_SECS`, `NOFILE` and `RIG_NOTE` too, with
-the same meanings and defaults, alongside its own `MOCK_HOST`, `DURATION` and
-`CONFIG_FILE` — full contract in the script header. `RIG_NOTE` matters most
+`run-mcp.sh` (Box B) takes `PORT_WAIT_SECS`, `NOFILE`, `RIG_NOTE` and `WARMUP`
+too, with the same meanings and defaults, alongside its own `MOCK_HOST`,
+`DURATION` and `CONFIG_FILE` — full contract in the script header. `RIG_NOTE` matters most
 there: Box B is the rig whose CPU and RSS a campaign actually compares.
 
 ## Running the self-tests
 
-None of these needs a broker, a server, fixtures or a network — they run in a
-`mktemp` dir in a couple of seconds:
+None of these needs a broker, a server or fixtures. The first three run in a
+`mktemp` dir in a couple of seconds; the fourth stubs a server and takes about
+twenty:
 
 ```
 ./lib.test.sh              # lib.sh: run record, _source labels, port wait,
                            # and summary.sh's load-phase windowing
 ./gen-mock-config.test.sh  # the N-broker config generator
 go test ./memsampler/      # the /proc parse and the descriptor count
+./run-mcp.test.sh          # run-mcp.sh's cleanup path: a terminated run still
+                           # records its peaks, once, and marks them partial
 ```
+
+`run-mcp.test.sh` binds :9090 and :18081 with stubs, the ports a real run uses,
+and exits without running if either is already held — it will not interrupt a
+campaign to make its point.
 
 `lib.test.sh` is the one that covers the numbers a campaign is compared on. Its
 sampler fixture is deliberately bimodal — six idle samples, then six loaded
@@ -213,11 +222,12 @@ Format is one `key=value` per line with `#` comments, the same shape the
 |---|---|
 | rig | `host`, `kernel`, `arch`, `cores_logical`, `cores_physical`, `cpu_model`, `mem_total_kb`, plus `instance_type` / `availability_zone` on EC2 and `rig_note` when `RIG_NOTE` is set |
 | code | `commit`, `commit_dirty`, and a `<binary>_sha256` for every binary the run executed |
+| runtime | `gomaxprocs_env`, `cgroup_path`, `cgroup_cpu_max`, `cgroup_cpu_quota_cores` — how much processor the Go runtime was entitled to. MCP records only; see [What the runtime fields say](#what-the-runtime-fields-say-and-what-they-deliberately-do-not) |
 | fixtures | `fixtures_manifest_sha256`, `fixtures_files`, `fixtures_captured_at`, `fixtures_capture_commit`, `fixtures_capture_dirty`, `fixtures_vpn`, `fixtures_rdp`, `fixtures_broker_alias` |
 | admission | `semp_max_concurrent_per_broker`, `semp_request_min_interval`, `semp_max_queue_wait`, `semp_fair_scheduling`, each with a `_source` |
-| descriptors | `nofile_requested`, `nofile_granted`, `nofile_effective_soft`, `nofile_effective_hard`, `fd_peak`, `threads_peak` |
-| workload | `clients`, `duration`, `tools`, `broker_count`, `vpn`, `rdp`, `latency_ms`, `total_rps`, the error-injection knobs |
-| load phase | `load_start_epoch`, `load_end_epoch`, `load_window_source` |
+| descriptors | `nofile_requested`, `nofile_granted`, `nofile_effective_soft`, `nofile_effective_hard`, `fd_peak`, `threads_peak`, `fd_peak_source`, plus `run_terminated` when the run did not finish |
+| workload | `clients`, `duration`, `stats_warmup`, `tools`, `broker_count`, `vpn`, `rdp`, `latency_ms`, `total_rps`, the error-injection knobs |
+| load phase | `load_start_epoch`, `load_end_epoch`, `load_window_source`, and `stats_start_epoch` when `WARMUP` is set |
 
 The governing rule is that **an absent field is honest and a guessed one is a
 trap**. Anything the harness cannot establish is either omitted (EC2 fields on
@@ -238,6 +248,107 @@ practice this only ever affects `RIG_NOTE`, the one free-text field.
 > shared between engineers and archived: do not paste one into a public issue,
 > PR or page. Each record repeats this in its own header so a copied file
 > carries the warning with it.
+
+### What `commit_dirty` and `capture_dirty` mean
+
+Both answer one question — *was the tracked code at the commit this record
+names?* — and both ignore untracked files. That is deliberate, and it is a
+correction: computed the obvious way, `git status --porcelain` reports the
+whole repository regardless of the directory it is pointed at, so a scratch
+note or a downloaded toolchain anywhere in the tree pinned the flag to `true`
+for good. It read `true` for every capture of a 120-run campaign whose tree had
+no tracked modification at all, and a flag that is always on trains the reader
+to ignore it.
+
+The blind spot this buys, stated plainly: **a fixture regenerated but never
+`git add`ed reads clean.** For the question the flag answers that is the right
+trade — but if you are chasing a fidelity mismatch, `git status` yourself.
+
+### What the runtime fields say, and what they deliberately do not
+
+The rig fields describe the machine; these describe how much of it the Go
+runtime was entitled to. Without them, two runs on one box with different
+`GOMAXPROCS` produce records identical in every field.
+
+| field | meaning |
+|---|---|
+| `gomaxprocs_env` | `GOMAXPROCS` in the server process's own environment, or `unset` |
+| `cgroup_path` | the process's cgroup (unified hierarchy), or `unknown` |
+| `cgroup_cpu_max` | that cgroup's `cpu.max`, verbatim; the nearest ancestor's when the leaf has none; `none` when nothing up to the root sets one |
+| `cgroup_cpu_quota_cores` | the same as a core count — `0.25` for `25000 100000` — or `none` |
+
+All three read `unknown` where the harness could not establish them: a cgroup
+v1 or hybrid host, an unreadable `/proc/<pid>/cgroup`, or a `cpu.max` line that
+does not parse. `none` and `unknown` are different answers and are not
+interchangeable — the first says there is no limit, the second says we could
+not tell. These fields are written for the MCP server process only, so a
+split-host loadgen record does not carry them.
+
+There is deliberately **no** single "effective GOMAXPROCS" field. Go 1.25 (what
+`go.mod` requires) derives `GOMAXPROCS` from the cgroup CPU limit when there is
+one, so a field that fell back to `nproc` would be confidently wrong in exactly
+the case these fields exist to detect: `deploy/kubernetes/deployment.yaml` sets
+`requests.cpu: 100m` and **no CPU limit**, so a pod falls back to the node's
+core count and runs with 64 Ps on a 64-core node while entitled to a tenth of a
+core. Go 1.25 also updates `GOMAXPROCS` as cgroup limits change, so no single
+startup value is the whole story. Record the inputs, name where each came from,
+and leave the derivation to the reader.
+
+cgroup v2 only. A v1 or hybrid host writes `unknown` rather than guessing at a
+layout it did not read.
+
+### When a run does not finish
+
+`fd_peak` and `threads_peak` are written from the runners' `EXIT` traps, so a
+run that is interrupted still records them — previously they were written at
+the end of the main flow and any terminated run lost both, which is how a
+connection-cap run whose entire purpose was measuring `fd_peak` came back
+without it.
+
+A peak over a run that was cut short is not the peak the run would have
+reached, though, and absence used to be the marker for that. So the record now
+says which it is: `fd_peak_source=complete` or `fd_peak_source=partial`, the
+latter alongside `run_terminated=true`. This matters most on the split-host MCP
+box, which stamps no load window by design and so has nothing else that would
+distinguish an interrupted record from a whole one.
+
+A `SIGKILL`, or an instance stopped out from under the run, still loses both
+fields: nothing shell-side survives that, and the record simply stays short.
+
+### Warm-up and mid-run events
+
+`WARMUP` passes `loadgen -warmup`: samples taken in that opening stretch are
+discarded from the **statistics**, not skipped by the load. Three consequences,
+all of which the runners handle except the last:
+
+1. **The run gets longer.** `loadgen` holds its clients for `warmup + duration`.
+   Each runner extends **its own** samplers accordingly.
+2. **Two windows, not one.** The record keeps `load_start_epoch` (when load
+   began) and adds `stats_start_epoch` (when the stats began). For a run with a
+   warmup these are different spans, and the second is the one that matches the
+   percentiles — so `summary.sh` prefers it when it is present and labels its
+   report `stats span:` rather than `load phase:`. `run-loadgen.sh` also prints
+   the invocation that windows **Box B's** directory on the same span.
+   `stats_start_epoch` is `load_start_epoch + WARMUP`, which is early by
+   loadgen's process start and dial phase — a second or two at these client
+   counts, since `dialAll` fans out concurrently. Close enough to window CPU
+   on; not exact, and not a substitute for loadgen's own clock.
+3. **Box B needs telling.** The two boxes share no channel by design, so
+   `run-mcp.sh` cannot learn about a `WARMUP` set on Box A. Set the same
+   `WARMUP` there — it takes the knob purely to extend its hold and its
+   samplers — or give it a `DURATION` of at least `WARMUP + DURATION` by hand.
+   Left alone, its samplers stop before the load does and the server-side CPU
+   window misses exactly the tail the stats describe.
+
+What it is for: a run with a **mid-run event**. `loadgen` emits only summary
+percentiles, so a run that injects latency partway through reports a p50 that
+is mostly pre-event traffic and **cannot be re-windowed afterwards** — the
+throughput can be approximated from the progress lines, the percentiles cannot.
+(Approximated, not recovered: the ticker computes its `warmup`/`steady`
+transition from a clock started before the dial phase, while the clients start
+theirs after it, so the rows labelled `steady` begin slightly early.)
+Setting `WARMUP` to the injection offset makes the summary describe the
+post-event window only. For a steady-state ladder, leave it unset.
 
 ### Why the admission settings carry a `_source`
 
@@ -589,7 +700,8 @@ disk usage) drift with wall-clock time, so canned and goldens taken hours
 apart cannot match exact-mode comparison even when replaying the same data.
 It finishes by writing `fixtures.manifest` — a sha256 per file plus the
 capture time, the commit the capture was taken at (`# capture_commit:`, and
-`# capture_dirty:` for whether that tree was clean), the broker alias, the VPN,
+`# capture_dirty:` for whether that tree was clean — tracked files only, see
+[What `commit_dirty` and `capture_dirty` mean](#what-commit_dirty-and-capture_dirty-mean)), the broker alias, the VPN,
 and the RDP the capture pinned (`# rdp:`). The run record copies that
 provenance forward, so a run can name both the fixture set and the code that
 produced it.

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -108,7 +108,7 @@ Key env knobs (full list in `run.sh` header):
 | var | default | note |
 |---|---|---|
 | `CLIENTS` | 32 | MCP sessions in parallel |
-| `DURATION` | 60s | a number of `s`, `m` or `h`. Compound and sub-second forms (`1m30s`, `500ms`) are refused: the samplers count in whole seconds, and a duration they cannot express used to be silently replaced with 90 |
+| `DURATION` | 60s | a number of `s`, `m` or `h`, greater than zero. Compound and sub-second forms (`1m30s`, `500ms`) are refused: the samplers count in whole seconds, and a duration they cannot express used to be silently replaced with 90. Zero is refused too — `memsampler -duration 0s` means "run until the process disappears" |
 | `WARMUP` | — | `loadgen -warmup`: time discarded from the **stats** at the head of the run. The run still lasts `WARMUP + DURATION` and the samplers are extended to match. See [Warm-up and mid-run events](#warm-up-and-mid-run-events) |
 | `TOOLS` | all four | `get-broker-status,list-queues,list-rdps,get-rdp-status`; set it to a subset to isolate one tool's cost. Validated in the step-0 preflight, before the mock starts — an unknown tool aborts the run immediately |
 | `LATENCY_MS` | 0 | per-response sleep in mock; use to force per-broker semaphore queueing inside MCP |
@@ -225,7 +225,7 @@ Format is one `key=value` per line with `#` comments, the same shape the
 | runtime | `gomaxprocs_env`, `cgroup_path`, `cgroup_cpu_max`, `cgroup_cpu_quota_cores` — how much processor the Go runtime was entitled to. MCP records only; see [What the runtime fields say](#what-the-runtime-fields-say-and-what-they-deliberately-do-not) |
 | fixtures | `fixtures_manifest_sha256`, `fixtures_files`, `fixtures_captured_at`, `fixtures_capture_commit`, `fixtures_capture_dirty`, `fixtures_vpn`, `fixtures_rdp`, `fixtures_broker_alias` |
 | admission | `semp_max_concurrent_per_broker`, `semp_request_min_interval`, `semp_max_queue_wait`, `semp_fair_scheduling`, each with a `_source` |
-| descriptors | `nofile_requested`, `nofile_granted`, `nofile_effective_soft`, `nofile_effective_hard`, `fd_peak`, `threads_peak`, `fd_peak_source`, plus `run_terminated` when the run did not finish |
+| descriptors | `nofile_requested`, `nofile_granted`, `nofile_effective_soft`, `nofile_effective_hard`, `fd_peak`, `threads_peak`, `fd_peak_source`, plus `run_terminated` or `load_failed` when the run was not a whole one |
 | workload | `clients`, `duration`, `stats_warmup`, `tools`, `broker_count`, `vpn`, `rdp`, `latency_ms`, `total_rps`, the error-injection knobs |
 | load phase | `load_start_epoch`, `load_end_epoch`, `load_window_source`, and `stats_start_epoch` when `WARMUP` is set |
 
@@ -274,10 +274,19 @@ runtime was entitled to. Without them, two runs on one box with different
 |---|---|
 | `gomaxprocs_env` | `GOMAXPROCS` in the server process's own environment, or `unset` |
 | `cgroup_path` | the process's cgroup (unified hierarchy), or `unknown` |
-| `cgroup_cpu_max` | that cgroup's `cpu.max`, verbatim; the nearest ancestor's when the leaf has none; `none` when nothing up to the root sets one |
+| `cgroup_cpu_max` | the binding `cpu.max`, verbatim; `none` when nothing on the path sets one |
 | `cgroup_cpu_quota_cores` | the same as a core count — `0.25` for `25000 100000` — or `none` |
+| `cgroup_cpu_quota_from` | which cgroup on the path that limit came from |
 
-All three read `unknown` where the harness could not establish them: a cgroup
+**The limit reported is the one that binds, not the nearest.** v2 CPU limits
+are hierarchical — a parent's bandwidth bounds its whole subtree — so every
+cgroup from the process's own up to the root is read and the most restrictive
+wins. A 2-core leaf under a half-core parent gets half a core, and reporting
+the leaf would overstate it fourfold. `cgroup_cpu_quota_from` names the level
+that actually binds; a level whose `cpu.max` does not parse is skipped rather
+than treated as permission.
+
+All four read `unknown` where the harness could not establish them: a cgroup
 v1 or hybrid host, an unreadable `/proc/<pid>/cgroup`, or a `cpu.max` line that
 does not parse. `none` and `unknown` are different answers and are not
 interchangeable — the first says there is no limit, the second says we could
@@ -311,6 +320,13 @@ says which it is: `fd_peak_source=complete` or `fd_peak_source=partial`, the
 latter alongside `run_terminated=true`. This matters most on the split-host MCP
 box, which stamps no load window by design and so has nothing else that would
 distinguish an interrupted record from a whole one.
+
+There are three outcomes, not two, because a load that exits non-zero is not
+the same as a run that was interrupted: the runner reached its end, but the
+samplers spent the rest of their clock over an idle server, so the peak is real
+and the run is not a measurement. That case records `load_failed=true` beside
+`fd_peak_source=partial`, and `load_rc` carries the load generator's exit code
+on every single-host run.
 
 A `SIGKILL`, or an instance stopped out from under the run, still loses both
 fields: nothing shell-side survives that, and the record simply stays short.

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -225,6 +225,11 @@ a devserver: the metadata call simply fails there, which is the expected answer
 for "not EC2", not an error) or written as the literal `unknown`. A later
 comparison will trust whatever is written here.
 
+One formatting note, since the record is meant to be read with `awk -F=`: a
+value containing `=` would read back truncated at the first one, so `=` is
+substituted with `:` on write and the substitution is reported on stderr. In
+practice this only ever affects `RIG_NOTE`, the one free-text field.
+
 > **These records are internal.** The fixture fields name a real lab appliance
 > — `fixtures_vpn`, `fixtures_rdp` and `fixtures_broker_alias` are copied
 > straight out of `fixtures.manifest`, which is gitignored for exactly that

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -228,8 +228,21 @@ Format is one `key=value` per line with `#` comments, the same shape the
 | fixtures | `fixtures_manifest_sha256`, `fixtures_files`, `fixtures_captured_at`, `fixtures_capture_commit`, `fixtures_capture_dirty`, `fixtures_vpn`, `fixtures_rdp`, `fixtures_broker_alias` |
 | admission | `semp_max_concurrent_per_broker`, `semp_request_min_interval`, `semp_max_queue_wait`, `semp_fair_scheduling`, each with a `_source` |
 | descriptors | `nofile_requested`, `nofile_granted`, `nofile_effective_soft`, `nofile_effective_hard`, `fd_peak`, `threads_peak`, `fd_peak_source`, plus `run_terminated` or `load_failed` when the run was not a whole one |
-| workload | `clients`, `duration`, `stats_warmup`, `tools`, `broker_count`, `vpn`, `rdp`, `latency_ms`, `total_rps`, the error-injection knobs |
+| workload | `clients`, `duration`, `stats_warmup`, `tools`, `broker_count`, `vpn`, `rdp`, `latency_ms`, `total_rps`, the error-injection knobs, plus `mcp_url`, `brokers_csv`, `no_mock` and `mock_broker_ports` on the load box and `mock_host`, `config_file` and `hold_duration` on the MCP box |
+| outcome | `load_rc` — the load generator's exit code, on the runners that drive it |
 | load phase | `load_start_epoch`, `load_end_epoch`, `load_window_source`, and `stats_start_epoch` when `WARMUP` is set |
+
+Two of those describe different quantities and are easy to conflate.
+`broker_count` is how many aliases **this loadgen drives** — the entry count of
+`BROKERS_CSV` when a subset is pinned, `BROKERS` otherwise. `mock_broker_ports`
+is how many ports the mock **on that box** binds, and is written only when the
+box runs one: under `NO_MOCK=1` the mock belongs to someone else and its size is
+not this record's to state. They are equal unless `BROKERS_CSV` pinned a subset.
+
+`mcp_url` is recorded with any userinfo replaced by `***`. Nothing here produces
+a credential-bearing URL — the mock disables client auth and loadgen's only auth
+channel is `MCP_DEV_TOKEN`, an env var that is never persisted — but the URL is
+caller-supplied and the record is an archived artifact.
 
 The governing rule is that **an absent field is honest and a guessed one is a
 trap**. Anything the harness cannot establish is either omitted (EC2 fields on
@@ -464,6 +477,16 @@ the window. A bare `<from_epoch> <to_epoch>` pair still works and is marked
 plausible number rather than an error.
 
 ## More than 50 brokers
+
+> **`gen-mock-config.sh -port-start` is not honoured by the runners.** All three
+> bind, probe and inject at `18081` — the port wait, the error-injection payload
+> and Box B's reachability check all assume it. A config generated with a
+> different `-port-start` is valid and MCP will dial it, but no runner starts a
+> mock there, so the run fails at the fidelity gate before any load runs. That
+> is a loud, early failure rather than a wrong number, which is why the option
+> stays: for a large `-n` that would otherwise reach the control port at 19000,
+> drive `mock-semp` by hand with a matching `-listen-start` instead of using a
+> runner. The runners cap `BROKERS` at 919 for the same collision.
 
 `broker-config.mock.yaml` hand-lists 50 aliases. `mock-semp -listen-count` and
 `loadgen -broker-count` both already scale well past that, so the config was

--- a/test/performance/broker-config.mock.yaml
+++ b/test/performance/broker-config.mock.yaml
@@ -11,6 +11,14 @@
 # tool/s because MCP's per-broker semaphore + request_min_interval throttle
 # every client onto one broker's queue.
 #
+# For a run above 50 brokers, generate a config instead of editing this one:
+#
+#   ./gen-mock-config.sh -n 200 -o broker-config.gen200.yaml
+#   CONFIG_FILE=./broker-config.gen200.yaml ./run-mcp.sh
+#
+# The generator emits exactly the alias scheme loadgen generates and derives
+# the ports from the mock's -listen-start, so the two cannot drift.
+#
 # MOCK_HOST is required (MCP hard-fails on unset ${VAR}).
 #   - Single-host smoke: MOCK_HOST=localhost.
 #   - Split-host demo:   MOCK_HOST=<Box A LAN IP>, MCP runs on Box B.
@@ -34,10 +42,12 @@ mcp_client_auth:
 semp:
   max_concurrent_per_broker: 10
   request_timeout_duration: 1m
-  # Pacer disabled so the load run measures MCP's real ceiling rather
-  # than the per-broker throttle. Production configs typically keep this
-  # around 100ms to be polite to real appliances.
-  request_min_interval: 1ms
+  # Pacer off so the load run measures MCP's real ceiling rather than the
+  # per-broker throttle. Only 0s turns it off: any positive value builds a
+  # real ticker per broker, so the "disabled" this line used to claim at 1ms
+  # was a 1000/s-per-broker pacer, not an absent one. Production configs
+  # typically keep this around 100ms to be polite to real appliances.
+  request_min_interval: 0s
   retries: 10
   retry_min_interval: 3s
   retry_max_interval: 30s

--- a/test/performance/fixtures-manifest.sh
+++ b/test/performance/fixtures-manifest.sh
@@ -41,6 +41,10 @@
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# lib.sh is functions-only (perf_*), so sourcing it here costs nothing and
+# keeps capture_dirty and the run record's commit_dirty on one implementation.
+# shellcheck source=lib.sh
+source "$here/lib.sh"
 manifest="$here/fixtures.manifest"
 fixture_dirs=(mock-semp/canned fidelity/golden)
 
@@ -90,7 +94,12 @@ cmd_write() {
     # different commits can differ in what the tools select, so a run record
     # that names the fixture set should be able to name the code that made it.
     echo "# capture_commit: $(git -C "$here" rev-parse HEAD 2>/dev/null || echo unknown)"
-    echo "# capture_dirty: $( [[ -n "$(git -C "$here" status --porcelain 2>/dev/null)" ]] && echo true || echo false )"
+    # Tracked changes only. perf_tree_dirty carries the reasoning and the
+    # blind spot this buys: a fixture regenerated but never `git add`ed reads
+    # clean here. The alternative — counting untracked files — pinned this
+    # flag to `true` on any host that had ever left a scratch file in the
+    # tree, which is how it came to mean nothing.
+    echo "# capture_dirty: $(perf_tree_dirty "$here" || echo unknown)"
     echo "# broker_alias: ${BROKER_ALIAS:-unknown}"
     echo "# vpn: ${VPN:-unknown}"
     echo "# rdp: ${RDP_NAME:-unknown}"

--- a/test/performance/fixtures-manifest.sh
+++ b/test/performance/fixtures-manifest.sh
@@ -86,6 +86,11 @@ cmd_write() {
     echo "# Do not edit: the run scripts verify these hashes and will fail on a mismatch."
     echo "# run_id: $(date -u +%Y%m%dT%H%M%SZ)"
     echo "# captured_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    # The commit the capture was taken at. Two captures of the same broker from
+    # different commits can differ in what the tools select, so a run record
+    # that names the fixture set should be able to name the code that made it.
+    echo "# capture_commit: $(git -C "$here" rev-parse HEAD 2>/dev/null || echo unknown)"
+    echo "# capture_dirty: $( [[ -n "$(git -C "$here" status --porcelain 2>/dev/null)" ]] && echo true || echo false )"
     echo "# broker_alias: ${BROKER_ALIAS:-unknown}"
     echo "# vpn: ${VPN:-unknown}"
     echo "# rdp: ${RDP_NAME:-unknown}"

--- a/test/performance/fixtures-manifest.sh
+++ b/test/performance/fixtures-manifest.sh
@@ -192,7 +192,11 @@ EOF
 # preflight check reports the missing manifest properly.
 cmd_vpn() {
   [[ -f "$manifest" ]] || return 0
-  sed -n 's/^# vpn: //p' "$manifest" | head -1
+  # awk, not `sed | head`: a head that closes the pipe SIGPIPEs sed, and under
+  # `pipefail` that makes this function return non-zero on success. Benign here
+  # today (one matching line), but the shape is the one lib.sh removed for
+  # writing a malformed field, and leaving an instance behind reads as sanction.
+  awk '/^# vpn: / { sub(/^# vpn: /, ""); print; exit }' "$manifest"
 }
 
 # cmd_rdp prints the RDP name the capture pinned, for the same reason cmd_vpn
@@ -202,7 +206,7 @@ cmd_vpn() {
 # default in each script is how they would.
 cmd_rdp() {
   [[ -f "$manifest" ]] || return 0
-  sed -n 's/^# rdp: //p' "$manifest" | head -1
+  awk '/^# rdp: / { sub(/^# rdp: /, ""); print; exit }' "$manifest"
 }
 
 case "${1:-}" in

--- a/test/performance/gen-mock-config.sh
+++ b/test/performance/gen-mock-config.sh
@@ -88,17 +88,24 @@ if (( port_start < 1 || last_port > 65535 )); then
   echo "port range $port_start..$last_port is outside 1..65535 — lower -n or -port-start" >&2
   exit 2
 fi
-# The mock's control endpoint is a fixed :19000, which falls inside the broker
-# range from -n 920 (18081 + 919). A collision there does not fail loudly: the
-# broker on that port answers /_mock/config instead of SEMP, so the run 404s on
-# one broker and reads as a broker fault — the same non-loud class this file's
-# header enumerates.
-mock_control_port=19000
-if (( port_start <= mock_control_port && last_port >= mock_control_port )); then
-  echo "port range $port_start..$last_port spans the mock's control port $mock_control_port" >&2
-  echo "lower -n, or move the range with -port-start (the mock also needs -config-port moved)" >&2
-  exit 2
-fi
+# Two fixed ports must stay outside the broker range, and a collision with
+# either is not loud: the broker on that port answers something other than
+# SEMP, so the run 404s on one broker and reads as a broker fault — the same
+# non-loud class this file's header enumerates.
+#
+#   19000  the mock's control endpoint, inside the range from -n 920
+#   9090   the MCP server itself, reachable with a low -port-start
+for reserved in 19000 9090; do
+  if (( port_start <= reserved && last_port >= reserved )); then
+    case "$reserved" in
+      19000) what="the mock's control port" ;;
+      9090)  what="the MCP server's port" ;;
+    esac
+    echo "port range $port_start..$last_port spans $what ($reserved)" >&2
+    echo "lower -n, or move the range with -port-start" >&2
+    exit 2
+  fi
+done
 
 if ! [[ "$prefix" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
   # Broker aliases end up as YAML mapping keys and in URLs; keep them to the

--- a/test/performance/gen-mock-config.sh
+++ b/test/performance/gen-mock-config.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 Solace Corporation. All rights reserved.
+#
+# gen-mock-config.sh — write an MCP broker config for N mock brokers.
+#
+# broker-config.mock.yaml hand-lists 50 aliases. mock-semp -listen-count and
+# loadgen -broker-count both already scale past 50, so this generator is the
+# only thing standing between the harness and the ">50 brokers, find the
+# maximum" run.
+#
+# Usage:
+#   ./gen-mock-config.sh -n 200 -o broker-config.gen200.yaml
+#   ./gen-mock-config.sh -n 120 -prefix broker -port-start 18081 -o ./broker-config.gen120.yaml
+#
+#   -n <count>        number of brokers (required)
+#   -prefix <name>    alias prefix (default broker) — must match loadgen's
+#                     -broker-prefix
+#   -port-start <p>   first mock port (default 18081) — must match mock-semp's
+#                     -listen-start
+#   -o <path>         output path (required)
+#   -f                overwrite an existing output file
+#
+# Then run the three sides with matching numbers:
+#
+#   Box A:  BROKERS=200 ./run-loadgen.sh http://<box-b>:9090
+#   Box B:  CONFIG_FILE=./broker-config.gen200.yaml MOCK_HOST=<box-a> ./run-mcp.sh
+#
+# --- end usage ---
+#
+# Three constraints govern the output, and each has a failure mode that is not
+# loud:
+#
+#   1. The aliases must be byte-identical to the ones loadgen generates. loadgen
+#      builds "<prefix>-%02d" (see resolveBrokers in loadgen/main.go); a
+#      mismatch does not fail at startup — every tool call 404s and the run
+#      reads like a server fault.
+#   2. The three ${...} placeholders must survive verbatim. MCP hard-fails on an
+#      unset one, so a generator that expanded or dropped them would emit a
+#      config that cannot start.
+#   3. It must refuse to write over the committed broker-config.mock.yaml.
+#      Nobody should commit a 200-broker config; the generated ones are
+#      gitignored (broker-config.gen*.yaml).
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# perf_usage prints the usage block from this file's own header.
+#
+# Anchored on content rather than a line range: a hardcoded `sed -n '4,32p'`
+# printed the options plus the first half of the rationale paragraph below
+# them, so `--help` ended mid-clause — and it silently drifted every time the
+# header gained a line. The markers below bound exactly the usage text.
+perf_usage() {
+  sed -n '/^# Usage:/,/^# --- end usage ---/p' "${BASH_SOURCE[0]}" \
+    | sed -e '/^# --- end usage ---/d' -e 's/^# \{0,1\}//'
+}
+
+count="" prefix="broker" port_start=18081 out="" force=0
+
+while (( $# )); do
+  case "$1" in
+    -n)          count="${2:?-n needs a value}"; shift 2 ;;
+    -prefix)     prefix="${2:?-prefix needs a value}"; shift 2 ;;
+    -port-start) port_start="${2:?-port-start needs a value}"; shift 2 ;;
+    -o)          out="${2:?-o needs a value}"; shift 2 ;;
+    -f)          force=1; shift ;;
+    -h|--help)   perf_usage; exit 0 ;;
+    *)           echo "unknown argument: $1 (see -h)" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$count" ]] || { echo "-n <count> is required (see -h)" >&2; exit 2; }
+[[ -n "$out" ]]   || { echo "-o <path> is required (see -h)" >&2; exit 2; }
+
+if ! [[ "$count" =~ ^[0-9]+$ ]] || (( count < 1 )); then
+  echo "-n must be a positive integer, got: $count" >&2
+  exit 2
+fi
+if ! [[ "$port_start" =~ ^[0-9]+$ ]]; then
+  echo "-port-start must be an integer, got: $port_start" >&2
+  exit 2
+fi
+# The last port has to be a port. Catching it here beats a partial config and a
+# bind failure N brokers into startup.
+last_port=$(( port_start + count - 1 ))
+if (( port_start < 1 || last_port > 65535 )); then
+  echo "port range $port_start..$last_port is outside 1..65535 — lower -n or -port-start" >&2
+  exit 2
+fi
+# The mock's control endpoint is a fixed :19000, which falls inside the broker
+# range from -n 920 (18081 + 919). A collision there does not fail loudly: the
+# broker on that port answers /_mock/config instead of SEMP, so the run 404s on
+# one broker and reads as a broker fault — the same non-loud class this file's
+# header enumerates.
+mock_control_port=19000
+if (( port_start <= mock_control_port && last_port >= mock_control_port )); then
+  echo "port range $port_start..$last_port spans the mock's control port $mock_control_port" >&2
+  echo "lower -n, or move the range with -port-start (the mock also needs -config-port moved)" >&2
+  exit 2
+fi
+
+if ! [[ "$prefix" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
+  # Broker aliases end up as YAML mapping keys and in URLs; keep them to the
+  # shape loadgen's generated names take.
+  echo "-prefix must match [A-Za-z0-9][A-Za-z0-9_-]* , got: $prefix" >&2
+  exit 2
+fi
+
+# Check loadgen's alias format string here, every time the generator runs, and
+# not only from the self-test. The self-test has no runner in CI, so it fires
+# when someone remembers it; this fires when it matters. A mismatch is the
+# failure mode this whole script exists to avoid and the one that is not loud:
+# every tool call 404s at the mock and the run reads like a server fault.
+loadgen_src="$here/loadgen/main.go"
+if [[ -r "$loadgen_src" ]] && ! grep -q '"%s-%02d"' "$loadgen_src"; then
+  echo "loadgen's alias format string is no longer \"%s-%02d\" — this generator would" >&2
+  echo "produce names loadgen does not ask for, and every tool call would 404 at the mock." >&2
+  echo "Check resolveBrokers in $loadgen_src and update the printf below to match." >&2
+  exit 2
+fi
+
+# Refuse the committed config by identity, not by name: -o ./broker-config.mock.yaml,
+# an absolute path to it and a path through a symlink are all the same file.
+protected="$here/broker-config.mock.yaml"
+if [[ -e "$out" ]] && [[ "$(realpath "$out")" == "$(realpath "$protected")" ]]; then
+  echo "refusing to overwrite the committed $protected" >&2
+  echo "write to a gitignored path instead, e.g. -o broker-config.gen${count}.yaml" >&2
+  exit 2
+fi
+if [[ -e "$out" ]] && (( ! force )); then
+  echo "$out exists — pass -f to overwrite" >&2
+  exit 2
+fi
+
+# Single-quoted heredoc: the ${MOCK_HOST} / ${BROKER_USERNAME} /
+# ${BROKER_PASSWORD} placeholders below must reach the file unexpanded, because
+# MCP is what expands them. Anything this script does need to interpolate is
+# passed through the environment and printf'd by awk instead.
+# mktemp beside the target rather than "$out.tmp.$$": the latter is a
+# predictable name derived from the caller's own path, so with -o pointing at a
+# shared directory a local user could pre-create the name as a symlink and have
+# this script truncate whatever it points at. The content is non-secret, but
+# the fix costs one line.
+tmp="$(mktemp "$(dirname "$out")/.$(basename "$out").XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
+{
+  cat <<'HEADER_START'
+# This is to be used in LAB ONLY.
+#
+# Performance — MCP config pointing at mock-semp.
+#
+# GENERATED by gen-mock-config.sh. Do not edit and do not commit: regenerate it.
+HEADER_START
+  printf '# Generated %s for %d brokers on ports %d..%d.\n' \
+    "$(date -Iseconds)" "$count" "$port_start" "$last_port"
+  printf '#\n'
+  printf '# Reproduce with:\n'
+  printf '#   ./gen-mock-config.sh -n %d -prefix %s -port-start %d -o <path>\n' \
+    "$count" "$prefix" "$port_start"
+  printf '#\n'
+  printf '# Aliases %s-%02d..%s-%02d, matching what loadgen generates for\n' \
+    "$prefix" 1 "$prefix" "$count"
+  printf '#   -broker-count %d -broker-prefix %s\n' "$count" "$prefix"
+  printf '# and the ports mock-semp binds for\n'
+  printf '#   -listen-start %d -listen-count %d\n' "$port_start" "$count"
+  cat <<'HEADER_END'
+#
+# MOCK_HOST is required (MCP hard-fails on unset ${VAR}).
+#   - Single-host smoke: MOCK_HOST=localhost.
+#   - Split-host run:    MOCK_HOST=<Box A LAN IP>, MCP runs on Box B.
+#
+# The mock accepts any credentials (it doesn't validate auth), so
+# BROKER_USERNAME / BROKER_PASSWORD can be set to any non-empty value —
+# MCP still requires them to build the basic-auth header.
+
+listen_address: 0.0.0.0
+allow_remote_unauthenticated: true
+port: 9090
+log_level: info
+
+tls_cert_file: ""
+tls_key_file: ""
+
+mcp_client_auth:
+  mode: disabled
+
+semp:
+  max_concurrent_per_broker: 10
+  request_timeout_duration: 1m
+  # Pacer off. Only 0s turns it off: any positive value builds a real ticker
+  # per broker. See broker-config.mock.yaml for the long version.
+  request_min_interval: 0s
+  retries: 10
+  retry_min_interval: 3s
+  retry_max_interval: 30s
+
+brokers:
+HEADER_END
+
+  # %02d, not %d and not a width computed from $count: it is literally
+  # loadgen's format string, so 9 -> broker-09 and 100 -> broker-100 come out
+  # the same on both sides. A "sensible" %03d for a 200-broker run would
+  # rename every one of the first 99 brokers and 404 the lot.
+  for (( i = 1; i <= count; i++ )); do
+    printf '  %s-%02d: { url: "http://${MOCK_HOST}:%d", insecure_skip_verify: true, auth: { mode: basic, username: "${BROKER_USERNAME}", password: "${BROKER_PASSWORD}" } }\n' \
+      "$prefix" "$i" "$(( port_start + i - 1 ))"
+  done
+} >"$tmp"
+
+mv "$tmp" "$out"
+trap - EXIT
+
+echo "wrote $out: $count brokers, ${prefix}-$(printf '%02d' 1)..${prefix}-$(printf '%02d' "$count"), ports $port_start..$last_port"

--- a/test/performance/gen-mock-config.sh
+++ b/test/performance/gen-mock-config.sh
@@ -16,6 +16,13 @@
 #   -prefix <name>    alias prefix (default broker) — must match loadgen's
 #                     -broker-prefix
 #   -port-start <p>   first mock port (default 18081) — must match mock-semp's
+#                     -listen-start. NOTE: run.sh, run-loadgen.sh and
+#                     run-mcp.sh all assume 18081 (port waits, error injection
+#                     and Box B's reachability check), so a config generated
+#                     with a different value cannot be driven by them — start
+#                     mock-semp by hand with a matching -listen-start. The
+#                     failure is loud and early: the fidelity gate cannot
+#                     reach a mock that is not there.
 #                     -listen-start
 #   -o <path>         output path (required)
 #   -f                overwrite an existing output file

--- a/test/performance/gen-mock-config.test.sh
+++ b/test/performance/gen-mock-config.test.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 Solace Corporation. All rights reserved.
+#
+# Self-test for gen-mock-config.sh.
+#
+# The dangerous failure here is not a crash, it is a config that starts fine
+# and measures nothing: if the generated aliases differ from the ones loadgen
+# generates, every tool call 404s at the mock and the run reads like a broker
+# or server fault rather than a naming mismatch. So the alias scheme gets three
+# assertions of its own, at one, two and three digits, plus a guard on
+# loadgen's format string so a change there fails here instead of in a
+# four-hour >50-broker run.
+#
+# The anchor case is N=50 against the committed broker-config.mock.yaml. That
+# file is known-good — it is what starts the server today — so reproducing its
+# brokers block byte-for-byte proves the generated shape, the alias format and
+# the port derivation all at once, against a reference nobody had to invent.
+#
+# Usage: ./gen-mock-config.test.sh
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEN="$here/gen-mock-config.sh"
+COMMITTED="$here/broker-config.mock.yaml"
+LOADGEN_SRC="$here/loadgen/main.go"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+ok() {   printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() {  printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+
+# indent <file> [max-lines] — echo a file under the failure that names it.
+#
+# awk rather than `sed | head`: a `head` that closes the pipe early sends
+# SIGPIPE to sed, which under `set -o pipefail` aborts this script — so the
+# first real failure would kill the report instead of printing it. A test
+# harness that cannot narrate its own failures is worse than no harness.
+indent() {
+  awk -v max="${2:-12}" 'NR <= max { print "        " $0 }' "$1"
+}
+
+check() { # <name> <condition-description-already-evaluated:0|1>
+  if [[ "$2" == 0 ]]; then ok "$1"; else bad "$1"; fi
+}
+
+# assert_rc <name> <want_rc> <args...>
+assert_rc() {
+  local name=$1 want=$2; shift 2
+  local rc=0
+  "$GEN" "$@" >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [[ "$rc" == "$want" ]]; then
+    ok "$name"
+  else
+    bad "$name (rc=$rc, want $want)"
+    indent "$tmp/err" 3
+  fi
+}
+
+echo "== the committed 50-broker config is the reference"
+
+# 1. Byte-identical brokers block at N=50. Everything the generator has to get
+#    right about a broker line — alias, port, placeholders, YAML flow mapping,
+#    two-space indent — is in this one comparison.
+"$GEN" -n 50 -o "$tmp/gen50.yaml" >/dev/null
+if diff -u <(sed -n '/^brokers:/,$p' "$COMMITTED") \
+           <(sed -n '/^brokers:/,$p' "$tmp/gen50.yaml") >"$tmp/diff50"; then
+  ok "N=50 reproduces the committed brokers block byte-for-byte"
+else
+  bad "N=50 diverges from the committed brokers block"
+  indent "$tmp/diff50" 12
+fi
+
+# 1b. The block ABOVE `brokers:` is a second copy of the committed config's
+#     head — the four semp: admission scalars, port, mcp_client_auth, the tls_*
+#     fields. The diff above starts at `^brokers:` and so covered none of it,
+#     which left a future edit to the committed semp: block landing in one file
+#     only. The two arms of a 50-vs-200-broker campaign would then differ in an
+#     admission setting as well as in broker count.
+#
+#     Compared comment-stripped, because the comment blocks are *meant* to
+#     differ: the generated file carries its own provenance header and a
+#     shortened pacer note. Every semantic line must match.
+strip_semantic() { # <file> — the pre-brokers region, comments and blanks removed
+  sed -n '1,/^brokers:/p' "$1" | sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e '/^$/d'
+}
+if diff -u <(strip_semantic "$COMMITTED") \
+           <(strip_semantic "$tmp/gen50.yaml") >"$tmp/diffhead"; then
+  ok "N=50 reproduces the committed config's settings above brokers: (comments aside)"
+else
+  bad "the generated config's settings diverge from the committed config"
+  indent "$tmp/diffhead" 12
+fi
+
+echo "== alias scheme matches loadgen's generated names"
+
+# 2. loadgen builds its alias list with "%s-%02d" (resolveBrokers). %02d is a
+#    *minimum* width, so 9 -> broker-09 but 100 -> broker-100. If that literal
+#    ever changes, this test must fail rather than the run.
+if grep -q '"%s-%02d"' "$LOADGEN_SRC"; then
+  ok "loadgen still generates aliases as \"%s-%02d\""
+else
+  bad "loadgen's alias format string changed — gen-mock-config.sh must follow it"
+  grep -n '%s-%0' "$LOADGEN_SRC" >"$tmp/fmt" || true
+  indent "$tmp/fmt" 3
+fi
+
+# 3. One, two and three digits. The three-digit case is the one a plausibly
+#    wrong implementation breaks: padding to the width of N would emit
+#    broker-001 for a 200-broker run and rename all 99 of the first brokers.
+"$GEN" -n 9   -o "$tmp/gen9.yaml"   >/dev/null
+"$GEN" -n 200 -o "$tmp/gen200.yaml" >/dev/null
+
+has() { grep -qE "^  $2: " "$1"; }
+lacks() { ! grep -qE "^  $2: " "$1"; }
+
+for want in broker-01 broker-09; do
+  if has "$tmp/gen9.yaml" "$want"; then ok "N=9 emits $want"; else bad "N=9 missing $want"; fi
+done
+if lacks "$tmp/gen9.yaml" broker-10; then ok "N=9 stops at broker-09"; else bad "N=9 emitted broker-10"; fi
+
+for want in broker-01 broker-09 broker-10 broker-99 broker-100 broker-200; do
+  if has "$tmp/gen200.yaml" "$want"; then ok "N=200 emits $want"; else bad "N=200 missing $want"; fi
+done
+for unwanted in broker-009 broker-0100 broker-201; do
+  if lacks "$tmp/gen200.yaml" "$unwanted"; then
+    ok "N=200 does not emit $unwanted"
+  else
+    bad "N=200 emitted $unwanted — width was padded to N instead of %02d"
+  fi
+done
+
+# 4. Exactly N brokers, no more. A trailing extra or a fencepost error at the
+#    top of the range would still pass every spot check above.
+for n in 9 50 200; do
+  # `|| true`: grep -c exits 1 on zero matches, and under `set -e` that would
+  # kill this script mid-report on exactly the worst regression — a generator
+  # that emitted no broker lines at all would abort the run instead of printing
+  # a FAIL. Same reason indent() avoids `sed | head`.
+  got=$(grep -cE '^  broker-[0-9]+: ' "$tmp/gen$n.yaml" || true)
+  if [[ "$got" == "$n" ]]; then
+    ok "N=$n emits exactly $n broker entries"
+  else
+    bad "N=$n emitted $got broker entries"
+  fi
+done
+
+echo "== environment placeholders survive verbatim"
+
+# 5. MCP hard-fails on an unset ${VAR}, so a generator that expanded or dropped
+#    one produces a config that cannot start. Count them: one of each per
+#    broker line, unexpanded.
+for n in 9 200; do
+  bad_ph=0
+  for ph in 'MOCK_HOST' 'BROKER_USERNAME' 'BROKER_PASSWORD'; do
+    got=$(grep -cF "\${$ph}" "$tmp/gen$n.yaml" || true)
+    [[ "$got" == "$n" ]] || { bad "N=$n has $got \${$ph} placeholders, want $n"; bad_ph=1; }
+  done
+  (( bad_ph )) || ok "N=$n preserves all three \${...} placeholders on every broker line"
+done
+
+echo "== ports derive from -port-start"
+
+"$GEN" -n 3 -port-start 20000 -o "$tmp/ports.yaml" >/dev/null
+if grep -q 'broker-01: .*:20000"' "$tmp/ports.yaml" &&
+   grep -q 'broker-03: .*:20002"' "$tmp/ports.yaml"; then
+  ok "-port-start 20000 maps broker-01..03 onto 20000..20002"
+else
+  bad "-port-start did not map onto consecutive ports"
+  indent "$tmp/ports.yaml"
+fi
+
+"$GEN" -n 2 -prefix mock -o "$tmp/prefix.yaml" >/dev/null
+if grep -qE '^  mock-01: ' "$tmp/prefix.yaml" && grep -qE '^  mock-02: ' "$tmp/prefix.yaml"; then
+  ok "-prefix mock emits mock-01..mock-02"
+else
+  bad "-prefix was not honoured"
+fi
+
+echo "== the committed config is protected"
+
+# 6. By name, by absolute path, and through a symlink — all the same file, and
+#    all must be refused. Nobody should commit a 200-broker config, and losing
+#    the committed 50-broker one to a stray -o is a silent, annoying loss.
+before_hash=$(sha256sum "$COMMITTED" | cut -d' ' -f1)
+assert_rc "refuses -o ./broker-config.mock.yaml"           2 -n 5 -o "$here/broker-config.mock.yaml"
+assert_rc "refuses it even with -f"                        2 -n 5 -f -o "$here/broker-config.mock.yaml"
+ln -s "$COMMITTED" "$tmp/link.yaml"
+assert_rc "refuses a symlink to the committed config"      2 -n 5 -o "$tmp/link.yaml"
+after_hash=$(sha256sum "$COMMITTED" | cut -d' ' -f1)
+check "the committed config is unmodified after the refusals" \
+  "$([[ "$before_hash" == "$after_hash" ]] && echo 0 || echo 1)"
+
+echo "== overwrite protection and argument validation"
+
+assert_rc "refuses an existing output without -f"          2 -n 5 -o "$tmp/gen50.yaml"
+assert_rc "overwrites an existing output with -f"          0 -n 5 -f -o "$tmp/gen50.yaml"
+assert_rc "rejects -n 0"                                   2 -n 0 -o "$tmp/x.yaml"
+assert_rc "rejects a non-numeric -n"                       2 -n abc -o "$tmp/x.yaml"
+assert_rc "rejects a missing -n"                           2 -o "$tmp/x.yaml"
+assert_rc "rejects a missing -o"                           2 -n 5
+assert_rc "rejects an unknown argument"                     2 -n 5 -o "$tmp/x.yaml" -wat
+assert_rc "rejects a port range past 65535"                2 -n 100 -port-start 65500 -o "$tmp/x.yaml"
+assert_rc "rejects a non-numeric -port-start"              2 -n 5 -port-start abc -o "$tmp/x.yaml"
+assert_rc "rejects a prefix with a space"                  2 -n 5 -prefix 'bad name' -o "$tmp/x.yaml"
+assert_rc "rejects -o into a directory that does not exist" 1 -n 5 -o "$tmp/nope/x.yaml"
+
+# The mock's control endpoint is a fixed :19000, inside the broker range from
+# -n 920. A collision is not loud: that broker answers /_mock/config instead of
+# SEMP, so the run 404s on one broker and reads as a broker fault.
+assert_rc "rejects a range spanning the mock control port"  2 -n 920 -o "$tmp/x.yaml"
+assert_rc "accepts -n 919, which stops just below it"       0 -n 919 -o "$tmp/big.yaml"
+
+# 7. A rejected run must leave nothing behind — not the output, and not the
+#    temp file it writes through.
+if [[ ! -e "$tmp/x.yaml" ]] && ! compgen -G "$tmp/x.yaml.tmp.*" >/dev/null; then
+  ok "a rejected run leaves no output and no temp file"
+else
+  bad "a rejected run left a file behind"
+  ls -1 "$tmp" >"$tmp/listing" || true
+  indent "$tmp/listing"
+fi
+
+echo "== --help is complete"
+
+# A hardcoded `sed -n '4,32p'` over the script's own header printed the options
+# plus half of the paragraph below them, so --help ended mid-clause — and it
+# drifted every time the header gained a line. Assert the shape instead of the
+# line count: the usage marker must be present, the terminator must not leak,
+# and the last line must be a whole line rather than a severed clause.
+"$GEN" --help >"$tmp/help" 2>&1
+help_ok=1
+grep -q '^Usage:' "$tmp/help" || { bad "--help does not start with Usage:"; help_ok=0; }
+grep -q '^  -n <count>' "$tmp/help" || { bad "--help omits the -n option"; help_ok=0; }
+grep -q -- 'end usage' "$tmp/help" && { bad "--help leaks its own end-of-usage marker"; help_ok=0; }
+# The old bug's signature: the final line ended with a dangling ", a" / "; a".
+if tail -1 "$tmp/help" | grep -qE '[,;] *[a-z]$'; then
+  bad "--help ends mid-clause (line-range drift)"
+  indent "$tmp/help" 40
+  help_ok=0
+fi
+(( help_ok )) && ok "--help prints a complete usage block"
+
+echo "== the output is valid YAML with the expected broker count"
+
+# Optional: only pyyaml can answer "is this actually parseable", and the gate
+# must not depend on it being installed. Skipping is reported, not silent — a
+# check that quietly inspects nothing is not a check.
+if python3 -c 'import yaml' >/dev/null 2>&1; then
+  if python3 - "$tmp/gen200.yaml" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    doc = yaml.safe_load(f)
+brokers = doc["brokers"]
+assert len(brokers) == 200, f"{len(brokers)} brokers, want 200"
+assert brokers["broker-200"]["url"] == "http://${MOCK_HOST}:18280", brokers["broker-200"]["url"]
+assert doc["semp"]["request_min_interval"] == "0s", doc["semp"]["request_min_interval"]
+PY
+  then
+    ok "N=200 parses as YAML with 200 brokers and the pacer off"
+  else
+    bad "N=200 is not valid YAML, or its contents are wrong"
+  fi
+else
+  echo "  skip  YAML parse check (python3 yaml module not installed)"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -626,50 +626,72 @@ perf_duration_secs() {
   printf '%s\n' "$secs"
 }
 
-# perf_cgroup_cpu_max <root> <cgroup_path> — the `cpu.max` that binds a process
-# in <cgroup_path>, searched from that cgroup upwards to <root>. Echoes the
-# file's contents, or nothing when no ancestor sets one.
-#
-# Split out from perf_record_runtime_cpu so the search is testable with a
-# nested path. It is one of the two parts here that could write a confident
-# wrong number, and a test that derives its fixture from the *test host's* own
-# cgroup cannot exercise it at all on a host whose shell sits at the root —
-# leaf and ancestor collapse to one directory and the walk is never taken.
-#
-# The walk is necessary, not defensive: cpu.max exists only where the cpu
-# controller has been enabled, and a limit set on an ancestor still binds.
-perf_cgroup_cpu_max() {
-  local root=${1%/} dir
-  [[ -z "$root" ]] && root=/
-  dir="$root${2%/}"
-  while :; do
-    if [[ -r "$dir/cpu.max" ]]; then
-      cat "$dir/cpu.max"
-      return 0
-    fi
-    [[ "$dir" == "$root" || "$dir" == "/" ]] && return 0
-    dir=$(dirname "$dir")
-  done
-}
-
 # perf_cgroup_quota_cores <cpu.max contents> — that quota as a core count:
 # `0.25` for "25000 100000", `none` for an unlimited one, `unknown` for a line
 # this cannot read.
 #
-# Cores rather than the raw pair because the raw pair is already recorded next
-# to it, and because a reader comparing two runs wants the number the runtime
-# would have derived, not two integers to divide by hand.
+# The two-field shape is validated before either branch. A truncated file
+# holding just "25000" would otherwise pass `${cpumax%% *}` and `${cpumax##* }`
+# as the same token and report a confident 1.00 core, and a bare "max" would
+# report `none` — both of them entitlements nobody measured. `unknown` is the
+# contract for a line that does not parse.
 perf_cgroup_quota_cores() {
   local cpumax=${1-} quota period
-  quota=${cpumax%% *}
-  period=${cpumax##* }
-  if [[ "$quota" == "max" ]]; then
+  # Exactly two whitespace-separated fields, or it is not a cpu.max.
+  if [[ ! "$cpumax" =~ ^[^[:space:]]+[[:space:]]+[^[:space:]]+$ ]]; then
+    printf 'unknown\n'
+    return 0
+  fi
+  quota=${cpumax%%[[:space:]]*}
+  period=${cpumax##*[[:space:]]}
+  if [[ "$quota" == "max" && "$period" =~ ^[0-9]+$ ]]; then
     printf 'none\n'
   elif [[ "$quota" =~ ^[0-9]+$ && "$period" =~ ^[0-9]+$ ]] && (( period > 0 )); then
     awk -v q="$quota" -v p="$period" 'BEGIN { printf "%.2f\n", q / p }'
   else
     printf 'unknown\n'
   fi
+}
+
+# perf_cgroup_binding_quota <root> <cgroup_path> — the CPU quota that actually
+# constrains a process in <cgroup_path>, as "<cores> <cgroup> <cpu.max>".
+# Echoes nothing when no cgroup on the path sets one.
+#
+# Every cgroup from the process's own up to the root is read, not just the
+# nearest with a cpu.max, because v2 CPU limits are hierarchical: a parent's
+# bandwidth bounds its whole subtree, so a 2-core leaf under a half-core parent
+# gets half a core. Reporting the nearest file would have overstated that by
+# fourfold — a confident wrong number, which is the one thing this record is
+# built not to produce.
+#
+# The most restrictive wins, and the cgroup that set it is returned alongside,
+# so the record can name what binds rather than leaving the reader to guess
+# which level it came from. An unparsable cpu.max on the path is skipped rather
+# than treated as unlimited: a file we cannot read is not permission.
+perf_cgroup_binding_quota() {
+  local root=${1%/} dir cores best="" best_dir="" best_raw="" raw
+  [[ -z "$root" ]] && root=/
+  dir="$root${2%/}"
+  while :; do
+    if [[ -r "$dir/cpu.max" ]]; then
+      raw=$(cat "$dir/cpu.max")
+      cores=$(perf_cgroup_quota_cores "$raw")
+      if [[ "$cores" != none && "$cores" != unknown ]]; then
+        if [[ -z "$best" ]] || awk -v a="$cores" -v b="$best" 'BEGIN { exit !(a < b) }'; then
+          best=$cores
+          best_raw=$raw
+          # Report the cgroup relative to the root, which is what
+          # /proc/<pid>/cgroup names.
+          best_dir=${dir#"$root"}
+          [[ -z "$best_dir" ]] && best_dir=/
+        fi
+      fi
+    fi
+    [[ "$dir" == "$root" || "$dir" == "/" ]] && break
+    dir=$(dirname "$dir")
+  done
+  [[ -n "$best" ]] && printf '%s %s %s\n' "$best" "$best_dir" "$best_raw"
+  return 0
 }
 
 # perf_record_runtime_cpu <record> <pid> — how much processor the Go runtime in
@@ -736,7 +758,14 @@ perf_record_runtime_cpu() {
   fi
   perf_record_kv "$record" cgroup_path "$cg"
 
-  cpumax=$(perf_cgroup_cpu_max "$cg_root" "$cg")
+  local binding cores from
+  binding=$(perf_cgroup_binding_quota "$cg_root" "$cg")
+  cpumax=""
+  if [[ -n "$binding" ]]; then
+    cores=${binding%% *}
+    from=$(printf '%s' "$binding" | cut -d' ' -f2)
+    cpumax=$(printf '%s' "$binding" | cut -d' ' -f3-)
+  fi
   if [[ -z "$cpumax" ]]; then
     # Reaching the root without finding the file is an answer, not a gap: the
     # v2 root cgroup has no cpu.max by design and imposes no limit, so the
@@ -748,7 +777,11 @@ perf_record_runtime_cpu() {
     return 0
   fi
   perf_record_kv "$record" cgroup_cpu_max "$cpumax"
-  perf_record_kv "$record" cgroup_cpu_quota_cores "$(perf_cgroup_quota_cores "$cpumax")"
+  perf_record_kv "$record" cgroup_cpu_quota_cores "$cores"
+  # Which cgroup on the path actually binds. Equal to cgroup_path when the
+  # process's own cgroup is the tightest; an ancestor otherwise, and that
+  # difference is the whole reason the walk reads every level.
+  perf_record_kv "$record" cgroup_cpu_quota_from "$from"
   return 0
 }
 

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -594,8 +594,9 @@ perf_record_assert_fields() {
 # figures — the diluted number the run record exists to stop people quoting.
 #
 # Deliberately stricter than Go's own parser, which also takes "1m30s" and
-# "500ms". The samplers here count in whole seconds, so a duration they cannot
-# express is better refused at the door than silently truncated. Pure bash and
+# "500ms". This harness counts in whole seconds — sampler windows are sized in
+# them and `stats_start_epoch` is one — so a duration that cannot be expressed
+# in them is refused at the door rather than silently rounded into one. Pure bash and
 # awk arithmetic: no gawk-only 3-argument match(), because this file is sourced
 # by the self-test on developer laptops where awk is mawk.
 perf_duration_secs() {
@@ -607,8 +608,16 @@ perf_duration_secs() {
     echo "duration must be a number of s, m or h (e.g. 30s, 1.5m), got: '$v'" >&2
     return 1
   fi
+  # A duration is accepted only when it lands on a whole second. Rounding into
+  # one looked harmless — it sizes a sampler window, where a second either way
+  # is nothing — but the same resolved value also positions `stats_start_epoch`,
+  # and an epoch is a point, not a span: WARMUP=0.5s would place the statistics
+  # window half a second away from where loadgen actually opened it, silently.
+  # Fractional inputs that *do* land whole are fine (1.5m is 90s exactly), so
+  # this rejects the ones that cannot be represented rather than the notation.
+  #
   # The epsilon is not cosmetic: 1.1 * 3600 is 3960.0000000000005 in floating
-  # point, so a bare `s == int(s)` rounds 1.1h up to 3961 seconds.
+  # point, so a bare `s == int(s)` would reject 1.1h as fractional.
   #
   # The upper bound stops a fat-fingered value becoming a number that wraps
   # when the caller adds to it: `$(( 1e20 + 10 ))` is negative-adjacent
@@ -617,12 +626,17 @@ perf_duration_secs() {
     mult = (u == "h" ? 3600 : (u == "m" ? 60 : 1))
     s = n * mult
     if (s > 86400) { print "over"; exit }
-    print (s <= int(s) + 1e-9) ? int(s) : int(s) + 1
+    if (s - int(s) > 1e-9 && int(s) + 1 - s > 1e-9) { print "fractional"; exit }
+    printf "%d\n", (s + 1e-9)
   }')
-  if [[ "$secs" == over ]]; then
-    echo "duration must be 24h or less, got: '$v'" >&2
-    return 1
-  fi
+  case "$secs" in
+    over)
+      echo "duration must be 24h or less, got: '$v'" >&2
+      return 1 ;;
+    fractional)
+      echo "duration must be a whole number of seconds, got: '$v'" >&2
+      return 1 ;;
+  esac
   printf '%s\n' "$secs"
 }
 

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -171,6 +171,15 @@ perf_raise_nofile() {
     return 1
   fi
   local want=${1:-1048576}
+  # NOFILE is operator input and reaches an arithmetic comparison below, where
+  # bash treats a non-numeric word as a variable name — so `NOFILE=abc` aborted
+  # the whole runner under `set -u` with "abc: unbound variable", from inside a
+  # library, several steps before anything measured. Validate it here where the
+  # message can name the variable.
+  if ! [[ "$want" =~ ^[0-9]+$ ]] || (( want < 1 )); then
+    echo "NOFILE must be a positive integer number of descriptors, got: $want" >&2
+    return 1
+  fi
   local hard target
   hard=$(ulimit -Hn)
   target=$want
@@ -211,6 +220,17 @@ perf_record_kv() {
   value=${value//$'\n'/ }
   value=${value//$'\r'/ }
   value=${value//$'\t'/ }
+  # '=' is the field separator. The record's documented format is one
+  # key=value per line, read with `awk -F=`, so a value containing '=' reads
+  # back truncated at the first one — RIG_NOTE="instance=m5.large" became
+  # "instance". Substituted rather than rejected, because losing the note
+  # entirely is worse than losing one character, and warned rather than
+  # silently altered, because a provenance file that quietly rewrites what it
+  # was told is the opposite of the point.
+  if [[ "$value" == *=* ]]; then
+    echo "   note: '=' in the value of $2 replaced with ':' to keep the record parseable" >&2
+    value=${value//=/:}
+  fi
   printf '%s=%s\n' "$2" "${value:0:200}" >>"$1"
 }
 

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -450,7 +450,16 @@ perf_record_admission() {
 # class of error the _source scheme exists to prevent.
 perf_semp_block() {
   awk '
-    /^[^[:space:]#]/ { in_semp = ($0 ~ /^semp:[[:space:]]*$/); next }
+    # Strip a trailing comment before matching: `semp:  # the pacer` is a legal
+    # and unremarkable thing to write, and an exact-match on the raw line made
+    # the entire block invisible — so every setting in it was reported as a
+    # server default when it was written down. A wrong _source is the class of
+    # error the _source scheme exists to prevent.
+    /^[^[:space:]#]/ {
+      l = $0; sub(/#.*/, "", l); sub(/[[:space:]]+$/, "", l)
+      in_semp = (l == "semp:")
+      next
+    }
     in_semp { print }
   ' "$1"
 }
@@ -464,8 +473,14 @@ perf_semp_block() {
 # nesting or lists, the right answer is for the server to report the value.
 perf_yaml_semp_value() {
   awk -v want="$2" '
-    # Leaving the semp block: any key at column 0.
-    /^[^[:space:]#]/ { in_semp = ($0 ~ /^semp:[[:space:]]*$/) ; next }
+    # Leaving the semp block: any key at column 0. A trailing comment on the
+    # `semp:` line itself is stripped before matching, for the same reason
+    # perf_semp_block does it.
+    /^[^[:space:]#]/ {
+      l = $0; sub(/#.*/, "", l); sub(/[[:space:]]+$/, "", l)
+      in_semp = (l == "semp:")
+      next
+    }
     !in_semp { next }
     {
       line = $0

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -395,6 +395,37 @@ perf_record_fixtures() {
   return 0
 }
 
+# perf_redact_userinfo <url> — the URL with any userinfo replaced by `***`.
+#
+# `http://user:secret@host:9090` becomes `http://***@host:9090`. Nothing in
+# this harness produces such a URL — the mock disables client auth entirely and
+# loadgen's only auth channel is MCP_DEV_TOKEN, an env var that is never
+# persisted — but the URL is caller-supplied, the record is an archived
+# artifact that gets shared between engineers, and userinfo is worth nothing as
+# provenance. Cheaper to make the shape impossible than to argue about how
+# likely it is.
+perf_redact_userinfo() {
+  local url=${1-}
+  # Only the authority component: a `@` later in a path or query is not
+  # userinfo, and rewriting it would corrupt the URL the run actually used.
+  if [[ "$url" =~ ^([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@]+@(.*)$ ]]; then
+    printf '%s***@%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  else
+    printf '%s\n' "$url"
+  fi
+}
+
+# perf_alias_count <csv> — how many broker aliases a comma-separated list pins.
+#
+# Empty entries do not count: "a,,b" pins two aliases, not three, and an empty
+# string pins none. Split out here rather than inlined in the runner because
+# the number it produces goes into the run record as `broker_count`, and a
+# provenance field that cannot be tested is how the previous one came to say
+# 50 for a run driving three brokers.
+perf_alias_count() {
+  awk -F, '{ n = 0; for (i = 1; i <= NF; i++) if ($i ~ /[^[:space:]]/) n++; print n }' <<<"${1-}"
+}
+
 # perf_record_admission <record> <mcp_log> <config_used> — the four settings
 # that move admission behaviour, each with the source it came from.
 #

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -303,6 +303,30 @@ perf_record_rig() {
   return 0
 }
 
+# perf_tree_dirty <dir> — `true` when the checkout has uncommitted changes to
+# tracked files, `false` when it does not; rc=1 when <dir> is not a checkout.
+#
+# `--untracked-files=no` is the whole point of this existing. `git status`
+# reports the entire repository regardless of the directory it is pointed at,
+# so without it an untracked file anywhere in the tree — a scratch note, a
+# downloaded toolchain, an editor backup — flips the flag. That is not
+# hypothetical: this read `true` for every capture of a 120-run campaign whose
+# tree carried no tracked modification at all, and a provenance flag that is
+# always on is worse than no flag, because it trains the reader to ignore it.
+#
+# The cost of ignoring untracked files is real and worth stating: a fixture
+# regenerated but never `git add`ed reads clean. For the question the flag
+# answers — "was the tracked code at the recorded commit?" — that is the right
+# trade, but both callers repeat the caveat where they write the field.
+#
+# One helper for both callers on purpose. The defect it fixes existed twice,
+# in two files, written the same wrong way; a second copy would drift again.
+perf_tree_dirty() {
+  local out
+  out=$(git -C "$1" status --porcelain --untracked-files=no 2>/dev/null) || return 1
+  [[ -n "$out" ]] && printf 'true\n' || printf 'false\n'
+}
+
 # perf_record_code <record> <repo_root> <bin_dir> <binary>... — what was built.
 #
 # The commit alone does not identify what ran: a run from a dirty tree is not
@@ -315,11 +339,10 @@ perf_record_code() {
   perf_record_comment "$record" "code"
   if commit=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null); then
     perf_record_kv "$record" commit "$commit"
-    if [[ -n "$(git -C "$repo_root" status --porcelain 2>/dev/null)" ]]; then
-      dirty=true
-    else
-      dirty=false
-    fi
+    # Tracked changes only — see perf_tree_dirty. An untracked file in the
+    # tree is not a difference between this run and the commit it names; a
+    # regenerated-but-unadded fixture is the blind spot that buys.
+    dirty=$(perf_tree_dirty "$repo_root") || dirty=unknown
     perf_record_kv "$record" commit_dirty "$dirty"
   else
     # A tarball deploy with no .git. Say so rather than leaving the reader to
@@ -534,6 +557,198 @@ perf_record_proc_nofile() {
     perf_record_kv "$record" nofile_effective_soft unknown
     perf_record_kv "$record" nofile_effective_hard unknown
   fi
+  return 0
+}
+
+# perf_record_assert_fields <record> <field>... — warn loudly when a record is
+# closed without a field it should carry. rc=1 when any is missing.
+#
+# Named fields, never a line count. A count breaks on the next field anyone
+# adds and on every comment line, and "a record that is short by one" is
+# precisely what no reader notices: a 48-line record looks complete unless you
+# count it against another one.
+#
+# Warns rather than aborts. By the time a record is closed the measurement is
+# already in the CSVs, and turning a provenance gap into a non-zero exit would
+# discard a completed run over a missing line. The caller decides what to do
+# with rc=1; the runners deliberately let it stand as a warning.
+perf_record_assert_fields() {
+  local record=$1; shift
+  local f
+  local missing=()
+  for f in "$@"; do
+    grep -q "^$f=" "$record" 2>/dev/null || missing+=("$f")
+  done
+  if (( ${#missing[@]} > 0 )); then
+    echo "!! incomplete run record ${record##*/}: missing ${missing[*]}" >&2
+    return 1
+  fi
+  return 0
+}
+
+# perf_duration_secs <duration> — a Go duration string as whole seconds,
+# rounded up. rc=1 with a message on anything else.
+#
+# Rounded up because every caller sizes a sampler window with the result, and a
+# window that ends before the load does clips the tail off the load-phase
+# figures — the diluted number the run record exists to stop people quoting.
+#
+# Deliberately stricter than Go's own parser, which also takes "1m30s" and
+# "500ms". The samplers here count in whole seconds, so a duration they cannot
+# express is better refused at the door than silently truncated. Pure bash and
+# awk arithmetic: no gawk-only 3-argument match(), because this file is sourced
+# by the self-test on developer laptops where awk is mawk.
+perf_duration_secs() {
+  local v=${1-} n unit secs
+  if [[ "$v" =~ ^([0-9]+(\.[0-9]+)?)(s|m|h)$ ]]; then
+    n=${BASH_REMATCH[1]}
+    unit=${BASH_REMATCH[3]}
+  else
+    echo "duration must be a number of s, m or h (e.g. 30s, 1.5m), got: '$v'" >&2
+    return 1
+  fi
+  # The epsilon is not cosmetic: 1.1 * 3600 is 3960.0000000000005 in floating
+  # point, so a bare `s == int(s)` rounds 1.1h up to 3961 seconds.
+  #
+  # The upper bound stops a fat-fingered value becoming a number that wraps
+  # when the caller adds to it: `$(( 1e20 + 10 ))` is negative-adjacent
+  # nonsense, and no window this harness sizes is longer than a day.
+  secs=$(awk -v n="$n" -v u="$unit" 'BEGIN {
+    mult = (u == "h" ? 3600 : (u == "m" ? 60 : 1))
+    s = n * mult
+    if (s > 86400) { print "over"; exit }
+    print (s <= int(s) + 1e-9) ? int(s) : int(s) + 1
+  }')
+  if [[ "$secs" == over ]]; then
+    echo "duration must be 24h or less, got: '$v'" >&2
+    return 1
+  fi
+  printf '%s\n' "$secs"
+}
+
+# perf_cgroup_cpu_max <root> <cgroup_path> — the `cpu.max` that binds a process
+# in <cgroup_path>, searched from that cgroup upwards to <root>. Echoes the
+# file's contents, or nothing when no ancestor sets one.
+#
+# Split out from perf_record_runtime_cpu so the search is testable with a
+# nested path. It is one of the two parts here that could write a confident
+# wrong number, and a test that derives its fixture from the *test host's* own
+# cgroup cannot exercise it at all on a host whose shell sits at the root —
+# leaf and ancestor collapse to one directory and the walk is never taken.
+#
+# The walk is necessary, not defensive: cpu.max exists only where the cpu
+# controller has been enabled, and a limit set on an ancestor still binds.
+perf_cgroup_cpu_max() {
+  local root=${1%/} dir
+  [[ -z "$root" ]] && root=/
+  dir="$root${2%/}"
+  while :; do
+    if [[ -r "$dir/cpu.max" ]]; then
+      cat "$dir/cpu.max"
+      return 0
+    fi
+    [[ "$dir" == "$root" || "$dir" == "/" ]] && return 0
+    dir=$(dirname "$dir")
+  done
+}
+
+# perf_cgroup_quota_cores <cpu.max contents> — that quota as a core count:
+# `0.25` for "25000 100000", `none` for an unlimited one, `unknown` for a line
+# this cannot read.
+#
+# Cores rather than the raw pair because the raw pair is already recorded next
+# to it, and because a reader comparing two runs wants the number the runtime
+# would have derived, not two integers to divide by hand.
+perf_cgroup_quota_cores() {
+  local cpumax=${1-} quota period
+  quota=${cpumax%% *}
+  period=${cpumax##* }
+  if [[ "$quota" == "max" ]]; then
+    printf 'none\n'
+  elif [[ "$quota" =~ ^[0-9]+$ && "$period" =~ ^[0-9]+$ ]] && (( period > 0 )); then
+    awk -v q="$quota" -v p="$period" 'BEGIN { printf "%.2f\n", q / p }'
+  else
+    printf 'unknown\n'
+  fi
+}
+
+# perf_record_runtime_cpu <record> <pid> — how much processor the Go runtime in
+# <pid> was entitled to, as separately sourced facts.
+#
+# The record already says everything about the machine (cores_logical,
+# cores_physical, cpu_model, instance_type) and nothing about how much of it
+# the runtime will use. Two runs on one box with different GOMAXPROCS produce
+# records identical in every field, which defeats the purpose the record exists
+# for.
+#
+# Three facts, never one derived "effective GOMAXPROCS", for two reasons:
+#
+#   * Go 1.25 — what go.mod requires — derives GOMAXPROCS from the cgroup CPU
+#     limit when there is one. A field that fell back to nproc would therefore
+#     be confidently wrong in exactly the containerised case this exists to
+#     detect: deploy/kubernetes/deployment.yaml sets requests.cpu 100m and no
+#     CPU limit, so a pod falls back to the node's core count and runs with 64
+#     Ps on a 64-core node while entitled to a tenth of a core.
+#   * Go 1.25 also updates GOMAXPROCS as cgroup limits change, so no single
+#     value read at startup is the whole story anyway.
+#
+# So: record what can be read, name where each part came from, and leave the
+# derivation to the reader — the same rule the admission settings follow.
+#
+# cgroup v2 only (unified hierarchy, `0::<path>` in /proc/<pid>/cgroup). The
+# rig hosts are cgroup2fs throughout; a v1 or hybrid host writes `unknown`
+# rather than guessing at a layout it did not read.
+perf_record_runtime_cpu() {
+  local record=$1 pid=$2
+  local env_val cg cpumax
+  perf_record_comment "$record" "runtime CPU entitlement (GOMAXPROCS is derived from these, not recorded as one value)"
+
+  # As the process was actually launched, from its own environment — not this
+  # shell's, which can differ across a re-exec, and not the value some later
+  # reader assumes.
+  if [[ -r "/proc/$pid/environ" ]]; then
+    # `|| true`, and the redirect's own error silenced: the readability check
+    # above and the open below are two moments, and a process that exits
+    # between them makes the redirect fail — which, inside a command
+    # substitution feeding an assignment, aborts the whole run under `set -e`.
+    # Every other best-effort probe here is guarded the same way; this one is
+    # in the main flow of two runners, right after the health check.
+    env_val=$( { tr '\0' '\n' <"/proc/$pid/environ" || true; } 2>/dev/null \
+               | awk -F= '$1 == "GOMAXPROCS" { print substr($0, index($0, "=") + 1); exit }')
+    # `unset` is a third value alongside the record's two absences, and it is a
+    # measured answer rather than either of them: the variable was looked for
+    # and was not there, which is what makes the runtime fall back.
+    perf_record_kv "$record" gomaxprocs_env "$(perf_or_unknown "${env_val:-unset}")"
+  else
+    perf_record_kv "$record" gomaxprocs_env unknown
+  fi
+
+  # PERF_CGROUP_ROOT is a test seam and nothing else: the self-test builds a
+  # synthetic hierarchy under a temp dir. Unset in every real run, where the
+  # root is the mount point and the mount type is checked.
+  local cg_root=${PERF_CGROUP_ROOT:-/sys/fs/cgroup}
+  cg=$(awk -F: '$1 == "0" { print $3; exit }' "/proc/$pid/cgroup" 2>/dev/null) || true
+  if [[ -z "$cg" ]] || { [[ -z "${PERF_CGROUP_ROOT:-}" ]] && [[ "$(stat -fc %T "$cg_root" 2>/dev/null)" != cgroup2fs ]]; }; then
+    perf_record_kv "$record" cgroup_path unknown
+    perf_record_kv "$record" cgroup_cpu_max unknown
+    perf_record_kv "$record" cgroup_cpu_quota_cores unknown
+    return 0
+  fi
+  perf_record_kv "$record" cgroup_path "$cg"
+
+  cpumax=$(perf_cgroup_cpu_max "$cg_root" "$cg")
+  if [[ -z "$cpumax" ]]; then
+    # Reaching the root without finding the file is an answer, not a gap: the
+    # v2 root cgroup has no cpu.max by design and imposes no limit, so the
+    # runtime sized itself from the visible core count that cores_logical
+    # already records. The mount-type check above is what separates this from
+    # "we looked in the wrong place".
+    perf_record_kv "$record" cgroup_cpu_max none
+    perf_record_kv "$record" cgroup_cpu_quota_cores none
+    return 0
+  fi
+  perf_record_kv "$record" cgroup_cpu_max "$cpumax"
+  perf_record_kv "$record" cgroup_cpu_quota_cores "$(perf_cgroup_quota_cores "$cpumax")"
   return 0
 }
 

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -1,0 +1,557 @@
+# Copyright 2024-2026 Solace Corporation. All rights reserved.
+#
+# lib.sh — helpers shared by run.sh, run-mcp.sh and run-loadgen.sh.
+#
+# Sourced, never executed. Three concerns live here, all of them about making
+# one measurement run comparable with another:
+#
+#   1. the run record  — what rig, what code, what fixtures, what settings
+#   2. the load window — the two timestamps that let summary.sh report CPU over
+#                        the load phase instead of over the whole hold
+#   3. preconditions   — a free port and a raised descriptor limit
+#
+# Everything here is deliberately shell-and-/proc only: no jq, no python, no
+# curl beyond the one optional EC2 metadata probe. A measurement harness that
+# needs a toolchain installed to describe its own run is a harness that stops
+# describing it on the first host that lacks the toolchain.
+#
+# Every function is prefixed perf_ and every global PERF_, so a sourcing script
+# can tell at a glance what came from here.
+#
+# Deliberately NOT here: kill_tree, wait_for_http and wait_for_tcp, which each
+# runner still carries its own copy of. They are process-lifecycle code whose
+# copies have already diverged (run-mcp.sh has no wait_for_tcp), they are wired
+# into three different trap/cleanup orderings, and nothing in this suite can
+# test them without a live broker — so consolidating them is a change with real
+# risk and no coverage, and it does not belong in the same diff as the run
+# record. It is worth doing; it is worth doing on its own. See test/e2e-common/lib.sh
+# for where they should end up.
+
+# ---------------------------------------------------------------------------
+# Ports
+# ---------------------------------------------------------------------------
+
+# perf_first_held_port <port>... — print the first of the named ports that has
+# a listener, and return 0; return 1 when all of them are free.
+#
+# "Free" deliberately means "no listener", not "no socket". A socket in
+# TIME_WAIT does not stop a bind with SO_REUSEADDR, so waiting for every socket
+# on the port to disappear would wait out a 60s kernel timer for nothing — or,
+# worse, time out and fail a run that could have started.
+#
+# Matches on the State column rather than a trailing-space grep so an IPv6
+# listener ([::]:9090) counts too, and so the header row cannot match.
+#
+# One `ss` call for the whole set, not one per port: a 200-broker run passes
+# 202 ports, and a poll loop that shelled out per port would spend more time in
+# `ss` than the port takes to clear.
+perf_first_held_port() {
+  local ports="$*"
+  ss -ltn 2>/dev/null | awk -v want="$ports" '
+    BEGIN { n = split(want, w, " "); for (i = 1; i <= n; i++) order[i] = w[i] }
+    $1 != "LISTEN" { next }
+    {
+      # $4 is Local Address:Port — take the text after the last colon, which
+      # is the port for both 0.0.0.0:9090 and [::]:9090.
+      c = split($4, a, ":")
+      listening[a[c]] = 1
+    }
+    END {
+      for (i = 1; i <= n; i++) {
+        if (order[i] in listening) { print order[i]; exit 0 }
+      }
+      exit 1
+    }
+  '
+}
+
+# perf_wait_ports_free <timeout_s> <port>... — poll until no listener holds any
+# of the named ports, or fail naming the one that stayed held.
+#
+# This exists because a back-to-back sweep point was silently lost: the
+# previous point's MCP server still held :9090 when the next one started. The
+# old behaviour was to abort immediately, which turns a two-second wait into a
+# missing data point in the middle of a sweep. Starting anyway is worse still —
+# the run would measure the *previous* server.
+#
+# Bounded on purpose. A port held past the timeout is a stuck process, not a
+# slow one, and reporting which port was held is what makes that diagnosable.
+perf_wait_ports_free() {
+  local timeout_s=$1; shift
+
+  # Fail closed if we cannot look. An `ss` that is missing or broken makes
+  # perf_first_held_port print nothing, which is indistinguishable from "every
+  # port is free" — so the guard that exists because a sweep point was lost to
+  # a held :9090 would silently stop guarding, and the run would measure the
+  # previous server. "Cannot tell" is not "safe to start".
+  if ! command -v ss >/dev/null 2>&1; then
+    echo "ss (iproute2) not found — cannot verify the ports are free, refusing to start." >&2
+    echo "   Install iproute2, or set PORT_WAIT_SECS=0 deliberately to skip the check." >&2
+    return 1
+  fi
+
+  # An explicit zero is the operator saying "I know what is on this box, do not
+  # check". Distinct from the fail-closed path above: one is a decision, the
+  # other is a missing tool.
+  if (( timeout_s == 0 )); then
+    echo "   PORT_WAIT_SECS=0 — skipping the port-free check"
+    return 0
+  fi
+
+  local deadline=$((SECONDS + timeout_s))
+  local held announced=0
+  while :; do
+    held=$(perf_first_held_port "$@") || return 0
+    if (( SECONDS >= deadline )); then
+      echo "port $held still has a listener after ${timeout_s}s — refusing to start:" >&2
+      ss -ltnp 2>/dev/null | awk -v p="$held" '$1=="LISTEN" { c=split($4,a,":"); if (a[c]==p) print "   " $0 }' >&2
+      echo "   a previous run is still holding it. Kill it, or raise PORT_WAIT_SECS." >&2
+      return 1
+    fi
+    if (( ! announced )); then
+      echo "   waiting up to ${timeout_s}s for port $held (and any other still held) to be released..."
+      announced=1
+    fi
+    sleep 0.5
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Descriptor limit
+# ---------------------------------------------------------------------------
+
+# perf_raise_nofile [want] — raise RLIMIT_NOFILE for this shell and everything
+# it spawns, and record what was asked for versus what was granted.
+#
+# Sets PERF_NOFILE_REQUESTED and PERF_NOFILE_GRANTED. MUST be called in the
+# runner's own shell, not in a $(...) — a subshell's raised limit dies with the
+# subshell and the server would inherit the old one.
+#
+# A flat generous request rather than an arithmetic one derived from the broker
+# count and the concurrency cap: the arithmetic is fragile (two idle pools per
+# broker, each up to the cap, plus one inbound socket per load-generator
+# session) and the descriptors are free. Falls back to the hard limit when that
+# is lower, which is the common unprivileged case.
+perf_raise_nofile() {
+  # Enforce the invariant the comment above states, rather than trusting a
+  # reviewer to police it. A subshell's raised limit dies with the subshell, so
+  # a mis-call leaves the server running under the operator's login-shell limit
+  # while the record claims the raised one — a silently wrong record, which is
+  # the one failure mode this whole file exists to prevent.
+  if [[ "$BASHPID" != "$$" ]]; then
+    echo "perf_raise_nofile called in a subshell — the raised limit would not survive" >&2
+    return 1
+  fi
+  local want=${1:-1048576}
+  local hard target
+  hard=$(ulimit -Hn)
+  target=$want
+  if [[ "$hard" != "unlimited" ]] && (( hard < want )); then
+    target=$hard
+  fi
+  ulimit -n "$target" 2>/dev/null || true
+  PERF_NOFILE_REQUESTED=$want
+  PERF_NOFILE_GRANTED=$(ulimit -n)
+}
+
+# ---------------------------------------------------------------------------
+# Run record
+# ---------------------------------------------------------------------------
+#
+# Format is one key=value per line with '#' comments, the shape sampler.sh's
+# .info sidecar already uses and summary.sh already parses with `awk -F=`.
+# JSON would only pay for itself if something outside the harness consumed the
+# record, and nothing does.
+#
+# The governing rule for every field below: an absent field is honest, a
+# guessed one is a trap. A later comparison will trust whatever is written
+# here, so anything we cannot establish is either omitted or written as the
+# literal `unknown` — never inferred.
+
+# perf_record_kv <record> <key> <value> — append one field.
+#
+# The value is flattened to one line and capped. Two of the inputs here are not
+# fully trusted: RIG_NOTE is free text from the operator, and the EC2 metadata
+# responses come off the network — on a box where 169.254.169.254 is a
+# container network or a hostile LAN rather than AWS, the reply is whatever
+# that endpoint chose to send. A newline in either would inject arbitrary extra
+# `key=value` lines into a file this harness's own doctrine says "a later
+# comparison will trust", so a forged `semp_fair_scheduling=false` is worth one
+# line of defence at the single choke point every field passes through.
+perf_record_kv() {
+  local value=${3-}
+  value=${value//$'\n'/ }
+  value=${value//$'\r'/ }
+  value=${value//$'\t'/ }
+  printf '%s=%s\n' "$2" "${value:0:200}" >>"$1"
+}
+
+# perf_or_unknown <value> — echo the value, or `unknown` when it is empty.
+#
+# The record's contract has exactly two absences: a field left out entirely
+# ("does not apply to this host") and the literal `unknown` ("could not
+# establish"). An empty value is a third state with no defined meaning, and it
+# is the one a consumer is most likely to misread — `cores_logical=` reads as
+# zero cores, not as a missing `nproc`. Every best-effort rig fact goes through
+# here so a missing tool or an unreadable /proc file lands in the vocabulary
+# the header documents.
+perf_or_unknown() {
+  local v=${1-}
+  # Trim, then decide: a value of only whitespace is as absent as an empty one.
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  [[ -n "$v" ]] && printf '%s\n' "$v" || printf 'unknown\n'
+}
+
+# perf_record_comment <record> <text> — append a comment line.
+perf_record_comment() {
+  printf '# %s\n' "$2" >>"$1"
+}
+
+# perf_ec2_meta <record> — write instance_type and availability_zone if this is
+# an EC2 instance, and nothing at all if it is not.
+#
+# IMDSv2 (token first) with a one-second timeout. On a devserver the token PUT
+# simply fails; that is the expected answer for "not EC2", not an error, so no
+# instance fields are written rather than fields reading "unknown". Absent
+# means "this box does not describe itself that way".
+perf_ec2_meta() {
+  local record=$1
+  local imds=http://169.254.169.254/latest
+  local token type az
+  command -v curl >/dev/null 2>&1 || return 0
+  token=$(curl -fsS -m 1 -X PUT "$imds/api/token" \
+            -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' 2>/dev/null) || return 0
+  [[ -n "$token" ]] || return 0
+  type=$(curl -fsS -m 1 -H "X-aws-ec2-metadata-token: $token" \
+           "$imds/meta-data/instance-type" 2>/dev/null) || true
+  az=$(curl -fsS -m 1 -H "X-aws-ec2-metadata-token: $token" \
+         "$imds/meta-data/placement/availability-zone" 2>/dev/null) || true
+  [[ -n "$type" ]] && perf_record_kv "$record" instance_type "$type"
+  [[ -n "$az" ]]   && perf_record_kv "$record" availability_zone "$az"
+  return 0
+}
+
+# perf_record_rig <record> — the facts every host can state about itself.
+#
+# cores/memory/kernel/CPU model are read the same way sampler.sh reads them, so
+# the record and the .info sidecar cannot disagree. RIG_NOTE is the free-text
+# escape hatch for a host that cannot describe itself (a VM with a generic
+# model line, a shared devserver with noisy neighbours worth naming).
+perf_record_rig() {
+  local record=$1
+  perf_record_comment "$record" "rig"
+  perf_record_kv "$record" host "$(perf_or_unknown "$(hostname)")"
+  perf_record_kv "$record" kernel "$(perf_or_unknown "$(uname -r)")"
+  perf_record_kv "$record" arch "$(perf_or_unknown "$(uname -m)")"
+  perf_record_kv "$record" cores_logical "$(perf_or_unknown "$(nproc)")"
+  perf_record_kv "$record" cores_physical \
+    "$(perf_or_unknown "$(lscpu 2>/dev/null | awk -F: '/^Core\(s\) per socket/ {c=$2} /^Socket\(s\)/ {s=$2} END {gsub(/ /,"",c); gsub(/ /,"",s); if (c*s) print c*s}')")"
+  perf_record_kv "$record" cpu_model \
+    "$(perf_or_unknown "$(awk -F: '/model name/ {gsub(/^ +/, "", $2); print $2; exit}' /proc/cpuinfo 2>/dev/null)")"
+  perf_record_kv "$record" mem_total_kb "$(perf_or_unknown "$(awk '/MemTotal/ {print $2}' /proc/meminfo 2>/dev/null)")"
+  perf_ec2_meta "$record"
+  [[ -n "${RIG_NOTE:-}" ]] && perf_record_kv "$record" rig_note "$RIG_NOTE"
+  return 0
+}
+
+# perf_record_code <record> <repo_root> <bin_dir> <binary>... — what was built.
+#
+# The commit alone does not identify what ran: a run from a dirty tree is not
+# the commit it names, and the binaries under bin/ may predate the checkout
+# they sit in (build.sh is a separate step). So record both the commit and the
+# hash of each binary actually executed.
+perf_record_code() {
+  local record=$1 repo_root=$2 bin_dir=$3; shift 3
+  local commit dirty b
+  perf_record_comment "$record" "code"
+  if commit=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null); then
+    perf_record_kv "$record" commit "$commit"
+    if [[ -n "$(git -C "$repo_root" status --porcelain 2>/dev/null)" ]]; then
+      dirty=true
+    else
+      dirty=false
+    fi
+    perf_record_kv "$record" commit_dirty "$dirty"
+  else
+    # A tarball deploy with no .git. Say so rather than leaving the reader to
+    # assume the binaries match some commit.
+    perf_record_kv "$record" commit unknown
+    perf_record_kv "$record" commit_dirty unknown
+  fi
+  for b in "$@"; do
+    if [[ -r "$bin_dir/$b" ]]; then
+      perf_record_kv "$record" "${b//-/_}_sha256" "$(sha256sum "$bin_dir/$b" | cut -d' ' -f1)"
+    fi
+  done
+  return 0
+}
+
+# perf_record_fixtures <record> <perf_dir> — capture provenance.
+#
+# The manifest's own hash pins the whole fixture set in one field: the run
+# scripts already verified every recorded file against it in their preflight,
+# so two runs with the same manifest hash replayed the same bytes. The capture
+# date, commit, VPN and RDP come out of the manifest's provenance header.
+perf_record_fixtures() {
+  local record=$1 perf_dir=$2
+  local manifest="$perf_dir/fixtures.manifest"
+  perf_record_comment "$record" "fixtures"
+  if [[ ! -r "$manifest" ]]; then
+    perf_record_kv "$record" fixtures_manifest_sha256 unknown
+    return 0
+  fi
+  perf_record_kv "$record" fixtures_manifest_sha256 "$(sha256sum "$manifest" | cut -d' ' -f1)"
+  perf_record_kv "$record" fixtures_files "$(grep -cE '^[0-9a-f]{64}  ' "$manifest" || true)"
+  # One awk per key rather than `sed | head`: a `head` that closes the pipe
+  # early sends SIGPIPE to sed, and under `pipefail` that fails the pipeline,
+  # so the `|| echo unknown` fallback would *append* a second line and write a
+  # malformed two-line field into a record everything downstream parses with
+  # `awk -F=`. It only bites on a duplicated header key, which is exactly why
+  # it would never show up in testing.
+  #
+  # capture_dirty matters for the same reason commit_dirty does for the run's
+  # own tree: a capture taken from a dirty checkout is not the commit it names.
+  local k v
+  for k in captured_at capture_commit capture_dirty broker_alias vpn rdp; do
+    v=$(awk -v key="$k" 'index($0, "# " key ": ") == 1 { print substr($0, length(key) + 5); exit }' "$manifest")
+    perf_record_kv "$record" "fixtures_$k" "$(perf_or_unknown "$v")"
+  done
+  return 0
+}
+
+# perf_record_admission <record> <mcp_log> <config_used> — the four settings
+# that move admission behaviour, each with the source it came from.
+#
+# Two of these post-date the last full measurement pass and both change
+# admission (semp.max_queue_wait, semp.fair_scheduling), so a run that does not
+# record them cannot be compared with one that does.
+#
+# Where the value comes from matters as much as the value, because unset is not
+# off: the defaults are a 100ms pacer, 10 in-flight slots, a 30s admission
+# bound and fair scheduling ON. A plain YAML parse would therefore report a
+# blank — read as "no throttle" by the next person — for any config relying on
+# a default.
+#
+# So each field carries a <key>_source:
+#   server-log   the server reported its own effective value at startup
+#   config-file  the value was written explicitly in the config the run used
+#   unreported-server-default
+#                not written down and not reported, so the server applied its
+#                default and this harness cannot prove which. Value is
+#                `unknown`; a wrong value here is worse than an absent one,
+#                because a later comparison would trust it.
+#
+# Only fair_scheduling is on the `config loaded` line today (it is published
+# there deliberately, as a kill switch an operator must be able to confirm).
+# Putting the other three on that line is a one-line server change that would
+# make all four read server-log — worth doing, but it is production surface and
+# this story is scoped to test/performance/.
+perf_record_admission() {
+  local record=$1 mcp_log=$2 config_used=$3
+  perf_record_comment "$record" "admission settings (effective; see lib.sh for what each _source means)"
+
+  # fair_scheduling: the server's own report. JSON logs, so match the key
+  # directly rather than depending on field order.
+  #
+  # Two-stage on purpose. This grep is the harness's only coupling to the
+  # server's log output, and it is therefore also the only place that can tell
+  # us the coupling broke. Collapsing "the server never logged the line" and
+  # "the line is there but the field was renamed" into one `unknown` would let
+  # a log-schema change silently degrade every future run forever, with no
+  # signal — and the whole justification for reading this value here is that it
+  # *is* obtainable.
+  local line="" fair=""
+  if [[ -r "$mcp_log" ]]; then
+    line=$(grep -m1 '"msg":"config loaded"' "$mcp_log" 2>/dev/null) || true
+  fi
+  if [[ -n "$line" ]]; then
+    fair=$(printf '%s' "$line" | sed -n 's/.*"fair_scheduling":\([a-z]*\).*/\1/p')
+  fi
+  if [[ -n "$fair" ]]; then
+    perf_record_kv "$record" semp_fair_scheduling "$fair"
+    perf_record_kv "$record" semp_fair_scheduling_source server-log
+  elif [[ -n "$line" ]]; then
+    echo "   WARNING: the server logged 'config loaded' but no fair_scheduling field —" >&2
+    echo "            the log schema changed and lib.sh's reader needs updating." >&2
+    perf_record_kv "$record" semp_fair_scheduling unknown
+    perf_record_kv "$record" semp_fair_scheduling_source server-log-schema-changed
+  else
+    perf_record_kv "$record" semp_fair_scheduling unknown
+    perf_record_kv "$record" semp_fair_scheduling_source server-log-absent
+  fi
+
+  # The remaining three: explicit in the config the run actually used, or not
+  # established at all.
+  local key val
+  for key in max_concurrent_per_broker request_min_interval max_queue_wait; do
+    val=""
+    if [[ -r "$config_used" ]]; then
+      val=$(perf_yaml_semp_value "$config_used" "$key")
+    fi
+    if [[ -n "$val" ]]; then
+      perf_record_kv "$record" "semp_$key" "$val"
+      perf_record_kv "$record" "semp_${key}_source" config-file
+    elif [[ -r "$config_used" ]] && grep -qE "^[[:space:]]*$key:" "$config_used"; then
+      # The key is in the file but the narrow reader could not extract it — a
+      # shape it does not handle (nesting, flow style, an anchor). Recording
+      # `unreported-server-default` here would be a lie about provenance: the
+      # value IS written down, we just failed to read it. A wrong _source is in
+      # the same family as a wrong value, because a later comparison trusts it.
+      echo "   WARNING: semp.$key is set in $(basename "$config_used") but lib.sh could not parse it" >&2
+      perf_record_kv "$record" "semp_$key" unknown
+      perf_record_kv "$record" "semp_${key}_source" config-file-unparsed
+    else
+      perf_record_kv "$record" "semp_$key" unknown
+      perf_record_kv "$record" "semp_${key}_source" unreported-server-default
+    fi
+  done
+  return 0
+}
+
+# perf_yaml_semp_value <config> <key> — the value of one scalar key inside the
+# top-level `semp:` block, or empty when it is not written down.
+#
+# Deliberately narrow: it reads exactly the four flat scalars under one known
+# top-level key, stops at the next top-level key, and ignores comments. It is
+# not a YAML parser and must not grow into one — the moment a caller needs
+# nesting or lists, the right answer is for the server to report the value.
+perf_yaml_semp_value() {
+  awk -v want="$2" '
+    # Leaving the semp block: any key at column 0.
+    /^[^[:space:]#]/ { in_semp = ($0 ~ /^semp:[[:space:]]*$/) ; next }
+    !in_semp { next }
+    {
+      line = $0
+      sub(/#.*/, "", line)                 # strip trailing comment
+      if (line !~ /^[[:space:]]+[A-Za-z_]+:/) next
+      k = line; sub(/^[[:space:]]+/, "", k); sub(/:.*/, "", k)
+      if (k != want) next
+      v = line; sub(/^[^:]*:[[:space:]]*/, "", v)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+      gsub(/^["'\''"]|["'\''"]$/, "", v)
+      if (v != "") { print v; exit }
+    }
+  ' "$1"
+}
+
+# perf_record_proc_nofile <record> <pid> — the descriptor limit the sampled
+# process actually runs under.
+#
+# Read from the process's own /proc/<pid>/limits, not from the launching shell:
+# the two diverge across a re-exec or a systemd-style wrapper, and the
+# process's own view is the one that constrains the run.
+perf_record_proc_nofile() {
+  local record=$1 pid=$2
+  local soft hard
+  if [[ -r "/proc/$pid/limits" ]]; then
+    soft=$(awk -F'  +' '/^Max open files/ {print $2}' "/proc/$pid/limits")
+    hard=$(awk -F'  +' '/^Max open files/ {print $3}' "/proc/$pid/limits")
+    perf_record_kv "$record" nofile_effective_soft "${soft:-unknown}"
+    perf_record_kv "$record" nofile_effective_hard "${hard:-unknown}"
+  else
+    perf_record_kv "$record" nofile_effective_soft unknown
+    perf_record_kv "$record" nofile_effective_hard unknown
+  fi
+  return 0
+}
+
+# perf_record_fd_peak <record> <mem_csv> — the highest open-descriptor and
+# thread counts the sampler saw.
+#
+# Appended after the run, because a peak is not knowable at the start. Recorded
+# next to the limit so a run that came close to its ceiling is visible
+#
+# A row whose fd column is "NA" (memsampler could not read the descriptor
+# directory) is skipped rather than read as 0, and a run with no readable fd
+# sample at all writes no fd_peak field. fd_peak=0 would say the server held no
+# descriptors, which is never true and would be believed.
+perf_record_fd_peak() {
+  local record=$1 csv=$2
+  [[ -r "$csv" ]] || return 0
+  # Columns resolved by name from the header row, not by index: memsampler
+  # owns the layout (see its csvHeader) and this reader must not encode a
+  # position that a future column could shift.
+  awk -F, -v rec="$record" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) { gsub(/^[ \t]+|[ \t]+$/, "", $i); ix[$i] = i }
+      tc = ix["threads"]; fc = ix["open_fds"]
+      next
+    }
+    {
+      if (tc && $tc ~ /^[0-9]+$/ && $tc+0 > tmax) { tmax = $tc+0; tseen = 1 }
+      if (fc && $fc ~ /^[0-9]+$/ && $fc+0 > fmax) { fmax = $fc+0; fseen = 1 }
+    }
+    END {
+      if (tseen) printf "threads_peak=%d\n", tmax >> rec
+      if (fseen) printf "fd_peak=%d\n", fmax >> rec
+    }
+  ' "$csv"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Load phase
+# ---------------------------------------------------------------------------
+
+# perf_stamp_load_start <record> / perf_stamp_load_end <record>
+#
+# The load window is stamped by the runner that drives the load, never inferred
+# from the numbers. Inferring it from a CPU threshold would use the metric to
+# define the window it is measured over, and would break on exactly the runs
+# that matter: a saturated arm and an idle-pacer arm look nothing alike.
+#
+# Epoch seconds, because summary.sh windows the sampler CSV on its epoch column
+# and comparing wall-clock strings would break at midnight.
+# The optional second argument is an epoch the caller already read. run.sh
+# stamps two records for one load phase and must give both the same instant;
+# without it, two `date` calls could disagree by a second and the window a run
+# reports would depend on which record summary.sh happened to read first.
+perf_stamp_load_start() {
+  local epoch=${2:-$(date +%s)}
+  perf_record_comment "$1" "load phase (stamped by the runner that drives the load)"
+  perf_record_kv "$1" load_start_epoch "$epoch"
+  perf_record_kv "$1" load_start_at "$(date -d "@$epoch" -Iseconds)"
+}
+
+perf_stamp_load_end() {
+  local epoch=${2:-$(date +%s)}
+  perf_record_kv "$1" load_end_epoch "$epoch"
+  perf_record_kv "$1" load_end_at "$(date -d "@$epoch" -Iseconds)"
+  perf_record_kv "$1" load_window_source runner-stamped
+}
+
+# perf_no_load_window <record> <why> — declare that this box cannot stamp the
+# window, and why.
+#
+# The split-host MCP box is this case: the load is driven from the other box
+# and the halves share no channel by design, so run-mcp.sh genuinely does not
+# know when load started. Saying so — and telling the reader how to window the
+# numbers once both run directories are archived together — is the honest
+# answer. Guessing a boundary would poison every later comparison.
+perf_no_load_window() {
+  perf_record_comment "$1" "load phase"
+  perf_record_kv "$1" load_window_source "$2"
+}
+
+# perf_record_begin <record> <role> <run_dir> — start a record.
+perf_record_begin() {
+  local record=$1 role=$2 run_dir=$3
+  : >"$record"
+  perf_record_comment "$record" "perf run record — written by the run scripts (test/performance/lib.sh)."
+  perf_record_comment "$record" "One key=value per line. 'unknown' means the harness could not establish the"
+  perf_record_comment "$record" "value; an absent field means it does not apply to this host."
+  perf_record_comment "$record" ""
+  # State the classification in the file itself. The fixture identifiers below
+  # (vpn, rdp, broker alias) name a real lab appliance, which is why
+  # fixtures.manifest is gitignored — this record copies them into a new file
+  # that gets shared between engineers and archived, so it has to carry the
+  # same warning rather than relying on whoever pastes it to remember.
+  perf_record_comment "$record" "INTERNAL: names lab identifiers (vpn/rdp/broker alias) and this host."
+  perf_record_comment "$record" "Do not paste into public issues, PRs or pages."
+  perf_record_kv "$record" record_version 1
+  perf_record_kv "$record" role "$role"
+  perf_record_kv "$record" run_dir "$run_dir"
+  perf_record_kv "$record" started_at "$(date -Iseconds)"
+  perf_record_kv "$record" started_epoch "$(date +%s)"
+}

--- a/test/performance/lib.sh
+++ b/test/performance/lib.sh
@@ -46,8 +46,16 @@
 # 202 ports, and a poll loop that shelled out per port would spend more time in
 # `ss` than the port takes to clear.
 perf_first_held_port() {
-  local ports="$*"
-  ss -ltn 2>/dev/null | awk -v want="$ports" '
+  local ports="$*" listing
+  # Capture ss separately rather than piping it, so a present-but-failing ss
+  # (no /proc/net, restricted namespace) is distinguishable from "no listeners".
+  # Piping it made both cases produce empty input, which the caller read as
+  # "every port free" — the exact indistinguishability this guard is for.
+  if ! listing=$(ss -ltn 2>/dev/null); then
+    echo "ss failed — cannot determine which ports are listening" >&2
+    return 2
+  fi
+  printf '%s\n' "$listing" | awk -v want="$ports" '
     BEGIN { n = split(want, w, " "); for (i = 1; i <= n; i++) order[i] = w[i] }
     $1 != "LISTEN" { next }
     {
@@ -79,6 +87,26 @@ perf_first_held_port() {
 perf_wait_ports_free() {
   local timeout_s=$1; shift
 
+  # Validate the timeout before using it in arithmetic. It comes from
+  # PORT_WAIT_SECS, so a plausible fat-finger ("60s") otherwise produced two
+  # raw `value too great for base` errors, left $deadline unset, and degraded
+  # the guard to a single poll — bash internals instead of the deliberate
+  # diagnostic this function exists to give.
+  if ! [[ "$timeout_s" =~ ^[0-9]+$ ]]; then
+    echo "PORT_WAIT_SECS must be a non-negative integer number of seconds, got: $timeout_s" >&2
+    return 1
+  fi
+
+  # The opt-out comes FIRST, before the ss probe. An explicit zero is the
+  # operator saying "I know what is on this box, do not check", and it has to
+  # work on a box that has no ss — which is precisely the box the branch below
+  # tells them to use it on. Checking ss first made that instruction a dead
+  # end.
+  if (( timeout_s == 0 )); then
+    echo "   PORT_WAIT_SECS=0 — skipping the port-free check"
+    return 0
+  fi
+
   # Fail closed if we cannot look. An `ss` that is missing or broken makes
   # perf_first_held_port print nothing, which is indistinguishable from "every
   # port is free" — so the guard that exists because a sweep point was lost to
@@ -90,18 +118,18 @@ perf_wait_ports_free() {
     return 1
   fi
 
-  # An explicit zero is the operator saying "I know what is on this box, do not
-  # check". Distinct from the fail-closed path above: one is a decision, the
-  # other is a missing tool.
-  if (( timeout_s == 0 )); then
-    echo "   PORT_WAIT_SECS=0 — skipping the port-free check"
-    return 0
-  fi
-
   local deadline=$((SECONDS + timeout_s))
-  local held announced=0
+  local held rc announced=0
   while :; do
-    held=$(perf_first_held_port "$@") || return 0
+    rc=0
+    held=$(perf_first_held_port "$@") || rc=$?
+    # rc 1 = every port free. rc 2 = ss could not tell us, which is
+    # fail-closed: starting on an unverifiable box is what lost a sweep point.
+    (( rc == 1 )) && return 0
+    if (( rc > 1 )); then
+      echo "   refusing to start without a usable port check (set PORT_WAIT_SECS=0 to override)" >&2
+      return 1
+    fi
     if (( SECONDS >= deadline )); then
       echo "port $held still has a listener after ${timeout_s}s — refusing to start:" >&2
       ss -ltnp 2>/dev/null | awk -v p="$held" '$1=="LISTEN" { c=split($4,a,":"); if (a[c]==p) print "   " $0 }' >&2
@@ -314,7 +342,11 @@ perf_record_fixtures() {
   # own tree: a capture taken from a dirty checkout is not the commit it names.
   local k v
   for k in captured_at capture_commit capture_dirty broker_alias vpn rdp; do
-    v=$(awk -v key="$k" 'index($0, "# " key ": ") == 1 { print substr($0, length(key) + 5); exit }' "$manifest")
+    # sub() rather than substr() with a computed offset: there is no arithmetic
+    # to get wrong. (The old offset was correct, and perf_or_unknown's trim made
+    # an off-by-one invisible anyway — which is exactly why it was not worth a
+    # test to pin. Removing the computation beats asserting it.)
+    v=$(awk -v key="$k" 'index($0, "# " key ": ") == 1 { sub("^# " key ": ", ""); print; exit }' "$manifest")
     perf_record_kv "$record" "fixtures_$k" "$(perf_or_unknown "$v")"
   done
   return 0
@@ -392,7 +424,7 @@ perf_record_admission() {
     if [[ -n "$val" ]]; then
       perf_record_kv "$record" "semp_$key" "$val"
       perf_record_kv "$record" "semp_${key}_source" config-file
-    elif [[ -r "$config_used" ]] && grep -qE "^[[:space:]]*$key:" "$config_used"; then
+    elif [[ -r "$config_used" ]] && perf_semp_block "$config_used" | grep -qE "^[[:space:]]*$key:"; then
       # The key is in the file but the narrow reader could not extract it — a
       # shape it does not handle (nesting, flow style, an anchor). Recording
       # `unreported-server-default` here would be a lie about provenance: the
@@ -407,6 +439,20 @@ perf_record_admission() {
     fi
   done
   return 0
+}
+
+# perf_semp_block <config> — the lines of the top-level `semp:` block.
+#
+# The presence probe in perf_record_admission has to be scoped the same way the
+# value reader is. Grepping the whole file would let a same-named key under
+# another top-level mapping (brokers:, say) mark a setting `config-file-unparsed`
+# when it is genuinely a server default — the wrong _source, which is the exact
+# class of error the _source scheme exists to prevent.
+perf_semp_block() {
+  awk '
+    /^[^[:space:]#]/ { in_semp = ($0 ~ /^semp:[[:space:]]*$/); next }
+    in_semp { print }
+  ' "$1"
 }
 
 # perf_yaml_semp_value <config> <key> — the value of one scalar key inside the

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -886,6 +886,36 @@ got=$("$here/summary.sh" "$tmp/run-badwin" 2>&1)
 contains "a reversed pair is refused rather than reported as an empty window" \
   "$got" "is not before end"
 
+# The number this produces is written into the run record as `broker_count`.
+# The field previously took BROKERS, which keeps its default of 50 on the
+# BROKERS_CSV path (setting both is forbidden), so a run pinned to three
+# aliases recorded fifty — false provenance for exactly the split-population
+# case that path exists for.
+echo "== perf_redact_userinfo keeps credentials out of an archived record"
+
+eq "userinfo is replaced, host and port kept" \
+  "$(perf_redact_userinfo 'http://user:secret@box-b:9090')" "http://***@box-b:9090"
+eq "a bare username too" \
+  "$(perf_redact_userinfo 'https://token@host:9090/mcp')" "https://***@host:9090/mcp"
+eq "an ordinary URL is untouched" \
+  "$(perf_redact_userinfo 'http://198.51.100.31:9090')" "http://198.51.100.31:9090"
+# A `@` after the authority is part of the path or query, not userinfo, and
+# rewriting it would corrupt the URL the run actually used.
+eq "an @ in the path is not userinfo" \
+  "$(perf_redact_userinfo 'http://host:9090/a@b')" "http://host:9090/a@b"
+eq "nor in a query string" \
+  "$(perf_redact_userinfo 'http://host:9090/x?u=a@b')" "http://host:9090/x?u=a@b"
+eq "an empty URL stays empty"  "$(perf_redact_userinfo '')" ""
+
+echo "== perf_alias_count counts what a pinned list actually drives"
+
+eq "three pinned aliases"        "$(perf_alias_count "broker-01,broker-07,broker-42")" "3"
+eq "one is one"                  "$(perf_alias_count "solo")"      "1"
+eq "an empty list pins none"     "$(perf_alias_count "")"          "0"
+eq "an empty entry is not an alias" "$(perf_alias_count "a,,b")"   "2"
+eq "nor is whitespace"           "$(perf_alias_count "a, ,b")"     "2"
+eq "surrounding spaces do not create entries" "$(perf_alias_count " a , b , c ")" "3"
+
 echo "== perf_record_assert_fields names what is missing"
 
 rec="$tmp/rec-assert"

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 Solace Corporation. All rights reserved.
+#
+# Self-test for lib.sh and summary.sh's rollup.
+#
+# These two files decide the numbers a measurement campaign is compared on, and
+# almost all of that logic is awk over a file. The dangerous failure is not a
+# crash: a field-index slip in the load-phase window degrades to "no samples
+# inside the stamped window" and a mis-sourced admission setting writes a
+# confident `config-file` over a value nobody wrote down. Both produce a report
+# that looks right.
+#
+# So the assertions here are on the two things a later comparison actually
+# trusts: the load-phase figure, and the `_source` label next to each setting.
+#
+# Every function under test is pure over a file or a string, so the fixtures
+# are synthetic and the whole thing runs in a mktemp dir with no broker, no
+# server and no network.
+#
+# Usage: ./lib.test.sh
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+
+# indent <file> [max] — awk, not `sed | head`: a head that closes the pipe
+# early SIGPIPEs its producer, and under `pipefail` that aborts this script, so
+# the first real failure would kill the report instead of printing it.
+indent() { awk -v max="${2:-12}" 'NR <= max { print "        " $0 }' "$1"; }
+
+eq() { # <name> <got> <want>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1"$'\n'"        got:  [$2]"$'\n'"        want: [$3]"; fi
+}
+
+contains() { # <name> <haystack> <needle>
+  if [[ "$2" == *"$3"* ]]; then ok "$1"; else bad "$1 (missing: $3)"$'\n'"$(printf '%s\n' "$2" | awk 'NR<=8{print "        " $0}')"; fi
+}
+
+lacks() { # <name> <haystack> <needle>
+  if [[ "$2" != *"$3"* ]]; then ok "$1"; else bad "$1 (unexpectedly present: $3)"; fi
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+# A sampler CSV with a deliberately bimodal shape: six idle samples at ~1% of
+# box, then six loaded ones at 50-55%. The whole-run average lands near 26%,
+# which is the diluted figure item 1 of the story exists to stop people
+# quoting, and the load-phase average lands near 52% — so a windowing bug
+# cannot pass by accident, because the two numbers are far apart.
+BASE=1788878000
+make_sampler_csv() { # <path> [--no-epoch]
+  local out=$1 no_epoch=${2:-}
+  {
+    if [[ "$no_epoch" == "--no-epoch" ]]; then
+      echo "t_sec,wall,mcp_cpu,mcp_cpu_pct_of_box,mcp_rss_kb,mcp_pss_kb,mcp_uss_kb,mock_cpu,mock_cpu_pct_of_box,mock_rss_kb,mock_pss_kb,mock_uss_kb,loadavg1,sys_mem_used_kb"
+    else
+      echo "t_sec,wall,mcp_cpu,mcp_cpu_pct_of_box,mcp_rss_kb,mcp_pss_kb,mcp_uss_kb,mock_cpu,mock_cpu_pct_of_box,mock_rss_kb,mock_pss_kb,mock_uss_kb,loadavg1,sys_mem_used_kb,epoch"
+    fi
+    local i e row
+    for i in $(seq 0 11); do
+      e=$((BASE + i * 5))
+      if (( i < 6 )); then
+        row="$((i*5)),$(date -d "@$e" +%H:%M:%S),16.0,1.0,80000,70000,60000,NA,NA,NA,NA,NA,0.5,900000"
+      else
+        row="$((i*5)),$(date -d "@$e" +%H:%M:%S),8$i.0,50.0,190000,180000,170000,NA,NA,NA,NA,NA,7.5,1200000"
+      fi
+      [[ "$no_epoch" == "--no-epoch" ]] && echo "$row" || echo "$row,$e"
+    done
+  } >"$out"
+  printf 'host=fixture\ncores_logical=16\nmem_total_kb=16777216\nmode=mcp-only\n' >"$out.info"
+}
+
+# --- summary.sh: the load-phase window ---------------------------------------
+
+echo "== summary.sh windows CPU on the stamped load phase"
+
+run_a="$tmp/run-a"
+mkdir -p "$run_a"
+make_sampler_csv "$run_a/sampler.csv"
+{
+  echo "record_version=1"
+  echo "role=mcp"
+  echo "started_at=2026-09-08T10:33:20-04:00"
+  # Cover exactly the six loaded samples: t=30s..55s.
+  echo "load_start_epoch=$((BASE + 30))"
+  echo "load_end_epoch=$((BASE + 55))"
+} >"$run_a/run-record.mcp"
+
+out=$("$here/summary.sh" "$run_a")
+
+contains "the whole-run average is still reported, and is the diluted one" \
+  "$out" "avg= 25.5%"
+contains "a labelled load-phase average is reported alongside it" \
+  "$out" "load-phase  avg= 50.0%"
+contains "the load-phase line reports its maximum" \
+  "$out" "max= 50.0%"
+contains "the load-phase line says how many samples fell inside the window" \
+  "$out" "(6 of 12 samples"
+contains "the window's source record is named, so an archived report is traceable" \
+  "$out" "window from $run_a/run-record.mcp"
+contains "the source record's role and start time are named" \
+  "$out" "role=mcp"
+
+# The point of the whole change: the two figures must differ, and the
+# load-phase one must be the higher. If a future edit silently windows on
+# everything, this is the assertion that catches it.
+# Pull the two averages by pattern, not by field index: the report pads with
+# multiple spaces ("min=  1.0%"), so awk splits "avg=" and its value into
+# separate fields and a positional read lands on the wrong one.
+avg_of() { # <line-pattern>
+  printf '%s\n' "$out" | sed -n "/$1/{s/.*avg=[[:space:]]*\([0-9.]*\)%.*/\1/p;q}"
+}
+whole=$(avg_of 'mcp   cpu:  min=')
+phase=$(avg_of 'load-phase')
+if awk -v w="$whole" -v p="$phase" 'BEGIN { exit !(p > w + 10) }'; then
+  ok "the load-phase figure is materially higher than the diluted whole-run one ($phase% vs $whole%)"
+else
+  bad "load-phase ($phase%) is not materially above whole-run ($whole%) — is the window being applied?"
+fi
+
+echo "== summary.sh degrades honestly when it cannot window"
+
+run_b="$tmp/run-b"
+mkdir -p "$run_b"
+make_sampler_csv "$run_b/sampler.csv"
+out=$("$here/summary.sh" "$run_b")
+contains "no run record: says the window is not stamped" "$out" "load phase: not stamped"
+lacks    "no run record: prints no load-phase figure"    "$out" "load-phase  avg="
+contains "no run record: the whole-run figure is unchanged" "$out" "avg= 25.5%"
+
+# A run directory from before this change: 14 columns, no epoch. It must read
+# exactly as it did before, and must NOT sprout a load-phase line even when a
+# window is supplied — there is no column to window on.
+run_c="$tmp/run-c"
+mkdir -p "$run_c"
+make_sampler_csv "$run_c/sampler.csv" --no-epoch
+out=$("$here/summary.sh" "$run_c" $((BASE + 30)) $((BASE + 55)))
+contains "pre-epoch CSV: the whole-run figure still reports" "$out" "avg= 25.5%"
+lacks    "pre-epoch CSV: no load-phase line is invented"     "$out" "load-phase  avg="
+
+# A window that misses every sample must say so rather than print a figure
+# over zero samples (which would divide by zero or print 0.0%).
+run_d="$tmp/run-d"
+mkdir -p "$run_d"
+make_sampler_csv "$run_d/sampler.csv"
+out=$("$here/summary.sh" "$run_d" $((BASE + 9000)) $((BASE + 9100)))
+contains "a window matching no samples says so" "$out" "no samples inside the stamped window"
+lacks    "a window matching no samples prints no average" "$out" "load-phase  avg="
+
+echo "== summary.sh --window-from"
+
+out=$("$here/summary.sh" "$run_b" --window-from "$run_a")
+contains "--window-from a run directory finds its record" "$out" "load-phase  avg= 50.0%"
+contains "--window-from names the record it read"          "$out" "run-record.mcp"
+out=$("$here/summary.sh" "$run_b" --window-from "$run_a/run-record.mcp")
+contains "--window-from a record path works too" "$out" "load-phase  avg= 50.0%"
+
+rc=0
+"$here/summary.sh" "$run_a" --window-from "$run_b" >/dev/null 2>&1 || rc=$?
+eq "--window-from a directory with no stamped window fails loudly" "$rc" "2"
+
+# --- perf_yaml_semp_value ----------------------------------------------------
+
+echo "== perf_yaml_semp_value reads only the top-level semp: block"
+
+cat >"$tmp/cfg-full.yaml" <<'YAML'
+port: 9090
+semp:
+  max_concurrent_per_broker: 10
+  request_timeout_duration: 1m
+  # request_min_interval: 100ms   <- commented out, must not be read
+  request_min_interval: 0s
+  max_queue_wait: 45s
+brokers:
+  broker-01: { url: "http://${MOCK_HOST}:18081" }
+  max_queue_wait: 9s
+YAML
+
+eq "reads an integer scalar"  "$(perf_yaml_semp_value "$tmp/cfg-full.yaml" max_concurrent_per_broker)" "10"
+eq "reads a duration scalar"  "$(perf_yaml_semp_value "$tmp/cfg-full.yaml" request_min_interval)"      "0s"
+eq "reads max_queue_wait"     "$(perf_yaml_semp_value "$tmp/cfg-full.yaml" max_queue_wait)"            "45s"
+eq "a key absent from semp: reads empty" "$(perf_yaml_semp_value "$tmp/cfg-full.yaml" fair_scheduling)" ""
+
+# The block boundary is the whole correctness argument: a same-named key under
+# another top-level mapping must not be picked up, or a broker-level value
+# would be recorded as the server's admission setting.
+cat >"$tmp/cfg-elsewhere.yaml" <<'YAML'
+semp:
+  max_concurrent_per_broker: 10
+brokers:
+  max_queue_wait: 9s
+YAML
+eq "a same-named key under brokers: is not read" \
+  "$(perf_yaml_semp_value "$tmp/cfg-elsewhere.yaml" max_queue_wait)" ""
+
+cat >"$tmp/cfg-commented.yaml" <<'YAML'
+semp:
+  # max_queue_wait: 30s
+  max_concurrent_per_broker: 10
+YAML
+eq "a commented-out key reads empty, not its commented value" \
+  "$(perf_yaml_semp_value "$tmp/cfg-commented.yaml" max_queue_wait)" ""
+
+# --- perf_record_admission ---------------------------------------------------
+
+echo "== perf_record_admission never guesses a provenance"
+
+# Only fair_scheduling is on the server's `config loaded` line today.
+printf '%s\n' '{"time":"x","level":"INFO","msg":"config loaded","broker_count":50,"port":9090,"log_level":"info","fair_scheduling":true}' >"$tmp/mcp.log"
+
+rec="$tmp/rec-admission"
+: >"$rec"
+perf_record_admission "$rec" "$tmp/mcp.log" "$tmp/cfg-full.yaml" 2>/dev/null
+got=$(cat "$rec")
+
+contains "fair_scheduling comes from the server's own report" "$got" "semp_fair_scheduling=true"
+contains "and is labelled server-log"                          "$got" "semp_fair_scheduling_source=server-log"
+contains "a setting written in the config is recorded"         "$got" "semp_max_concurrent_per_broker=10"
+contains "and is labelled config-file"                         "$got" "semp_max_concurrent_per_broker_source=config-file"
+contains "max_queue_wait is read from the config when present" "$got" "semp_max_queue_wait=45s"
+
+# The story's rule: a value the harness cannot establish reads `unknown`, never
+# a guess — because the defaults are a 100ms pacer, 10 slots, a 30s bound and
+# fair scheduling ON, so "unset" is emphatically not "off".
+rec="$tmp/rec-defaults"
+: >"$rec"
+cat >"$tmp/cfg-bare.yaml" <<'YAML'
+port: 9090
+semp:
+  request_timeout_duration: 1m
+YAML
+perf_record_admission "$rec" "$tmp/mcp.log" "$tmp/cfg-bare.yaml" 2>/dev/null
+got=$(cat "$rec")
+contains "a setting nobody wrote down reads unknown"     "$got" "semp_max_queue_wait=unknown"
+contains "and is labelled unreported-server-default"     "$got" "semp_max_queue_wait_source=unreported-server-default"
+lacks    "no server default is ever written as a value"  "$got" "semp_request_min_interval=100ms"
+lacks    "no in-flight default is ever written as a value" "$got" "semp_max_concurrent_per_broker=10"
+
+# A server that never logged the line, versus one that logged it without the
+# field. Collapsing those into one `unknown` would let a log-schema change
+# silently degrade every future run with no signal.
+rec="$tmp/rec-nolog"
+: >"$rec"
+perf_record_admission "$rec" "$tmp/does-not-exist.log" "$tmp/cfg-full.yaml" 2>/dev/null
+contains "no server log at all is labelled server-log-absent" \
+  "$(cat "$rec")" "semp_fair_scheduling_source=server-log-absent"
+
+rec="$tmp/rec-schema"
+: >"$rec"
+printf '%s\n' '{"msg":"config loaded","broker_count":50,"port":9090}' >"$tmp/mcp-noschema.log"
+perf_record_admission "$rec" "$tmp/mcp-noschema.log" "$tmp/cfg-full.yaml" 2>/dev/null
+contains "a config-loaded line without the field is labelled server-log-schema-changed" \
+  "$(cat "$rec")" "semp_fair_scheduling_source=server-log-schema-changed"
+
+# A shape the narrow reader cannot handle must not be reported as "nobody wrote
+# it down". A wrong _source is in the same family as a wrong value.
+rec="$tmp/rec-unparsed"
+: >"$rec"
+cat >"$tmp/cfg-flow.yaml" <<'YAML'
+semp:
+  max_queue_wait:
+    value: 45s
+YAML
+perf_record_admission "$rec" "$tmp/mcp.log" "$tmp/cfg-flow.yaml" 2>/dev/null
+got=$(cat "$rec")
+contains "an unparseable-but-present setting reads unknown" "$got" "semp_max_queue_wait=unknown"
+contains "and is labelled config-file-unparsed, not a default" "$got" "semp_max_queue_wait_source=config-file-unparsed"
+
+# --- perf_record_fd_peak -----------------------------------------------------
+
+echo "== perf_record_fd_peak reads peaks by column name and skips NA"
+
+cat >"$tmp/mem.csv" <<'CSV'
+t_sec,wall_ts,rss_kb,vm_kb,threads,open_fds
+0.000,x,80000,900000,14,42
+1.000,x,190000,900000,58,913
+2.000,x,150000,900000,31,NA
+CSV
+rec="$tmp/rec-peak"
+: >"$rec"
+perf_record_fd_peak "$rec" "$tmp/mem.csv"
+eq "fd_peak is the mid-run maximum, not the last sample" \
+  "$(awk -F= '/^fd_peak=/ {print $2}' "$rec")" "913"
+eq "threads_peak likewise" \
+  "$(awk -F= '/^threads_peak=/ {print $2}' "$rec")" "58"
+
+# All-NA must produce no field at all: fd_peak=0 would say the server held no
+# descriptors, which is never true and would be believed.
+cat >"$tmp/mem-na.csv" <<'CSV'
+t_sec,wall_ts,rss_kb,vm_kb,threads,open_fds
+0.000,x,80000,900000,14,NA
+1.000,x,80000,900000,15,NA
+CSV
+rec="$tmp/rec-na"
+: >"$rec"
+perf_record_fd_peak "$rec" "$tmp/mem-na.csv"
+lacks "an all-NA fd column writes no fd_peak field at all" "$(cat "$rec")" "fd_peak"
+contains "but threads_peak is still recorded"              "$(cat "$rec")" "threads_peak=15"
+
+# A pre-open_fds mem.csv, and a column order this reader must not assume.
+cat >"$tmp/mem-old.csv" <<'CSV'
+t_sec,wall_ts,rss_kb,vm_kb,threads
+0.000,x,80000,900000,14
+CSV
+rec="$tmp/rec-old"
+: >"$rec"
+perf_record_fd_peak "$rec" "$tmp/mem-old.csv"
+lacks "a mem.csv predating open_fds writes no fd_peak" "$(cat "$rec")" "fd_peak"
+
+cat >"$tmp/mem-reordered.csv" <<'CSV'
+t_sec,wall_ts,open_fds,threads,rss_kb,vm_kb
+0.000,x,777,9,80000,900000
+CSV
+rec="$tmp/rec-reordered"
+: >"$rec"
+perf_record_fd_peak "$rec" "$tmp/mem-reordered.csv"
+eq "columns are found by name, not position" \
+  "$(awk -F= '/^fd_peak=/ {print $2}' "$rec")" "777"
+
+# --- perf_first_held_port ----------------------------------------------------
+
+echo "== perf_first_held_port"
+
+if ! command -v ss >/dev/null 2>&1; then
+  echo "  skip  port checks (ss not installed)"
+else
+  # Two listeners, so the "first held in the caller's order" contract is
+  # actually exercised rather than trivially satisfied.
+  port_a=19187 port_b=19193
+  python3 - "$port_a" "$port_b" <<'PY' &
+import socket, sys, time
+socks = []
+for p in sys.argv[1:]:
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", int(p)))
+    s.listen(1)
+    socks.append(s)
+time.sleep(6)
+PY
+  helper=$!
+  # Give the listeners a moment; skip rather than flake if they never come up.
+  for _ in $(seq 1 20); do
+    perf_first_held_port "$port_a" >/dev/null && break
+    sleep 0.2
+  done
+
+  if perf_first_held_port "$port_a" >/dev/null; then
+    eq "reports a held port" "$(perf_first_held_port 19180 "$port_a" 19199)" "$port_a"
+    eq "reports the FIRST held port in the caller's order" \
+      "$(perf_first_held_port 19180 "$port_b" "$port_a")" "$port_b"
+    rc=0; perf_first_held_port 19181 19182 19183 >/dev/null || rc=$?
+    eq "returns non-zero when every port is free" "$rc" "1"
+
+    # The bounded wait must fail, not hang, and must name the port.
+    werr="$tmp/wait.err"
+    rc=0
+    perf_wait_ports_free 1 19180 "$port_a" >"$tmp/wait.out" 2>"$werr" || rc=$?
+    eq "the bounded wait fails when a port stays held" "$rc" "1"
+    contains "and names the port it waited on" "$(cat "$werr")" "port $port_a still has a listener"
+
+    # PORT_WAIT_SECS=0 is the operator opting out — distinct from a missing ss.
+    rc=0
+    perf_wait_ports_free 0 "$port_a" >/dev/null 2>&1 || rc=$?
+    eq "a zero timeout skips the check deliberately" "$rc" "0"
+  else
+    echo "  skip  port checks (could not bind fixture listeners)"
+  fi
+  kill "$helper" 2>/dev/null || true
+  wait "$helper" 2>/dev/null || true
+
+  rc=0
+  perf_wait_ports_free 1 19181 >/dev/null 2>&1 || rc=$?
+  eq "the wait succeeds immediately when the port is free" "$rc" "0"
+fi
+
+# --- perf_record_kv / perf_or_unknown ---------------------------------------
+
+echo "== the record's own field discipline"
+
+rec="$tmp/rec-kv"
+: >"$rec"
+# RIG_NOTE is free text and the EC2 metadata replies come off the network; a
+# newline in either would forge extra key=value lines into a file the harness's
+# doctrine says a later comparison will trust.
+perf_record_kv "$rec" rig_note "line one
+semp_fair_scheduling=false"
+eq "a value containing a newline stays one field" "$(wc -l <"$rec")" "1"
+lacks "and cannot forge a second field" "$(cat "$rec")" $'\n'"semp_fair_scheduling=false"
+contains "the value is flattened, not dropped" "$(cat "$rec")" "line one semp_fair_scheduling=false"
+
+rec="$tmp/rec-long"
+: >"$rec"
+perf_record_kv "$rec" rig_note "$(printf 'x%.0s' $(seq 1 500))"
+if (( $(awk -F= '{print length($2)}' "$rec") <= 200 )); then
+  ok "an over-long value is capped"
+else
+  bad "an over-long value was not capped"
+fi
+
+eq "perf_or_unknown passes a real value through" "$(perf_or_unknown "i9-11900H")" "i9-11900H"
+eq "an empty value becomes unknown"              "$(perf_or_unknown "")"          "unknown"
+eq "a whitespace-only value becomes unknown"     "$(perf_or_unknown "   ")"       "unknown"
+
+# --- perf_raise_nofile -------------------------------------------------------
+
+echo "== perf_raise_nofile refuses to run where it would not take effect"
+
+# The invariant is that it must run in the caller's own shell: a subshell's
+# raised limit dies with the subshell, leaving the server on the login-shell
+# limit while the record claims the raised one.
+rc=0
+( perf_raise_nofile 4096 ) >/dev/null 2>&1 || rc=$?
+eq "called in a subshell, it fails rather than silently doing nothing" "$rc" "1"
+
+perf_raise_nofile 4096
+if [[ -n "${PERF_NOFILE_REQUESTED:-}" && -n "${PERF_NOFILE_GRANTED:-}" ]]; then
+  ok "called in the caller's shell, it sets requested and granted ($PERF_NOFILE_REQUESTED/$PERF_NOFILE_GRANTED)"
+else
+  bad "PERF_NOFILE_REQUESTED/PERF_NOFILE_GRANTED were not set"
+fi
+eq "the requested value is recorded verbatim" "$PERF_NOFILE_REQUESTED" "4096"
+
+echo
+echo "$pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -807,14 +807,24 @@ eq "seconds"        "$(perf_duration_secs 60s)"   "60"
 eq "minutes"        "$(perf_duration_secs 2m)"    "120"
 eq "hours"          "$(perf_duration_secs 1h)"    "3600"
 eq "fractional minutes"  "$(perf_duration_secs 1.5m)" "90"
-# Rounded up, never down: the result sizes a sampler window, and a window that
-# ends before the load does clips the tail off the load-phase figures.
-eq "a fractional second rounds up"  "$(perf_duration_secs 0.5s)" "1"
-eq "1.1s rounds up to 2"            "$(perf_duration_secs 1.1s)" "2"
+# A fractional notation is fine when it lands on a whole second — the harness
+# counts in them — and refused when it does not. Rounding into one looked
+# harmless while the result only sized a window, but the same value positions
+# `stats_start_epoch`, and an epoch is a point: a rounded WARMUP would place
+# the statistics window somewhere loadgen did not open it.
+eq "a fractional minute that lands whole is fine" "$(perf_duration_secs 1.1m)" "66"
+eq "and so does half a minute"                    "$(perf_duration_secs 0.5m)" "30"
+for frac_dur in 0.5s 1.1s 1.01m 0.5001h; do
+  rc=0
+  perf_duration_secs "$frac_dur" >/dev/null 2>&1 || rc=$?
+  eq "a duration that cannot be expressed in whole seconds ('$frac_dur') is refused" "$rc" "1"
+done
 
 # Floating-point multiplication makes 1.1 * 3600 = 3960.0000000000005, so a
 # bare equality check against int() rounds this up by a whole second.
-eq "1.1h is 3960, not 3961"          "$(perf_duration_secs 1.1h)" "3960"
+# 1.1 * 3600 is 3960.0000000000005 in floating point, so a bare integrality
+# check would reject this exactly-representable duration as fractional.
+eq "1.1h is 3960, and is not mistaken for fractional" "$(perf_duration_secs 1.1h)" "3960"
 eq "the bound itself is accepted"    "$(perf_duration_secs 24h)"  "86400"
 # An absurd value must be refused rather than resolved to a number that wraps
 # when the runners add their sampler buffer to it.
@@ -834,6 +844,47 @@ for bad_dur in 90 30ms 1m30s "" abc "60 s" -5s; do
 done
 
 # --- perf_record_assert_fields ----------------------------------------------
+
+# The label on the per-process line has to follow the heading. When a warmup
+# excludes part of the load, a CPU figure labelled `load-phase` under a
+# `stats span:` heading claims to cover an interval it deliberately does not.
+echo "== summary.sh labels the per-process line with the window it used"
+
+mkdir -p "$tmp/run-stats"
+make_sampler_csv "$tmp/run-stats/sampler.csv"
+{
+  echo "role=loadgen"
+  echo "load_start_epoch=$((BASE + 30))"
+  echo "load_end_epoch=$((BASE + 55))"
+} >"$tmp/run-stats/run-record.loadgen"
+got=$("$here/summary.sh" "$tmp/run-stats" 2>/dev/null)
+contains "without a warmup the heading is the load phase" "$got" "load phase:"
+contains "and the per-process line says load-phase"       "$got" "load-phase  avg="
+
+echo "stats_start_epoch=$((BASE + 30))" >>"$tmp/run-stats/run-record.loadgen"
+got=$("$here/summary.sh" "$tmp/run-stats" 2>/dev/null)
+contains "with one, the heading becomes the stats span" "$got" "stats span:"
+contains "and the per-process line follows it"          "$got" "stats-span  avg="
+lacks "so nothing still claims to cover the load phase" "$got" "load-phase  avg="
+
+# A window read out of a record gets the same checks a typed one gets: a record
+# can be truncated mid-write or hand-edited, and an unchecked value reaches
+# `date -d` and arithmetic.
+echo "== summary.sh validates a window it reads from a record"
+
+mkdir -p "$tmp/run-badwin"
+make_sampler_csv "$tmp/run-badwin/sampler.csv"
+printf 'role=x\nload_start_epoch=abc\nload_end_epoch=%d\n' "$((BASE + 55))" \
+  >"$tmp/run-badwin/run-record.mcp"
+got=$("$here/summary.sh" "$tmp/run-badwin" 2>&1)
+contains "a non-integer epoch in a record is refused, not passed to date" "$got" "not integer seconds"
+lacks "and no load-phase figure is printed from it" "$got" "load-phase  avg="
+
+printf 'role=x\nload_start_epoch=%d\nload_end_epoch=%d\n' "$((BASE + 55))" "$((BASE + 30))" \
+  >"$tmp/run-badwin/run-record.mcp"
+got=$("$here/summary.sh" "$tmp/run-badwin" 2>&1)
+contains "a reversed pair is refused rather than reported as an empty window" \
+  "$got" "is not before end"
 
 echo "== perf_record_assert_fields names what is missing"
 

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -729,6 +729,224 @@ else
 fi
 eq "the requested value is recorded verbatim" "$PERF_NOFILE_REQUESTED" "4096"
 
+# --- perf_tree_dirty ---------------------------------------------------------
+
+echo "== perf_tree_dirty answers about tracked files only"
+
+# The defect this replaced: `git status --porcelain` with no
+# --untracked-files=no reports the whole repository, so a scratch file
+# anywhere in the tree pinned the flag to `true` forever. It went unnoticed
+# because the only coverage read a manifest with a hardcoded value, never the
+# computation — so the fixtures here are a real checkout, not a canned string.
+repo="$tmp/tree"
+mkdir -p "$repo"
+git -C "$repo" init -q
+git -C "$repo" config user.email t@example.com
+git -C "$repo" config user.name  Test
+echo tracked >"$repo/tracked.txt"
+git -C "$repo" add tracked.txt
+git -C "$repo" -c commit.gpgsign=false commit -qm initial
+
+eq "a clean checkout is false" "$(perf_tree_dirty "$repo")" "false"
+
+echo scratch >"$repo/untracked-note.md"
+eq "an untracked file does NOT flip it — the defect this fixes" \
+  "$(perf_tree_dirty "$repo")" "false"
+
+echo modified >>"$repo/tracked.txt"
+eq "a tracked modification DOES flip it" "$(perf_tree_dirty "$repo")" "true"
+
+git -C "$repo" checkout -q -- tracked.txt
+eq "and it goes back to false once the modification is reverted" \
+  "$(perf_tree_dirty "$repo")" "false"
+
+rc=0; perf_tree_dirty "$tmp" >/dev/null 2>&1 || rc=$?
+eq "a directory that is not a checkout returns rc=1, not a guess" "$rc" "1"
+
+# The run record's own field, end to end: perf_record_code is the caller that
+# writes commit_dirty, and the untracked file is still sitting in the tree.
+rec="$tmp/rec-dirty"
+: >"$rec"
+perf_record_code "$rec" "$repo" "$tmp/no-such-bin"
+eq "commit_dirty=false with an untracked file present" "$(field commit_dirty)" "false"
+echo modified >>"$repo/tracked.txt"
+: >"$rec"
+perf_record_code "$rec" "$repo" "$tmp/no-such-bin"
+eq "commit_dirty=true on a tracked modification" "$(field commit_dirty)" "true"
+git -C "$repo" checkout -q -- tracked.txt
+
+# capture_dirty is the second site, and it is the one that actually misreported
+# a whole campaign — so assert it through the script that writes it rather than
+# only through the shared helper.
+cap="$tmp/capture"
+mkdir -p "$cap/mock-semp/canned" "$cap/fidelity/golden"
+cp "$here/fixtures-manifest.sh" "$here/lib.sh" "$cap/"
+echo '{}' >"$cap/mock-semp/canned/a.json"
+echo '{}' >"$cap/fidelity/golden/b.json"
+git -C "$cap" init -q
+git -C "$cap" config user.email t@example.com
+git -C "$cap" config user.name  Test
+git -C "$cap" add -A
+git -C "$cap" -c commit.gpgsign=false commit -qm capture
+echo scratch >"$cap/.gotools-stand-in"
+( cd "$cap" && ./fixtures-manifest.sh write >/dev/null 2>&1 ) \
+  || bad "fixtures-manifest.sh write failed — the assertions below read a stale manifest"
+eq "capture_dirty=false with an untracked file in the capture checkout" \
+  "$(awk '/^# capture_dirty: / {print $3; exit}' "$cap/fixtures.manifest")" "false"
+echo modified >>"$cap/mock-semp/canned/a.json"
+( cd "$cap" && ./fixtures-manifest.sh write >/dev/null 2>&1 ) \
+  || bad "fixtures-manifest.sh write failed on the dirty tree"
+eq "capture_dirty=true when a tracked fixture was modified" \
+  "$(awk '/^# capture_dirty: / {print $3; exit}' "$cap/fixtures.manifest")" "true"
+
+# --- perf_duration_secs ------------------------------------------------------
+
+echo "== perf_duration_secs takes what the samplers can express, and refuses the rest"
+
+eq "seconds"        "$(perf_duration_secs 60s)"   "60"
+eq "minutes"        "$(perf_duration_secs 2m)"    "120"
+eq "hours"          "$(perf_duration_secs 1h)"    "3600"
+eq "fractional minutes"  "$(perf_duration_secs 1.5m)" "90"
+# Rounded up, never down: the result sizes a sampler window, and a window that
+# ends before the load does clips the tail off the load-phase figures.
+eq "a fractional second rounds up"  "$(perf_duration_secs 0.5s)" "1"
+eq "1.1s rounds up to 2"            "$(perf_duration_secs 1.1s)" "2"
+
+# Floating-point multiplication makes 1.1 * 3600 = 3960.0000000000005, so a
+# bare equality check against int() rounds this up by a whole second.
+eq "1.1h is 3960, not 3961"          "$(perf_duration_secs 1.1h)" "3960"
+eq "the bound itself is accepted"    "$(perf_duration_secs 24h)"  "86400"
+# An absurd value must be refused rather than resolved to a number that wraps
+# when the runners add their sampler buffer to it.
+for over_dur in 25h 1000000s 99999999999999999999s; do
+  rc=0
+  perf_duration_secs "$over_dur" >/dev/null 2>&1 || rc=$?
+  eq "a duration past the 24h bound ('$over_dur') is refused" "$rc" "1"
+done
+
+# Deliberately stricter than Go's parser. A bare number and a millisecond
+# duration are both things Go's flag would take (or reject much later, after
+# the expensive part of a run has been paid for).
+for bad_dur in 90 30ms 1m30s "" abc "60 s" -5s; do
+  rc=0
+  perf_duration_secs "$bad_dur" >/dev/null 2>&1 || rc=$?
+  eq "an unusable duration ('$bad_dur') is rejected at the door" "$rc" "1"
+done
+
+# --- perf_record_assert_fields ----------------------------------------------
+
+echo "== perf_record_assert_fields names what is missing"
+
+rec="$tmp/rec-assert"
+: >"$rec"
+perf_record_kv "$rec" fd_peak 4512
+rc=0; msg=$(perf_record_assert_fields "$rec" fd_peak threads_peak 2>&1) || rc=$?
+eq "a short record returns rc=1" "$rc" "1"
+contains "and names the field that is absent" "$msg" "threads_peak"
+lacks "without naming the one that is present" "$msg" "fd_peak "
+perf_record_kv "$rec" threads_peak 40
+rc=0; perf_record_assert_fields "$rec" fd_peak threads_peak >/dev/null 2>&1 || rc=$?
+eq "a complete record returns rc=0" "$rc" "0"
+
+# The match is anchored to the start of a line and includes the `=`, which is
+# the only thing separating this from the line-counting approach its docblock
+# rejects: a comment mentioning a field is not that field.
+rec="$tmp/rec-assert-anchor"
+: >"$rec"
+perf_record_comment "$rec" "fd_peak not available on this host"
+rc=0; perf_record_assert_fields "$rec" fd_peak >/dev/null 2>&1 || rc=$?
+eq "a comment naming the field does not satisfy the assertion" "$rc" "1"
+
+# --- perf_record_runtime_cpu -------------------------------------------------
+
+echo "== perf_record_runtime_cpu records the entitlement, never a derived GOMAXPROCS"
+
+# A child with GOMAXPROCS set: read from the process's own environment, which
+# is the only place that says what the runtime was actually launched with.
+GOMAXPROCS=7 sleep 30 &
+gmp_pid=$!
+sleep 0.3
+rec="$tmp/rec-gomaxprocs"
+: >"$rec"
+perf_record_runtime_cpu "$rec" "$gmp_pid"
+eq "GOMAXPROCS is read from the process's own environ" "$(field gomaxprocs_env)" "7"
+kill "$gmp_pid" 2>/dev/null || true
+
+rec="$tmp/rec-runtime-self"
+: >"$rec"
+perf_record_runtime_cpu "$rec" $$
+eq "a process with no GOMAXPROCS set records 'unset', not a guessed core count" \
+  "$(field gomaxprocs_env)" "unset"
+lacks "and no effective GOMAXPROCS is derived — the reader is left to do it" \
+  "$(cat "$rec")" "gomaxprocs_effective"
+
+# The walk-up and the quota arithmetic are the two parts that could write a
+# confident wrong number, and neither is observable on a rig host that has no
+# quota. They are tested through the pure helpers with an explicit nested path:
+# an earlier version of this test derived its fixture from /proc/self/cgroup,
+# which is `/` on this host and on any non-systemd container — so "leaf" and
+# "ancestor" collapsed to one directory, and the test passed against an
+# implementation with no walk in it at all.
+cgroot="$tmp/cgroup"
+mkdir -p "$cgroot/user.slice/app.scope/leaf"
+
+echo "25000 100000" >"$cgroot/user.slice/app.scope/leaf/cpu.max"
+eq "cpu.max on the process's own cgroup is read verbatim" \
+  "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)" "25000 100000"
+eq "and a quota of a quarter core reads 0.25, not 25000" \
+  "$(perf_cgroup_quota_cores "25000 100000")" "0.25"
+
+# A limit on an ancestor still binds the process, so the search has to climb
+# rather than stop at a leaf that has no cpu.max of its own.
+rm "$cgroot/user.slice/app.scope/leaf/cpu.max"
+echo "50000 100000" >"$cgroot/user.slice/cpu.max"
+eq "a quota two levels up is found by walking up" \
+  "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)" "50000 100000"
+
+# The nearest one wins: a leaf limit is not overridden by a looser ancestor.
+echo "10000 100000" >"$cgroot/user.slice/app.scope/cpu.max"
+eq "the nearest cgroup with a limit wins over a further ancestor" \
+  "$(perf_cgroup_quota_cores "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)")" "0.10"
+
+rm "$cgroot/user.slice/cpu.max" "$cgroot/user.slice/app.scope/cpu.max"
+eq "no cpu.max anywhere up to the root returns nothing" \
+  "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)" ""
+eq "a root given with a trailing slash still terminates" \
+  "$(perf_cgroup_cpu_max "$cgroot/" /user.slice)" ""
+
+eq "an unlimited quota reads none"        "$(perf_cgroup_quota_cores "max 100000")" "none"
+eq "a zero period is not divided by"      "$(perf_cgroup_quota_cores "25000 0")"    "unknown"
+eq "an unreadable cpu.max line reads unknown" "$(perf_cgroup_quota_cores "garbage")" "unknown"
+eq "half a core"                          "$(perf_cgroup_quota_cores "50000 100000")" "0.50"
+
+# And the composition: the record function maps "found nothing" to `none`,
+# which must not read the same as "could not establish".
+self_cg=$(awk -F: '$1 == "0" { print $3; exit }' /proc/self/cgroup 2>/dev/null || true)
+if [[ -n "$self_cg" ]]; then
+  mkdir -p "$cgroot$self_cg"
+  rec="$tmp/rec-noquota"
+  : >"$rec"
+  PERF_CGROUP_ROOT="$cgroot" perf_record_runtime_cpu "$rec" $$
+  eq "no quota anywhere reads 'none', not 'unknown'" \
+    "$(field cgroup_cpu_quota_cores)" "none"
+  echo "25000 100000" >"$cgroot$self_cg/cpu.max"
+  rec="$tmp/rec-quota"
+  : >"$rec"
+  PERF_CGROUP_ROOT="$cgroot" perf_record_runtime_cpu "$rec" $$
+  eq "a quota reaches the record as cores" "$(field cgroup_cpu_quota_cores)" "0.25"
+  eq "with the raw pair beside it"         "$(field cgroup_cpu_max)" "25000 100000"
+else
+  skip "record-level cgroup composition (this host has no unified cgroup line)"
+fi
+
+# A pid that no longer exists: both halves unreadable, and the record says so
+# rather than describing this shell's own entitlement.
+rec="$tmp/rec-nopid"
+: >"$rec"
+perf_record_runtime_cpu "$rec" 999999
+eq "a vanished pid records unknown for the environment" "$(field gomaxprocs_env)" "unknown"
+eq "and unknown for the cgroup"  "$(field cgroup_cpu_quota_cores)" "unknown"
+
 echo
 if (( skip )); then
   echo "$pass passed, $fail failed, $skip skipped"

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -891,33 +891,73 @@ cgroot="$tmp/cgroup"
 mkdir -p "$cgroot/user.slice/app.scope/leaf"
 
 echo "25000 100000" >"$cgroot/user.slice/app.scope/leaf/cpu.max"
-eq "cpu.max on the process's own cgroup is read verbatim" \
-  "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)" "25000 100000"
+eq "the process's own cpu.max is read verbatim" \
+  "$(perf_cgroup_binding_quota "$cgroot" /user.slice/app.scope/leaf | cut -d' ' -f3-)" "25000 100000"
 eq "and a quota of a quarter core reads 0.25, not 25000" \
   "$(perf_cgroup_quota_cores "25000 100000")" "0.25"
 
-# A limit on an ancestor still binds the process, so the search has to climb
-# rather than stop at a leaf that has no cpu.max of its own.
+# A limit set two levels up still binds a leaf that sets none of its own, so
+# the search has to climb rather than stop where it started. An earlier version
+# of this test derived its fixture from /proc/self/cgroup, which is `/` on this
+# host and on any non-systemd container — leaf and ancestor collapsed into one
+# directory, and it passed against an implementation with no walk in it at all.
 rm "$cgroot/user.slice/app.scope/leaf/cpu.max"
 echo "50000 100000" >"$cgroot/user.slice/cpu.max"
 eq "a quota two levels up is found by walking up" \
-  "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)" "50000 100000"
+  "$(perf_cgroup_binding_quota "$cgroot" /user.slice/app.scope/leaf | cut -d' ' -f1)" "0.50"
 
-# The nearest one wins: a leaf limit is not overridden by a looser ancestor.
-echo "10000 100000" >"$cgroot/user.slice/app.scope/cpu.max"
-eq "the nearest cgroup with a limit wins over a further ancestor" \
-  "$(perf_cgroup_quota_cores "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)")" "0.10"
-
-rm "$cgroot/user.slice/cpu.max" "$cgroot/user.slice/app.scope/cpu.max"
-eq "no cpu.max anywhere up to the root returns nothing" \
-  "$(perf_cgroup_cpu_max "$cgroot" /user.slice/app.scope/leaf)" ""
 eq "a root given with a trailing slash still terminates" \
-  "$(perf_cgroup_cpu_max "$cgroot/" /user.slice)" ""
+  "$(perf_cgroup_binding_quota "$cgroot/" /nowhere)" ""
 
 eq "an unlimited quota reads none"        "$(perf_cgroup_quota_cores "max 100000")" "none"
 eq "a zero period is not divided by"      "$(perf_cgroup_quota_cores "25000 0")"    "unknown"
 eq "an unreadable cpu.max line reads unknown" "$(perf_cgroup_quota_cores "garbage")" "unknown"
 eq "half a core"                          "$(perf_cgroup_quota_cores "50000 100000")" "0.50"
+
+# A cpu.max is two fields. A truncated one holding a single token would
+# otherwise make ${x%% *} and ${x##* } the same token and report a confident
+# 1.00 core, and a bare "max" would report `none` — entitlements nobody
+# measured. The contract for a line that does not parse is `unknown`.
+eq "a truncated one-token cpu.max is not read as a ratio of itself" \
+  "$(perf_cgroup_quota_cores "25000")" "unknown"
+eq "a bare 'max' with no period does not read as unlimited" \
+  "$(perf_cgroup_quota_cores "max")" "unknown"
+eq "three fields is not a cpu.max either" \
+  "$(perf_cgroup_quota_cores "25000 100000 7")" "unknown"
+eq "an empty line reads unknown"          "$(perf_cgroup_quota_cores "")"          "unknown"
+
+echo "== perf_cgroup_binding_quota takes the limit that actually binds"
+
+# v2 CPU limits are hierarchical: a parent's bandwidth bounds its whole
+# subtree, so the nearest cpu.max is not authoritative. Reporting it would
+# overstate a 2-core leaf under a half-core parent by fourfold.
+bq="$tmp/bq"
+mkdir -p "$bq/parent/leaf"
+echo "50000 100000"  >"$bq/parent/cpu.max"       # 0.5 core
+echo "200000 100000" >"$bq/parent/leaf/cpu.max"  # 2 cores, but cannot have them
+eq "a tighter ancestor binds a looser leaf" \
+  "$(perf_cgroup_binding_quota "$bq" /parent/leaf | cut -d' ' -f1)" "0.50"
+eq "and the record can name which cgroup binds" \
+  "$(perf_cgroup_binding_quota "$bq" /parent/leaf | cut -d' ' -f2)" "/parent"
+
+echo "10000 100000" >"$bq/parent/leaf/cpu.max"   # 0.1 core
+eq "a tighter leaf binds under a looser ancestor" \
+  "$(perf_cgroup_binding_quota "$bq" /parent/leaf | cut -d' ' -f1)" "0.10"
+eq "named as the leaf this time" \
+  "$(perf_cgroup_binding_quota "$bq" /parent/leaf | cut -d' ' -f2)" "/parent/leaf"
+
+# An unlimited level does not lift a limit set above or below it, and a level
+# whose file we cannot parse is not permission either — both are skipped.
+echo "max 100000" >"$bq/parent/leaf/cpu.max"
+eq "an unlimited leaf still yields to a limited ancestor" \
+  "$(perf_cgroup_binding_quota "$bq" /parent/leaf | cut -d' ' -f1)" "0.50"
+echo "garbage" >"$bq/parent/leaf/cpu.max"
+eq "an unparsable leaf is skipped, not read as unlimited" \
+  "$(perf_cgroup_binding_quota "$bq" /parent/leaf | cut -d' ' -f1)" "0.50"
+
+rm "$bq/parent/cpu.max" "$bq/parent/leaf/cpu.max"
+eq "no limit anywhere on the path returns nothing" \
+  "$(perf_cgroup_binding_quota "$bq" /parent/leaf)" ""
 
 # And the composition: the record function maps "found nothing" to `none`,
 # which must not read the same as "could not establish".
@@ -935,6 +975,7 @@ if [[ -n "$self_cg" ]]; then
   PERF_CGROUP_ROOT="$cgroot" perf_record_runtime_cpu "$rec" $$
   eq "a quota reaches the record as cores" "$(field cgroup_cpu_quota_cores)" "0.25"
   eq "with the raw pair beside it"         "$(field cgroup_cpu_max)" "25000 100000"
+  eq "and the cgroup it binds at"          "$(field cgroup_cpu_quota_from)" "$self_cg"
 else
   skip "record-level cgroup composition (this host has no unified cgroup line)"
 fi

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -671,7 +671,22 @@ perf_record_kv "$rec" rig_note "line one
 semp_fair_scheduling=false"
 eq "a value containing a newline stays one field" "$(wc -l <"$rec")" "1"
 lacks "and cannot forge a second field" "$(cat "$rec")" $'\n'"semp_fair_scheduling=false"
-contains "the value is flattened, not dropped" "$(cat "$rec")" "line one semp_fair_scheduling=false"
+# Doubly defused now: the newline is flattened AND the '=' is substituted, so
+# the injected text cannot even take the shape of a key=value pair.
+contains "the value is flattened, not dropped" "$(cat "$rec")" "line one semp_fair_scheduling:false"
+eq "and the flattened line holds exactly one '=' — the real separator" \
+  "$(awk -F= '{print NF}' "$rec")" "2"
+
+# '=' is the record's field separator, so a value containing one used to read
+# back truncated at the first — RIG_NOTE="instance=m5.large" became "instance".
+# Reported by Copilot on this PR.
+rec="$tmp/rec-eq"
+: >"$rec"
+perf_record_kv "$rec" rig_note "instance=m5.large, tuned=yes" 2>/dev/null
+eq "a value containing '=' survives the documented awk -F= reader intact" \
+  "$(awk -F= '/^rig_note=/ {print $2}' "$rec")" "instance:m5.large, tuned:yes"
+eq "and the line still has exactly one '=' before the value" \
+  "$(awk -F= '{print NF}' "$rec")" "2"
 
 rec="$tmp/rec-long"
 : >"$rec"
@@ -696,6 +711,15 @@ echo "== perf_raise_nofile refuses to run where it would not take effect"
 rc=0
 ( perf_raise_nofile 4096 ) >/dev/null 2>&1 || rc=$?
 eq "called in a subshell, it fails rather than silently doing nothing" "$rc" "1"
+
+# NOFILE is operator input and reaches an arithmetic comparison, where bash
+# reads a non-numeric word as a variable name — so it aborted the whole runner
+# under `set -u` from inside a library. Reported by Copilot on this PR.
+for bad_nofile in abc 0 -1 "12 34"; do
+  rc=0
+  perf_raise_nofile "$bad_nofile" >/dev/null 2>&1 || rc=$?
+  eq "a non-numeric or non-positive NOFILE ($bad_nofile) is rejected, not passed to arithmetic" "$rc" "1"
+done
 
 perf_raise_nofile 4096
 if [[ -n "${PERF_NOFILE_REQUESTED:-}" && -n "${PERF_NOFILE_GRANTED:-}" ]]; then

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -30,9 +30,13 @@ trap 'rm -rf "$tmp"' EXIT
 
 pass=0
 fail=0
+skip=0
 
-ok()  { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
-bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+ok()   { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+# Counted, not just printed. A section that skips silently looks like coverage
+# in CI output, which is worse than a visible gap.
+skip() { printf '  skip  %s\n' "$1"; skip=$((skip + 1)); }
 
 # indent <file> [max] — awk, not `sed | head`: a head that closes the pipe
 # early SIGPIPEs its producer, and under `pipefail` that aborts this script, so
@@ -73,7 +77,13 @@ make_sampler_csv() { # <path> [--no-epoch]
       if (( i < 6 )); then
         row="$((i*5)),$(date -d "@$e" +%H:%M:%S),16.0,1.0,80000,70000,60000,NA,NA,NA,NA,NA,0.5,900000"
       else
-        row="$((i*5)),$(date -d "@$e" +%H:%M:%S),8$i.0,50.0,190000,180000,170000,NA,NA,NA,NA,NA,7.5,1200000"
+        # The loaded samples deliberately differ from each other. With all six
+        # identical, the load-phase *average* was insensitive to which of them
+        # fell inside the window, so a slipped inclusive bound was caught only
+        # by the sample count. These six average to exactly 51.0, and any
+        # off-by-one at either edge moves that number.
+        box=$(awk -v k="$i" 'BEGIN { split("46 48 50 52 54 56", v, " "); print v[k-5] ".0" }')
+        row="$((i*5)),$(date -d "@$e" +%H:%M:%S),8$i.0,$box,190000,180000,170000,NA,NA,NA,NA,NA,7.5,1200000"
       fi
       [[ "$no_epoch" == "--no-epoch" ]] && echo "$row" || echo "$row,$e"
     done
@@ -100,11 +110,12 @@ make_sampler_csv "$run_a/sampler.csv"
 out=$("$here/summary.sh" "$run_a")
 
 contains "the whole-run average is still reported, and is the diluted one" \
-  "$out" "avg= 25.5%"
-contains "a labelled load-phase average is reported alongside it" \
-  "$out" "load-phase  avg= 50.0%"
-contains "the load-phase line reports its maximum" \
-  "$out" "max= 50.0%"
+  "$out" "avg= 26.0%"
+# Anchored to the load-phase line as a whole, not to a bare "max=" needle: the
+# whole-run line above also prints a max, so a needle of "max= 56.0%" alone
+# matched the wrong line and survived deleting the load-phase max entirely.
+contains "a labelled load-phase mean AND maximum are reported alongside it" \
+  "$out" "load-phase  avg= 51.0%   max= 56.0%"
 contains "the load-phase line says how many samples fell inside the window" \
   "$out" "(6 of 12 samples"
 contains "the window's source record is named, so an archived report is traceable" \
@@ -118,8 +129,14 @@ contains "the source record's role and start time are named" \
 # Pull the two averages by pattern, not by field index: the report pads with
 # multiple spaces ("min=  1.0%"), so awk splits "avg=" and its value into
 # separate fields and a positional read lands on the wrong one.
+# awk over a here-string, not `printf | sed …;q`: a sed that quits early
+# SIGPIPEs printf, and under `pipefail` that aborts this script inside an
+# assignment — the same hazard indent() above exists to avoid. Latent only
+# because the report currently fits the pipe buffer.
 avg_of() { # <line-pattern>
-  printf '%s\n' "$out" | sed -n "/$1/{s/.*avg=[[:space:]]*\([0-9.]*\)%.*/\1/p;q}"
+  awk -v pat="$1" 'index($0, pat) && match($0, /avg=[ ]*[0-9.]+%/) {
+    v = substr($0, RSTART, RLENGTH); gsub(/avg=|[ ]|%/, "", v); print v; exit
+  }' <<<"$out"
 }
 whole=$(avg_of 'mcp   cpu:  min=')
 phase=$(avg_of 'load-phase')
@@ -137,7 +154,7 @@ make_sampler_csv "$run_b/sampler.csv"
 out=$("$here/summary.sh" "$run_b")
 contains "no run record: says the window is not stamped" "$out" "load phase: not stamped"
 lacks    "no run record: prints no load-phase figure"    "$out" "load-phase  avg="
-contains "no run record: the whole-run figure is unchanged" "$out" "avg= 25.5%"
+contains "no run record: the whole-run figure is unchanged" "$out" "avg= 26.0%"
 
 # A run directory from before this change: 14 columns, no epoch. It must read
 # exactly as it did before, and must NOT sprout a load-phase line even when a
@@ -146,7 +163,7 @@ run_c="$tmp/run-c"
 mkdir -p "$run_c"
 make_sampler_csv "$run_c/sampler.csv" --no-epoch
 out=$("$here/summary.sh" "$run_c" $((BASE + 30)) $((BASE + 55)))
-contains "pre-epoch CSV: the whole-run figure still reports" "$out" "avg= 25.5%"
+contains "pre-epoch CSV: the whole-run figure still reports" "$out" "avg= 26.0%"
 lacks    "pre-epoch CSV: no load-phase line is invented"     "$out" "load-phase  avg="
 
 # A window that misses every sample must say so rather than print a figure
@@ -158,13 +175,71 @@ out=$("$here/summary.sh" "$run_d" $((BASE + 9000)) $((BASE + 9100)))
 contains "a window matching no samples says so" "$out" "no samples inside the stamped window"
 lacks    "a window matching no samples prints no average" "$out" "load-phase  avg="
 
+echo "== summary.sh resolves CSV columns by header name"
+
+# The whole point of resolving by name is that a column's position may move.
+# Every fixture above uses the canonical order, so hardcoding bc=4/rc=5/ec=15
+# back into roll() would pass all of them — this is the fixture that stops it.
+run_e="$tmp/run-e"
+mkdir -p "$run_e"
+# Same data, header and every row reordered: epoch first, then the mcp columns
+# in a different order. The reported numbers must not change.
+awk -F, 'BEGIN { OFS="," }
+  { print $15, $2, $1, $4, $3, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14 }' \
+  "$run_a/sampler.csv" >"$run_e/sampler.csv"
+cp "$run_a/sampler.csv.info" "$run_e/sampler.csv.info"
+cp "$run_a/run-record.mcp" "$run_e/run-record.mcp"
+out=$("$here/summary.sh" "$run_e")
+contains "a reordered header still yields the same whole-run figure" "$out" "avg= 26.0%"
+contains "a reordered header still yields the same load-phase figure" \
+  "$out" "load-phase  avg= 51.0%   max= 56.0%"
+contains "and still finds epoch, so the window still applies" "$out" "(6 of 12 samples"
+
+# A column the report needs but the CSV does not have is a producer/consumer
+# mismatch. It must say so, not fall through to "(no samples)", which is a real
+# and very different state (an idle process).
+run_f="$tmp/run-f"
+mkdir -p "$run_f"
+sed '1s/mcp_cpu_pct_of_box/mcp_cpu_pct_renamed/' "$run_a/sampler.csv" >"$run_f/sampler.csv"
+cp "$run_a/sampler.csv.info" "$run_f/sampler.csv.info"
+out=$("$here/summary.sh" "$run_f")
+contains "a renamed column is reported as a header mismatch" \
+  "$out" "column mcp_cpu_pct_of_box not in this CSV"
+lacks    "and is not passed off as an idle process" "$out" "mcp   (no samples)"
+
+echo "== summary.sh's mem.csv block"
+
+run_g="$tmp/run-g"
+mkdir -p "$run_g"
+cat >"$run_g/sampler.csv" <<'CSV'
+t_sec,wall,mcp_cpu,mcp_cpu_pct_of_box,mcp_rss_kb,mcp_pss_kb,mcp_uss_kb,mock_cpu,mock_cpu_pct_of_box,mock_rss_kb,mock_pss_kb,mock_uss_kb,loadavg1,sys_mem_used_kb,epoch
+5,10:00:05,16.0,1.0,80000,70000,60000,NA,NA,NA,NA,NA,0.5,900000,1788878005
+CSV
+printf 'host=fixture\ncores_logical=16\nmem_total_kb=16777216\nmode=mcp-only\n' >"$run_g/sampler.csv.info"
+# A trailing unreadable fd sample, which is what a process winding down
+# produces. `end=` must report that, not the last readable value.
+cat >"$run_g/mem.csv" <<'CSV'
+t_sec,wall_ts,rss_kb,vm_kb,threads,open_fds
+0.000,x,80000,900000,14,42
+1.000,x,190000,900000,58,913
+2.000,x,150000,900000,31,NA
+CSV
+printf 'nofile_effective_soft=1048576\n' >"$run_g/run-record.mcp"
+out=$("$here/summary.sh" "$run_g")
+contains "mem.csv peaks are reported"              "$out" "peak=913"
+contains "thread peak too"                          "$out" "peak=58"
+contains "a trailing unreadable fd sample reports end=NA, not a stale value" \
+  "$out" "fds:  end=NA"
+lacks    "and does not report the last readable sample as the end" "$out" "end=120"
+contains "the descriptor limit is shown next to the peak" "$out" "limit=1048576"
+
 echo "== summary.sh --window-from"
 
 out=$("$here/summary.sh" "$run_b" --window-from "$run_a")
-contains "--window-from a run directory finds its record" "$out" "load-phase  avg= 50.0%"
+contains "--window-from a run directory finds its record" "$out" "load-phase  avg= 51.0%"
 contains "--window-from names the record it read"          "$out" "run-record.mcp"
 out=$("$here/summary.sh" "$run_b" --window-from "$run_a/run-record.mcp")
-contains "--window-from a record path works too" "$out" "load-phase  avg= 50.0%"
+contains "--window-from a record path works too" "$out" "load-phase  avg= 51.0%"
 
 rc=0
 "$here/summary.sh" "$run_a" --window-from "$run_b" >/dev/null 2>&1 || rc=$?
@@ -242,10 +317,16 @@ semp:
 YAML
 perf_record_admission "$rec" "$tmp/mcp.log" "$tmp/cfg-bare.yaml" 2>/dev/null
 got=$(cat "$rec")
-contains "a setting nobody wrote down reads unknown"     "$got" "semp_max_queue_wait=unknown"
-contains "and is labelled unreported-server-default"     "$got" "semp_max_queue_wait_source=unreported-server-default"
-lacks    "no server default is ever written as a value"  "$got" "semp_request_min_interval=100ms"
-lacks    "no in-flight default is ever written as a value" "$got" "semp_max_concurrent_per_broker=10"
+# The real invariant is that the VALUE reads unknown for every setting the
+# harness cannot establish — asserted positively, per key. The previous form
+# was `lacks "…=100ms"`, which no code path could ever emit (100ms appears
+# nowhere but a prose comment), so it could not fail.
+for key in max_concurrent_per_broker request_min_interval max_queue_wait; do
+  eq "an unestablished semp.$key reads unknown, never its server default" \
+    "$(awk -F= -v k="semp_$key" '$1 == k {print $2; exit}' "$rec")" "unknown"
+  eq "and semp.$key is labelled unreported-server-default" \
+    "$(awk -F= -v k="semp_${key}_source" '$1 == k {print $2; exit}' "$rec")" "unreported-server-default"
+done
 
 # A server that never logged the line, versus one that logged it without the
 # field. Collapsing those into one `unknown` would let a log-schema change
@@ -276,6 +357,87 @@ perf_record_admission "$rec" "$tmp/mcp.log" "$tmp/cfg-flow.yaml" 2>/dev/null
 got=$(cat "$rec")
 contains "an unparseable-but-present setting reads unknown" "$got" "semp_max_queue_wait=unknown"
 contains "and is labelled config-file-unparsed, not a default" "$got" "semp_max_queue_wait_source=config-file-unparsed"
+
+# --- perf_record_fixtures ----------------------------------------------------
+
+echo "== perf_record_fixtures reads the manifest's provenance header"
+
+# These fields are how a run names the capture it replayed, and they had no
+# test at all. The assertions are on the extracted values — the actual
+# contract — rather than on the extraction mechanism: the reader strips a
+# literal prefix with sub(), so there is no offset arithmetic left to pin, and
+# the values below are what a consumer reads.
+cat >"$tmp/fixtures.manifest" <<'MANIFEST'
+# perf fixtures manifest — written by regen-golden.sh. Local only, not committed.
+# run_id: 20260901T100000Z
+# captured_at: 2026-09-01T10:00:00Z
+# capture_commit: 0123456789abcdef0123456789abcdef01234567
+# capture_dirty: false
+# broker_alias: lab-broker-a
+# vpn: lab_vpn_one
+# rdp: lab_rdp_one
+0000000000000000000000000000000000000000000000000000000000000000  mock-semp/canned/a.json
+1111111111111111111111111111111111111111111111111111111111111111  fidelity/golden/b.json
+MANIFEST
+rec="$tmp/rec-fixtures"
+: >"$rec"
+perf_record_fixtures "$rec" "$tmp"
+field() { awk -F= -v k="$1" '$1 == k {print $2; exit}' "$rec"; }
+eq "captured_at is read exactly, with no leading or trailing character" \
+  "$(field fixtures_captured_at)" "2026-09-01T10:00:00Z"
+eq "capture_commit likewise"      "$(field fixtures_capture_commit)" "0123456789abcdef0123456789abcdef01234567"
+eq "capture_dirty is read"        "$(field fixtures_capture_dirty)"  "false"
+eq "broker_alias is read"         "$(field fixtures_broker_alias)"   "lab-broker-a"
+eq "vpn is read"                  "$(field fixtures_vpn)"            "lab_vpn_one"
+eq "rdp is read"                  "$(field fixtures_rdp)"            "lab_rdp_one"
+eq "the fixture files are counted, not the comment lines" \
+  "$(field fixtures_files)" "2"
+if [[ "$(field fixtures_manifest_sha256)" == "$(sha256sum "$tmp/fixtures.manifest" | cut -d' ' -f1)" ]]; then
+  ok "the manifest hash pins the whole fixture set in one field"
+else
+  bad "fixtures_manifest_sha256 does not match the manifest's actual hash"
+fi
+
+rec="$tmp/rec-nofixtures"
+: >"$rec"
+perf_record_fixtures "$rec" "$tmp/nonexistent-dir"
+eq "an absent manifest reads unknown rather than empty" \
+  "$(awk -F= '/^fixtures_manifest_sha256=/ {print $2; exit}' "$rec")" "unknown"
+
+echo "== perf_stamp_load_start/_end share one clock read"
+
+# run.sh stamps two records for one load phase. Without the optional epoch
+# argument the two `date` calls could disagree by a second, and summary.sh
+# reads whichever record its glob yields first — so the window a run reports
+# would depend on directory order.
+ra="$tmp/stamp-a" rb="$tmp/stamp-b"
+: >"$ra"; : >"$rb"
+shared=$(date +%s)
+perf_stamp_load_start "$ra" "$shared"
+perf_stamp_load_start "$rb" "$shared"
+perf_stamp_load_end "$ra" "$((shared + 60))"
+perf_stamp_load_end "$rb" "$((shared + 60))"
+eq "both records carry the identical load_start_epoch" \
+  "$(awk -F= '/^load_start_epoch=/ {print $2}' "$ra")" \
+  "$(awk -F= '/^load_start_epoch=/ {print $2}' "$rb")"
+eq "both records carry the identical load_end_epoch" \
+  "$(awk -F= '/^load_end_epoch=/ {print $2}' "$ra")" \
+  "$(awk -F= '/^load_end_epoch=/ {print $2}' "$rb")"
+eq "the supplied epoch is used verbatim, not re-read" \
+  "$(awk -F= '/^load_start_epoch=/ {print $2}' "$ra")" "$shared"
+eq "load_window_source records that a runner stamped it" \
+  "$(awk -F= '/^load_window_source=/ {print $2}' "$ra")" "runner-stamped"
+
+# Omitting the argument must still work — run-loadgen.sh stamps one record and
+# passes none.
+rc="$tmp/stamp-c"
+: >"$rc"
+perf_stamp_load_start "$rc"
+if [[ "$(awk -F= '/^load_start_epoch=/ {print $2}' "$rc")" =~ ^[0-9]{10}$ ]]; then
+  ok "with no argument it reads the clock itself"
+else
+  bad "the default (no-argument) stamp path did not record an epoch"
+fi
 
 # --- perf_record_fd_peak -----------------------------------------------------
 
@@ -333,7 +495,7 @@ eq "columns are found by name, not position" \
 echo "== perf_first_held_port"
 
 if ! command -v ss >/dev/null 2>&1; then
-  echo "  skip  port checks (ss not installed)"
+  skip "port checks (ss not installed)"
 else
   # Two listeners, so the "first held in the caller's order" contract is
   # actually exercised rather than trivially satisfied.
@@ -375,7 +537,7 @@ PY
     perf_wait_ports_free 0 "$port_a" >/dev/null 2>&1 || rc=$?
     eq "a zero timeout skips the check deliberately" "$rc" "0"
   else
-    echo "  skip  port checks (could not bind fixture listeners)"
+    skip "port checks (could not bind fixture listeners)"
   fi
   kill "$helper" 2>/dev/null || true
   wait "$helper" 2>/dev/null || true
@@ -433,5 +595,9 @@ fi
 eq "the requested value is recorded verbatim" "$PERF_NOFILE_REQUESTED" "4096"
 
 echo
-echo "$pass passed, $fail failed"
+if (( skip )); then
+  echo "$pass passed, $fail failed, $skip skipped"
+else
+  echo "$pass passed, $fail failed"
+fi
 [[ "$fail" -eq 0 ]]

--- a/test/performance/lib.test.sh
+++ b/test/performance/lib.test.sh
@@ -194,6 +194,16 @@ contains "a reordered header still yields the same whole-run figure" "$out" "avg
 contains "a reordered header still yields the same load-phase figure" \
   "$out" "load-phase  avg= 51.0%   max= 56.0%"
 contains "and still finds epoch, so the window still applies" "$out" "(6 of 12 samples"
+# The window-bounds field is the only part of the load-phase line that says
+# WHICH samples were averaged, and it was read positionally long after every
+# other column had been converted — so on a reordered header it printed an
+# unrelated column. Assert it looks like a wall clock.
+if printf '%s\n' "$out" | grep -q 'load-phase.*samples, [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.\.[0-9][0-9]:[0-9][0-9]:[0-9][0-9])'; then
+  ok "a reordered header still reports wall-clock window bounds, not another column"
+else
+  bad "the load-phase window bounds are not wall-clock times on a reordered header"
+  printf '%s\n' "$out" | awk '/load-phase/ { print "        " $0 }'
+fi
 
 # A column the report needs but the CSV does not have is a producer/consumer
 # mismatch. It must say so, not fall through to "(no samples)", which is a real
@@ -244,6 +254,42 @@ contains "--window-from a record path works too" "$out" "load-phase  avg= 51.0%"
 rc=0
 "$here/summary.sh" "$run_a" --window-from "$run_b" >/dev/null 2>&1 || rc=$?
 eq "--window-from a directory with no stamped window fails loudly" "$rc" "2"
+
+echo "== summary.sh rejects a window it cannot trust"
+
+# Each of these paths exists because a mistyped invocation used to produce a
+# confident report of the wrong window — or of no window, silently. Table-driven
+# so the next person adding a form adds a row.
+#   <label> | <expected needle in stderr> | <args...>
+while IFS='|' read -r label needle args; do
+  [[ -n "$label" ]] || continue
+  rc=0
+  err=$("$here/summary.sh" "$run_a" $args 2>&1 >/dev/null) || rc=$?
+  if [[ "$rc" != 2 ]]; then
+    bad "$label (rc=$rc, want 2)"
+  elif [[ "$err" != *"$needle"* ]]; then
+    bad "$label — rejected, but the message did not say why (wanted: $needle)"
+  else
+    ok "$label"
+  fi
+done <<TABLE
+a typo'd flag is rejected, not read as an epoch|unknown option|--window-form $run_a
+an unknown option is rejected|unknown option|--bogus
+--window-from with no value is rejected|needs a run directory|--window-from
+a single epoch is rejected, not silently dropped|needs two epochs|1788878030
+a trailing extra argument is rejected|unexpected extra|1788878030 1788878055 EXTRA
+a non-numeric epoch is rejected|must be integer seconds|abc 1788878055
+a reversed window is rejected|must be before its end|1788878055 1788878030
+an empty window is rejected|must be before its end|1788878030 1788878030
+--window-from a path that is not a record is rejected|no load window stamped|--window-from $tmp/cfg-full.yaml
+TABLE
+
+# And the two valid forms must still be accepted.
+for form in "$((BASE + 30)) $((BASE + 55))" "--window-from $run_a"; do
+  rc=0
+  "$here/summary.sh" "$run_a" $form >/dev/null 2>&1 || rc=$?
+  eq "the valid form [$form] is accepted" "$rc" "0"
+done
 
 # --- perf_yaml_semp_value ----------------------------------------------------
 
@@ -344,6 +390,37 @@ perf_record_admission "$rec" "$tmp/mcp-noschema.log" "$tmp/cfg-full.yaml" 2>/dev
 contains "a config-loaded line without the field is labelled server-log-schema-changed" \
   "$(cat "$rec")" "semp_fair_scheduling_source=server-log-schema-changed"
 
+# The presence probe has to be scoped to the semp: block, exactly as the value
+# reader is. Unscoped, a same-named key under another top-level mapping makes a
+# genuine server default read `config-file-unparsed` — the wrong provenance,
+# which is the class of error the whole _source scheme exists to prevent.
+rec="$tmp/rec-elsewhere"
+: >"$rec"
+cat >"$tmp/cfg-key-under-brokers.yaml" <<'YAML'
+semp:
+  max_concurrent_per_broker: 10
+brokers:
+  broker-01: { url: "http://x:1" }
+  max_queue_wait: 9s
+YAML
+perf_record_admission "$rec" "$tmp/mcp.log" "$tmp/cfg-key-under-brokers.yaml" 2>/dev/null
+eq "a same-named key outside semp: does not make a default read config-file-unparsed" \
+  "$(awk -F= '/^semp_max_queue_wait_source=/ {print $2; exit}' "$rec")" \
+  "unreported-server-default"
+
+# A `semp:` line carrying a trailing comment must not hide the whole block.
+rec="$tmp/rec-semp-comment"
+: >"$rec"
+cat >"$tmp/cfg-semp-comment.yaml" <<'YAML'
+semp:  # the pacer lives in here
+  request_min_interval: 100ms
+YAML
+perf_record_admission "$rec" "$tmp/mcp.log" "$tmp/cfg-semp-comment.yaml" 2>/dev/null
+eq "a trailing comment on the semp: line does not hide the block" \
+  "$(awk -F= '/^semp_request_min_interval=/ {print $2; exit}' "$rec")" "100ms"
+eq "and the value is correctly sourced to the config file" \
+  "$(awk -F= '/^semp_request_min_interval_source=/ {print $2; exit}' "$rec")" "config-file"
+
 # A shape the narrow reader cannot handle must not be reported as "nobody wrote
 # it down". A wrong _source is in the same family as a wrong value.
 rec="$tmp/rec-unparsed"
@@ -412,7 +489,12 @@ echo "== perf_stamp_load_start/_end share one clock read"
 # would depend on directory order.
 ra="$tmp/stamp-a" rb="$tmp/stamp-b"
 : >"$ra"; : >"$rb"
-shared=$(date +%s)
+# A fixed sentinel in the past, NOT `date +%s`. With the live clock as the
+# sentinel, an implementation that ignored the argument and re-read the clock
+# passed whenever both reads landed in the same second — so this assertion,
+# which guards the fix for two records disagreeing about their window, could
+# not fail. A literal makes any re-read wrong by years.
+shared=1769000000
 perf_stamp_load_start "$ra" "$shared"
 perf_stamp_load_start "$rb" "$shared"
 perf_stamp_load_end "$ra" "$((shared + 60))"
@@ -545,6 +627,35 @@ PY
   rc=0
   perf_wait_ports_free 1 19181 >/dev/null 2>&1 || rc=$?
   eq "the wait succeeds immediately when the port is free" "$rc" "0"
+
+  # A present-but-FAILING ss (no /proc/net, a restricted namespace) is the
+  # third state: not "no listeners", but "cannot tell". Reading it as free is
+  # what lets a run measure the previous point's server, which is the whole
+  # reason this guard exists. Stub ss on PATH inside a subshell so the real one
+  # is untouched.
+  stub="$tmp/stub"
+  mkdir -p "$stub"
+  printf '#!/bin/sh\nexit 3\n' >"$stub/ss"
+  chmod +x "$stub/ss"
+
+  rc=0
+  ( PATH="$stub:$PATH"; perf_first_held_port 19181 ) >/dev/null 2>&1 || rc=$?
+  eq "a failing ss reports 'cannot tell' (rc=2), not 'free' (rc=1)" "$rc" "2"
+
+  rc=0
+  werr2="$tmp/wait-stub.err"
+  ( PATH="$stub:$PATH"; perf_wait_ports_free 1 19181 ) >/dev/null 2>"$werr2" || rc=$?
+  eq "and the wait then refuses to start rather than proceeding" "$rc" "1"
+  # The exit code alone is not enough: with the fail-closed branch removed the
+  # loop simply times out and also returns 1 — the right code for the wrong
+  # reason. Only the fail-closed branch says why.
+  contains "and says it refused because the port check was unusable" \
+    "$(cat "$werr2")" "refusing to start without a usable port check"
+
+  # The documented escape hatch has to work on exactly that box.
+  rc=0
+  ( PATH="$stub:$PATH"; perf_wait_ports_free 0 19181 ) >/dev/null 2>&1 || rc=$?
+  eq "PORT_WAIT_SECS=0 still opts out when ss is unusable" "$rc" "0"
 fi
 
 # --- perf_record_kv / perf_or_unknown ---------------------------------------

--- a/test/performance/memsampler/main.go
+++ b/test/performance/memsampler/main.go
@@ -79,8 +79,9 @@ func main() {
 }
 
 // csvHeader is the CSV's column contract. lib.sh's fd/thread peak reader and
-// summary.sh both index these columns positionally, so a new column goes on
-// the end and never in the middle.
+// summary.sh both resolve these columns by name from the header row, so
+// reordering them is safe and *renaming* one is the breaking change. Adding a
+// column is free. Do not re-encode a position in a consumer.
 var csvHeader = []string{"t_sec", "wall_ts", "rss_kb", "vm_kb", "threads", "open_fds"}
 
 func run(ctx context.Context, pid int, interval, duration time.Duration, outPath string, quiet bool) error {

--- a/test/performance/memsampler/main.go
+++ b/test/performance/memsampler/main.go
@@ -12,16 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Command memsampler polls /proc/<pid>/status at a fixed interval and
-// writes a CSV row per sample. Meant to run alongside test/performance/loadgen
+// Command memsampler polls /proc/<pid>/status and /proc/<pid>/fd at a fixed
+// interval and writes a CSV row per sample. Meant to run alongside test/performance/loadgen
 // so a plot of RSS vs. wall-clock during a load run reveals whether MCP's
 // footprint climbs (leak) or holds steady (per plan step 8's <10% drift
 // over 30s bar).
 //
 // The plan calls for HeapAlloc / Sys from Go's runtime alongside RSS, but
-// MCP does not expose pprof/expvar today. RSS + VmSize + thread count from
-// /proc is what we can get without touching production code. Add a
-// Go-heap column here if MCP later exposes /debug/vars or /debug/pprof.
+// MCP does not expose pprof/expvar today. RSS + VmSize + thread count +
+// open-descriptor count from /proc is what we can get without touching
+// production code. Add a Go-heap column here if MCP later exposes
+// /debug/vars or /debug/pprof.
+//
+// Descriptors are sampled here rather than scraped off /metrics, and the
+// reason is not convenience. Collecting the process collector's fd gauge
+// requires running with OBS_METRICS_ENABLED on, which changes the thing under
+// test — a histogram observation per tool invocation plus a scrape listener —
+// and makes the numbers non-comparable with every run measured so far, all of
+// which had it off. Reading /proc costs nothing and perturbs nothing. What it
+// does not give is the goroutine count and GC internals; the soak's pass
+// criteria (RSS drift, threads flat, descriptors flat) do not need them, and
+// GODEBUG=gctrace=1 answers "was that memory collectable garbage?" for free.
 //
 // Usage:
 //
@@ -40,6 +51,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -66,6 +78,11 @@ func main() {
 	}
 }
 
+// csvHeader is the CSV's column contract. lib.sh's fd/thread peak reader and
+// summary.sh both index these columns positionally, so a new column goes on
+// the end and never in the middle.
+var csvHeader = []string{"t_sec", "wall_ts", "rss_kb", "vm_kb", "threads", "open_fds"}
+
 func run(ctx context.Context, pid int, interval, duration time.Duration, outPath string, quiet bool) error {
 	// Open the CSV sink first so we fail fast on a bad path before starting
 	// the ticker. stdout support keeps ad-hoc invocation cheap.
@@ -75,7 +92,7 @@ func run(ctx context.Context, pid int, interval, duration time.Duration, outPath
 	}
 	defer closeFn()
 
-	if err := w.Write([]string{"t_sec", "wall_ts", "rss_kb", "vm_kb", "threads"}); err != nil {
+	if err := w.Write(csvHeader); err != nil {
 		return fmt.Errorf("writing header: %w", err)
 	}
 	w.Flush()
@@ -99,18 +116,15 @@ func run(ctx context.Context, pid int, interval, duration time.Duration, outPath
 	t := time.NewTicker(interval)
 	defer t.Stop()
 
-	var last procSample
-	last = first
-	samples := 1
-	rssMin, rssMax := first.rssKB, first.rssKB
+	st := newStats(first)
 
 	for {
 		select {
 		case <-ctx.Done():
-			return finish(w, start, samples, rssMin, rssMax, first, last, quiet, "context canceled")
+			return finish(w, start, st, quiet, "context canceled")
 		case now := <-t.C:
 			if duration > 0 && !now.Before(deadline) {
-				return finish(w, start, samples, rssMin, rssMax, first, last, quiet, "duration elapsed")
+				return finish(w, start, st, quiet, "duration elapsed")
 			}
 			s, err := sampleProc(pid)
 			if err != nil {
@@ -118,62 +132,195 @@ func run(ctx context.Context, pid int, interval, duration time.Duration, outPath
 				// the former is a clean end-of-run, the latter shouldn't
 				// swallow silently.
 				if errors.Is(err, os.ErrNotExist) {
-					return finish(w, start, samples, rssMin, rssMax, first, last, quiet, "process exited")
+					return finish(w, start, st, quiet, "process exited")
 				}
 				fmt.Fprintf(os.Stderr, "memsampler: sample error at t+%s: %v\n", now.Sub(start).Round(time.Millisecond), err)
 				continue
 			}
 			writeRow(w, now.Sub(start), now, s)
 			w.Flush()
-			samples++
-			last = s
-			if s.rssKB < rssMin {
-				rssMin = s.rssKB
-			}
-			if s.rssKB > rssMax {
-				rssMax = s.rssKB
-			}
+			st.observe(s)
 		}
 	}
 }
 
-// procSample is what one poll of /proc/<pid>/status extracts. Kept small on
-// purpose — anything beyond RSS/VmSize/Threads should be added deliberately
-// with a matching CSV column.
+// stats is the running roll-up the end-of-run summary prints. Peaks matter as
+// much as the drift figure: a descriptor count that touched its ceiling
+// mid-run is invisible in a start-vs-end comparison, and that is exactly the
+// failure the >50-broker and concurrency-cap runs are looking for.
+type stats struct {
+	samples     int
+	first, last procSample
+	rssMin      int
+	rssMax      int
+	threadsMax  int
+	fdMax       int // fdUnavailable until a readable sample arrives
+}
+
+func newStats(first procSample) *stats {
+	return &stats{
+		samples:    1,
+		first:      first,
+		last:       first,
+		rssMin:     first.rssKB,
+		rssMax:     first.rssKB,
+		threadsMax: first.threads,
+		fdMax:      first.openFDs,
+	}
+}
+
+func (st *stats) observe(s procSample) {
+	st.samples++
+	st.last = s
+	if s.rssKB < st.rssMin {
+		st.rssMin = s.rssKB
+	}
+	if s.rssKB > st.rssMax {
+		st.rssMax = s.rssKB
+	}
+	if s.threads > st.threadsMax {
+		st.threadsMax = s.threads
+	}
+	if s.openFDs > st.fdMax {
+		st.fdMax = s.openFDs
+	}
+}
+
+// procSample is what one poll of /proc/<pid> extracts. Kept small on purpose —
+// anything beyond RSS/VmSize/Threads/open descriptors should be added
+// deliberately with a matching CSV column.
+//
+// openFDs is fdUnavailable when the descriptor directory could not be read
+// (another user's process, or the process exiting between the two reads).
+// A sentinel rather than 0: "no descriptors" and "we could not look" are
+// different facts, and a 0 in a run record would read as the former.
 type procSample struct {
 	rssKB   int
 	vmKB    int
 	threads int
+	openFDs int
 }
 
-// sampleProc parses the handful of fields we care about out of
-// /proc/<pid>/status. Not using gopsutil to keep this tool dependency-free.
+// fdUnavailable marks a sample whose descriptor count could not be read.
+// Written to the CSV as "NA", the same token sampler.sh already uses.
+const fdUnavailable = -1
+
+// sampleProc reads one sample: the status fields, then the descriptor count.
+// Not using gopsutil to keep this tool dependency-free.
+//
+// A failure to read the descriptor directory is not fatal to the sample. The
+// status read is what proves the process is alive, so an fd read that races a
+// process exit degrades that one row to NA and lets the next poll report the
+// exit properly, instead of dropping a row of memory data we did have.
 func sampleProc(pid int) (procSample, error) {
 	path := fmt.Sprintf("/proc/%d/status", pid)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return procSample{}, err
 	}
+	s, err := parseStatus(string(data))
+	if err != nil {
+		return procSample{}, fmt.Errorf("%s: %w", path, err)
+	}
+	s.openFDs, err = countOpenFDs(pid)
+	if err != nil {
+		s.openFDs = fdUnavailable
+		warnFDOnce(pid, err)
+	}
+	return s, nil
+}
+
+// parseStatus pulls the fields we record out of /proc/<pid>/status content.
+// Split from the file read so it can be tested without a live process — the
+// format is stable but the parse is where a silent zero would come from.
+func parseStatus(data string) (procSample, error) {
 	var s procSample
-	for line := range strings.SplitSeq(string(data), "\n") {
+	s.openFDs = fdUnavailable
+	// A field that is present but will not parse is an error, not a zero. The
+	// both-fields-bad case would be caught by the guard below, but a malformed
+	// VmRSS beside a valid VmSize used to record rss_kb=0 and carry on —
+	// writing a plausible number into a CSV a later comparison trusts, which
+	// is the exact silent zero splitting this parse out was meant to prevent.
+	for line := range strings.SplitSeq(data, "\n") {
 		key, val, ok := strings.Cut(line, ":")
 		if !ok {
 			continue
 		}
 		val = strings.TrimSpace(val)
+		var err error
 		switch key {
 		case "VmRSS":
-			s.rssKB, _ = parseKB(val)
+			if s.rssKB, err = parseKB(val); err != nil {
+				return procSample{}, fmt.Errorf("VmRSS %q: %w", val, err)
+			}
 		case "VmSize":
-			s.vmKB, _ = parseKB(val)
+			if s.vmKB, err = parseKB(val); err != nil {
+				return procSample{}, fmt.Errorf("VmSize %q: %w", val, err)
+			}
 		case "Threads":
-			s.threads, _ = strconv.Atoi(val)
+			if s.threads, err = strconv.Atoi(val); err != nil {
+				return procSample{}, fmt.Errorf("Threads %q: %w", val, err)
+			}
 		}
 	}
 	if s.rssKB == 0 && s.vmKB == 0 {
-		return procSample{}, fmt.Errorf("no VmRSS/VmSize in %s", path)
+		return procSample{}, errors.New("no VmRSS/VmSize")
 	}
 	return s, nil
+}
+
+// countOpenFDs counts the entries in /proc/<pid>/fd.
+//
+// Readdirnames rather than os.ReadDir: it needs no stat per entry, so a
+// descriptor closing mid-read drops out of the listing instead of producing an
+// error. Partial results are still counted — a count one short of the truth is
+// a better answer than none, at a sampling interval of one second.
+//
+// The open directory handle holds a descriptor of its own, and it is visible in
+// the listing only when we are sampling ourselves. Subtract it in exactly that
+// case rather than unconditionally, which would under-report every real run
+// by one.
+func countOpenFDs(pid int) (int, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/fd", pid))
+	if err != nil {
+		return fdUnavailable, err
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(-1)
+	if err != nil && len(names) == 0 {
+		// Nothing read at all. Report it as unavailable *with* the error, so
+		// the caller warns. Applying the self-handle correction first would
+		// turn a zero-name read of our own /proc/self/fd into (-1, nil) —
+		// the unavailable sentinel arrived at by arithmetic accident, with no
+		// error to explain it, which is the one diagnostic that would tell an
+		// operator why a whole fd column reads NA.
+		return fdUnavailable, err
+	}
+	n := len(names)
+	if pid == os.Getpid() {
+		n--
+	}
+	return n, nil
+}
+
+// warnFDOnce reports an unreadable descriptor directory a single time. A
+// permission problem repeats on every poll, and a warning per second would
+// bury the summary the operator is actually reading.
+func warnFDOnce(pid int, err error) {
+	fdWarnOnce.Do(func() {
+		fmt.Fprintf(os.Stderr, "memsampler: cannot read /proc/%d/fd (%v); open_fds recorded as NA\n", pid, err)
+	})
+}
+
+var fdWarnOnce sync.Once
+
+// fdField renders openFDs for the CSV, as NA when it was not readable.
+func fdField(n int) string {
+	if n == fdUnavailable {
+		return "NA"
+	}
+	return strconv.Itoa(n)
 }
 
 // parseKB pulls the integer off strings like "12345 kB". /proc/<pid>/status
@@ -194,6 +341,7 @@ func writeRow(w *csv.Writer, elapsed time.Duration, wall time.Time, s procSample
 		strconv.Itoa(s.rssKB),
 		strconv.Itoa(s.vmKB),
 		strconv.Itoa(s.threads),
+		fdField(s.openFDs),
 	})
 }
 
@@ -212,11 +360,13 @@ func openCSV(path string) (*csv.Writer, func(), error) {
 	}, nil
 }
 
-func finish(w *csv.Writer, start time.Time, samples, rssMin, rssMax int, first, last procSample, quiet bool, reason string) error {
+func finish(w *csv.Writer, start time.Time, st *stats, quiet bool, reason string) error {
 	w.Flush()
 	if quiet {
 		return nil
 	}
+	samples, rssMin, rssMax := st.samples, st.rssMin, st.rssMax
+	first, last := st.first, st.last
 
 	// Drift vs the first sample is what the plan's <10% steady-state bar
 	// actually measures. Report both min/max span and end-vs-start delta;
@@ -242,6 +392,11 @@ func finish(w *csv.Writer, start time.Time, samples, rssMin, rssMax int, first, 
 			fmt.Println("  verdict:   PASS (<10% RSS drift end-vs-start)")
 		}
 	}
-	fmt.Printf("  threads:   start %d, end %d\n", first.threads, last.threads)
+	fmt.Printf("  threads:   start %d, end %d, peak %d\n", first.threads, last.threads, st.threadsMax)
+	// Descriptors are the signal the concurrency-cap and >50-broker runs turn
+	// on, so report the peak even when the run itself passed: a run that came
+	// within a hair of RLIMIT_NOFILE is a result, not a footnote.
+	fmt.Printf("  open fds:  start %s, end %s, peak %s\n",
+		fdField(first.openFDs), fdField(last.openFDs), fdField(st.fdMax))
 	return nil
 }

--- a/test/performance/memsampler/main.go
+++ b/test/performance/memsampler/main.go
@@ -251,15 +251,15 @@ func parseStatus(data string) (procSample, error) {
 		switch key {
 		case "VmRSS":
 			if s.rssKB, err = parseKB(val); err != nil {
-				return procSample{}, fmt.Errorf("VmRSS %q: %w", val, err)
+				return procSample{}, fmt.Errorf("parsing VmRSS %q: %w", val, err)
 			}
 		case "VmSize":
 			if s.vmKB, err = parseKB(val); err != nil {
-				return procSample{}, fmt.Errorf("VmSize %q: %w", val, err)
+				return procSample{}, fmt.Errorf("parsing VmSize %q: %w", val, err)
 			}
 		case "Threads":
 			if s.threads, err = strconv.Atoi(val); err != nil {
-				return procSample{}, fmt.Errorf("Threads %q: %w", val, err)
+				return procSample{}, fmt.Errorf("parsing Threads %q: %w", val, err)
 			}
 		}
 	}

--- a/test/performance/memsampler/main_test.go
+++ b/test/performance/memsampler/main_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The parse is the only place in this tool where a wrong answer is silent. A
@@ -285,18 +286,43 @@ func TestCountOpenFDsChildProcessIsNotCorrected(t *testing.T) {
 		_, _ = cmd.Process.Wait()
 	})
 	pid := cmd.Process.Pid
+	fdDir := fmt.Sprintf("/proc/%d/fd", pid)
+
+	// Wait for the child's descriptor table to settle before comparing.
+	//
+	// A freshly started process is still closing the loader's descriptors, so
+	// sampling it once and comparing against a second read taken a moment
+	// later compares two different instants — which made this test flake (a
+	// 4-vs-3 disagreement on one run in seven). Poll until two consecutive
+	// direct reads agree, then compare that settled count against the
+	// function's answer.
+	var settled int
+	for attempt := 0; attempt < 50; attempt++ {
+		first, err := os.ReadDir(fdDir)
+		if err != nil {
+			t.Fatalf("reading %s: %v", fdDir, err)
+		}
+		second, err := os.ReadDir(fdDir)
+		if err != nil {
+			t.Fatalf("reading %s: %v", fdDir, err)
+		}
+		if len(first) == len(second) {
+			settled = len(first)
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if settled == 0 {
+		t.Skip("the child's descriptor table never settled; nothing to compare against")
+	}
 
 	got, err := countOpenFDs(pid)
 	if err != nil {
 		t.Fatalf("countOpenFDs(%d): %v", pid, err)
 	}
-	names, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", pid))
-	if err != nil {
-		t.Fatalf("reading /proc/%d/fd: %v", pid, err)
-	}
-	if got != len(names) {
+	if got != settled {
 		t.Errorf("countOpenFDs(child) = %d, want %d (no correction applies to another process)",
-			got, len(names))
+			got, settled)
 	}
 }
 

--- a/test/performance/memsampler/main_test.go
+++ b/test/performance/memsampler/main_test.go
@@ -1,0 +1,376 @@
+// Copyright 2024-2026 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The parse is the only place in this tool where a wrong answer is silent. A
+// mis-parsed VmRSS does not crash the run; it writes a plausible number into a
+// CSV that a later comparison trusts, which is the failure mode the whole run
+// record exists to prevent. Hence a test per shape that could produce one:
+// unit suffix, unexpected whitespace, a field that is absent, and a status
+// file that names none of the three.
+
+func TestParseStatus(t *testing.T) {
+	// Trimmed from a real /proc/<pid>/status. The interleaved unrelated fields
+	// are kept deliberately: the parser keys on the name before the colon, and
+	// a substring match would pick VmRSS out of nothing but also match a
+	// hypothetical VmRSSAnon, so the neighbours are part of the fixture.
+	const status = `Name:	mcp-server
+Umask:	0022
+State:	S (sleeping)
+Tgid:	4242
+Pid:	4242
+VmPeak:	  1841232 kB
+VmSize:	  1775696 kB
+VmLck:	       0 kB
+VmHWM:	   84120 kB
+VmRSS:	   79284 kB
+RssAnon:	   61240 kB
+RssFile:	   18044 kB
+Threads:	23
+SigQ:	0/62481
+`
+
+	got, err := parseStatus(status)
+	if err != nil {
+		t.Fatalf("parseStatus: unexpected error: %v", err)
+	}
+	if got.rssKB != 79284 {
+		t.Errorf("rssKB = %d, want 79284 (VmRSS, not VmHWM/RssAnon)", got.rssKB)
+	}
+	if got.vmKB != 1775696 {
+		t.Errorf("vmKB = %d, want 1775696 (VmSize, not VmPeak)", got.vmKB)
+	}
+	if got.threads != 23 {
+		t.Errorf("threads = %d, want 23", got.threads)
+	}
+	// parseStatus reads /proc/<pid>/status only; the descriptor count comes
+	// from a separate read, so a parsed sample must not claim a count of zero.
+	if got.openFDs != fdUnavailable {
+		t.Errorf("openFDs = %d, want fdUnavailable (%d) — status carries no fd count",
+			got.openFDs, fdUnavailable)
+	}
+}
+
+func TestParseStatusFieldVariants(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		wantRSS     int
+		wantVM      int
+		wantThreads int
+	}{
+		{
+			name:        "space separated instead of tab",
+			status:      "VmSize: 2048 kB\nVmRSS: 1024 kB\nThreads: 7\n",
+			wantRSS:     1024,
+			wantVM:      2048,
+			wantThreads: 7,
+		},
+		{
+			name: "no trailing newline on the last field",
+			// The final line has no "\n"; SplitSeq must still yield it, or the
+			// last field of a real status file could be dropped.
+			status:      "VmRSS:\t1024 kB\nVmSize:\t2048 kB\nThreads:\t7",
+			wantRSS:     1024,
+			wantVM:      2048,
+			wantThreads: 7,
+		},
+		{
+			name: "Threads absent",
+			// Threads is not optional in practice, but a zero here must come
+			// from the field being absent rather than from a parse failure
+			// that also loses the memory numbers.
+			status:      "VmRSS:\t1024 kB\nVmSize:\t2048 kB\n",
+			wantRSS:     1024,
+			wantVM:      2048,
+			wantThreads: 0,
+		},
+		{
+			name: "VmSize absent but VmRSS present",
+			// A kernel thread has no VmSize. RSS alone is still a usable
+			// sample, so this must not be an error.
+			status:      "VmRSS:\t1024 kB\nThreads:\t2\n",
+			wantRSS:     1024,
+			wantVM:      0,
+			wantThreads: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseStatus(tc.status)
+			if err != nil {
+				t.Fatalf("parseStatus: unexpected error: %v", err)
+			}
+			if got.rssKB != tc.wantRSS {
+				t.Errorf("rssKB = %d, want %d", got.rssKB, tc.wantRSS)
+			}
+			if got.vmKB != tc.wantVM {
+				t.Errorf("vmKB = %d, want %d", got.vmKB, tc.wantVM)
+			}
+			if got.threads != tc.wantThreads {
+				t.Errorf("threads = %d, want %d", got.threads, tc.wantThreads)
+			}
+		})
+	}
+}
+
+// A status file with neither memory field is not a sample worth writing — it
+// means we read something that is not a process status (or read it as the
+// process was being reaped). Failing loudly is what stops a CSV filling with
+// zero rows that look like a process using no memory.
+func TestParseStatusRejectsMissingMemory(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status string
+	}{
+		{"empty", ""},
+		{"no memory fields", "Name:\tmcp-server\nThreads:\t23\n"},
+		{"unparseable values", "VmRSS:\tnot-a-number kB\nVmSize:\tnope kB\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseStatus(tc.status); err == nil {
+				t.Fatal("parseStatus: want error, got nil")
+			}
+		})
+	}
+}
+
+// A field that is present but malformed must fail, even when the other fields
+// are fine. This is the case a "no VmRSS/VmSize at all" guard cannot catch: a
+// bad VmRSS beside a good VmSize would otherwise be recorded as rss_kb=0 — a
+// plausible number written into a CSV that a later comparison trusts, which is
+// strictly worse than no sample at all.
+func TestParseStatusRejectsMalformedFieldBesideGoodOnes(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status string
+	}{
+		{
+			name:   "bad VmRSS, good VmSize",
+			status: "VmRSS:\tnot-a-number kB\nVmSize:\t2048 kB\nThreads:\t7\n",
+		},
+		{
+			name:   "good VmRSS, bad VmSize",
+			status: "VmRSS:\t1024 kB\nVmSize:\tnope kB\nThreads:\t7\n",
+		},
+		{
+			name:   "bad Threads, good memory",
+			status: "VmRSS:\t1024 kB\nVmSize:\t2048 kB\nThreads:\tmany\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseStatus(tc.status)
+			if err == nil {
+				t.Fatalf("parseStatus: want error, got %+v — a malformed field became a silent zero", got)
+			}
+		})
+	}
+}
+
+func TestParseKB(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{in: "79284 kB", want: 79284},
+		{in: "79284", want: 79284}, // no unit suffix
+		{in: "0 kB", want: 0},
+		{in: "", wantErr: true},
+		{in: "kB", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.in), func(t *testing.T) {
+			got, err := parseKB(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseKB(%q) = %d, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseKB(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseKB(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The self-handle correction is the one piece of arithmetic in the fd path
+// that can be silently wrong, so it gets an absolute assertion rather than a
+// delta one.
+//
+// A delta test — open N files, require the count to move by N — looks like it
+// covers this and does not: the correction is a constant, so it cancels out of
+// any difference. Deleting `n--` from countOpenFDs leaves a delta test green.
+// The count is therefore compared against a directly-read /proc/self/fd
+// listing, which is the ground truth the function is correcting.
+func TestCountOpenFDsSelfExcludesItsOwnHandle(t *testing.T) {
+	// Hold a descriptor open so the counts are not incidentally zero.
+	held, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("opening %s: %v", os.DevNull, err)
+	}
+	defer held.Close()
+
+	got, err := countOpenFDs(os.Getpid())
+	if err != nil {
+		t.Fatalf("countOpenFDs: %v", err)
+	}
+
+	// Read the same directory the same way, immediately after, and keep the
+	// handle open across the read so the listing includes it — exactly the
+	// condition countOpenFDs has to correct for.
+	f, err := os.Open("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("opening /proc/self/fd: %v", err)
+	}
+	names, err := f.Readdirnames(-1)
+	_ = f.Close()
+	if err != nil {
+		t.Fatalf("reading /proc/self/fd: %v", err)
+	}
+	raw := len(names)
+
+	if raw <= 1 {
+		t.Fatalf("/proc/self/fd listed %d entries — expected at least the standard streams", raw)
+	}
+	// The raw listing counts the reading handle; countOpenFDs must not.
+	if got != raw-1 {
+		t.Errorf("countOpenFDs(self) = %d, want %d (raw listing %d minus the directory handle) — "+
+			"the self-handle correction is missing or applied when it should not be", got, raw-1, raw)
+	}
+}
+
+// The correction must apply ONLY to a self-sample. A different process's fd
+// table does not contain our directory handle, so subtracting unconditionally
+// would under-report every real run of this tool by one — which is the whole
+// point of keying it on the pid.
+func TestCountOpenFDsChildProcessIsNotCorrected(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start a child process to sample: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	pid := cmd.Process.Pid
+
+	got, err := countOpenFDs(pid)
+	if err != nil {
+		t.Fatalf("countOpenFDs(%d): %v", pid, err)
+	}
+	names, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", pid))
+	if err != nil {
+		t.Fatalf("reading /proc/%d/fd: %v", pid, err)
+	}
+	if got != len(names) {
+		t.Errorf("countOpenFDs(child) = %d, want %d (no correction applies to another process)",
+			got, len(names))
+	}
+}
+
+// A PID that does not exist must report unavailable with an error, not zero:
+// run() keys "process exited" off the status read, and a zero here would write
+// a row claiming the process held no descriptors.
+func TestCountOpenFDsMissingProcess(t *testing.T) {
+	// PID 0 is never a userspace process, so /proc/0/fd never exists.
+	got, err := countOpenFDs(0)
+	if err == nil {
+		t.Fatalf("countOpenFDs(0) = %d, want an error", got)
+	}
+	if got != fdUnavailable {
+		t.Errorf("countOpenFDs(0) = %d, want fdUnavailable (%d)", got, fdUnavailable)
+	}
+}
+
+// The CSV is consumed by awk in summary.sh and lib.sh, both of which treat a
+// non-numeric field as "no data". "NA" is the token sampler.sh already uses,
+// so an unreadable descriptor directory must render as that and not as -1,
+// which would average into a run's numbers as a real value.
+func TestFDField(t *testing.T) {
+	if got := fdField(fdUnavailable); got != "NA" {
+		t.Errorf("fdField(fdUnavailable) = %q, want \"NA\"", got)
+	}
+	if got := fdField(0); got != "0" {
+		t.Errorf("fdField(0) = %q, want \"0\" — zero descriptors is a value, not a gap", got)
+	}
+	if got := fdField(137); got != "137" {
+		t.Errorf("fdField(137) = %q, want \"137\"", got)
+	}
+}
+
+// The stats roll-up feeds both the printed summary and (through the CSV) the
+// run record's fd_peak. A peak that only tracked the last sample would hide
+// exactly the mid-run spike these runs are hunting.
+func TestStatsTracksPeaks(t *testing.T) {
+	st := newStats(procSample{rssKB: 100, threads: 10, openFDs: 50})
+	st.observe(procSample{rssKB: 300, threads: 40, openFDs: 900})
+	st.observe(procSample{rssKB: 80, threads: 12, openFDs: 60})
+
+	if st.samples != 3 {
+		t.Errorf("samples = %d, want 3", st.samples)
+	}
+	if st.rssMin != 80 || st.rssMax != 300 {
+		t.Errorf("rss min/max = %d/%d, want 80/300", st.rssMin, st.rssMax)
+	}
+	if st.threadsMax != 40 {
+		t.Errorf("threadsMax = %d, want 40", st.threadsMax)
+	}
+	if st.fdMax != 900 {
+		t.Errorf("fdMax = %d, want 900 (the mid-run peak, not the last sample)", st.fdMax)
+	}
+	if st.last.rssKB != 80 {
+		t.Errorf("last.rssKB = %d, want 80", st.last.rssKB)
+	}
+}
+
+// An unreadable descriptor directory must not poison the peak. fdUnavailable
+// is negative precisely so it loses every max comparison; if the sentinel ever
+// becomes a large value, a single unreadable sample would report as the peak.
+func TestStatsIgnoresUnavailableFDs(t *testing.T) {
+	st := newStats(procSample{rssKB: 100, openFDs: fdUnavailable})
+	if st.fdMax != fdUnavailable {
+		t.Fatalf("fdMax = %d, want fdUnavailable before any readable sample", st.fdMax)
+	}
+	st.observe(procSample{rssKB: 100, openFDs: 12})
+	st.observe(procSample{rssKB: 100, openFDs: fdUnavailable})
+	if st.fdMax != 12 {
+		t.Errorf("fdMax = %d, want 12 — an unreadable sample must not beat a real one", st.fdMax)
+	}
+}
+
+// Guards the CSV's column contract. lib.sh reads open_fds as column 6 and
+// threads as column 5 by index, and summary.sh reads mem.csv the same way, so
+// inserting a column here silently reassigns both.
+func TestCSVHeaderColumnOrder(t *testing.T) {
+	const want = "t_sec,wall_ts,rss_kb,vm_kb,threads,open_fds"
+	got := strings.Join(csvHeader, ",")
+	if got != want {
+		t.Errorf("CSV header = %q, want %q (lib.sh and summary.sh index these columns)", got, want)
+	}
+}

--- a/test/performance/memsampler/main_test.go
+++ b/test/performance/memsampler/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -270,12 +271,17 @@ func TestCountOpenFDsSelfExcludesItsOwnHandle(t *testing.T) {
 // would under-report every real run of this tool by one — which is the whole
 // point of keying it on the pid.
 func TestCountOpenFDsChildProcessIsNotCorrected(t *testing.T) {
-	cmd := exec.Command("sleep", "30")
+	// CommandContext, not Command: the repo lints for it (noctx), and the
+	// context also guarantees the child dies with the test rather than
+	// outliving a panic.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sleep", "30")
 	if err := cmd.Start(); err != nil {
 		t.Skipf("cannot start a child process to sample: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
+		cancel()
 		_, _ = cmd.Process.Wait()
 	})
 	pid := cmd.Process.Pid

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -145,9 +145,17 @@ if [[ -n "$BROKERS_CSV" ]]; then
   fi
   broker_args=(-brokers "$BROKERS_CSV")
   broker_note="brokers=$BROKERS_CSV"
+  # Count what this instance actually drives. BROKERS keeps its default of 50
+  # on this path — the mutual-exclusion check above forbids setting it — so
+  # recording it here would state a number that corresponds to nothing,
+  # loudest in the split-population case this path exists for, where NO_MOCK=1
+  # means the 50 is not even the size of a mock this box owns.
+  # Empty entries are not counted: "a,,b" pins two aliases, not three.
+  broker_count=$(perf_alias_count "$BROKERS_CSV")
 else
   broker_args=(-broker-count "$BROKERS" -broker-prefix "$BROKER_PREFIX")
   broker_note="broker-count=$BROKERS"
+  broker_count=$BROKERS
 fi
 ERROR_RATE="${ERROR_RATE:-0}"
 ERROR_COUNT="${ERROR_COUNT:-0}"
@@ -263,7 +271,9 @@ perf_record_rig "$record"
 perf_record_code "$record" "$repo_root" "$bin" loadgen mock-semp fidelity
 perf_record_fixtures "$record" "$here"
 perf_record_comment "$record" "workload"
-perf_record_kv "$record" mcp_url "$mcp_url"
+# Userinfo stripped: the record is archived and shared, and a scheme://user:pass@
+# authority is worth nothing as provenance. See perf_redact_userinfo.
+perf_record_kv "$record" mcp_url "$(perf_redact_userinfo "$mcp_url")"
 perf_record_kv "$record" clients "$CLIENTS"
 perf_record_kv "$record" duration "$DURATION"
 # What the stats exclude, not what the load skipped: the run still drives load
@@ -271,7 +281,9 @@ perf_record_kv "$record" duration "$DURATION"
 # would read as a measured zero.
 perf_record_kv "$record" stats_warmup "${WARMUP:-none}"
 perf_record_kv "$record" tools "$TOOLS"
-perf_record_kv "$record" broker_count "$BROKERS"
+# The number of aliases this loadgen drives — not the size of the mock, which
+# is a different quantity whenever BROKERS_CSV pins a subset.
+perf_record_kv "$record" broker_count "$broker_count"
 # Only when an explicit alias list was pinned; an empty field would read as a
 # value rather than as "this run used the generated broker-01..N list".
 [[ -n "$BROKERS_CSV" ]] && perf_record_kv "$record" brokers_csv "$BROKERS_CSV"
@@ -283,6 +295,10 @@ perf_record_kv "$record" error_rate "$ERROR_RATE"
 perf_record_kv "$record" error_count "$ERROR_COUNT"
 perf_record_kv "$record" error_statuses "$ERROR_STATUSES"
 perf_record_kv "$record" no_mock "$NO_MOCK"
+# How many ports the mock on this box binds. Only when this box runs one:
+# under NO_MOCK=1 the mock belongs to someone else and its size is not ours to
+# state. Equal to broker_count unless BROKERS_CSV pinned a subset.
+[[ "$NO_MOCK" != "1" ]] && perf_record_kv "$record" mock_broker_ports "$BROKERS"
 perf_record_kv "$record" nofile_requested "$PERF_NOFILE_REQUESTED"
 perf_record_kv "$record" nofile_granted "$PERF_NOFILE_GRANTED"
 

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -55,8 +55,10 @@
 #                  the hard limit, and both are recorded). At high client counts
 #                  this box needs the most of it: every loadgen session is one
 #                  outbound socket here and one inbound socket on the MCP box.
-#   RIG_NOTE       free-text note about this host, recorded verbatim in the run
-#                  record
+#   RIG_NOTE       free-text note about this host. Control characters are
+#                  flattened, `=` becomes `:` and the value is capped at 200
+#                  characters so the record stays parseable — the substitutions
+#                  are reported on stderr.
 
 set -euo pipefail
 
@@ -77,7 +79,23 @@ TOOLS="${TOOLS:-get-broker-status,list-queues,list-rdps,get-rdp-status}"
 # so the BROKERS_CSV conflict check below can tell "caller set 50" from
 # "nobody set anything".
 brokers_explicit="${BROKERS+set}"
+# The generator's -prefix and loadgen's -broker-prefix have to agree, and until
+# now only the generator had a knob: a config generated with `-prefix mock`
+# gave MCP aliases mock-01... while loadgen kept asking for broker-01..., so
+# every lookup missed. Both defaults are `broker`, so an existing invocation is
+# unchanged.
+BROKER_PREFIX="${BROKER_PREFIX:-broker}"
 BROKERS="${BROKERS:-50}"
+
+# The mock binds BROKERS ports from 18081 and its control endpoint at the fixed
+# 19000, so a count of 920 or more makes a broker land on the control port —
+# they race, and /_mock/config goes to whichever won. gen-mock-config.sh
+# already refuses this range; the runners have to as well, because a config
+# generated for a smaller count can still be driven with a larger BROKERS.
+if (( BROKERS > 919 )); then
+  echo "BROKERS must be 919 or fewer: 18081 + $BROKERS - 1 would reach the mock's control port 19000" >&2
+  exit 2
+fi
 BROKERS_CSV="${BROKERS_CSV:-}"
 LATENCY_MS="${LATENCY_MS:-0}"
 TOTAL_RPS="${TOTAL_RPS:-0}"
@@ -128,7 +146,7 @@ if [[ -n "$BROKERS_CSV" ]]; then
   broker_args=(-brokers "$BROKERS_CSV")
   broker_note="brokers=$BROKERS_CSV"
 else
-  broker_args=(-broker-count "$BROKERS")
+  broker_args=(-broker-count "$BROKERS" -broker-prefix "$BROKER_PREFIX")
   broker_note="broker-count=$BROKERS"
 fi
 ERROR_RATE="${ERROR_RATE:-0}"
@@ -139,7 +157,9 @@ ERROR_STATUSES="${ERROR_STATUSES:-503:70,429:20,500:10}"
 # mock alias. VPN must match the capture and is resolved from
 # fixtures.manifest after the preflight below — hardcoding a default here is
 # how it drifted from regen-golden.sh's.
-BROKER_ALIAS="${BROKER_ALIAS:-broker-01}"
+# Derived from the prefix, so setting BROKER_PREFIX alone cannot leave the
+# fidelity gate dialling an alias the generated config does not contain.
+BROKER_ALIAS="${BROKER_ALIAS:-${BROKER_PREFIX}-01}"
 runs="$bin/runs/$(date +%Y%m%d-%H%M%S)-loadgen-$RUN_TAG"
 mkdir -p "$runs"
 record="$runs/run-record.loadgen"

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -9,6 +9,15 @@
 # Env overrides (same names as run.sh so the two scripts share vocabulary):
 #   CLIENTS      loadgen -clients                (default 200)
 #   DURATION     loadgen -duration               (default 60s)
+#   WARMUP       loadgen -warmup                 (default unset = no warmup).
+#                Time discarded from the STATS at the head of the run. The run
+#                still drives load for WARMUP + DURATION and this box's
+#                samplers are extended to match — but Box B's are not, because
+#                the two boxes share no channel: give run-mcp.sh a DURATION of
+#                at least WARMUP + DURATION or its samplers stop before the
+#                load does. Use it for a run with a mid-run event: only the
+#                summary percentiles are emitted, so a run that injects
+#                latency partway through cannot be re-windowed afterwards.
 #   TOOLS        loadgen -tools                  (default get-broker-status,list-queues,list-rdps,get-rdp-status)
 #   BROKERS      loadgen -broker-count           (default 50)
 #   BROKERS_CSV  loadgen -brokers <csv>          (default empty = use BROKERS).
@@ -61,6 +70,8 @@ source "$here/lib.sh"
 
 CLIENTS="${CLIENTS:-200}"
 DURATION="${DURATION:-60s}"
+# Unset by default, so an existing invocation behaves exactly as it did.
+WARMUP="${WARMUP:-}"
 TOOLS="${TOOLS:-get-broker-status,list-queues,list-rdps,get-rdp-status}"
 # Record whether BROKERS came from the environment before the default lands,
 # so the BROKERS_CSV conflict check below can tell "caller set 50" from
@@ -73,6 +84,31 @@ TOTAL_RPS="${TOTAL_RPS:-0}"
 RUN_TAG="${RUN_TAG:-${CLIENTS}c}"
 NO_MOCK="${NO_MOCK:-0}"
 PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
+
+# Validated before anything starts. loadgen would reject a malformed duration
+# itself, but only after the mock, the wait for Box B and the fidelity gate
+# have been paid for — and on this box that is minutes, not seconds.
+# DURATION and WARMUP both size sampler windows, so both are resolved to whole
+# seconds here, once, and a value that cannot be resolved stops the run before
+# the mock, the wait for Box B and the fidelity gate have been paid for.
+# Stricter than Go's own parser — see run.sh for why the old arrangement, with
+# a separate awk that fell back to a hardcoded 90, sampled the wrong span in
+# silence.
+duration_secs=$(perf_duration_secs "$DURATION") || exit 2
+warmup_secs=0
+warmup_args=()
+if [[ -n "$WARMUP" ]]; then
+  warmup_secs=$(perf_duration_secs "$WARMUP") || exit 2
+  # A zero warmup is the same run as no warmup, so it is normalised to one
+  # rather than recorded as a warmup with no stats window beside it.
+  if (( warmup_secs > 0 )); then
+    warmup_args=(-warmup "$WARMUP")
+  else
+    WARMUP=""
+  fi
+fi
+# The load lasts warmup + duration, so every window over it must too.
+load_secs=$(( duration_secs + warmup_secs ))
 
 # loadgen rejects -brokers and -broker-count together; catch it here instead,
 # where the message can name the environment variables the caller actually set.
@@ -186,15 +222,9 @@ fi
 # names would drift the first time a tool is added.
 "$bin/loadgen" -validate-only -tools "$TOOLS" -vpn "$VPN" -rdp "$RDP"
 
-# Convert Go duration to seconds for the sampler's -duration arg.
-sample_secs=$(awk -v d="$DURATION" 'BEGIN {
-  if (match(d, /^([0-9.]+)s$/, m)) { print int(m[1]); exit }
-  if (match(d, /^([0-9.]+)m$/, m)) { print int(m[1]*60); exit }
-  if (match(d, /^([0-9.]+)h$/, m)) { print int(m[1]*3600); exit }
-  print 90
-}')
-# Give the sampler a small buffer so it captures loadgen's teardown too.
-sample_secs=$(( sample_secs + 10 ))
+# Resolved at the top, from the same parser the run record and Box B use.
+# Plus a small buffer so the sampler captures loadgen's teardown too.
+sample_secs=$(( load_secs + 10 ))
 
 # The run record for this box. One per box, never a merged one: the two halves
 # of a split-host run have different rigs, and merging them would need a
@@ -208,6 +238,10 @@ perf_record_comment "$record" "workload"
 perf_record_kv "$record" mcp_url "$mcp_url"
 perf_record_kv "$record" clients "$CLIENTS"
 perf_record_kv "$record" duration "$DURATION"
+# What the stats exclude, not what the load skipped: the run still drives load
+# for the whole of WARMUP + DURATION. `none` rather than an empty value, which
+# would read as a measured zero.
+perf_record_kv "$record" stats_warmup "${WARMUP:-none}"
 perf_record_kv "$record" tools "$TOOLS"
 perf_record_kv "$record" broker_count "$BROKERS"
 # Only when an explicit alias list was pinned; an empty field would read as a
@@ -424,10 +458,18 @@ fi
 # report CPU over the load phase instead of over a window that also contains
 # the idle stretch the fidelity gate ran in. Never inferred from the samples.
 perf_stamp_load_start "$record"
+# With a warmup, the load window and the window the stats describe are not the
+# same span. Record the second one so CPU can be read over the span the
+# percentiles actually cover rather than over one that also contains the
+# traffic they exclude.
+if (( warmup_secs > 0 )); then
+  lw_load_start=$(awk -F= '/^load_start_epoch=/ {print $2; exit}' "$record")
+  perf_record_kv "$record" stats_start_epoch "$(( lw_load_start + warmup_secs ))"
+fi
 
-echo "== 4. loadgen against $mcp_url ($CLIENTS clients, $DURATION, tools=$TOOLS, $broker_note${TOTAL_RPS:+, total-rps=$TOTAL_RPS}; $inject_note)"
+echo "== 4. loadgen against $mcp_url ($CLIENTS clients, $DURATION${WARMUP:+ after $WARMUP warmup}, tools=$TOOLS, $broker_note${TOTAL_RPS:+, total-rps=$TOTAL_RPS}; $inject_note)"
 "$bin/loadgen" -mcp-url "$mcp_url" "${broker_args[@]}" \
-  -clients "$CLIENTS" -duration "$DURATION" -tools "$TOOLS" \
+  -clients "$CLIENTS" -duration "$DURATION" ${warmup_args[@]+"${warmup_args[@]}"} -tools "$TOOLS" \
   -vpn "$VPN" -rdp "$RDP" \
   "${extra_args[@]}" \
   > >(tee "$runs/loadgen.log") 2>&1 &
@@ -466,4 +508,12 @@ lw_start=$(awk -F= '/^load_start_epoch=/ {print $2; exit}' "$record")
 lw_end=$(awk -F= '/^load_end_epoch=/ {print $2; exit}' "$record")
 echo "to window the MCP box's CPU on this run's load phase:"
 echo "  ./summary.sh <box-b-run-dir> $lw_start $lw_end"
+# With a warmup, the load phase and the span the percentiles describe are
+# different windows, and the second is the one that matches the numbers a
+# mid-run-event run is quoted from.
+if (( warmup_secs > 0 )); then
+  lw_stats=$(awk -F= '/^stats_start_epoch=/ {print $2; exit}' "$record")
+  echo "to window it on the span the stats cover (after the ${WARMUP} warmup):"
+  echo "  ./summary.sh <box-b-run-dir> $lw_stats $lw_end"
+fi
 exit "$lg_rc"

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -95,6 +95,14 @@ PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
 # a separate awk that fell back to a hardcoded 90, sampled the wrong span in
 # silence.
 duration_secs=$(perf_duration_secs "$DURATION") || exit 2
+# Zero is a legitimate WARMUP and never a legitimate DURATION: `loadgen`
+# rejects a non-positive -duration, and `memsampler -duration 0s` means "run
+# until the process disappears", so a zero would sail through this preflight
+# and hang the run at its final wait. Refuse it here, where refusing is free.
+if (( duration_secs == 0 )); then
+  echo "DURATION must be greater than zero, got: '$DURATION'" >&2
+  exit 2
+fi
 warmup_secs=0
 warmup_args=()
 if [[ -n "$WARMUP" ]]; then
@@ -491,6 +499,10 @@ sampler_pid=$!
 lg_rc=0
 wait "$lg_pid" || lg_rc=$?
 perf_stamp_load_end "$record"
+# Whether the load itself succeeded. Without it a record describes a run that
+# may have ended in errors and says nothing about it, and this box is the only
+# one that knows.
+perf_record_kv "$record" load_rc "$lg_rc"
 
 # Let the samplers flush; they exit on their own via kill -0 / duration.
 wait "$sampler_pid" 2>/dev/null || true

--- a/test/performance/run-loadgen.sh
+++ b/test/performance/run-loadgen.sh
@@ -40,12 +40,24 @@
 #                  fixtures.manifest at capture time — set only to override)
 #   RDP            fidelity/loadgen -rdp (default: the RDP recorded in
 #                  fixtures.manifest; the mock serves get-rdp-status for it only)
+#   PORT_WAIT_SECS how long to wait for a port held by a previous sweep point to
+#                  be released before giving up (default 60)
+#   NOFILE         descriptor limit to request (default 1048576; falls back to
+#                  the hard limit, and both are recorded). At high client counts
+#                  this box needs the most of it: every loadgen session is one
+#                  outbound socket here and one inbound socket on the MCP box.
+#   RIG_NOTE       free-text note about this host, recorded verbatim in the run
+#                  record
 
 set -euo pipefail
 
 mcp_url="${1:?usage: $0 <mcp-url>   e.g.  $0 http://198.51.100.31:9090}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 bin="$here/bin"
+repo_root="$(cd "$here/../.." && pwd)"
+
+# shellcheck source=lib.sh
+source "$here/lib.sh"
 
 CLIENTS="${CLIENTS:-200}"
 DURATION="${DURATION:-60s}"
@@ -60,6 +72,7 @@ LATENCY_MS="${LATENCY_MS:-0}"
 TOTAL_RPS="${TOTAL_RPS:-0}"
 RUN_TAG="${RUN_TAG:-${CLIENTS}c}"
 NO_MOCK="${NO_MOCK:-0}"
+PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
 
 # loadgen rejects -brokers and -broker-count together; catch it here instead,
 # where the message can name the environment variables the caller actually set.
@@ -85,6 +98,7 @@ ERROR_STATUSES="${ERROR_STATUSES:-503:70,429:20,500:10}"
 BROKER_ALIAS="${BROKER_ALIAS:-broker-01}"
 runs="$bin/runs/$(date +%Y%m%d-%H%M%S)-loadgen-$RUN_TAG"
 mkdir -p "$runs"
+record="$runs/run-record.loadgen"
 
 required_bins=(loadgen fidelity)
 [[ "$NO_MOCK" != "1" ]] && required_bins+=(mock-semp)
@@ -95,12 +109,43 @@ for b in "${required_bins[@]}"; do
   fi
 done
 
-if [[ "$NO_MOCK" != "1" ]] && ss -tln 2>/dev/null | grep -q ":18081 "; then
-  echo "port 18081 already in use — mock-semp may already be running:" >&2
-  ss -tlnp 2>/dev/null | grep ":18081 " >&2
-  echo "kill it, or re-run with NO_MOCK=1 to reuse the existing mock." >&2
+# A non-numeric or zero BROKERS would build an empty port list and hand
+# mock-semp a -listen-count it rejects several steps later. Catch it here,
+# where the message can name the variable.
+if ! [[ "$BROKERS" =~ ^[0-9]+$ ]] || (( BROKERS < 1 )); then
+  echo "BROKERS must be a positive integer, got: $BROKERS" >&2
   exit 2
 fi
+
+# Wait for the ports this box needs rather than aborting on a held one. A
+# back-to-back sweep point was lost that way. Bounded, and the failure names
+# the port it waited on; starting anyway would have the run talk to the
+# previous point's mock.
+#
+# The mock's whole port range is covered, not just 18081, plus its control
+# port: a previous point with a larger BROKERS leaves the tail of the range
+# bound while 18081 is already free, and the run would then 404 on exactly the
+# brokers whose ports were missing.
+#
+# "Free" means no listener, not no socket — a TIME_WAIT socket does not block a
+# bind with SO_REUSEADDR. See perf_first_held_port.
+if [[ "$NO_MOCK" != "1" ]]; then
+  mock_ports=()
+  for (( p = 18081; p < 18081 + BROKERS; p++ )); do mock_ports+=("$p"); done
+  if ! perf_wait_ports_free "$PORT_WAIT_SECS" 19000 "${mock_ports[@]}"; then
+    echo "   (or re-run with NO_MOCK=1 to reuse the existing mock)" >&2
+    exit 2
+  fi
+fi
+
+# Raise the descriptor limit before loadgen or the mock start, so both inherit
+# it. This is the box that needs it: every one of CLIENTS sessions is an
+# outbound socket here, and the mock holds the matching inbound one, so a
+# 2000-client run needs several thousand descriptors on this host alone. It was
+# never raised anywhere in the suite before, which left the ceiling varying
+# with the operator's login shell — invisible in the results.
+perf_raise_nofile "${NOFILE:-1048576}"
+echo "== 0a. descriptor limit: requested $PERF_NOFILE_REQUESTED, granted $PERF_NOFILE_GRANTED"
 
 # Fixture preflight. The canned responses and goldens are lab captures kept
 # out of git, so "absent" is the normal state of a fresh clone — fail here
@@ -150,6 +195,34 @@ sample_secs=$(awk -v d="$DURATION" 'BEGIN {
 }')
 # Give the sampler a small buffer so it captures loadgen's teardown too.
 sample_secs=$(( sample_secs + 10 ))
+
+# The run record for this box. One per box, never a merged one: the two halves
+# of a split-host run have different rigs, and merging them would need a
+# channel between the boxes that this harness deliberately does not have. The
+# halves are collected together when the run directories are archived.
+perf_record_begin "$record" loadgen "$runs"
+perf_record_rig "$record"
+perf_record_code "$record" "$repo_root" "$bin" loadgen mock-semp fidelity
+perf_record_fixtures "$record" "$here"
+perf_record_comment "$record" "workload"
+perf_record_kv "$record" mcp_url "$mcp_url"
+perf_record_kv "$record" clients "$CLIENTS"
+perf_record_kv "$record" duration "$DURATION"
+perf_record_kv "$record" tools "$TOOLS"
+perf_record_kv "$record" broker_count "$BROKERS"
+# Only when an explicit alias list was pinned; an empty field would read as a
+# value rather than as "this run used the generated broker-01..N list".
+[[ -n "$BROKERS_CSV" ]] && perf_record_kv "$record" brokers_csv "$BROKERS_CSV"
+perf_record_kv "$record" vpn "$VPN"
+perf_record_kv "$record" rdp "$RDP"
+perf_record_kv "$record" latency_ms "$LATENCY_MS"
+perf_record_kv "$record" total_rps "$TOTAL_RPS"
+perf_record_kv "$record" error_rate "$ERROR_RATE"
+perf_record_kv "$record" error_count "$ERROR_COUNT"
+perf_record_kv "$record" error_statuses "$ERROR_STATUSES"
+perf_record_kv "$record" no_mock "$NO_MOCK"
+perf_record_kv "$record" nofile_requested "$PERF_NOFILE_REQUESTED"
+perf_record_kv "$record" nofile_granted "$PERF_NOFILE_GRANTED"
 
 mock_pid= lg_pid= sampler_pid= mock_top_pid=
 # kill_tree signals a pid (and its process group if reachable) and returns.
@@ -346,6 +419,12 @@ else
   inject_note="no error injection"
 fi
 
+# Stamp the load window. This box drives the load, so it is the one that knows
+# when the load phase began and ended — and the stamp is what lets summary.sh
+# report CPU over the load phase instead of over a window that also contains
+# the idle stretch the fidelity gate ran in. Never inferred from the samples.
+perf_stamp_load_start "$record"
+
 echo "== 4. loadgen against $mcp_url ($CLIENTS clients, $DURATION, tools=$TOOLS, $broker_note${TOTAL_RPS:+, total-rps=$TOTAL_RPS}; $inject_note)"
 "$bin/loadgen" -mcp-url "$mcp_url" "${broker_args[@]}" \
   -clients "$CLIENTS" -duration "$DURATION" -tools "$TOOLS" \
@@ -367,8 +446,9 @@ echo "== 5. loadgen-sampler (~${sample_secs}s at 5s intervals)"
   > "$runs/loadgen-sampler.log" 2>&1 &
 sampler_pid=$!
 
-wait "$lg_pid"
-lg_rc=$?
+lg_rc=0
+wait "$lg_pid" || lg_rc=$?
+perf_stamp_load_end "$record"
 
 # Let the samplers flush; they exit on their own via kill -0 / duration.
 wait "$sampler_pid" 2>/dev/null || true
@@ -377,4 +457,13 @@ wait "$mock_top_pid" 2>/dev/null || true
 echo "== done (loadgen rc=$lg_rc)"
 echo
 "$here/summary.sh" "$runs" || true
+echo "run record: $record"
+echo
+# The MCP box cannot stamp its own load window (no channel between the boxes),
+# so hand the operator the exact command that windows Box B's numbers on the
+# window this box measured. Both run directories are archived together.
+lw_start=$(awk -F= '/^load_start_epoch=/ {print $2; exit}' "$record")
+lw_end=$(awk -F= '/^load_end_epoch=/ {print $2; exit}' "$record")
+echo "to window the MCP box's CPU on this run's load phase:"
+echo "  ./summary.sh <box-b-run-dir> $lw_start $lw_end"
 exit "$lg_rc"

--- a/test/performance/run-mcp.sh
+++ b/test/performance/run-mcp.sh
@@ -15,6 +15,12 @@
 #                  used is copied into the run directory so the numbers stay
 #                  traceable to it.
 #   BROKER_USERNAME / BROKER_PASSWORD   (default perf/perf; mock accepts anything)
+#   PORT_WAIT_SECS how long to wait for :9090 to be released by a previous
+#                  sweep point before giving up (default 60)
+#   NOFILE         descriptor limit to request for the server (default 1048576;
+#                  falls back to the hard limit, and both are recorded)
+#   RIG_NOTE       free-text note about this host, recorded verbatim in the run
+#                  record. For a box that cannot describe itself.
 
 set -euo pipefail
 
@@ -24,12 +30,17 @@ bin="$here/bin"
 runs="$bin/runs/$(date +%Y%m%d-%H%M%S)-mcp"
 mkdir -p "$runs"
 
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+record="$runs/run-record.mcp"
+
 : "${MOCK_HOST:?MOCK_HOST unset — set to the Box A LAN IP, e.g. MOCK_HOST=198.51.100.30}"
 export MOCK_HOST
 export BROKER_USERNAME="${BROKER_USERNAME:-perf}"
 export BROKER_PASSWORD="${BROKER_PASSWORD:-perf}"
 DURATION="${DURATION:-90s}"
 CONFIG_FILE="${CONFIG_FILE:-$here/broker-config.mock.yaml}"
+PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
 
 # Fail loud on a bad path. Silently falling back to the committed config would
 # make every run measure the interval that file happens to ship, and a sweep
@@ -49,12 +60,26 @@ for b in memsampler mcp-server; do
   fi
 done
 
-if ss -tln 2>/dev/null | grep -q ":9090 "; then
-  echo "port 9090 already in use — another MCP is running:" >&2
-  ss -tlnp 2>/dev/null | grep ":9090 " >&2
-  echo "kill it before running this script." >&2
-  exit 2
-fi
+# Wait for the port rather than aborting on it. A back-to-back sweep point was
+# lost this way: the previous point's MCP still held :9090 when the next one
+# started, and an immediate abort turns a two-second wait into a missing data
+# point in the middle of a sweep. Bounded — a port held past the timeout is a
+# stuck process, not a slow one — and starting anyway is not an option, because
+# the run would then measure the previous server.
+perf_wait_ports_free "$PORT_WAIT_SECS" 9090 || exit 2
+
+# Raise the descriptor limit before anything is launched, so the server
+# inherits it. Nothing in this suite, cmd/ or deploy/ raised RLIMIT_NOFILE
+# before, which means it silently varied with whatever the login shell handed
+# the operator — a result-moving input that was invisible in the output.
+#
+# Two idle connection pools per broker, each holding up to
+# max_concurrent_per_broker for IdleConnTimeout, put the server's own
+# descriptor use at up to twice the cap per broker under a protocol-alternating
+# workload. The load generator's inbound sessions are one socket each and
+# dominate a 2000-caller run, but those land on the load box, not this one.
+perf_raise_nofile "${NOFILE:-1048576}"
+echo "== 0. descriptor limit: requested $PERF_NOFILE_REQUESTED, granted $PERF_NOFILE_GRANTED"
 
 # Confirm Box A's mock is reachable before spinning MCP; a silent
 # unreachable-mock reads as a broken MCP in the load run.
@@ -101,6 +126,19 @@ wait_for_http() {
   return 1
 }
 
+# The run record is what makes this run comparable with the next one. Written
+# before MCP starts so a run that dies during startup still says what it was.
+perf_record_begin "$record" mcp "$runs"
+perf_record_rig "$record"
+perf_record_code "$record" "$repo_root" "$bin" mcp-server memsampler
+perf_record_fixtures "$record" "$here"
+perf_record_comment "$record" "workload (driven from the load box; this box only holds MCP up)"
+perf_record_kv "$record" hold_duration "$DURATION"
+perf_record_kv "$record" mock_host "$MOCK_HOST"
+perf_record_kv "$record" config_file "$CONFIG_FILE"
+perf_record_kv "$record" nofile_requested "$PERF_NOFILE_REQUESTED"
+perf_record_kv "$record" nofile_granted "$PERF_NOFILE_GRANTED"
+
 echo "== 1. MCP server on :9090 (config: $CONFIG_FILE, MOCK_HOST=$MOCK_HOST)"
 # Keep the exact config alongside the numbers it produced. Recording only the
 # filename is not enough: the per-run copies are local and get overwritten.
@@ -112,6 +150,20 @@ setsid bash -c "cd '$repo_root' && CONFIG_FILE='$CONFIG_FILE' exec '$bin/mcp-ser
   >"$runs/mcp.log" 2>&1 &
 mcp_pid=$!
 wait_for_http "http://localhost:9090/health" mcp-server
+
+# Now that the server has reported its own effective configuration, record the
+# four settings that move admission behaviour, and the descriptor limit the
+# process actually runs under (its own /proc view, not this shell's — the two
+# diverge across a re-exec).
+perf_record_kv "$record" mcp_pid "$mcp_pid"
+perf_record_admission "$record" "$runs/mcp.log" "$runs/broker-config.used.yaml"
+perf_record_proc_nofile "$record" "$mcp_pid"
+
+# This box drives no load, so it cannot stamp the load window: the load runs on
+# the other box and the two share no channel by design. Say so in the record
+# rather than inferring a boundary — a guessed window would poison every later
+# comparison, and both run directories are archived together anyway.
+perf_no_load_window "$record" split-host-load-on-other-box
 
 # Convert Go duration to seconds for the samplers.
 top_secs=$(awk -v d="$DURATION" 'BEGIN {
@@ -138,5 +190,13 @@ wait "$mem_pid" 2>/dev/null || true
 wait "$top_pid" 2>/dev/null || true
 
 echo "== done"
+
+# Peaks are only knowable once the samplers have stopped.
+# `|| true`: a provenance write failing before the load starts is a fair
+# abort, but failing after a completed run would discard the report for a
+# measurement that is already safely in the CSVs.
+perf_record_fd_peak "$record" "$runs/mem.csv" || true
+
 echo
 "$here/summary.sh" "$runs" || true
+echo "run record: $record"

--- a/test/performance/run-mcp.sh
+++ b/test/performance/run-mcp.sh
@@ -9,7 +9,15 @@
 # Env:
 #   MOCK_HOST      required — LAN address of Box A running mock-semp
 #   DURATION       how long to hold MCP up for the loadgen run (default 90s;
-#                  should exceed the loadgen -duration you use on Box A)
+#                  should exceed the loadgen -duration you use on Box A). A
+#                  number of s, m or h — "1m30s" and "500ms" are refused, since
+#                  the samplers count in whole seconds.
+#   WARMUP         set this to the WARMUP Box A is using (default unset). The
+#                  two boxes share no channel, so this box cannot learn it:
+#                  under a warmup the load lasts WARMUP + DURATION, and without
+#                  it this box's samplers stop before the load does and the
+#                  server-side CPU window misses exactly the tail the stats
+#                  describe.
 #   CONFIG_FILE    MCP broker config (default ./broker-config.mock.yaml). Point
 #                  this at a per-run copy to vary request_min_interval; the file
 #                  used is copied into the run directory so the numbers stay
@@ -41,6 +49,23 @@ export BROKER_PASSWORD="${BROKER_PASSWORD:-perf}"
 DURATION="${DURATION:-90s}"
 CONFIG_FILE="${CONFIG_FILE:-$here/broker-config.mock.yaml}"
 PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
+WARMUP="${WARMUP:-}"
+
+# Both size this box's sampler windows, so both are resolved once, here, and a
+# value that cannot be resolved stops the run before the server is started.
+# Stricter than Go's parser on purpose — see run.sh for why the old two-parser
+# arrangement sampled the wrong span in silence.
+duration_secs=$(perf_duration_secs "$DURATION") || exit 2
+warmup_secs=0
+if [[ -n "$WARMUP" ]]; then
+  warmup_secs=$(perf_duration_secs "$WARMUP") || exit 2
+  # A zero warmup is the same run as no warmup; normalise so the record does
+  # not claim one.
+  (( warmup_secs > 0 )) || WARMUP=""
+fi
+# The load on the other box lasts WARMUP + DURATION; this box has to hold, and
+# sample, for at least that long.
+load_secs=$(( duration_secs + warmup_secs ))
 
 # Fail loud on a bad path. Silently falling back to the committed config would
 # make every run measure the interval that file happens to ship, and a sweep
@@ -105,12 +130,54 @@ kill_tree() {
   fi
   wait "$pid" 2>/dev/null || true
 }
+# Set once the peaks have been written, so a run interrupted with Ctrl-C does
+# not append them twice: cleanup is the handler for INT and TERM as well as
+# EXIT, and its `exit` re-enters it through the EXIT trap.
+peaks_recorded=0
+# Set at the end of the main flow. cleanup() is reached on every path, so this
+# is what tells it whether the peaks it is about to record cover a whole run.
+run_finished=0
 cleanup() {
   local rc=$?
   set +e
+  # kill_tree waits for each pid, so mem.csv is final and complete by the time
+  # the peaks are read below.
   kill_tree "$top_pid"
   kill_tree "$mem_pid"
   kill_tree "$mcp_pid"
+  # The peaks are recorded HERE, not in the main flow, because the runs that
+  # lose them are exactly the runs that never reach the main flow's end. A
+  # terminated run used to produce a record short by two fields — fd_peak and
+  # threads_peak — and Run H of the last campaign, whose whole purpose was
+  # measuring fd_peak under a raised connection cap, came back without it.
+  #
+  # This covers EXIT, INT and TERM. A SIGKILL, or an instance stopped out from
+  # under the run, still loses them: nothing shell-side can survive that, and
+  # the record simply stays short.
+  if (( ! peaks_recorded )); then
+    peaks_recorded=1
+    perf_record_fd_peak "$record" "$runs/mem.csv"
+    # A peak over a run that was cut short is not the peak the run would have
+    # reached, and on this box nothing else marks a short record: it never
+    # stamps a load window by design, so an interrupted record was otherwise
+    # field-for-field identical to a complete one. fd_peak is the number Run H
+    # exists to quote, so it says which kind it is.
+    if (( run_finished )); then
+      perf_record_kv "$record" fd_peak_source complete
+    else
+      perf_record_kv "$record" run_terminated true
+      perf_record_kv "$record" fd_peak_source partial
+    fi
+    # Assert only where there were samples to take a peak from: -s is true for
+    # a header-only CSV, which is what a run terminated inside the first
+    # sampling interval leaves, so count rows rather than bytes. A run that
+    # aborts in preflight — a held port, a failed fidelity gate — has no
+    # mem.csv and no peaks to miss, and warning there would bury the real
+    # error under a provenance complaint.
+    if [[ -r "$runs/mem.csv" ]] && (( $(wc -l <"$runs/mem.csv") > 1 )); then
+      perf_record_assert_fields "$record" fd_peak threads_peak
+    fi
+  fi
   echo "artifacts: $runs"
   exit "$rc"
 }
@@ -134,6 +201,9 @@ perf_record_code "$record" "$repo_root" "$bin" mcp-server memsampler
 perf_record_fixtures "$record" "$here"
 perf_record_comment "$record" "workload (driven from the load box; this box only holds MCP up)"
 perf_record_kv "$record" hold_duration "$DURATION"
+# What Box A told us it is discarding from its stats. This box drives no load
+# and cannot verify it; it is recorded so the two halves can be read together.
+perf_record_kv "$record" stats_warmup "${WARMUP:-none}"
 perf_record_kv "$record" mock_host "$MOCK_HOST"
 perf_record_kv "$record" config_file "$CONFIG_FILE"
 perf_record_kv "$record" nofile_requested "$PERF_NOFILE_REQUESTED"
@@ -158,6 +228,9 @@ wait_for_http "http://localhost:9090/health" mcp-server
 perf_record_kv "$record" mcp_pid "$mcp_pid"
 perf_record_admission "$record" "$runs/mcp.log" "$runs/broker-config.used.yaml"
 perf_record_proc_nofile "$record" "$mcp_pid"
+# How much processor the Go runtime was entitled to. Without this, two runs on
+# one box with different GOMAXPROCS write records identical in every field.
+perf_record_runtime_cpu "$record" "$mcp_pid"
 
 # This box drives no load, so it cannot stamp the load window: the load runs on
 # the other box and the two share no channel by design. Say so in the record
@@ -165,16 +238,14 @@ perf_record_proc_nofile "$record" "$mcp_pid"
 # comparison, and both run directories are archived together anyway.
 perf_no_load_window "$record" split-host-load-on-other-box
 
-# Convert Go duration to seconds for the samplers.
-top_secs=$(awk -v d="$DURATION" 'BEGIN {
-  if (match(d, /^([0-9.]+)s$/, m)) { print int(m[1]); exit }
-  if (match(d, /^([0-9.]+)m$/, m)) { print int(m[1]*60); exit }
-  if (match(d, /^([0-9.]+)h$/, m)) { print int(m[1]*3600); exit }
-  print 90
-}')
+# Resolved once at the top, and the same number both samplers use. They used to
+# size themselves from two different parsers, and this one fell back to a
+# hardcoded 90 on anything it could not read — including on a mawk host, where
+# its match() form does not exist at all.
+top_secs=$load_secs
 
 echo "== 2. memsampler alongside MCP (pid=$mcp_pid)"
-"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "$DURATION" \
+"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "${load_secs}s" \
   -out "$runs/mem.csv" >"$runs/memsampler.log" 2>&1 &
 mem_pid=$!
 
@@ -189,13 +260,12 @@ ss -tn state established 2>/dev/null | awk -v h="$MOCK_HOST" '$0 ~ h {n++} END {
 wait "$mem_pid" 2>/dev/null || true
 wait "$top_pid" 2>/dev/null || true
 
+run_finished=1
+
 echo "== done"
 
-# Peaks are only knowable once the samplers have stopped.
-# `|| true`: a provenance write failing before the load starts is a fair
-# abort, but failing after a completed run would discard the report for a
-# measurement that is already safely in the CSVs.
-perf_record_fd_peak "$record" "$runs/mem.csv" || true
+# The peaks are written by cleanup(), which runs on the way out of every path
+# including a terminated one — see the trap.
 
 echo
 "$here/summary.sh" "$runs" || true

--- a/test/performance/run-mcp.sh
+++ b/test/performance/run-mcp.sh
@@ -27,8 +27,10 @@
 #                  sweep point before giving up (default 60)
 #   NOFILE         descriptor limit to request for the server (default 1048576;
 #                  falls back to the hard limit, and both are recorded)
-#   RIG_NOTE       free-text note about this host, recorded verbatim in the run
-#                  record. For a box that cannot describe itself.
+#   RIG_NOTE       free-text note about this host. Control characters are
+#                  flattened, `=` becomes `:` and the value is capped at 200
+#                  characters so the record stays parseable — the substitutions
+#                  are reported on stderr.
 
 set -euo pipefail
 
@@ -267,7 +269,12 @@ top_pid=$!
 
 echo "== 4. holding MCP+samplers for ${top_secs}s — drive loadgen from Box A now"
 echo "     ss check (before load):"
-ss -tn state established 2>/dev/null | awk -v h="$MOCK_HOST" '$0 ~ h {n++} END {print "     established conns to " h ": " (n+0)}'
+# `|| true`: this is a diagnostic, not a check. Under `pipefail` a missing ss
+# would fail the pipeline and abort the run — which would make the documented
+# `PORT_WAIT_SECS=0` escape hatch for a box without iproute2 not actually work
+# on this runner.
+{ ss -tn state established 2>/dev/null || true; } \
+  | awk -v h="$MOCK_HOST" '$0 ~ h {n++} END {print "     established conns to " h ": " (n+0)}'
 
 wait "$mem_pid" 2>/dev/null || true
 wait "$top_pid" 2>/dev/null || true

--- a/test/performance/run-mcp.sh
+++ b/test/performance/run-mcp.sh
@@ -56,6 +56,14 @@ WARMUP="${WARMUP:-}"
 # Stricter than Go's parser on purpose — see run.sh for why the old two-parser
 # arrangement sampled the wrong span in silence.
 duration_secs=$(perf_duration_secs "$DURATION") || exit 2
+# Zero is a legitimate WARMUP and never a legitimate DURATION: `loadgen`
+# rejects a non-positive -duration, and `memsampler -duration 0s` means "run
+# until the process disappears", so a zero would sail through this preflight
+# and hang the run at its final wait. Refuse it here, where refusing is free.
+if (( duration_secs == 0 )); then
+  echo "DURATION must be greater than zero, got: '$DURATION'" >&2
+  exit 2
+fi
 warmup_secs=0
 if [[ -n "$WARMUP" ]]; then
   warmup_secs=$(perf_duration_secs "$WARMUP") || exit 2
@@ -245,7 +253,11 @@ perf_no_load_window "$record" split-host-load-on-other-box
 top_secs=$load_secs
 
 echo "== 2. memsampler alongside MCP (pid=$mcp_pid)"
-"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "${load_secs}s" \
+# Plus the tail buffer sampler.sh gets. On this box the case is stronger still:
+# the load is driven from the other box, which dials its sessions before its
+# own clock starts, so a window of exactly load_secs reliably ends early — and
+# what it clips is fd_peak, the number Run H exists to measure.
+"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "$(( load_secs + 10 ))s" \
   -out "$runs/mem.csv" >"$runs/memsampler.log" 2>&1 &
 mem_pid=$!
 

--- a/test/performance/run-mcp.test.sh
+++ b/test/performance/run-mcp.test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 Solace Corporation. All rights reserved.
+#
+# Self-test for run-mcp.sh's cleanup path — the one part of the run record that
+# cannot be tested by calling a function.
+#
+# What it pins: a run that is terminated rather than allowed to finish still
+# writes fd_peak and threads_peak, writes them exactly once despite cleanup
+# being the handler for EXIT, INT and TERM alike, and marks the peaks as
+# partial so a short run cannot be quoted as a whole one. All three regressed
+# invisibly before — the peaks were written in the main flow, so any terminated
+# run simply lost them, and the run whose entire purpose was measuring fd_peak
+# under a raised connection cap came back without it.
+#
+# Everything real is stubbed: a Python listener stands in for MCP's /health, a
+# shell loop for memsampler, a bare socket for the mock on the other box. No
+# broker, no fixtures, no network beyond loopback.
+#
+# Usage: ./run-mcp.test.sh
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+
+pass=0
+fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+eq()  { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1"$'\n'"        got:  [$2]"$'\n'"        want: [$3]"; fi; }
+
+# The stub MCP binds 9090 and the stub mock 18081, the same ports a real run
+# uses. Bail out rather than fight a run already in progress — a test that
+# killed someone's campaign to prove a point would be a poor trade.
+if held=$(perf_first_held_port 9090 18081); then
+  echo "port $held is in use — is a run in progress? Not running this test." >&2
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+work="$tmp/perf"
+mkdir -p "$work/bin"
+# The runner reads its neighbours by path, so it needs a directory that looks
+# like test/performance — but only the files it actually sources or execs.
+cp "$here/run-mcp.sh" "$here/lib.sh" "$here/sampler.sh" "$here/summary.sh" "$work/"
+printf 'stub — this run replays nothing\n' >"$work/fixtures.manifest"
+cp "$here/broker-config.mock.yaml" "$work/" 2>/dev/null || printf 'brokers: []\n' >"$work/broker-config.mock.yaml"
+
+cat >"$work/bin/mcp-server" <<'EOF'
+#!/usr/bin/env python3
+import http.server, socketserver
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200); self.end_headers(); self.wfile.write(b"ok")
+    def log_message(self, *a): pass
+socketserver.TCPServer.allow_reuse_address = True
+socketserver.TCPServer(("", 9090), H).serve_forever()
+EOF
+# Appends a row a second and flushes each one, which is what makes a peak
+# readable from a file whose writer was killed mid-run.
+cat >"$work/bin/memsampler" <<'EOF'
+#!/usr/bin/env bash
+out=""
+while [[ $# -gt 0 ]]; do [[ "$1" == "-out" ]] && out=$2; shift; done
+echo "t_sec,wall_ts,rss_kb,vm_kb,threads,open_fds" >"$out"
+for i in $(seq 1 600); do
+  echo "$i,x,1000,2000,$((40 + i)),$((500 + i))" >>"$out"
+  sleep 1
+done
+EOF
+chmod +x "$work/bin/mcp-server" "$work/bin/memsampler"
+
+cleanup_all() {
+  [[ -n "${mock_pid:-}" ]] && kill "$mock_pid" 2>/dev/null
+  [[ -n "${run_pid:-}" ]]  && kill -KILL "$run_pid" 2>/dev/null
+  pkill -f "$work/bin/" 2>/dev/null
+  rm -rf "$tmp"
+  return 0
+}
+trap cleanup_all EXIT
+
+# Stands in for mock-semp on Box A: run-mcp.sh refuses to start MCP until
+# something is listening there, which is itself worth not breaking.
+python3 -c "
+import socketserver
+class H(socketserver.BaseRequestHandler):
+    def handle(self): self.request.recv(1024)
+socketserver.TCPServer.allow_reuse_address = True
+socketserver.TCPServer(('127.0.0.1', 18081), H).serve_forever()" &
+mock_pid=$!
+sleep 1
+
+echo "== a run terminated mid-hold still describes itself"
+
+# Two things this launch has to get right, both of them learned the hard way:
+#
+#   `exec`  — without it $! is the subshell's pid, a SIGTERM there never
+#             reaches the script, and the trap this test exists to exercise
+#             does not run.
+#   `setsid`— the runner's own kill_tree signals its *process group*, so a
+#             runner sharing this test's group takes the test down with it
+#             mid-assertion. Its own session keeps the blast radius where it
+#             belongs. (That kill_tree reaches its own group is pre-existing
+#             behaviour, not something this test is asserting.)
+( cd "$work" && exec setsid env MOCK_HOST=127.0.0.1 DURATION=120s ./run-mcp.sh >"$work/run.log" 2>&1 ) &
+run_pid=$!
+# Long enough for the health check, the record, and several sampler rows.
+sleep 14
+
+if ! kill -TERM "$run_pid" 2>/dev/null; then
+  bad "the runner exited before it could be interrupted"
+  sed -n '1,15p' "$work/run.log"
+  echo; echo "$pass passed, $fail failed"; exit 1
+fi
+sleep 3
+
+rec=$(find "$work/bin/runs" -name 'run-record.mcp' 2>/dev/null | head -1)
+if [[ -z "$rec" ]]; then
+  bad "no run record was written at all"
+  sed -n '1,15p' "$work/run.log"
+  echo; echo "$pass passed, $fail failed"; exit 1
+fi
+field() { awk -F= -v k="$1" '$1 == k {print $2; exit}' "$rec"; }
+
+# The defect this whole change exists for: these were written in the main flow,
+# so a terminated run reached the end of neither and lost both.
+[[ -n "$(field fd_peak)" ]]      && ok "fd_peak survives a terminated run"      || bad "fd_peak is missing from a terminated run's record"
+[[ -n "$(field threads_peak)" ]] && ok "threads_peak survives a terminated run" || bad "threads_peak is missing from a terminated run's record"
+
+# cleanup() handles EXIT, INT and TERM, and its own `exit` re-enters it through
+# the EXIT trap — so without the peaks_recorded guard the record grows a second
+# copy of every peak, and `awk -F= ... exit` would read whichever came first.
+eq "fd_peak is written exactly once, not once per trap entry" \
+  "$(grep -c '^fd_peak=' "$rec")" "1"
+eq "threads_peak likewise" "$(grep -c '^threads_peak=' "$rec")" "1"
+
+# A peak over a run that was cut short is not the peak the run would have
+# reached. Absence used to be the marker for that; now the record says it.
+eq "the record says the run was terminated" "$(field run_terminated)" "true"
+eq "and marks the peak partial rather than letting it be quoted as complete" \
+  "$(field fd_peak_source)" "partial"
+
+# This box stamps no load window by design, so these fields are the only thing
+# separating an interrupted record from a whole one.
+eq "the load window is still declared, not guessed" \
+  "$(field load_window_source)" "split-host-load-on-other-box"
+
+echo
+echo "$pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]

--- a/test/performance/run-mcp.test.sh
+++ b/test/performance/run-mcp.test.sh
@@ -33,8 +33,18 @@ eq()  { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1"$'\n'"        got:  [$
 # The stub MCP binds 9090 and the stub mock 18081, the same ports a real run
 # uses. Bail out rather than fight a run already in progress — a test that
 # killed someone's campaign to prove a point would be a poor trade.
-if held=$(perf_first_held_port 9090 18081); then
+# Three outcomes, not two. rc=0 is "a port is held", rc=1 is "both free", and
+# rc=2 is "ss is missing, so I cannot tell" — and on that last host run-mcp.sh
+# fails closed before it writes a record, so treating it as all-clear turns an
+# unsupported environment into a test failure. lib.test.sh skips there; so does
+# this.
+port_rc=0
+held=$(perf_first_held_port 9090 18081) || port_rc=$?
+if (( port_rc == 0 )); then
   echo "port $held is in use — is a run in progress? Not running this test." >&2
+  exit 0
+elif (( port_rc == 2 )); then
+  echo "ss (iproute2) not found, so the ports cannot be checked — skipping." >&2
   exit 0
 fi
 

--- a/test/performance/run-mcp.test.sh
+++ b/test/performance/run-mcp.test.sh
@@ -91,6 +91,30 @@ socketserver.TCPServer(('127.0.0.1', 18081), H).serve_forever()" &
 mock_pid=$!
 sleep 1
 
+echo "== the durations that cannot work are refused before anything starts"
+
+# Zero is a legitimate WARMUP and never a legitimate DURATION: loadgen rejects
+# a non-positive -duration, and `memsampler -duration 0s` means "run until the
+# process disappears" — so a zero that got past preflight would hold MCP up
+# forever and hang the run at its final wait, after the expensive setup.
+rc=0
+( cd "$work" && MOCK_HOST=127.0.0.1 DURATION=0s ./run-mcp.sh >"$work/zero.log" 2>&1 ) || rc=$?
+eq "DURATION=0s exits 2 rather than starting a run that cannot end" "$rc" "2"
+if grep -q "DURATION must be greater than zero" "$work/zero.log"; then
+  ok "and says so, naming the value"
+else
+  bad "the refusal did not name DURATION"
+fi
+
+rc=0
+( cd "$work" && MOCK_HOST=127.0.0.1 DURATION=1m30s ./run-mcp.sh >"$work/compound.log" 2>&1 ) || rc=$?
+eq "a compound duration the samplers cannot express is refused too" "$rc" "2"
+
+# The knob Box A sets, which this box cannot learn for itself.
+rc=0
+( cd "$work" && MOCK_HOST=127.0.0.1 DURATION=30s WARMUP=nonsense ./run-mcp.sh >"$work/warmup.log" 2>&1 ) || rc=$?
+eq "and so is a WARMUP that is not a duration" "$rc" "2"
+
 echo "== a run terminated mid-hold still describes itself"
 
 # Two things this launch has to get right, both of them learned the hard way:

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -52,8 +52,10 @@
 #                to be released before giving up (default 60)
 #   NOFILE       descriptor limit to request (default 1048576; falls back to the
 #                hard limit, and both are recorded)
-#   RIG_NOTE     free-text note about this host, recorded verbatim in the run
-#                record
+#   RIG_NOTE     free-text note about this host. Control characters are
+#                flattened, `=` becomes `:` and the value is capped at 200
+#                characters so the record stays parseable — the substitutions
+#                are reported on stderr.
 
 set -euo pipefail
 
@@ -85,9 +87,27 @@ ERROR_STATUSES="${ERROR_STATUSES:-503:70,429:20,500:10}"
 # mock alias. VPN must match the capture and is resolved from
 # fixtures.manifest after the preflight below — hardcoding a default here is
 # how it drifted from regen-golden.sh's.
-BROKER_ALIAS="${BROKER_ALIAS:-broker-01}"
+# Derived from the prefix, so setting BROKER_PREFIX alone cannot leave the
+# fidelity gate dialling an alias the generated config does not contain.
+BROKER_ALIAS="${BROKER_ALIAS:-${BROKER_PREFIX}-01}"
 CONFIG_FILE="${CONFIG_FILE:-$here/broker-config.mock.yaml}"
+# The generator's -prefix and loadgen's -broker-prefix have to agree, and until
+# now only the generator had a knob: a config generated with `-prefix mock`
+# gave MCP aliases mock-01... while loadgen kept asking for broker-01..., so
+# every lookup missed. Both defaults are `broker`, so an existing invocation is
+# unchanged.
+BROKER_PREFIX="${BROKER_PREFIX:-broker}"
 BROKERS="${BROKERS:-50}"
+
+# The mock binds BROKERS ports from 18081 and its control endpoint at the fixed
+# 19000, so a count of 920 or more makes a broker land on the control port —
+# they race, and /_mock/config goes to whichever won. gen-mock-config.sh
+# already refuses this range; the runners have to as well, because a config
+# generated for a smaller count can still be driven with a larger BROKERS.
+if (( BROKERS > 919 )); then
+  echo "BROKERS must be 919 or fewer: 18081 + $BROKERS - 1 would reach the mock's control port 19000" >&2
+  exit 2
+fi
 PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
 
 # Validated before anything starts. loadgen would reject a malformed duration
@@ -530,6 +550,7 @@ if (( warmup_secs > 0 )); then
   perf_record_kv "$lg_record"  stats_start_epoch "$(( load_start_epoch + warmup_secs ))"
 fi
 "$bin/loadgen" -mcp-url http://localhost:9090 -broker-count "$BROKERS" \
+  -broker-prefix "$BROKER_PREFIX" \
   -clients "$CLIENTS" -duration "$DURATION" ${warmup_args[@]+"${warmup_args[@]}"} -tools "$TOOLS" \
   -vpn "$VPN" -rdp "$RDP" \
   | tee "$runs/loadgen.log" || lg_rc=$?

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -11,6 +11,13 @@
 # Env overrides:
 #   CLIENTS      loadgen -clients      (default 32)
 #   DURATION     loadgen -duration     (default 60s)
+#   WARMUP       loadgen -warmup       (default unset = no warmup). Time
+#                discarded from the STATS at the head of the run; the run
+#                still lasts WARMUP + DURATION and the samplers are extended
+#                to match. For a run with a mid-run event: an isolation run
+#                that injects latency partway through otherwise reports
+#                percentiles over the whole run, and since only the summary is
+#                emitted they cannot be re-windowed afterwards.
 #   TOOLS        loadgen -tools        (default get-broker-status,list-queues,list-rdps,get-rdp-status)
 #   LATENCY_MS   mock-semp -default-latency-ms (default 0). Set >0 to make every
 #                broker response take that long — with max_concurrent_per_broker=10
@@ -66,6 +73,8 @@ lg_record="$runs/run-record.loadgen"
 
 CLIENTS="${CLIENTS:-32}"
 DURATION="${DURATION:-60s}"
+# Unset by default, so an existing invocation behaves exactly as it did.
+WARMUP="${WARMUP:-}"
 TOOLS="${TOOLS:-get-broker-status,list-queues,list-rdps,get-rdp-status}"
 LATENCY_MS="${LATENCY_MS:-0}"
 ERROR_RATE="${ERROR_RATE:-0}"
@@ -80,6 +89,37 @@ BROKER_ALIAS="${BROKER_ALIAS:-broker-01}"
 CONFIG_FILE="${CONFIG_FILE:-$here/broker-config.mock.yaml}"
 BROKERS="${BROKERS:-50}"
 PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
+
+# Validated before anything starts. loadgen would reject a malformed duration
+# itself, but only after the mock, the server and the fidelity gate have been
+# paid for — and a run that dies there has already spent the expensive part.
+# DURATION and WARMUP both size sampler windows, so both are resolved to whole
+# seconds here, once, and a value that cannot be resolved stops the run before
+# the mock, the server and the fidelity gate have been paid for.
+#
+# This is stricter than Go's own duration parser, which also takes "1m30s" and
+# "500ms" — deliberately. The samplers count in whole seconds, and the previous
+# arrangement (Go string to loadgen, a separate awk to the samplers, with a
+# silent `print 90` fallback for anything it could not parse) meant a
+# DURATION=2m30s run drove 150s of load while sampling 100s of it and said
+# nothing. A refusal at the door beats a window that quietly describes the
+# wrong span.
+duration_secs=$(perf_duration_secs "$DURATION") || exit 2
+warmup_secs=0
+warmup_args=()
+if [[ -n "$WARMUP" ]]; then
+  warmup_secs=$(perf_duration_secs "$WARMUP") || exit 2
+  # A zero warmup is the same run as no warmup, so it is normalised to one
+  # rather than recorded as a warmup with no stats window beside it.
+  if (( warmup_secs > 0 )); then
+    warmup_args=(-warmup "$WARMUP")
+  else
+    WARMUP=""
+  fi
+fi
+# One number for every window in this run: the load lasts warmup + duration, so
+# the samplers must cover that, not DURATION alone.
+load_secs=$(( duration_secs + warmup_secs ))
 
 # Fail loud on a bad path. Silently falling back to the committed config would
 # make every run measure the interval that file happens to ship, and a sweep
@@ -190,6 +230,10 @@ perf_record_fixtures "$lg_record" "$here"
 perf_record_comment "$lg_record" "workload"
 perf_record_kv "$lg_record" clients "$CLIENTS"
 perf_record_kv "$lg_record" duration "$DURATION"
+# What the stats exclude, not what the load skipped: the run still drives load
+# for the whole of WARMUP + DURATION. `none` rather than an empty value, which
+# would read as a measured zero.
+perf_record_kv "$lg_record" stats_warmup "${WARMUP:-none}"
 perf_record_kv "$lg_record" tools "$TOOLS"
 perf_record_kv "$lg_record" broker_count "$BROKERS"
 perf_record_kv "$lg_record" vpn "$VPN"
@@ -218,12 +262,44 @@ kill_tree() {
     kill -TERM "$pid" 2>/dev/null || true
   fi
 }
+# Set once the peaks have been written, so a run interrupted with Ctrl-C does
+# not append them twice: cleanup handles INT and TERM as well as EXIT, and its
+# `exit` re-enters it through the EXIT trap.
+peaks_recorded=0
+# Set at the end of the main flow. cleanup() is reached on every path, so this
+# is what tells it whether the peaks it is about to record cover a whole run.
+run_finished=0
 cleanup() {
   local rc=$?
   set +e
   kill_tree "$top_pid";  wait "$top_pid" 2>/dev/null
   kill_tree "$mem_pid";  wait "$mem_pid" 2>/dev/null
   kill_tree "$mcp_pid";  wait "$mcp_pid" 2>/dev/null
+  # Peaks recorded here rather than at the end of the main flow: the runs that
+  # lose them are the ones that never reach the end. The samplers are waited
+  # for above, so mem.csv is final. A SIGKILL still loses them — nothing
+  # shell-side survives that — and the record then stays short.
+  if (( ! peaks_recorded )); then
+    peaks_recorded=1
+    perf_record_fd_peak "$mcp_record" "$runs/mem.csv"
+    # A peak taken over a run that was cut short is not the peak the run would
+    # have reached, and fd_peak is exactly the number a capacity claim gets
+    # quoted from. Absence used to be the marker that a run did not finish;
+    # now that the field is always written, say so in the record instead.
+    if (( run_finished )); then
+      perf_record_kv "$mcp_record" fd_peak_source complete
+    else
+      perf_record_kv "$mcp_record" run_terminated true
+      perf_record_kv "$mcp_record" fd_peak_source partial
+    fi
+    # Assert only where there were samples to peak over: -s is true for a
+    # header-only CSV, which is what a run terminated inside the first sampling
+    # interval leaves behind, so count rows rather than bytes. A preflight
+    # abort has none, and the warning would bury the real error.
+    if [[ -r "$runs/mem.csv" ]] && (( $(wc -l <"$runs/mem.csv") > 1 )); then
+      perf_record_assert_fields "$mcp_record" fd_peak threads_peak
+    fi
+  fi
   if [[ -n "$mock_pid" ]]; then
     kill_tree "$mock_pid"
     wait "$mock_pid"
@@ -346,6 +422,9 @@ wait_for_http "http://localhost:9090/health" mcp-server
 perf_record_kv "$mcp_record" mcp_pid "$mcp_pid"
 perf_record_admission "$mcp_record" "$runs/mcp.log" "$runs/broker-config.used.yaml"
 perf_record_proc_nofile "$mcp_record" "$mcp_pid"
+# How much processor the Go runtime was entitled to. Without it, two runs on
+# one box with different GOMAXPROCS write records identical in every field.
+perf_record_runtime_cpu "$mcp_record" "$mcp_pid"
 
 echo "== 3. fidelity gate (exact mode; broker=$BROKER_ALIAS vpn=$VPN rdp=$RDP; exclusions in fidelity/exclusions.txt)"
 # BROKER_ALIAS + VPN must match how the goldens were captured; the mock
@@ -376,19 +455,21 @@ if awk -v r="$ERROR_RATE" 'BEGIN { exit !(r+0 > 0) }'; then
 fi
 
 echo "== 4. memsampler alongside MCP (pid=$mcp_pid)"
-"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "$DURATION" \
+# load_secs, not DURATION: WARMUP extends the run, so it extends the sampling.
+# A sampler sized on DURATION alone would stop before the load did and clip the
+# tail off the numbers.
+"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "${load_secs}s" \
   -out "$runs/mem.csv" >"$runs/memsampler.log" 2>&1 &
 mem_pid=$!
 
 # sampler samples MCP + mock CPU + RSS/PSS/USS via /proc, and box totals, in
-# parallel with memsampler. Duration argument is seconds; DURATION here is a
-# Go duration string (e.g. "60s", "2m") so convert with a tiny awk.
-top_secs=$(awk -v d="$DURATION" 'BEGIN {
-  if (match(d, /^([0-9.]+)s$/, m)) { print int(m[1]); exit }
-  if (match(d, /^([0-9.]+)m$/, m)) { print int(m[1]*60); exit }
-  if (match(d, /^([0-9.]+)h$/, m)) { print int(m[1]*3600); exit }
-  print 90  # fallback if duration is unparseable
-}')
+# parallel with memsampler. Same resolved seconds the memsampler got: the two
+# samplers used to size themselves from different parsers, and the awk one
+# fell back to a hardcoded 90 on anything it could not read — so on a mawk host
+# (its match() form is gawk-only) every run sampled 100s regardless of
+# DURATION, while memsampler sampled the right span. Two windows over one run,
+# one of them silently wrong.
+top_secs=$load_secs
 # Small tail buffer, the same one run-loadgen.sh gives its samplers. The
 # samplers start just before loadgen does, so an exactly-DURATION window ends a
 # few seconds before the load does and clips the tail off the load-phase
@@ -403,7 +484,7 @@ inject_note="no error injection"
 if awk -v r="$ERROR_RATE" 'BEGIN { exit !(r+0 > 0) }'; then
   inject_note="inject rate=$ERROR_RATE count=$ERROR_COUNT/port statuses=$ERROR_STATUSES"
 fi
-echo "== 5. loadgen ($CLIENTS clients, $DURATION, tools=$TOOLS, broker-count=$BROKERS; $inject_note)"
+echo "== 5. loadgen ($CLIENTS clients, $DURATION${WARMUP:+ after $WARMUP warmup}, tools=$TOOLS, broker-count=$BROKERS; $inject_note)"
 # Stamp the load window into both records. summary.sh windows the sampler CSV
 # on it so the reported CPU is the load phase, not the load phase averaged
 # together with the idle stretch the fidelity gate ran in. Stamped by the
@@ -415,22 +496,29 @@ echo "== 5. loadgen ($CLIENTS clients, $DURATION, tools=$TOOLS, broker-count=$BR
 load_start_epoch=$(date +%s)
 perf_stamp_load_start "$mcp_record" "$load_start_epoch"
 perf_stamp_load_start "$lg_record" "$load_start_epoch"
+# With a warmup, the load window and the window the stats describe are not the
+# same span. Record the second one too, so CPU can be read over the span the
+# percentiles actually cover rather than over one that also contains the
+# traffic they exclude.
+if (( warmup_secs > 0 )); then
+  perf_record_kv "$mcp_record" stats_start_epoch "$(( load_start_epoch + warmup_secs ))"
+  perf_record_kv "$lg_record"  stats_start_epoch "$(( load_start_epoch + warmup_secs ))"
+fi
 lg_rc=0
 "$bin/loadgen" -mcp-url http://localhost:9090 -broker-count "$BROKERS" \
-  -clients "$CLIENTS" -duration "$DURATION" -tools "$TOOLS" \
+  -clients "$CLIENTS" -duration "$DURATION" ${warmup_args[@]+"${warmup_args[@]}"} -tools "$TOOLS" \
   -vpn "$VPN" -rdp "$RDP" \
   | tee "$runs/loadgen.log" || lg_rc=$?
 load_end_epoch=$(date +%s)
 perf_stamp_load_end "$mcp_record" "$load_end_epoch"
 perf_stamp_load_end "$lg_record" "$load_end_epoch"
 
-# Peaks are only knowable once the samplers have stopped.
-# `|| true`: a provenance write failing before the load starts is a fair
-# abort, but failing after a completed run would discard the report for a
-# measurement that is already safely in the CSVs.
+# Let the samplers flush. The peaks themselves are written by cleanup(), which
+# runs on the way out of every path including a terminated one.
 wait "$mem_pid" 2>/dev/null || true
 wait "$top_pid" 2>/dev/null || true
-perf_record_fd_peak "$mcp_record" "$runs/mem.csv" || true
+
+run_finished=1
 
 echo "== done"
 echo

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -36,6 +36,17 @@
 #   RDP          fidelity/loadgen -rdp (default: the RDP recorded in fixtures.manifest;
 #                the mock serves get-rdp-status for that RDP only)
 #   BROKER_USERNAME / BROKER_PASSWORD  (default perf/perf; mock accepts anything non-empty)
+#   BROKERS      number of mock brokers, and loadgen -broker-count (default 50).
+#                Above 50 the committed config runs out of aliases, so generate
+#                one to match:
+#                  ./gen-mock-config.sh -n 120 -o broker-config.gen120.yaml
+#                  BROKERS=120 CONFIG_FILE=./broker-config.gen120.yaml ./run.sh
+#   PORT_WAIT_SECS  how long to wait for a port held by a previous sweep point
+#                to be released before giving up (default 60)
+#   NOFILE       descriptor limit to request (default 1048576; falls back to the
+#                hard limit, and both are recorded)
+#   RIG_NOTE     free-text note about this host, recorded verbatim in the run
+#                record
 
 set -euo pipefail
 
@@ -44,6 +55,14 @@ repo_root="$(cd "$here/../.." && pwd)"
 bin="$here/bin"
 runs="$bin/runs/$(date +%Y%m%d-%H%M%S)"
 mkdir -p "$runs"
+
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+# Single host, so both halves of the run live in one directory — but still two
+# records, one per role, so a consumer reads a single-host run the same way it
+# reads the two halves of a split-host one.
+mcp_record="$runs/run-record.mcp"
+lg_record="$runs/run-record.loadgen"
 
 CLIENTS="${CLIENTS:-32}"
 DURATION="${DURATION:-60s}"
@@ -59,6 +78,8 @@ ERROR_STATUSES="${ERROR_STATUSES:-503:70,429:20,500:10}"
 # how it drifted from regen-golden.sh's.
 BROKER_ALIAS="${BROKER_ALIAS:-broker-01}"
 CONFIG_FILE="${CONFIG_FILE:-$here/broker-config.mock.yaml}"
+BROKERS="${BROKERS:-50}"
+PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
 
 # Fail loud on a bad path. Silently falling back to the committed config would
 # make every run measure the interval that file happens to ship, and a sweep
@@ -83,12 +104,42 @@ for b in "${required_bins[@]}"; do
   fi
 done
 
-if ss -tln 2>/dev/null | grep -q ":9090 "; then
-  echo "port 9090 already in use — another MCP is running:" >&2
-  ss -tlnp 2>/dev/null | grep ":9090 " >&2
-  echo "kill it before running this script." >&2
+# A non-numeric or zero BROKERS would build an empty port list and hand
+# mock-semp a -listen-count it rejects several steps later. Catch it here,
+# where the message can name the variable.
+if ! [[ "$BROKERS" =~ ^[0-9]+$ ]] || (( BROKERS < 1 )); then
+  echo "BROKERS must be a positive integer, got: $BROKERS" >&2
   exit 2
 fi
+
+mock_start=18081
+mock_count="$BROKERS"
+
+# Wait for every port this run needs rather than aborting on a held one. A
+# back-to-back sweep point was lost this way: the previous point's server still
+# held :9090 when the next one started. An immediate abort turns a two-second
+# wait into a missing data point; starting anyway would measure the previous
+# process. Bounded, and the failure names the port it waited on.
+#
+# "Free" means no listener, not no socket: a TIME_WAIT socket does not block a
+# bind with SO_REUSEADDR, so waiting for every socket to clear would wait for
+# something that never happens. See perf_first_held_port.
+#
+# The mock's whole port range is covered, not just its first port — a previous
+# run with a larger BROKERS leaves the tail bound while 18081 is already free.
+mock_ports=()
+for (( p = mock_start; p < mock_start + mock_count; p++ )); do mock_ports+=("$p"); done
+perf_wait_ports_free "$PORT_WAIT_SECS" 9090 19000 "${mock_ports[@]}" || exit 2
+
+# Raise the descriptor limit before anything is launched, so both the server
+# and the mock inherit it. Nothing in this suite, cmd/ or deploy/ raised
+# RLIMIT_NOFILE before, which left it varying with whatever the login shell
+# handed the operator — a result-moving input that was invisible in the output.
+# On a single host this shell's limit covers the server's two idle pools per
+# broker AND the load generator's inbound sessions, which is the larger of the
+# two by far at high client counts.
+perf_raise_nofile "${NOFILE:-1048576}"
+echo "== 0. descriptor limit: requested $PERF_NOFILE_REQUESTED, granted $PERF_NOFILE_GRANTED"
 
 # Fixture preflight. The canned responses and goldens are lab captures kept
 # out of git, so "absent" is the normal state of a fresh clone — fail here
@@ -122,6 +173,33 @@ fi
 # check is delegated rather than duplicated here: a bash copy of the valid
 # names would drift the first time a tool is added.
 "$bin/loadgen" -validate-only -tools "$TOOLS" -vpn "$VPN" -rdp "$RDP"
+
+# Records first: a run that dies in startup should still say what it was.
+perf_record_begin "$mcp_record" mcp "$runs"
+perf_record_rig "$mcp_record"
+perf_record_code "$mcp_record" "$repo_root" "$bin" mcp-server memsampler
+perf_record_fixtures "$mcp_record" "$here"
+perf_record_kv "$mcp_record" config_file "$CONFIG_FILE"
+perf_record_kv "$mcp_record" nofile_requested "$PERF_NOFILE_REQUESTED"
+perf_record_kv "$mcp_record" nofile_granted "$PERF_NOFILE_GRANTED"
+
+perf_record_begin "$lg_record" loadgen "$runs"
+perf_record_rig "$lg_record"
+perf_record_code "$lg_record" "$repo_root" "$bin" loadgen mock-semp fidelity
+perf_record_fixtures "$lg_record" "$here"
+perf_record_comment "$lg_record" "workload"
+perf_record_kv "$lg_record" clients "$CLIENTS"
+perf_record_kv "$lg_record" duration "$DURATION"
+perf_record_kv "$lg_record" tools "$TOOLS"
+perf_record_kv "$lg_record" broker_count "$BROKERS"
+perf_record_kv "$lg_record" vpn "$VPN"
+perf_record_kv "$lg_record" rdp "$RDP"
+perf_record_kv "$lg_record" latency_ms "$LATENCY_MS"
+perf_record_kv "$lg_record" error_rate "$ERROR_RATE"
+perf_record_kv "$lg_record" error_count "$ERROR_COUNT"
+perf_record_kv "$lg_record" error_statuses "$ERROR_STATUSES"
+perf_record_kv "$lg_record" nofile_requested "$PERF_NOFILE_REQUESTED"
+perf_record_kv "$lg_record" nofile_granted "$PERF_NOFILE_GRANTED"
 
 mock_pid= mcp_pid= mem_pid= top_pid=
 # kill_tree signals a pid (and its process group if reachable) and waits for
@@ -185,8 +263,6 @@ wait_for_tcp() {
   return 1
 }
 
-mock_start=18081
-mock_count=50
 echo "== 1. mock-semp on :$mock_start..$((mock_start + mock_count - 1)) (default-latency-ms=$LATENCY_MS)"
 # mock-semp reads canned/ from disk at startup (auto-located next to the
 # binary), so it replays whatever the last capture produced — no rebuild
@@ -264,6 +340,13 @@ setsid bash -c "cd '$repo_root' && CONFIG_FILE='$CONFIG_FILE' exec '$bin/mcp-ser
 mcp_pid=$!
 wait_for_http "http://localhost:9090/health" mcp-server
 
+# The server has now reported its own effective configuration, so record the
+# four settings that move admission behaviour and the limit the process
+# actually runs under.
+perf_record_kv "$mcp_record" mcp_pid "$mcp_pid"
+perf_record_admission "$mcp_record" "$runs/mcp.log" "$runs/broker-config.used.yaml"
+perf_record_proc_nofile "$mcp_record" "$mcp_pid"
+
 echo "== 3. fidelity gate (exact mode; broker=$BROKER_ALIAS vpn=$VPN rdp=$RDP; exclusions in fidelity/exclusions.txt)"
 # BROKER_ALIAS + VPN must match how the goldens were captured; the mock
 # replays canned bytes regardless of the alias in the request path, so
@@ -306,6 +389,12 @@ top_secs=$(awk -v d="$DURATION" 'BEGIN {
   if (match(d, /^([0-9.]+)h$/, m)) { print int(m[1]*3600); exit }
   print 90  # fallback if duration is unparseable
 }')
+# Small tail buffer, the same one run-loadgen.sh gives its samplers. The
+# samplers start just before loadgen does, so an exactly-DURATION window ends a
+# few seconds before the load does and clips the tail off the load-phase
+# figures. The extra idle samples land in the whole-run average, which is the
+# diluted number this change exists to stop anyone relying on.
+top_secs=$(( top_secs + 10 ))
 echo "== 4b. sampler alongside MCP+mock (~${top_secs}s at 5s intervals)"
 "$here/sampler.sh" "$runs/sampler.csv" 5 "$top_secs" >"$runs/sampler.log" 2>&1 &
 top_pid=$!
@@ -314,10 +403,37 @@ inject_note="no error injection"
 if awk -v r="$ERROR_RATE" 'BEGIN { exit !(r+0 > 0) }'; then
   inject_note="inject rate=$ERROR_RATE count=$ERROR_COUNT/port statuses=$ERROR_STATUSES"
 fi
-echo "== 5. loadgen ($CLIENTS clients, $DURATION, tools=$TOOLS; $inject_note)"
-"$bin/loadgen" -mcp-url http://localhost:9090 -broker-count 50 \
+echo "== 5. loadgen ($CLIENTS clients, $DURATION, tools=$TOOLS, broker-count=$BROKERS; $inject_note)"
+# Stamp the load window into both records. summary.sh windows the sampler CSV
+# on it so the reported CPU is the load phase, not the load phase averaged
+# together with the idle stretch the fidelity gate ran in. Stamped by the
+# runner that starts the load, never inferred from the samples.
+# One clock read for both records: four independent `date +%s` calls could
+# leave the two files disagreeing by a second, and summary.sh reads whichever
+# record its glob happens to yield first — so the window a run reports would
+# depend on directory order.
+load_start_epoch=$(date +%s)
+perf_stamp_load_start "$mcp_record" "$load_start_epoch"
+perf_stamp_load_start "$lg_record" "$load_start_epoch"
+lg_rc=0
+"$bin/loadgen" -mcp-url http://localhost:9090 -broker-count "$BROKERS" \
   -clients "$CLIENTS" -duration "$DURATION" -tools "$TOOLS" \
   -vpn "$VPN" -rdp "$RDP" \
-  | tee "$runs/loadgen.log"
+  | tee "$runs/loadgen.log" || lg_rc=$?
+load_end_epoch=$(date +%s)
+perf_stamp_load_end "$mcp_record" "$load_end_epoch"
+perf_stamp_load_end "$lg_record" "$load_end_epoch"
+
+# Peaks are only knowable once the samplers have stopped.
+# `|| true`: a provenance write failing before the load starts is a fair
+# abort, but failing after a completed run would discard the report for a
+# measurement that is already safely in the CSVs.
+wait "$mem_pid" 2>/dev/null || true
+wait "$top_pid" 2>/dev/null || true
+perf_record_fd_peak "$mcp_record" "$runs/mem.csv" || true
 
 echo "== done"
+echo
+"$here/summary.sh" "$runs" || true
+echo "run records: $mcp_record, $lg_record"
+exit "$lg_rc"

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -105,6 +105,14 @@ PORT_WAIT_SECS="${PORT_WAIT_SECS:-60}"
 # nothing. A refusal at the door beats a window that quietly describes the
 # wrong span.
 duration_secs=$(perf_duration_secs "$DURATION") || exit 2
+# Zero is a legitimate WARMUP and never a legitimate DURATION: `loadgen`
+# rejects a non-positive -duration, and `memsampler -duration 0s` means "run
+# until the process disappears", so a zero would sail through this preflight
+# and hang the run at its final wait. Refuse it here, where refusing is free.
+if (( duration_secs == 0 )); then
+  echo "DURATION must be greater than zero, got: '$DURATION'" >&2
+  exit 2
+fi
 warmup_secs=0
 warmup_args=()
 if [[ -n "$WARMUP" ]]; then
@@ -269,6 +277,9 @@ peaks_recorded=0
 # Set at the end of the main flow. cleanup() is reached on every path, so this
 # is what tells it whether the peaks it is about to record cover a whole run.
 run_finished=0
+# Initialised here, not at the load phase, because cleanup() reads it and is
+# reached from every path — including the ones that never start a load.
+lg_rc=0
 cleanup() {
   local rc=$?
   set +e
@@ -286,8 +297,17 @@ cleanup() {
     # have reached, and fd_peak is exactly the number a capacity claim gets
     # quoted from. Absence used to be the marker that a run did not finish;
     # now that the field is always written, say so in the record instead.
-    if (( run_finished )); then
+    # Three outcomes, not two. A load that exited non-zero leaves the samplers
+    # running out their clock over an idle server, so the peak is real but the
+    # run is not a measurement — calling that `complete` would let a failed run
+    # be quoted as a whole one. It is not `run_terminated` either: the runner
+    # reached its end. Say which of the two it was.
+    perf_record_kv "$mcp_record" load_rc "$lg_rc"
+    if (( run_finished && lg_rc == 0 )); then
       perf_record_kv "$mcp_record" fd_peak_source complete
+    elif (( run_finished )); then
+      perf_record_kv "$mcp_record" load_failed true
+      perf_record_kv "$mcp_record" fd_peak_source partial
     else
       perf_record_kv "$mcp_record" run_terminated true
       perf_record_kv "$mcp_record" fd_peak_source partial
@@ -458,7 +478,12 @@ echo "== 4. memsampler alongside MCP (pid=$mcp_pid)"
 # load_secs, not DURATION: WARMUP extends the run, so it extends the sampling.
 # A sampler sized on DURATION alone would stop before the load did and clip the
 # tail off the numbers.
-"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "${load_secs}s" \
+# load_secs plus the same tail buffer sampler.sh gets, and for the same
+# reason twice over: loadgen dials all its sessions BEFORE its warmup+duration
+# clock starts, so a window of exactly load_secs ends while load is still
+# running — and the value clipped off the end is fd_peak, the number this
+# sampler exists to record.
+"$bin/memsampler" -pid "$mcp_pid" -interval 1s -duration "$(( load_secs + 10 ))s" \
   -out "$runs/mem.csv" >"$runs/memsampler.log" 2>&1 &
 mem_pid=$!
 
@@ -504,7 +529,6 @@ if (( warmup_secs > 0 )); then
   perf_record_kv "$mcp_record" stats_start_epoch "$(( load_start_epoch + warmup_secs ))"
   perf_record_kv "$lg_record"  stats_start_epoch "$(( load_start_epoch + warmup_secs ))"
 fi
-lg_rc=0
 "$bin/loadgen" -mcp-url http://localhost:9090 -broker-count "$BROKERS" \
   -clients "$CLIENTS" -duration "$DURATION" ${warmup_args[@]+"${warmup_args[@]}"} -tools "$TOOLS" \
   -vpn "$VPN" -rdp "$RDP" \

--- a/test/performance/sampler.sh
+++ b/test/performance/sampler.sh
@@ -12,6 +12,12 @@
 # Also writes a <out>.info sidecar with host details so per-process CPU% and
 # memory numbers can be read against the total.
 #
+# The last column is the sample's epoch seconds. summary.sh needs it to window
+# the CSV on the load phase the runner stamped into the run record: t_sec is
+# relative to this script's own start, and the `wall` HH:MM:SS column has no
+# date, so neither can be compared with a stamp taken by another process. It is
+# appended last so every existing column index is unchanged.
+#
 # Usage: ./sampler.sh <out.csv> [interval_sec] [duration_sec]
 #   interval defaults to 5s, duration to 90s.
 #
@@ -109,7 +115,7 @@ prev_t=$(awk 'BEGIN{srand(); print systime()}')
 
 echo "sampling MCP=${mcp_pid:-NA} mock=${mock_pid:-NA} every ${interval}s for ${duration}s → $out"
 echo "host info → $info"
-echo "t_sec,wall,mcp_cpu,mcp_cpu_pct_of_box,mcp_rss_kb,mcp_pss_kb,mcp_uss_kb,mock_cpu,mock_cpu_pct_of_box,mock_rss_kb,mock_pss_kb,mock_uss_kb,loadavg1,sys_mem_used_kb" > "$out"
+echo "t_sec,wall,mcp_cpu,mcp_cpu_pct_of_box,mcp_rss_kb,mcp_pss_kb,mcp_uss_kb,mock_cpu,mock_cpu_pct_of_box,mock_rss_kb,mock_pss_kb,mock_uss_kb,loadavg1,sys_mem_used_kb,epoch" > "$out"
 
 start=$SECONDS
 sleep "$interval"
@@ -150,6 +156,6 @@ while (( SECONDS - start <= duration )); do
   [[ "$mcp_new_j" != "_" ]] && prev_mcp_j="$mcp_new_j"
   [[ "$mock_new_j" != "_" ]] && prev_mock_j="$mock_new_j"
 
-  echo "$t,$wall,$mcp_cpu,$mcp_box,$mcp_rss,$mcp_pss,$mcp_uss,$mock_cpu,$mock_box,$mock_rss,$mock_pss,$mock_uss,$loadavg,$sys_mem" | tee -a "$out"
+  echo "$t,$wall,$mcp_cpu,$mcp_box,$mcp_rss,$mcp_pss,$mcp_uss,$mock_cpu,$mock_box,$mock_rss,$mock_pss,$mock_uss,$loadavg,$sys_mem,$now" | tee -a "$out"
   sleep "$interval"
 done

--- a/test/performance/summary.sh
+++ b/test/performance/summary.sh
@@ -52,17 +52,30 @@ shift
 # code. It is also what lets the load-phase window find `epoch` without this
 # script knowing how wide the file is.
 
-# window_from_record <record> — echo "<start> <end>" from a run record, or
-# nothing when it did not stamp a window.
+# window_from_record <record> — echo "<start> <end> <kind>" from a run record,
+# or nothing when it did not stamp a window.
+#
+# `stats_start_epoch` wins over `load_start_epoch` when it is there. It is only
+# written for a run with a WARMUP, and it marks where the load generator's
+# statistics window opens — which is not where the load opens. Reporting CPU
+# over the load phase while loadgen prints percentiles over the stats window
+# puts two figures for two different spans under one heading, with nothing
+# saying they differ; the whole point of a warmup is that the opening stretch
+# is excluded, so the CPU has to exclude it too.
 window_from_record() {
   awk -F= '
-    /^load_start_epoch=/ { s = $2 }
-    /^load_end_epoch=/   { e = $2 }
-    END { if (s != "" && e != "") print s, e }
+    /^load_start_epoch=/  { s = $2 }
+    /^stats_start_epoch=/ { ss = $2 }
+    /^load_end_epoch=/    { e = $2 }
+    END {
+      if (e == "") exit
+      if (ss != "")     print ss, e, "stats"
+      else if (s != "") print s, e, "load"
+    }
   ' "$1"
 }
 
-load_start="" load_end="" window_source=""
+load_start="" load_end="" window_source="" window_kind=""
 
 # Reject an unrecognised flag rather than letting it fall through to the bare
 # epoch branch. A typo'd `--window-form` used to be read as an epoch: `date`
@@ -90,7 +103,7 @@ if [[ "${1:-}" == "--window-from" ]]; then
   fi
   for rec in "${cands[@]}"; do
     [[ -r "$rec" ]] || continue
-    read -r load_start load_end <<<"$(window_from_record "$rec")"
+    read -r load_start load_end window_kind <<<"$(window_from_record "$rec")"
     if [[ -n "$load_start" && -n "$load_end" ]]; then
       window_source="$rec"
       break
@@ -139,7 +152,7 @@ fi
 if [[ -z "$window_source" ]]; then
   for rec in "$runs"/run-record.*; do
     [[ -r "$rec" ]] || continue
-    read -r load_start load_end <<<"$(window_from_record "$rec")"
+    read -r load_start load_end window_kind <<<"$(window_from_record "$rec")"
     if [[ -n "$load_start" && -n "$load_end" ]]; then
       window_source="$rec"
       break
@@ -147,6 +160,8 @@ if [[ -z "$window_source" ]]; then
   done
 fi
 
+# An explicitly given pair of epochs is whatever the operator says it is; the
+# labelling above only claims a kind when a record supplied one.
 if [[ -n "$window_source" && -z "$load_start" ]]; then
   window_source=""
 fi
@@ -278,9 +293,21 @@ info_mem() {
 
 echo "runs dir: $runs"
 if [[ -n "$load_start" && -n "$load_end" ]]; then
-  printf 'load phase: %s..%s (%ds)\n' \
-    "$(date -d "@$load_start" +%H:%M:%S)" "$(date -d "@$load_end" +%H:%M:%S)" \
-    "$(( load_end - load_start ))"
+  # Name which window this is. A reader comparing this figure with loadgen's
+  # percentiles needs to know whether the two cover the same span.
+  if [[ "$window_kind" == "stats" ]]; then
+    # Same 12-character label width as "load phase:", so the provenance line
+    # below stays aligned under either heading.
+    printf 'stats span: %s..%s (%ds)\n' \
+      "$(date -d "@$load_start" +%H:%M:%S)" "$(date -d "@$load_end" +%H:%M:%S)" \
+      "$(( load_end - load_start ))"
+    printf '            the span loadgen'"'"'s percentiles cover: the load phase\n'
+    printf '            minus the warmup this run excluded from its stats.\n'
+  else
+    printf 'load phase: %s..%s (%ds)\n' \
+      "$(date -d "@$load_start" +%H:%M:%S)" "$(date -d "@$load_end" +%H:%M:%S)" \
+      "$(( load_end - load_start ))"
+  fi
   # Name the record, and its role and start time when it has them, so a
   # windowed figure in an archived report stays traceable to the run that
   # measured the window.

--- a/test/performance/summary.sh
+++ b/test/performance/summary.sh
@@ -64,6 +64,17 @@ window_from_record() {
 
 load_start="" load_end="" window_source=""
 
+# Reject an unrecognised flag rather than letting it fall through to the bare
+# epoch branch. A typo'd `--window-form` used to be read as an epoch: `date`
+# and the arithmetic both errored on stderr, the provenance line vanished, and
+# the report still exited 0 with whole-run-only numbers — the operator got no
+# signal their window had been dropped.
+if [[ "${1:-}" == -* && "${1:-}" != "--window-from" ]]; then
+  echo "unknown option: $1" >&2
+  echo "usage: $0 <runs-dir> [--window-from <dir-or-record> | <from_epoch> <to_epoch>]" >&2
+  exit 2
+fi
+
 if [[ "${1:-}" == "--window-from" ]]; then
   src="${2:?--window-from needs a run directory or a run-record path}"
   # Accept either a run directory or a record inside one, so the operator can
@@ -86,11 +97,37 @@ if [[ "${1:-}" == "--window-from" ]]; then
     exit 2
   fi
   shift 2
-elif [[ -n "${1:-}" && -n "${2:-}" ]]; then
+elif [[ -n "${1:-}" ]]; then
+  # A window is two epochs or nothing. A single trailing argument used to be
+  # discarded in silence, which is the same failure as a typo'd flag: the
+  # operator asked for a window and got a whole-run report with no complaint.
+  if [[ -z "${2:-}" ]]; then
+    echo "a bare window needs two epochs (<from> <to>); got one argument: $1" >&2
+    echo "or use --window-from <dir-or-record>, which reads them from a run record" >&2
+    exit 2
+  fi
+  for arg in "$1" "$2"; do
+    if ! [[ "$arg" =~ ^[0-9]+$ ]]; then
+      echo "window epochs must be integer seconds, got: $arg" >&2
+      exit 2
+    fi
+  done
+  if (( $1 >= $2 )); then
+    echo "window start ($1) must be before its end ($2)" >&2
+    exit 2
+  fi
   load_start="$1"
   load_end="$2"
   window_source="command-line arguments (unverified)"
   shift 2
+fi
+
+# Anything left over was not understood. Silently ignoring it is how a
+# mistyped invocation produces a confident report of the wrong window.
+if (( $# > 0 )); then
+  echo "unexpected extra argument(s): $*" >&2
+  echo "usage: $0 <runs-dir> [--window-from <dir-or-record> | <from_epoch> <to_epoch>]" >&2
+  exit 2
 fi
 
 # Nothing given: fall back to whatever a record in this directory stamped.
@@ -147,11 +184,25 @@ roll() {
       bc = ix[bf]
       rc = ix[rf]
       ec = ix["epoch"]
+      wc = ix["wall"]
       # A CSV predating the epoch column simply has no window; the whole-run
       # lines below are unchanged either way.
       windowable = (ec && from > 0 && to > 0)
       next
     }
+    # A named column that is not in this CSV is a harness/producer mismatch,
+    # reported as such. Falling through to "(no samples)" would read as an idle
+    # process, which is a real and very different state.
+    #
+    # A flag rather than a bare `exit`: in awk, exit still runs the END block,
+    # so exiting here printed the mismatch line AND a "(no samples)" line
+    # under it. Caught by lib.test.sh, which is why that assertion is there.
+    NR==2 && (!bc || !rc) {
+      printf "  %-5s (column %s not in this CSV — header/producer mismatch)\n",
+             L, (bc ? rf : bf)
+      mismatch = 1
+    }
+    mismatch { exit }
     !bc || !rc { next }
     $bc == "NA" || $bc == "ENDED" || $bc == "" { next }
     {
@@ -178,6 +229,7 @@ roll() {
       }
     }
     END {
+      if (mismatch) exit
       if (n == 0) { printf "  %-5s (no samples)\n", L; exit }
       printf "  %-5s cpu:  min=%5.1f%%   avg=%5.1f%%   max=%5.1f%%   (out of 100%% box)\n",
              L, box_min, box_sum/n, box_max
@@ -253,25 +305,36 @@ if [[ -r "$mock_only_csv" ]]; then
   echo
 fi
 
-# loadgen-metrics.csv layout (from loadgen-sampler.sh):
-# 1 t_sec 2 wall 3 lg_cpu 4 lg_res_kb 5 loadavg1 6 sys_cpu_used_pct 7 sys_mem_used_kb 8 tcp_established 9 tcp_time_wait
-# There's no lg_cpu_pct_of_box column, so compute it from CLK_TCK * nproc via .info.
+# loadgen-metrics.csv, from loadgen-sampler.sh. Columns are resolved by header
+# name here for the same reason they are everywhere else in this file.
+#
+# There is no lg_cpu_pct_of_box column, so it is computed from CLK_TCK * nproc
+# via .info. There is also no epoch column, so this block reports the whole run
+# only — the load box's own CPU is a property of the rig rather than of the
+# product under test, so it has not been worth an extra column. If that changes,
+# give loadgen-sampler.sh an epoch column and this block can window like roll()
+# does.
 if [[ -r "$lg_csv" ]]; then
   info="$lg_csv.info"
   ncores=$(awk -F= '/^cores_logical/ {print $2; exit}' "$info" 2>/dev/null || echo 1)
   mem=$(info_mem "$info")
   echo "-- loadgen-metrics.csv --"
   awk -F, -v n="$ncores" -v mem="$mem" '
-    NR==1 { next }
-    $3 == "ENDED" || $3 == "NA" || $3 == "" { next }
+    NR==1 {
+      for (i = 1; i <= NF; i++) { gsub(/^[ \t]+|[ \t]+$/, "", $i); ix[$i] = i }
+      cc = ix["lg_cpu"]; rc = ix["lg_res_kb"]; ec = ix["tcp_established"]
+      next
+    }
+    !cc || !rc { next }
+    $cc == "ENDED" || $cc == "NA" || $cc == "" { next }
     {
       k++
       # lg CPU is reported as % of one core; divide by ncores for % of box.
-      box = ($3 + 0) / n
-      res = $4 + 0
+      box = ($cc + 0) / n
+      res = $rc + 0
       box_sum += box; if (box > box_max) box_max = box; if (box_min == "" || box < box_min) box_min = box
       res_sum += res; if (res > res_max) res_max = res; if (res_min == "" || res < res_min) res_min = res
-      if ($8+0 > est_max) est_max = $8+0
+      if (ec && $ec+0 > est_max) est_max = $ec+0
     }
     END {
       if (k == 0) { print "  (no samples)"; exit }

--- a/test/performance/summary.sh
+++ b/test/performance/summary.sh
@@ -6,30 +6,153 @@
 #   split-host lg  (run-loadgen.sh): <runs>/mock-sampler.csv (mock cols only)
 #                                <runs>/loadgen-metrics.csv (loadgen box CPU/RSS)
 #
-# Usage: ./summary.sh <runs-dir>
+# Usage: ./summary.sh <runs-dir> [--window-from <dir-or-record> | <from_epoch> <to_epoch>]
 #   ./summary.sh bin/runs/20260729-131337-mcp
+#   ./summary.sh bin/runs/20260729-131337-mcp --window-from ../20260729-131201-loadgen-200c
+#   ./summary.sh bin/runs/20260729-131337-mcp 1769000000 1769000060
+#
+# CPU is reported twice: over the whole run, and over the load phase alone.
+#
+# The whole-run figure is diluted by however long the server sat idle before
+# the load started — the fidelity gate, and (split-host) the wait for the other
+# box. That dilution is unstated and varies per run, which makes a raw average
+# useless for comparing one run against another. CPU is the metric the
+# cross-environment disagreement over the first measurement pass turns on, so
+# it is the number that most needs to mean the same thing twice.
+#
+# The load window is not inferred from the samples. It is read from the
+# load_start_epoch / load_end_epoch the runner stamped into its run record when
+# it started and stopped the load. Inferring it from a CPU threshold would use
+# the metric to define the window it is measured over, and would break on
+# exactly the runs that matter: an idle-pacer arm and a saturated arm look
+# nothing alike.
+#
+# The split-host MCP box cannot stamp the window — the load runs on the other
+# box and the two share no channel by design — so its record says so and its
+# summary reports the whole-run figure only. Point `--window-from` at the load
+# box's run directory (or its record) to window it after the fact; the two run
+# directories are archived together, which is the channel that does exist.
+#
+# Prefer `--window-from` over the bare epoch pair. The report names the record
+# the window came from, so a windowed figure in an archived summary stays
+# traceable — a mistyped epoch otherwise produces a plausible number rather
+# than an error, and "from arguments" is the one line in the report that would
+# not say where its numbers came from.
 
 set -euo pipefail
 
-runs="${1:?usage: $0 <runs-dir>}"
+runs="${1:?usage: $0 <runs-dir> [--window-from <dir-or-record> | <from_epoch> <to_epoch>]}"
 [[ -d "$runs" ]] || { echo "not a directory: $runs" >&2; exit 2; }
+shift
 
-# CSV columns in sampler.csv (index):
-# 1 t_sec 2 wall
-# 3 mcp_cpu 4 mcp_cpu_pct_of_box 5 mcp_rss_kb 6 mcp_pss_kb 7 mcp_uss_kb
-# 8 mock_cpu 9 mock_cpu_pct_of_box 10 mock_rss_kb 11 mock_pss_kb 12 mock_uss_kb
-# 13 loadavg1 14 sys_mem_used_kb
+# Columns are resolved by NAME from each CSV's header row, never by a
+# hardcoded index. "Append new columns last so every index still holds" is a
+# convention a reviewer has to police; reading the header costs two lines of
+# awk and makes both the pre-epoch and post-epoch layouts readable by the same
+# code. It is also what lets the load-phase window find `epoch` without this
+# script knowing how wide the file is.
+
+# window_from_record <record> — echo "<start> <end>" from a run record, or
+# nothing when it did not stamp a window.
+window_from_record() {
+  awk -F= '
+    /^load_start_epoch=/ { s = $2 }
+    /^load_end_epoch=/   { e = $2 }
+    END { if (s != "" && e != "") print s, e }
+  ' "$1"
+}
+
+load_start="" load_end="" window_source=""
+
+if [[ "${1:-}" == "--window-from" ]]; then
+  src="${2:?--window-from needs a run directory or a run-record path}"
+  # Accept either a run directory or a record inside one, so the operator can
+  # paste whichever path they have to hand.
+  if [[ -d "$src" ]]; then
+    cands=("$src"/run-record.*)
+  else
+    cands=("$src")
+  fi
+  for rec in "${cands[@]}"; do
+    [[ -r "$rec" ]] || continue
+    read -r load_start load_end <<<"$(window_from_record "$rec")"
+    if [[ -n "$load_start" && -n "$load_end" ]]; then
+      window_source="$rec"
+      break
+    fi
+  done
+  if [[ -z "$window_source" ]]; then
+    echo "no load window stamped in $src — it has no run record with load_start_epoch/load_end_epoch" >&2
+    exit 2
+  fi
+  shift 2
+elif [[ -n "${1:-}" && -n "${2:-}" ]]; then
+  load_start="$1"
+  load_end="$2"
+  window_source="command-line arguments (unverified)"
+  shift 2
+fi
+
+# Nothing given: fall back to whatever a record in this directory stamped.
+# Absent that too, the load-phase lines are skipped rather than guessed.
+if [[ -z "$window_source" ]]; then
+  for rec in "$runs"/run-record.*; do
+    [[ -r "$rec" ]] || continue
+    read -r load_start load_end <<<"$(window_from_record "$rec")"
+    if [[ -n "$load_start" && -n "$load_end" ]]; then
+      window_source="$rec"
+      break
+    fi
+  done
+fi
+
+if [[ -n "$window_source" && -z "$load_start" ]]; then
+  window_source=""
+fi
+
+# A record_version this script does not know is a warning, not a failure: the
+# fields it reads are looked up by name, so an added field is harmless. Saying
+# so beats a silent misread if the schema ever changes meaning.
+for rec in "$runs"/run-record.*; do
+  [[ -r "$rec" ]] || continue
+  rv=$(awk -F= '/^record_version=/ {print $2; exit}' "$rec")
+  if [[ -n "$rv" && "$rv" != "1" ]]; then
+    echo "note: $(basename "$rec") is record_version=$rv; this summary.sh understands 1." >&2
+  fi
+done
 
 # Roll one process's columns into a one-line summary.
-#   csv=path  label="mcp"/"mock"  box_col=<idx>  rss_col=<idx>
-#   mem_total_kb=<from info>
+#   csv=path  label="mcp"/"mock"  box_field=<header name>  rss_field=<header name>
+#   mem_total_kb=<from info>  from=<epoch>  to=<epoch>
 # We report CPU as % of the whole box (box_col) rather than the raw
 # per-core column (cpu_col in sampler.csv), so cpu_col is not needed here.
+#
+# When a load window is given, a second CPU line reports the same column over
+# the load phase alone, immediately under the whole-run one. The whole-run
+# lines are unchanged, so a run directory from before this existed still reads
+# the same way; the load-phase line is additive and clearly labelled.
+#
+# The window is skipped silently for a process with no samples at all (the
+# mock columns of a split-host MCP run) and for a CSV predating the epoch
+# column — printing "no samples in the window" twice for the same absence is
+# noise, and windowing on a column that is not there is not possible.
 roll() {
-  local csv=$1 label=$2 box_col=$3 rss_col=$4 mem_total=$5
+  local csv=$1 label=$2 box_field=$3 rss_field=$4 mem_total=$5
+  local from="${6:-0}" to="${7:-0}"
   [[ -r "$csv" ]] || return 0
-  awk -F, -v bc="$box_col" -v rc="$rss_col" -v mem="$mem_total" -v L="$label" '
-    NR==1 { next }
+  awk -F, -v bf="$box_field" -v rf="$rss_field" -v mem="$mem_total" -v L="$label" \
+          -v from="${from:-0}" -v to="${to:-0}" '
+    NR==1 {
+      for (i = 1; i <= NF; i++) { gsub(/^[ \t]+|[ \t]+$/, "", $i); ix[$i] = i }
+      bc = ix[bf]
+      rc = ix[rf]
+      ec = ix["epoch"]
+      # A CSV predating the epoch column simply has no window; the whole-run
+      # lines below are unchanged either way.
+      windowable = (ec && from > 0 && to > 0)
+      next
+    }
+    !bc || !rc { next }
     $bc == "NA" || $bc == "ENDED" || $bc == "" { next }
     {
       n++
@@ -44,11 +167,27 @@ roll() {
       rss_sum += rss
       if (rss > rss_max) rss_max = rss
       if (rss_min == "" || rss < rss_min) rss_min = rss
+
+      # Same column again, restricted to the stamped load phase.
+      if (windowable && $ec+0 >= from && $ec+0 <= to) {
+        w_n++
+        w_sum += box
+        if (box > w_max) w_max = box
+        if (w_first == "") w_first = $2
+        w_last = $2
+      }
     }
     END {
       if (n == 0) { printf "  %-5s (no samples)\n", L; exit }
       printf "  %-5s cpu:  min=%5.1f%%   avg=%5.1f%%   max=%5.1f%%   (out of 100%% box)\n",
              L, box_min, box_sum/n, box_max
+      if (windowable) {
+        if (w_n > 0)
+          printf "  %-5s cpu:  load-phase  avg=%5.1f%%   max=%5.1f%%   (%d of %d samples, %s..%s)\n",
+                 L, w_sum/w_n, w_max, w_n, n, w_first, w_last
+        else
+          printf "  %-5s cpu:  load-phase  no samples inside the stamped window\n", L
+      }
       if (mem > 0)
         printf "  %-5s mem:  min=%5.2f%%   avg=%5.2f%%   max=%5.2f%%   (out of 100%% box, %.1f GB total)\n",
                L, 100*rss_min/mem, 100*(rss_sum/n)/mem, 100*rss_max/mem, mem/1024/1024
@@ -67,7 +206,28 @@ info_mem() {
   awk -F= '/^mem_total_kb/ {print $2; exit}' "$info"
 }
 
+
 echo "runs dir: $runs"
+if [[ -n "$load_start" && -n "$load_end" ]]; then
+  printf 'load phase: %s..%s (%ds)\n' \
+    "$(date -d "@$load_start" +%H:%M:%S)" "$(date -d "@$load_end" +%H:%M:%S)" \
+    "$(( load_end - load_start ))"
+  # Name the record, and its role and start time when it has them, so a
+  # windowed figure in an archived report stays traceable to the run that
+  # measured the window.
+  if [[ -r "$window_source" ]]; then
+    printf '            window from %s (role=%s, started %s)\n' \
+      "$window_source" \
+      "$(awk -F= '/^role=/ {print $2; exit}' "$window_source")" \
+      "$(awk -F= '/^started_at=/ {print $2; exit}' "$window_source")"
+  else
+    printf '            window from %s\n' "$window_source"
+  fi
+else
+  echo "load phase: not stamped in this run directory — CPU below is whole-run only."
+  echo "            (split-host MCP box: window it on the load box's run directory,"
+  echo "             ./summary.sh $runs --window-from <box-a-run-dir>)"
+fi
 echo
 
 # Pick whichever sampler CSVs exist. Single-host has both cols in one file;
@@ -79,17 +239,17 @@ lg_csv="$runs/loadgen-metrics.csv"
 if [[ -r "$main_csv" ]]; then
   mem=$(info_mem "$main_csv.info")
   echo "-- sampler.csv --"
-  roll "$main_csv" "mcp"  4 5  "$mem"
+  roll "$main_csv" "mcp"  mcp_cpu_pct_of_box  mcp_rss_kb  "$mem" "$load_start" "$load_end"
   # mock columns exist in single-host runs; in split-host mcp runs they're all NA
   # and roll() prints "(no samples)" — that's fine.
-  roll "$main_csv" "mock" 9 10 "$mem"
+  roll "$main_csv" "mock" mock_cpu_pct_of_box mock_rss_kb "$mem" "$load_start" "$load_end"
   echo
 fi
 
 if [[ -r "$mock_only_csv" ]]; then
   mem=$(info_mem "$mock_only_csv.info")
   echo "-- mock-sampler.csv --"
-  roll "$mock_only_csv" "mock" 9 10 "$mem"
+  roll "$mock_only_csv" "mock" mock_cpu_pct_of_box mock_rss_kb "$mem" "$load_start" "$load_end"
   echo
 fi
 
@@ -126,6 +286,58 @@ if [[ -r "$lg_csv" ]]; then
       printf "  lg    tcp:  max established=%d\n", est_max
     }
   ' "$lg_csv"
+  echo
+fi
+
+
+# mem.csv is memsampler's per-process series: RSS/VmSize/threads/open
+# descriptors, sampled once a second against the MCP process alone.
+#
+# The peaks are what the run record carries forward, so print them here too:
+# a descriptor count that touched RLIMIT_NOFILE mid-run is invisible in a
+# start-vs-end comparison, and it is the failure the concurrency-cap and
+# >50-broker runs are looking for. "NA" rows (descriptor directory unreadable)
+# are skipped rather than counted as zero.
+mem_csv="$runs/mem.csv"
+if [[ -r "$mem_csv" ]]; then
+  echo "-- mem.csv (MCP process) --"
+  awk -F, '
+    NR==1 {
+      for (i = 1; i <= NF; i++) { gsub(/^[ \t]+|[ \t]+$/, "", $i); ix[$i] = i }
+      rc = ix["rss_kb"]; tc = ix["threads"]; fc = ix["open_fds"]
+      next
+    }
+    rc && $rc ~ /^[0-9]+$/ {
+      m++
+      rss = $rc + 0
+      if (rss > rss_max) rss_max = rss
+      if (rss_min == "" || rss < rss_min) rss_min = rss
+    }
+    # Track the final row separately from the final *readable* row. An
+    # unreadable /proc/<pid>/fd as the process winds down would otherwise let a
+    # stale mid-run sample be reported as the end state, and a comparison would
+    # trust it.
+    {
+      rows++
+      if (tc) { th_final = $tc; if ($tc ~ /^[0-9]+$/) { if ($tc+0 > th_max) th_max = $tc+0; th_seen++ } }
+      if (fc) { fd_final = $fc; if ($fc ~ /^[0-9]+$/) { if ($fc+0 > fd_max) fd_max = $fc+0; fd_seen++ } }
+    }
+    END {
+      if (m == 0) { print "  (no samples)"; exit }
+      printf "  mcp   rss:  min=%6.1f MB   max=%6.1f MB   (%d samples)\n", rss_min/1024, rss_max/1024, m
+      if (th_seen) printf "  mcp   thr:  end=%s   peak=%d\n", th_final, th_max
+      if (fd_seen) printf "  mcp   fds:  end=%s   peak=%d\n", fd_final, fd_max
+      else if (fc)  printf "  mcp   fds:  not readable in any sample (/proc/<pid>/fd unreadable)\n"
+      else          printf "  mcp   fds:  not recorded (mem.csv predates the open_fds column)\n"
+    }
+  ' "$mem_csv"
+  # The limit the peak should be read against lives in the run record, not in
+  # the CSV: it is a property of the process, not of a sample.
+  for rec in "$runs"/run-record.*; do
+    [[ -r "$rec" ]] || continue
+    lim=$(awk -F= '/^nofile_effective_soft=/ {print $2; exit}' "$rec")
+    [[ -n "$lim" ]] && printf '  mcp   fds:  limit=%s   (nofile_effective_soft, %s)\n' "$lim" "$(basename "$rec")"
+  done
   echo
 fi
 

--- a/test/performance/summary.sh
+++ b/test/performance/summary.sh
@@ -76,6 +76,10 @@ window_from_record() {
 }
 
 load_start="" load_end="" window_source="" window_kind=""
+# The per-process lines carry this, so a figure is never labelled as covering
+# the load phase when the window it was computed over deliberately excludes
+# part of it. Kept the same width as "load-phase" so the columns still line up.
+window_label="load-phase"
 
 # Reject an unrecognised flag rather than letting it fall through to the bare
 # epoch branch. A typo'd `--window-form` used to be read as an epoch: `date`
@@ -166,6 +170,22 @@ if [[ -n "$window_source" && -z "$load_start" ]]; then
   window_source=""
 fi
 
+# A window read out of a record gets the same checks a window typed on the
+# command line gets. A record is a file, and a file can be truncated mid-write
+# or hand-edited — and an unchecked value from one reaches `date -d` and
+# arithmetic, where text produces stderr noise and a whole-run report that
+# still exits 0, and a reversed pair produces a confident "no samples inside
+# the stamped window". Refusing to trust the record is cheaper than either.
+if [[ -n "$load_start" && -n "$load_end" ]]; then
+  if ! [[ "$load_start" =~ ^[0-9]+$ && "$load_end" =~ ^[0-9]+$ ]]; then
+    echo "ignoring the window in ${window_source:-the run record}: epochs are not integer seconds ($load_start, $load_end)" >&2
+    load_start="" load_end="" window_source="" window_kind="" window_label="load-phase"
+  elif (( load_start >= load_end )); then
+    echo "ignoring the window in ${window_source:-the run record}: start ($load_start) is not before end ($load_end)" >&2
+    load_start="" load_end="" window_source="" window_kind="" window_label="load-phase"
+  fi
+fi
+
 # A record_version this script does not know is a warning, not a failure: the
 # fields it reads are looked up by name, so an added field is harmless. Saying
 # so beats a silent misread if the schema ever changes meaning.
@@ -197,6 +217,7 @@ roll() {
   local from="${6:-0}" to="${7:-0}"
   [[ -r "$csv" ]] || return 0
   awk -F, -v bf="$box_field" -v rf="$rss_field" -v mem="$mem_total" -v L="$label" \
+      -v wlabel="$window_label" \
           -v from="${from:-0}" -v to="${to:-0}" '
     NR==1 {
       for (i = 1; i <= NF; i++) { gsub(/^[ \t]+|[ \t]+$/, "", $i); ix[$i] = i }
@@ -267,10 +288,10 @@ roll() {
              L, box_min, box_sum/n, box_max
       if (windowable) {
         if (w_n > 0)
-          printf "  %-5s cpu:  load-phase  avg=%5.1f%%   max=%5.1f%%   (%d of %d samples, %s..%s)\n",
-                 L, w_sum/w_n, w_max, w_n, n, w_first, w_last
+          printf "  %-5s cpu:  %-12savg=%5.1f%%   max=%5.1f%%   (%d of %d samples, %s..%s)\n",
+                 L, wlabel, w_sum/w_n, w_max, w_n, n, w_first, w_last
         else
-          printf "  %-5s cpu:  load-phase  no samples inside the stamped window\n", L
+          printf "  %-5s cpu:  %-12sno samples inside the stamped window\n", L, wlabel
       }
       if (mem > 0)
         printf "  %-5s mem:  min=%5.2f%%   avg=%5.2f%%   max=%5.2f%%   (out of 100%% box, %.1f GB total)\n",
@@ -295,6 +316,7 @@ echo "runs dir: $runs"
 if [[ -n "$load_start" && -n "$load_end" ]]; then
   # Name which window this is. A reader comparing this figure with loadgen's
   # percentiles needs to know whether the two cover the same span.
+  [[ "$window_kind" == "stats" ]] && window_label="stats-span"
   if [[ "$window_kind" == "stats" ]]; then
     # Same 12-character label width as "load phase:", so the provenance line
     # below stays aligned under either heading.

--- a/test/performance/summary.sh
+++ b/test/performance/summary.sh
@@ -76,7 +76,11 @@ if [[ "${1:-}" == -* && "${1:-}" != "--window-from" ]]; then
 fi
 
 if [[ "${1:-}" == "--window-from" ]]; then
-  src="${2:?--window-from needs a run directory or a run-record path}"
+  if [[ -z "${2:-}" ]]; then
+    echo "--window-from needs a run directory or a run-record path" >&2
+    exit 2
+  fi
+  src="$2"
   # Accept either a run directory or a record inside one, so the operator can
   # paste whichever path they have to hand.
   if [[ -d "$src" ]]; then
@@ -188,6 +192,12 @@ roll() {
       # A CSV predating the epoch column simply has no window; the whole-run
       # lines below are unchanged either way.
       windowable = (ec && from > 0 && to > 0)
+      # Decided here, from the header alone, and inside this block because it
+      # ends with `next` — a separate NR==1 rule below would never be reached.
+      # Deciding it from the header also means a CSV with a valid header and
+      # zero data rows reports the mismatch, rather than falling through to
+      # "(no samples)", which reads as an idle process: a real, different state.
+      if (!bc || !rc) mismatch = 1
       next
     }
     # A named column that is not in this CSV is a harness/producer mismatch,
@@ -197,13 +207,7 @@ roll() {
     # A flag rather than a bare `exit`: in awk, exit still runs the END block,
     # so exiting here printed the mismatch line AND a "(no samples)" line
     # under it. Caught by lib.test.sh, which is why that assertion is there.
-    NR==2 && (!bc || !rc) {
-      printf "  %-5s (column %s not in this CSV — header/producer mismatch)\n",
-             L, (bc ? rf : bf)
-      mismatch = 1
-    }
     mismatch { exit }
-    !bc || !rc { next }
     $bc == "NA" || $bc == "ENDED" || $bc == "" { next }
     {
       n++
@@ -224,12 +228,25 @@ roll() {
         w_n++
         w_sum += box
         if (box > w_max) w_max = box
-        if (w_first == "") w_first = $2
-        w_last = $2
+        # The wall column, resolved by name like every other column here. This
+        # read was $2 until round 3 caught it: on a reordered header it printed
+        # whatever happened to sit in column 2 into the window-bounds field,
+        # which is the only part of the load-phase line that says which samples
+        # were averaged. Falls back to t_sec when the CSV carries no wall column.
+        if (wc) { if (w_first == "") w_first = $wc; w_last = $wc }
+        else    { if (w_first == "") w_first = $1 "s"; w_last = $1 "s" }
       }
     }
     END {
-      if (mismatch) exit
+      # Decided at NR==1 from the header alone, so a CSV with a valid header
+      # and zero data rows reports the mismatch too rather than falling through
+      # to "(no samples)", which reads as an idle process — a real and very
+      # different state.
+      if (mismatch) {
+        printf "  %-5s (column %s not in this CSV — header/producer mismatch)\n",
+               L, (bc ? rf : bf)
+        exit
+      }
       if (n == 0) { printf "  %-5s (no samples)\n", L; exit }
       printf "  %-5s cpu:  min=%5.1f%%   avg=%5.1f%%   max=%5.1f%%   (out of 100%% box)\n",
              L, box_min, box_sum/n, box_max


### PR DESCRIPTION
## Summary

Eleven contained changes to `test/performance/` so a measurement run's numbers are trustworthy and self-describing, and a later run can be honestly compared against an earlier one. No new measurement is added, and nothing outside `test/performance/` is touched.

Items 1-7 are the story as written. **Items 8-11 were added after this branch drove its first real campaign** (SOL-154097 — 120 runs, 57M requests), which is what a harness change that has never driven a campaign is for. Each is a case where the harness produced a number that was wrong, missing, or unattributable; they are detailed in [SOL-154095 comment 2190211](https://sol-jira.atlassian.net/browse/SOL-154095) and summarised below.

[SOL-154095](https://sol-jira.atlassian.net/browse/SOL-154095)

---

**For reviewers — the three judgement calls worth arguing with**, all deviations from the story's implementation notes, which asked for exactly this ("deviate if something here is wrong, but say so in review rather than silently choosing otherwise"):

1. **The `config loaded` line only reports `fair_scheduling`**, not the other three admission settings, so following the note literally would record three of four as `unknown` on every run. Each setting instead carries a `_source` — see [below](#deviation-1-the-four-admission-settings-carry-a-_source).
2. **The split-host MCP box cannot stamp its own load window** (the load runs on the other box, and the two share no channel by design), so it records that fact and `summary.sh` gained `--window-from`. See [below](#deviation-2-the-split-host-mcp-box-cannot-stamp-its-own-window).
3. **`sampler.csv` gained an `epoch` column**, which brushes against "extend `memsampler`, leave `sampler.sh` alone". I read that instruction as being about not adding a *second descriptor column* nobody reconciles with the first; windowing needs a timestamp comparable across processes, and `t_sec` is sampler-relative while `wall` carries no date. It is appended last, so every existing column index still holds. See [below](#deviation-3-sampler.csv-gained-an-epoch-column).

**Two behaviour changes to look at first**, both from items 8-11 and both deliberate:

1. **`DURATION` no longer accepts compound or sub-second Go durations.** `1m30s` and `500ms` are now refused at the door. Previously the Go string went to `loadgen` while a *separate*, gawk-only awk sized the samplers — and that awk fell back to a hardcoded `90` on anything it could not parse. So `DURATION=2m30s` drove 150s of load while sampling 100s of it, in silence, and on a mawk host every run sampled 100s regardless of `DURATION`. One parser now answers for both, and a duration the samplers cannot express is refused rather than mis-sizing a window quietly. Every `DURATION` value in this repo (`30s`, `60s`, `90s`, `2m`) is unaffected.
2. **`capture_dirty` and `commit_dirty` change value on most trees** — from `true` to `false` — because they now ignore untracked files. They are provenance strings, not measurements, so no number moves; but a run record from before this commit and one from after will disagree about a tree that never changed.

**One open question:** AC 3 cannot be fully ticked without a decision — do you want the one-line `config loaded` change filed as a follow-up, or folded in here despite the "no production surface" AC? My recommendation is a follow-up; details under deviation 1.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Motivation and Context

Each item was found while reviewing and re-running SOL-153311 in two environments. They fix ways the harness produces numbers that are wrong, unattributable, or silently missing — and one of them unblocks the ">50 brokers, find the maximum" test outright.

## Changes Made

Ten commits — five for the story's own items in its suggested order, one per review round, then one folding in what the campaign found. Each is independently revertable:

| Commit | Item(s) |
|---|---|
| `b19a5a8` | 7 — the mock config's pacer setting |
| `49c26b7` | 3 — `memsampler`'s descriptor column, and the tool's first test file |
| `5c789cf` | 4 — the N-broker config generator and its self-test |
| `ce92424` | 1, 2, 5, 6 — the run record, load-phase CPU, the port wait, `RLIMIT_NOFILE` |
| `4eb3de2` | documentation |
| `7d14f52` | CI lint: ST1005 and noctx in the memsampler changes |
| `09fe325` | review round 2 — 20 findings, incl. four vacuous assertions in the new tests |
| `daa63a9` | review round 3 — a fix claimed but unlanded, four more vacuous assertions, one flaky test |
| `561862a` | Copilot review — `NOFILE` validation, and `=` in record values |
| `62a69c7` | **8-11 — the four defects the SOL-154097 campaign found**, plus the one-parser `DURATION` change above |

The four in `7f55f4f` are together because they genuinely interlock: the record carries the timestamps the CPU window is computed from, the descriptor limit is one of the fields the record reports, and the port wait lives in the same shared library the other two need. Every intermediate commit was verified to build and pass its tests, so a bisect or a revert lands somewhere that works.

**1. CPU over the load phase, not the whole hold.** `run-mcp.sh` sampled for its entire `DURATION`, which includes the idle fidelity gate, so a raw average was diluted by an unstated amount and read low. The runner that drives the load stamps `load_start_epoch`/`load_end_epoch` into its record; `sampler.csv` carries an `epoch` column; `summary.sh` reports a labelled load-phase mean and max **alongside** the unchanged whole-run line:

```
  mcp   cpu:  min=  1.0%   avg= 25.5%   max= 50.0%   (out of 100% box)
  mcp   cpu:  load-phase  avg= 50.0%   max= 50.0%   (6 of 12 samples, 10:33:50..10:34:15)
```

The boundary is stamped, never inferred from a CPU threshold — that would use the metric to define the window it is measured over, and would break on exactly the runs that matter.

**2. A run record per role** (`run-record.mcp`, `run-record.loadgen`) with rig, commit + per-binary hashes, fixture provenance, the four admission settings, the descriptor limit and the workload. One per box, never merged. `key=value`, the shape the `.info` sidecars already use.

**3. Open-descriptor column in `memsampler`**, next to the thread count, plus the tool's first tests. Sampled from `/proc`, not scraped off `/metrics`: that needs `OBS_METRICS_ENABLED` on, which changes the thing under test and makes the numbers non-comparable with every run measured so far.

**4. `gen-mock-config.sh`** generates a config for N brokers — the only thing capping the broker count at 50. Aliases byte-identical to loadgen's `<prefix>-%02d` (asserted at generation time, not just in the self-test), the three `${...}` placeholders verbatim, output gitignored, refuses to overwrite the committed config by inode identity.

**5. Wait for held ports** instead of aborting. Bounded, covers the mock's whole range and control port, names the port on timeout, and fails *closed* when `ss` is unavailable. "Free" means no *listener* — a `TIME_WAIT` socket does not block a bind with `SO_REUSEADDR`.

**6. Set and record `RLIMIT_NOFILE`.** Nothing raised it before, so the ceiling varied with the operator's login shell, invisibly. Records requested, granted, the process's own `/proc` view, and the peak reached.

**7. `broker-config.mock.yaml`** claimed "Pacer disabled" over `request_min_interval: 1ms`. Only `0s` disables it (`NewRateLimiter` returns a closed channel for a non-positive interval; any positive value builds a real ticker per broker, so every broker carried an unadvertised 1000 req/s ceiling). Value and comment both corrected, and the README now warns that pre-change throughput figures are not directly comparable — those runs predate the run record, so nothing in their artifacts reveals the setting.

Plus: `fixtures-manifest.sh` records the capture's commit (item 2 needs it), and `run.sh` takes `BROKERS` so a >50-broker run works single-host too.

### The four the campaign found

**8. `capture_dirty` and `commit_dirty` counted untracked files.** `git status --porcelain` reports the whole repository regardless of the directory it is pointed at, so any untracked file anywhere pinned both flags to `true`. The flag read `true` for every capture of a 120-run campaign whose tree carried no tracked modification at all — and a provenance flag that is always on trains the reader to ignore it. One helper answers for both sites, since the defect existed twice, written the same wrong way. The blind spot this buys — a fixture regenerated but never `git add`ed reads clean — is documented where the flag is written.

**9. The sampler peaks were written in the main flow, so a terminated run lost them.** Run H of the campaign, whose entire purpose was measuring `fd_peak` under a raised connection cap, came back without it. Both runners now write them from the `EXIT` trap, after the samplers are reaped, guarded against the trap re-entering itself. A peak over a run that was cut short is not the peak the run would have reached, and absence used to be the marker for that — so the record now says which it is: `fd_peak_source=complete` or `partial`, the latter beside `run_terminated=true`. That matters most on the split-host MCP box, which stamps no load window by design and so had nothing else separating an interrupted record from a whole one.

**10. `loadgen`'s `-warmup` had no path through either runner.** Every run therefore reported percentiles over the whole run. Fine for a steady-state ladder; not for a run with a mid-run event — and since only the summary is emitted, those percentiles cannot be re-windowed afterwards. `WARMUP` now reaches the flag, is recorded, and extends each runner's own samplers. `run-mcp.sh` takes it too: the boxes share no channel, so Box B cannot learn it, and without it Box B's samplers stop before the load does. The record gains `stats_start_epoch`, and **`summary.sh` prefers it over the load window when present**, labelling the report `stats span:` — otherwise CPU over the load phase sits under the same heading as percentiles over the stats window with nothing saying they differ.

**11. The record described the machine but not how much of it the Go runtime would use.** Two runs on one box with different `GOMAXPROCS` were identical in every field. It now carries `gomaxprocs_env` from the server process's own `environ`, its cgroup path, `cpu.max`, and that quota as a core count. Deliberately **not** one derived "effective GOMAXPROCS": Go 1.25 derives it from the cgroup CPU limit, so an `nproc` fallback would be confidently wrong in exactly the containerised case these fields exist to detect — the shipped `deployment.yaml` sets `requests.cpu: 100m` and no limit, so a pod runs with a P per node core while entitled to a tenth of one.

## The three deviations

### Deviation 1: the four admission settings carry a `_source`

The story's note says to read all four off the server's `config loaded` line. That line carries `broker_count`, `port`, `log_level` and `fair_scheduling` — and nothing else logs the other three at startup. Following the note literally records three of four as `unknown` on every run, which defeats the item.

So each setting says where its value came from, and no value is ever guessed:

| `_source` | meaning |
|---|---|
| `server-log` | the server reported its own effective value |
| `config-file` | written explicitly in the config this run used |
| `unreported-server-default` | not written down and not reported; value reads `unknown` |
| `server-log-absent` | the server never logged the line; value reads `unknown` |
| `server-log-schema-changed` | the line is there but the field is not — the coupling broke; warns, and value reads `unknown` |
| `config-file-unparsed` | the key *is* in the config but the narrow reader could not extract it; warns, and value reads `unknown` |

The last three exist so a broken reader is distinguishable from an absent value. Collapsing them into one `unknown` would let a log-schema change silently degrade every future run with no signal — and the whole reason this field is read from the log is that it *is* obtainable.

**Recommended follow-up:** adding the other three to the `config loaded` line is a one-line server change that makes all four read `server-log`. That is production surface, so it is out of scope here — happy to file it, which is my recommendation for the open question above.

### Deviation 2: the split-host MCP box cannot stamp its own window

The load runs on the other box and the two share no channel by design, so `run-mcp.sh` records `load_window_source=split-host-load-on-other-box` and its summary reports the whole-run figure only. `run-loadgen.sh` prints the exact command to window Box B afterwards; both run directories are archived together, which is the channel that *does* exist:

```
./summary.sh <box-b-run-dir> --window-from <box-a-run-dir>
```

`--window-from` reads the window out of the load box's record and names that record in the report, so a windowed figure in an archived summary stays traceable. A bare epoch pair still works and is marked `unverified`. Inventing a boundary — from a connection count, say — would be the same class of mistake as inferring it from CPU. Single-host `run.sh` runs window automatically.

### Deviation 3: `sampler.csv` gained an `epoch` column

Appended last, so every existing column index holds. `summary.sh` and `lib.sh` now resolve columns by **header name** rather than by index, so both the pre-epoch and post-epoch layouts read correctly through the same code and the next column cannot silently shift a consumer.

## Testing

**Test Environment:** go1.25.0, Linux (WSL2). No broker — the harness runs against `mock-semp`.

**Review rounds:** four, run as independent agents against the pushed head. **Round 4** covered items 8-11 with three challengers (shell correctness, measurement semantics, tests-and-docs) and found five showstoppers, every one of them fixed before this push: a refactor that left **three functions defined twice** in `lib.sh`, where bash keeps the last definition — so the new, tested code was dead and the suite still reported green; a duration helper failing inside `$(( ))`, which yielded `memsampler -duration 0s`, meaning "run until Ctrl-C", so a *completed* run hung at its final `wait`; `stats_start_epoch` written but read by nothing; a cgroup walk-up test that passed against an implementation with no walk at all (it derived its fixture from the test host's own cgroup, which is `/` here, collapsing leaf and ancestor into one directory); and Box B's sampler extension documented but not implemented. Rounds 1-3 covered items 1-7: Round 1 raised 45 findings across five lenses (one challenged and downgraded — the challenge refuted its stated consequence empirically and rejected its recommended fix as worse than the problem). Round 2 raised 20, of which the most valuable were **four assertions in my own new tests that could not fail**. Round 3 caught a fix I had *claimed in a commit message but not actually landed* (an edit that targeted variable names not present in the file, so it silently did nothing), four more vacuous assertions, and a flaky Go test. **Copilot** also reviewed the first head and raised four points: two were already closed by rounds 2–3, and two were valid and open — `NOFILE` reaching an arithmetic comparison unvalidated (a non-numeric value aborted the whole runner from inside a library), and `=` in a record value truncating it under the documented `awk -F=` reader. Both are fixed in `a6477c2` with tests, and all four comments are answered inline. Every finding from every round is either fixed or listed under "Deliberately deferred" below with its reason.

**Tests added:**
- `memsampler/main_test.go` — the tool had none. The `/proc` parse (including a malformed field beside good ones, which used to become a silent zero), the descriptor count's self-handle correction, and the stats roll-up.
- `gen-mock-config.test.sh` — 42 assertions on the generator.
- `lib.test.sh` — 161 assertions on `lib.sh` and `summary.sh`'s rollup: the load-phase windowing, every `_source` label and its block scoping, the port wait including its "cannot tell" third state, the peak reader, the argument validator, the record's field discipline, name-based column resolution against a reordered header, and — from items 8-11 — the dirty flags through both their callers, the duration parser's grammar and bounds, and the cgroup walk-up and quota arithmetic.
- `run-mcp.test.sh` — new, and the only one that exercises a runner rather than a function. It interrupts a real `run-mcp.sh` mid-hold against stub binaries and asserts the peaks survive, appear **exactly once** despite `cleanup` handling `EXIT`, `INT` and `TERM` alike, and are marked `partial`. It binds :9090 and :18081 and exits without running if either is held, so it will not interrupt a campaign to make its point.

**None of these needs a broker, a server, fixtures or a network.** The first three run in a `mktemp` dir in seconds; the fourth takes about twenty.

**Gates:** full `make check` clean after the rebase onto `main` — build, vet, lint, race-enabled tests, coverage 89.7% against the 85% floor.

Note on `make check`: it fails locally on 23 pre-existing `staticcheck` findings in `internal/composite/` and `internal/tools/sempv1/redundancy/` test files, which reproduce on a clean `main`. That noise **hid two real lint errors of mine** (`4142ce2`) until CI caught them, so scoping the linter to the changed package is the check to run here.

**What was verified how:**

- **The generated 120-broker config loads in the real server** — `/health` 200 and `"msg":"config loaded" … "broker_count":120`. The alias/port/placeholder shape is proven against the real config loader, not a fixture.
- **The record, end to end against that live server** — `fair_scheduling` read off the log line, the other three sourced correctly, `nofile_effective_soft` from `/proc/<pid>/limits`, EC2 fields correctly *absent* on a non-EC2 host, `RIG_NOTE` carried through.
- **Load-phase windowing**, on a bimodal fixture: whole-run 25.5% vs load-phase 50.0% — the exact defect item 1 exists to fix. One assertion requires the two to stay materially apart, so a window that silently covers everything fails.
- **Port waiting** against real listeners: detected a held port, returned as soon as it cleared, named the port and its holder on timeout, and a 210-port set polls in 1.6s (one `ss` call per iteration, not one per port).
- **Backwards compatibility**: a run directory with a pre-`epoch` 14-column CSV and no run record prints exactly what it printed before, with no false load-phase line — even when a window is supplied.
- **Mutation-tested every new test file, across all three rounds, and re-ran every mutation a round reported as uncaught until it was caught.** `%02d`→`%03d` in the generator fails 10 assertions; expanding `${MOCK_HOST}` fails 4; removing the committed-config guard fails 2; deleting `memsampler`'s self-handle correction and applying it unconditionally each fail a *different* test; ignoring the load window fails 6; applying it without its bounds fails 6 including the average, not just the sample count; slipping either inclusive bound fails 6; hardcoding `roll()`'s column indices back fails 3; deleting the load-phase maximum fails 4; mislabelling an unparsed setting fails 3; unscoping the `semp:` presence probe fails 1; treating the port check's "cannot tell" as "free" fails 1; ignoring the stamp helpers' shared epoch fails 1; reading the `wall` column positionally fails 1. Editing `max_concurrent_per_broker` in the committed config without touching the generator fails the generator's anchor test.
- **The flaky test is gone.** `TestCountOpenFDsChildProcessIsNotCorrected` sampled a freshly started child twice at different instants and failed about one run in seven; it now polls until two consecutive reads agree. 25 consecutive runs clean, mutation still caught.

**Not yet verified — needs the lab:**

- [ ] A split-host run passing the exact-mode fidelity gate with these changes in place
- [ ] One run above 50 brokers end to end
- [ ] A `WARMUP` run end to end, with Box B's samplers covering the whole load and `summary.sh` reporting the `stats span:`
- [ ] `perf_record_runtime_cpu` against a real Go server under a real cgroup quota (a rig host has none, so `cgroup_cpu_quota_cores` reads `none` there — correct, but it does not exercise the arithmetic)

This checkout has no captured fixtures (they are gitignored lab captures), so neither can run here. Both are in the story's DoD and I will run them on the perf hosts before this comes out of draft.

## Breaking Changes

**One, to the harness's input contract:** `DURATION` no longer accepts compound or sub-second Go durations (`1m30s`, `500ms`). See the two behaviour changes at the top — the previous behaviour was not "these worked", it was "the samplers silently covered the wrong span". Every `DURATION` in this repo is unaffected, and the refusal is at the door with a message naming the value.

`capture_dirty` and `commit_dirty` will read `false` where they used to read `true` on a tree with untracked files. Provenance strings, not measurements — but two records of the same tree, taken either side of this commit, will disagree.

Otherwise none. `sampler.csv`'s `epoch` and `mem.csv`'s `open_fds` are appended last; `summary.sh`'s existing lines are unchanged; columns are now resolved by name, so old and new layouts both read. A pre-existing run directory reads exactly as before.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] Code is well-commented (explains "why")
- [x] No commented-out code or debug statements left in

### Security
- [x] No credentials in code — the record carries host/rig/commit/settings, never credentials; the config copied into the run directory holds `${...}` placeholders, not values
- [x] `/check-logs` clean. The only new output is a stderr warning carrying a pid and an OS error, in a `test/` CLI tool. No production logging changed
- [x] Record values are flattened and capped at the single choke point they pass through, so free-text `RIG_NOTE` and the EC2 metadata replies cannot inject forged `key=value` lines
- [x] The generator writes through `mktemp` beside its target rather than a predictable `$$` name

### Testing
- [x] All tests pass locally (`make test-cover`, race-enabled)
- [x] Edge cases and error paths covered — unreadable `/proc/<pid>/fd` → `NA` not `0`; a missing process; an absent manifest; a missing `ss` (fails closed); no window stamped; a window matching no samples; pre-`epoch` CSVs; reordered CSV columns

### Documentation
- [x] `test/performance/README.md`: the run record and its `_source` semantics, whole-run vs load-phase CPU, `gen-mock-config.sh`, descriptor accounting, both samplers' column contracts, the pacer change and its effect on comparability, Box B's env knobs, and how to run the self-tests
- [x] CHANGELOG intentionally **not** updated — test harness only, no production surface. CI's `CHANGELOG updated` check passes, so no label is needed

### Git & CI
- [x] Ten commits, each signed off (DCO) and each independently functional
- [x] Branch rebased onto `main` and up to date with it

## Additional Notes

**Deliberately deferred, with reasons**, rather than widening a diff that is already large:

- **`kill_tree` / `wait_for_http` / `wait_for_tcp` stay triplicated** across the three runners even though `lib.sh` now exists. They are process-lifecycle code whose copies have already diverged (`run-mcp.sh` has no `wait_for_tcp`), they are wired into three different trap/cleanup orderings, and nothing in this suite can test them without a live broker — so consolidating them is a change with real risk and no coverage. It is worth doing; it is worth doing on its own. `lib.sh`'s header says so, and points at `test/e2e-common/lib.sh` for where they should end up.
- **Wiring the self-tests into `make` and CI.** Both are worth it and neither is production surface, but they are outside `test/performance/`, which the "no production surface" AC scopes this story to. The alias-format guard — the one that would otherwise only fire when someone remembers to run a script — now runs inside the generator itself on every invocation, which covers the failure mode that mattered.
- **A `-print-brokers` flag on `loadgen`** so the generator consumes the alias list from the tool that defines it, rather than duplicating the format string and guarding the duplicate. Better design; worth doing next time the generator is touched.
- **Re-pointing the story.** 1 point / ~5 hours against seven items, three new test files and a new shared library was optimistic; worth recalibrating for the rest of epic SOL-153344.

**Two things worth knowing about the review, since they are the kind of thing that recurs:**

- A finding both the architecture and code lenses raised independently — that the generator's duplicated `semp:` block made the >50-broker and ≤50 arms "silently non-comparable" — was **refuted on its stated consequence** by building the two run records and diffing them: they differ by exactly one visible line, and each is truthful about the config its own run loaded. The duplication is real and worth guarding, but the recommended fix (splicing the committed file) would have traded a visible stale-value drift for an invisible empty-header failure. The test was extended instead. Convergence between two reviewers was not corroboration.
- The most valuable findings of rounds 2 and 3 were in **my own test code**, not the harness: eight assertions that could not fail under the bug they named. A test suite that cannot fail licenses confidence it has not earned, which is worse than having none.



