### PR TITLE
SOL-152095: Expose Go runtime and process metrics so SREs can diagnose memory pressure and goroutine leaks

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -127,10 +127,11 @@ counter (`mcp_auth_failure_total`) is recorded has its own flag,
 operator can set it independently, so the counter can be suppressed while the rest of the
 surface is on, or kept while the rest is off. The flag governs recording only. What is
 exposed when it is forced on while `OBS_METRICS_ENABLED` is false is a property of the
-`/metrics` endpoint and is settled when that endpoint is wired, not by this schema.
+`/metrics` endpoint and is settled by `OBS_METRICS_ENABLED`, not by this schema.
 
-The same instruments can additionally be **pushed over OTLP**, behind its own flag,
-`OBS_METRICS_OTLP_ENABLED`. The endpoint comes from the standard
+The `mcp_*` instruments can additionally be **pushed over OTLP**, behind its own flag,
+`OBS_METRICS_OTLP_ENABLED`. The `go_*`/`process_*` collectors are scrape-only and are
+**not** pushed — see [Go Runtime and Process Metrics](#go-runtime-and-process-metrics). The endpoint comes from the standard
 `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`. Push is off by
 default and does not activate merely because an endpoint variable is present in the
 environment; see [Decided Since the First Draft](#decided-since-the-first-draft) for why.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -46,7 +46,7 @@ capability headings carry the same tag:
 | Capability | Status | Notes |
 |---|---|---|
 | Correlation ID | **[Implemented]** | Wired and on by default (`OBS_CORRELATION_ID_ENABLED`). |
-| Metrics | **[Planned, with exceptions]** | Most instrument names and labels here are still the proposal under review. Wired and emitted today: the `/metrics` endpoint itself, `mcp_build_info`, `mcp_schema_version`, `mcp_metrics_scrape_total`, `mcp_http_active_requests`, `mcp_tool_invocation_total`, `mcp_tool_invocation_duration_seconds`, `mcp_semp_request_total`, `mcp_semp_request_duration_seconds`, the OTLP export-health counters, and `mcp_panic_recovered_total` (see [Panic Recovery](#panic-recovery--implemented)). Assume any other metric below is not yet emitted. |
+| Metrics | **[Planned, with exceptions]** | Most instrument names and labels here are still the proposal under review. Wired and emitted today: the `/metrics` endpoint itself, `mcp_build_info`, `mcp_schema_version`, `mcp_metrics_scrape_total`, `mcp_http_active_requests`, `mcp_tool_invocation_total`, `mcp_tool_invocation_duration_seconds`, `mcp_semp_request_total`, `mcp_semp_request_duration_seconds`, the OTLP export-health counters, `mcp_panic_recovered_total` (see [Panic Recovery](#panic-recovery--implemented)), and the `go_*`/`process_*` runtime collectors (see [Go Runtime and Process Metrics](#go-runtime-and-process-metrics)). Assume any other metric below is not yet emitted. |
 | Audit trail | **[Interim — all record types except `broker_authz_denied`]** | Destructive tool calls emit an `operation` record behind `OBS_AUDIT_LOG_ENABLED` (default off). `auth_success`, `auth_failure`, `authz_denied`, and `broker_auth_retry` also emit today (SOL-152097). `broker_authz_denied` and the `mcp_audit_events_dropped_total` counter are not emitted yet. See [Audit Trail](#audit-trail--interim--all-record-types-except-broker_authz_denied). |
 | Distributed tracing | **[Interim — request-path spans wired, per-attempt spans pending]** | Tracer provider, OTLP export, W3C context propagation, and spans at the HTTP boundary, the tool dispatcher, the composite executor, and each SEMP call are live behind `OBS_TRACING_ENABLED`. Per-*attempt* spans and the retry attributes are still pending (Story 27). See [Distributed Tracing](#distributed-tracing--interim-request-path-spans-wired). |
 | Saturation visibility | **[Interim — logs only]** | Shipped as structured log lines behind `OBS_SATURATION_EVENTS_ENABLED`, **not** as the metric this schema describes. See [Load and Saturation Visibility](#load-and-saturation-visibility--interim--logs-only). |
@@ -115,8 +115,9 @@ avoid. Pin dashboards to `mcp_schema_version` and SIEM queries to `audit_schema_
 > `/metrics` endpoint itself, `mcp_build_info`, `mcp_schema_version`,
 > `mcp_metrics_scrape_total`, `mcp_http_active_requests`, `mcp_tool_invocation_total`,
 > `mcp_tool_invocation_duration_seconds`, `mcp_semp_request_total`,
-> `mcp_semp_request_duration_seconds`, the OTLP export-health counters, and
-> `mcp_panic_recovered_total` (see [Panic Recovery](#panic-recovery--implemented)). Assume
+> `mcp_semp_request_duration_seconds`, the OTLP export-health counters,
+> `mcp_panic_recovered_total` (see [Panic Recovery](#panic-recovery--implemented)), and the
+> `go_*`/`process_*` runtime collectors (see [Go Runtime and Process Metrics](#go-runtime-and-process-metrics)). Assume
 > any other metric below is not yet emitted._
 
 All metrics are served on the `/metrics` endpoint in Prometheus text exposition
@@ -455,9 +456,17 @@ Exemplars add no new label keys and no new series.
 
 Standard `go_*` and `process_*` collectors from the Prometheus Go client library
 (`collectors.NewGoCollector()` and `collectors.NewProcessCollector()`): goroutine count,
-garbage-collection timing, memory stats, file descriptors, CPU. These names are upstream
-Prometheus conventions, not Solace-defined, and are listed here only so you know they will be
-present, once the metrics endpoint is wired, for diagnosing memory pressure and goroutine leaks.
+garbage-collection timing, memory stats, file descriptors, CPU. These are live whenever
+`OBS_METRICS_ENABLED` is on, with no extra configuration.
+
+**Naming.** These are upstream Prometheus conventions, not Solace-defined schema. A future
+`client_golang` upgrade that renames them is not a breach of the additive-only commitment.
+
+**Scrape-only.** These collectors are registered directly into the Prometheus registry, not
+through the OTel meter API. They appear on `/metrics` but not on the OTLP metrics stream
+(`OBS_METRICS_OTLP_ENABLED`). An OTLP-only consumer receives the `mcp_*` instruments and
+resource attributes, but not `go_*` or `process_*`. If your OTLP pipeline shows no `go_*`
+metrics, this is expected — scrape `/metrics` to get them.
 
 ---
 

--- a/internal/observability/metrics/provider_test.go
+++ b/internal/observability/metrics/provider_test.go
@@ -170,6 +170,22 @@ func scrapeCounterValue(t *testing.T, body string) int {
 	return 0
 }
 
+// TestGoAndProcessFamiliesPresent asserts the standard Go runtime and process
+// metric families are present in a plain-text scrape. Values are not checked —
+// they are environment-dependent.
+func TestGoAndProcessFamiliesPresent(t *testing.T) {
+	p, err := New(testVersion, sdkresource.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := scrapePlainText(t, p)
+	for _, prefix := range []string{"go_goroutines", "go_gc_", "go_memstats_", "process_"} {
+		if !strings.Contains(body, prefix) {
+			t.Errorf("scrape missing family with prefix %q", prefix)
+		}
+	}
+}
+
 // TestProviderAccessors covers the meter-provider accessors and a clean shutdown.
 func TestProviderAccessors(t *testing.T) {
 	p, err := New(testVersion, sdkresource.Default())

--- a/internal/observability/metrics/provider_test.go
+++ b/internal/observability/metrics/provider_test.go
@@ -172,7 +172,9 @@ func scrapeCounterValue(t *testing.T, body string) int {
 
 // TestGoAndProcessFamiliesPresent asserts the standard Go runtime and process
 // metric families are present in a plain-text scrape. Values are not checked —
-// they are environment-dependent.
+// they are environment-dependent. This test exercises New()'s MustRegister call;
+// TestExporterFidelity_SharedRegistry covers the same families on an isolated
+// harness registry and the two are not redundant.
 func TestGoAndProcessFamiliesPresent(t *testing.T) {
 	p, err := New(testVersion, sdkresource.Default())
 	if err != nil {
@@ -180,8 +182,16 @@ func TestGoAndProcessFamiliesPresent(t *testing.T) {
 	}
 	body := scrapePlainText(t, p)
 	for _, prefix := range []string{"go_goroutines", "go_gc_", "go_memstats_", "process_"} {
-		if !strings.Contains(body, prefix) {
-			t.Errorf("scrape missing family with prefix %q", prefix)
+		found := false
+		s := bufio.NewScanner(strings.NewReader(body))
+		for s.Scan() {
+			if strings.HasPrefix(s.Text(), prefix) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("scrape has no line matching %q", prefix)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `TestGoAndProcessFamiliesPresent` — scrapes `/metrics` and asserts the `go_goroutines`, `go_gc_*`, `go_memstats_*`, and `process_*` families are present (presence only, no value assertions).
- Updates `docs/observability.md`: marks `go_*`/`process_*` as live in the status table and section header, removes the stale "once the metrics endpoint is wired" wording, and documents the scrape-only limitation (these families come from Prometheus collectors, not OTel, so they do not appear on the OTLP stream).

The collector registration itself (`collectors.NewGoCollector()` / `collectors.NewProcessCollector()`) was done in SOL-152091 at `internal/observability/metrics/provider.go:89-92`. The golden file already excluded these families via `mcpFamilies()`. This PR closes out the remaining acceptance criteria for SOL-152095.

Fixes https://sol-jira.atlassian.net/browse/SOL-152095

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Motivation and Context

SREs need Go runtime metrics (`go_goroutines`, GC, heap, `process_*`) on `/metrics` to diagnose memory pressure and goroutine leaks using the community Grafana dashboards they already use for Go services. These are upstream Prometheus conventions registered directly into the shared `client_golang` registry — no extra configuration needed.

## Changes Made

- `internal/observability/metrics/provider_test.go`: `TestGoAndProcessFamiliesPresent` asserts all four metric family prefixes are present in a plain-text scrape.
- `docs/observability.md`: status table, section header, and "Go Runtime and Process Metrics" section updated to reflect the families are live and to document the scrape-only limitation.

## Testing

**Tests Performed:**
- [x] Unit tests added/updated
- [x] Tested locally with `go test -race ./...`

**Test Coverage:**
- `TestGoAndProcessFamiliesPresent`: spins up a provider, scrapes `/metrics`, asserts presence of `go_goroutines`, `go_gc_*`, `go_memstats_*`, and `process_*` prefixes.
- `make check` passes: coverage 89.5%, above the 85% floor.

## Checklist

### Code Quality
- [x] Self-review completed
- [x] No commented-out code or debug statements

### Security
- [x] No credentials in code
- [x] `/check-logs` scan passes

### Testing
- [x] All tests pass locally: `go test -race ./...`
- [x] No race conditions detected

### Documentation
- [x] docs/ updated

### Git & CI
- [x] All commits are signed off (DCO)
- [x] CI checks passing

## Related Issues/PRs

- Depends on SOL-152091 (#357) — collector registration